### PR TITLE
KAN-138: Restore homepage content — use cases, differentiators, parent callout

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -174,6 +174,108 @@ function Sections() {
     </section>
   );
 }
+function UseCases() {
+  const cases = [
+    {
+      title: "Parents",
+      desc: "Invite your children\u2019s teachers to create a quick profile. End-of-term gifts become easy instead of stressful. Two minutes is all it takes.",
+    },
+    {
+      title: "Friends & family",
+      desc: "Birthdays, Christmas, just because. Stop guessing. Check their Lyra profile and find something they\u2019ll actually love.",
+    },
+    {
+      title: "Colleagues",
+      desc: "New team member? Secret Santa? Share preferences and boundaries without the awkward conversations.",
+    },
+    {
+      title: "Teachers & carers",
+      desc: "A simple way to let parents know what you\u2019d appreciate \u2014 without asking. Just share your profile link.",
+    },
+  ];
+
+  return (
+    <section className="py-24 px-6 bg-white">
+      <div className="max-w-4xl mx-auto">
+        <h2 className="font-[family-name:var(--font-serif)] text-3xl sm:text-4xl text-stone-800 text-center mb-4">
+          Who it&apos;s for
+        </h2>
+        <p className="text-stone-500 text-center mb-16 max-w-lg mx-auto">
+          Anyone who&apos;s ever thought &ldquo;I wish they just knew what I wanted.&rdquo; Which is everyone.
+        </p>
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-x-12 gap-y-8 max-w-3xl mx-auto">
+          {cases.map((c) => (
+            <div key={c.title}>
+              <h3 className="font-medium text-stone-800 mb-2">{c.title}</h3>
+              <p className="text-sm text-stone-500 leading-relaxed">{c.desc}</p>
+            </div>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function WhatLyraIsNot() {
+  const items = [
+    "No likes, followers, or feeds",
+    "No algorithms deciding what you see",
+    "No pressure to post or engage",
+    "No selling your data",
+    "No notifications or FOMO",
+  ];
+
+  return (
+    <section className="py-24 px-6">
+      <div className="max-w-2xl mx-auto text-center">
+        <h2 className="font-[family-name:var(--font-serif)] text-3xl sm:text-4xl text-stone-800 mb-12">
+          What Lyra is not
+        </h2>
+        <div className="space-y-4">
+          {items.map((item) => (
+            <div
+              key={item}
+              className="flex items-center gap-3 text-left max-w-md mx-auto"
+            >
+              <span className="text-[var(--color-lyra-blush)] font-semibold text-sm shrink-0">No</span>
+              <span className="text-stone-500 text-sm">{item.replace(/^No /, "")}</span>
+            </div>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function ParentCallout() {
+  return (
+    <section className="py-16 px-6">
+      <div className="max-w-2xl mx-auto">
+        <div className="rounded-2xl border-2 border-[var(--color-lyra-sage-light)] bg-[var(--color-lyra-sage-50)] p-8 sm:p-10 text-center">
+          <h2 className="font-[family-name:var(--font-serif)] text-2xl text-stone-800 mb-4">
+            Are you a parent?
+          </h2>
+          <p className="text-stone-500 leading-relaxed mb-4 max-w-lg mx-auto">
+            End of term is coming. Instead of guessing what your children&apos;s teachers would like,
+            invite them to create a Lyra profile. It takes two minutes &mdash; just gift ideas and
+            things to avoid &mdash; and it makes everything easier for everyone.
+          </p>
+          <p className="text-sm text-stone-400 italic mb-6 max-w-md mx-auto">
+            &ldquo;Hi! I&apos;m using Lyra to help people know what I&apos;d appreciate.
+            It only takes a couple of minutes. Here&apos;s where you can create yours&hellip;&rdquo;
+          </p>
+          <Link
+            href="/signup"
+            className="inline-block px-8 py-3 rounded-full bg-[var(--color-lyra-sage)] text-white font-medium text-sm hover:bg-[#7A8E6D] transition-colors"
+          >
+            Create your free profile
+          </Link>
+        </div>
+      </div>
+    </section>
+  );
+}
+
 function CTA() {
   return (
     <section className="py-24 px-6 bg-[var(--color-lyra-sage-50)]">
@@ -236,6 +338,9 @@ export default function Home() {
         <ProfilePreview />
         <HowItWorks />
         <Sections />
+        <UseCases />
+        <WhatLyraIsNot />
+        <ParentCallout />
         <CTA />
       </main>
       <Footer />

--- a/tests/unit/homepage-content.test.js
+++ b/tests/unit/homepage-content.test.js
@@ -1,0 +1,83 @@
+/**
+ * Homepage content tests
+ * KAN-138: Restore missing homepage content from original Python site
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const root = path.join(__dirname, '../..');
+const homepagePath = path.join(root, 'src/app/page.tsx');
+
+describe('KAN-138: Homepage content restoration', () => {
+  let content;
+
+  beforeAll(() => {
+    content = fs.readFileSync(homepagePath, 'utf8');
+  });
+
+  test('homepage file exists', () => {
+    expect(fs.existsSync(homepagePath)).toBe(true);
+  });
+
+  test('contains UseCases component', () => {
+    expect(content).toContain('function UseCases');
+    expect(content).toContain('<UseCases');
+  });
+
+  test('UseCases includes all four audience segments', () => {
+    expect(content).toContain('Parents');
+    expect(content).toContain('Friends');
+    expect(content).toContain('Colleagues');
+    expect(content).toContain('Teachers');
+  });
+
+  test('contains WhatLyraIsNot component', () => {
+    expect(content).toContain('function WhatLyraIsNot');
+    expect(content).toContain('<WhatLyraIsNot');
+  });
+
+  test('WhatLyraIsNot includes key differentiators', () => {
+    expect(content).toContain('followers');
+    expect(content).toContain('algorithms');
+    expect(content).toContain('notifications');
+  });
+
+  test('contains ParentCallout component', () => {
+    expect(content).toContain('function ParentCallout');
+    expect(content).toContain('<ParentCallout');
+  });
+
+  test('ParentCallout references teacher/parent use case', () => {
+    expect(content).toContain('End of term');
+    expect(content).toContain('teachers');
+  });
+
+  test('all original sections still present', () => {
+    expect(content).toContain('function Hero');
+    expect(content).toContain('function ProfilePreview');
+    expect(content).toContain('function HowItWorks');
+    expect(content).toContain('function Sections');
+    expect(content).toContain('function CTA');
+    expect(content).toContain('function Footer');
+  });
+
+  test('components render in correct order', () => {
+    const heroPos = content.indexOf('<Hero');
+    const profilePos = content.indexOf('<ProfilePreview');
+    const howPos = content.indexOf('<HowItWorks');
+    const sectionsPos = content.indexOf('<Sections');
+    const useCasesPos = content.indexOf('<UseCases');
+    const whatNotPos = content.indexOf('<WhatLyraIsNot');
+    const parentPos = content.indexOf('<ParentCallout');
+    const ctaPos = content.indexOf('<CTA');
+
+    expect(heroPos).toBeLessThan(profilePos);
+    expect(profilePos).toBeLessThan(howPos);
+    expect(howPos).toBeLessThan(sectionsPos);
+    expect(sectionsPos).toBeLessThan(useCasesPos);
+    expect(useCasesPos).toBeLessThan(whatNotPos);
+    expect(whatNotPos).toBeLessThan(parentPos);
+    expect(parentPos).toBeLessThan(ctaPos);
+  });
+});


### PR DESCRIPTION
## What & Why
Restores three content sections from the original Python/Flask Lyra homepage that were lost in the Next.js migration. Part of KAN-131 epic (feature gap restoration).

## Changes
- `src/app/page.tsx`: Added 3 new components:
  - **UseCases** — "Who it's for" with 4 audience segments (parents, friends, colleagues, teachers)
  - **WhatLyraIsNot** — 5 key differentiators (no feeds, algorithms, pressure, data selling, FOMO)
  - **ParentCallout** — End-of-term teacher gift use case with signup CTA
- `tests/unit/homepage-content.test.js`: 9 new tests

## Tests (9 new, 108 total)
- Component existence checks for all 3 new components
- Content verification (audience segments, differentiators, teacher reference)
- Render order verification (new sections between Sections and CTA)
- All original components still present

## Security Review
- No security impact — static content only, no data queries
- No new auth requirements

## Architecture Impact
- No new routes, env vars, or dependencies
- Featured profiles section (needs Supabase query) deferred to follow-up PR