### PR TITLE
KAN-137: Restore 8 missing profile section types — books, media, causes, quotes, billboard, Q&A

### DIFF
--- a/src/app/[slug]/page.tsx
+++ b/src/app/[slug]/page.tsx
@@ -129,6 +129,14 @@ export default async function PublicProfilePage({ params }: Props) {
     gifts_to_avoid: 'Gifts to avoid',
     boundaries: 'Boundaries',
     helpful_to_know: 'Helpful to know',
+    favourite_books: 'Favourite books',
+    favourite_media: 'Favourite movies & series',
+    causes: 'Causes I care about',
+    quotes: 'Quotes I love',
+    proud_of: 'What I\'m most proud of',
+    life_hacks: 'Life hacks & recommendations',
+    questions: 'Questions I wish people asked',
+    billboard: 'My billboard',
   };
 
   const categoryIcons: Record<string, string> = {
@@ -138,6 +146,14 @@ export default async function PublicProfilePage({ params }: Props) {
     gifts_to_avoid: '🚫',
     boundaries: '🛑',
     helpful_to_know: '💡',
+    favourite_books: '📖',
+    favourite_media: '🎬',
+    causes: '🌍',
+    quotes: '💬',
+    proud_of: '🏆',
+    life_hacks: '✨',
+    questions: '❓',
+    billboard: '📢',
   };
 
   const groupedItems = typedItems.reduce((acc: Record<string, ProfileItem[]>, item) => {
@@ -147,7 +163,11 @@ export default async function PublicProfilePage({ params }: Props) {
   }, {});
 
   // Display order for categories
-  const categoryOrder = ['likes', 'dislikes', 'gift_ideas', 'gifts_to_avoid', 'helpful_to_know', 'boundaries'];
+  const categoryOrder = [
+    'likes', 'dislikes', 'gift_ideas', 'gifts_to_avoid', 'helpful_to_know', 'boundaries',
+    'favourite_books', 'favourite_media', 'causes', 'proud_of', 'life_hacks', 'questions',
+  ];
+  // quotes and billboard render separately with special styling
 
   // JSON-LD structured data for AI consumption (Schema.org Person)
   const jsonLd = {
@@ -251,24 +271,72 @@ export default async function PublicProfilePage({ params }: Props) {
               <h2 className="text-xs font-medium text-[var(--color-muted)] uppercase tracking-wide mb-3">
                 {categoryIcons[cat]} {categoryLabels[cat]}
               </h2>
-              <div className="flex flex-wrap gap-2">
-                {catItems.map((item) => (
-                  <div key={item.id} className="group relative">
-                    <span className="inline-block px-3 py-1.5 bg-stone-50 border border-stone-200 rounded-full text-sm text-[var(--color-ink)]">
-                      {item.title}
-                    </span>
-                    {item.description && (
-                      <div className="hidden group-hover:block absolute bottom-full left-0 mb-1 px-3 py-2 bg-[var(--color-ink)] text-white text-xs rounded-lg max-w-xs z-10">
-                        {item.description}
-                      </div>
-                    )}
-                  </div>
-                ))}
-              </div>
+              {cat === 'questions' ? (
+                <div className="space-y-3">
+                  {catItems.map((item) => (
+                    <div key={item.id} className="border-l-3 border-[var(--color-sage)] bg-stone-50 rounded-r-lg pl-4 pr-4 py-3">
+                      <p className="text-sm font-medium text-[var(--color-ink)]">{item.title}</p>
+                      {item.description && (
+                        <p className="text-sm text-[var(--color-muted)] mt-1 leading-relaxed">{item.description}</p>
+                      )}
+                    </div>
+                  ))}
+                </div>
+              ) : (
+                <div className="flex flex-wrap gap-2">
+                  {catItems.map((item) => (
+                    <div key={item.id} className="group relative">
+                      <span className="inline-block px-3 py-1.5 bg-stone-50 border border-stone-200 rounded-full text-sm text-[var(--color-ink)]">
+                        {item.title}
+                      </span>
+                      {item.description && (
+                        <div className="hidden group-hover:block absolute bottom-full left-0 mb-1 px-3 py-2 bg-[var(--color-ink)] text-white text-xs rounded-lg max-w-xs z-10">
+                          {item.description}
+                        </div>
+                      )}
+                    </div>
+                  ))}
+                </div>
+              )}
             </div>
           </div>
         );
       })}
+
+      {/* Quotes — styled with left accent border */}
+      {groupedItems['quotes'] && groupedItems['quotes'].length > 0 && (
+        <div className="max-w-2xl mx-auto px-6 pb-6">
+          <div className="bg-white rounded-xl border border-stone-200 p-5">
+            <h2 className="text-xs font-medium text-[var(--color-muted)] uppercase tracking-wide mb-3">
+              💬 Quotes I love
+            </h2>
+            <div className="space-y-3">
+              {groupedItems['quotes'].map((item) => (
+                <div key={item.id} className="border-l-3 border-[var(--color-sage)] pl-4 py-1">
+                  <p className="text-[var(--color-ink)] italic leading-relaxed">&ldquo;{item.title}&rdquo;</p>
+                  {item.description && (
+                    <p className="text-sm text-[var(--color-muted)] mt-1">— {item.description}</p>
+                  )}
+                </div>
+              ))}
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Billboard — large statement at the bottom */}
+      {groupedItems['billboard'] && groupedItems['billboard'].length > 0 && (
+        <div className="max-w-2xl mx-auto px-6 pb-6">
+          <div className="bg-[var(--color-sage)] rounded-xl p-8 text-center">
+            <p className="text-xs font-medium text-white/70 uppercase tracking-wide mb-3">
+              If I had a giant billboard, it would say&hellip;
+            </p>
+            <p className="text-xl sm:text-2xl font-[family-name:var(--font-serif)] text-white leading-relaxed">
+              &ldquo;{groupedItems['billboard'][0].title}&rdquo;
+            </p>
+          </div>
+        </div>
+      )}
 
       {/* Links */}
       {typedLinks.length > 0 && (

--- a/src/app/dashboard/profile/steps/items-step.tsx
+++ b/src/app/dashboard/profile/steps/items-step.tsx
@@ -16,6 +16,10 @@ export function ItemsStep({ title, description, categories, items, onAdd, onRemo
     likes: '💚 Like', dislikes: '💔 Dislike',
     gift_ideas: '🎁 Gift idea', gifts_to_avoid: '🚫 Avoid',
     boundaries: '🛑 Boundary', helpful_to_know: '💡 Helpful to know',
+    favourite_books: '📖 Book', favourite_media: '🎬 Movie/Series',
+    causes: '🌍 Cause', quotes: '💬 Quote',
+    proud_of: '🏆 Proud of', life_hacks: '💡 Life hack',
+    questions: '❓ Question', billboard: '📢 Billboard',
   };
 
   const handleAdd = () => {

--- a/src/app/dashboard/profile/wizard.tsx
+++ b/src/app/dashboard/profile/wizard.tsx
@@ -25,6 +25,9 @@ const STEPS = [
   { id: 'likes', label: 'Likes & Dislikes', icon: '💚' },
   { id: 'gifts', label: 'Gift ideas', icon: '🎁' },
   { id: 'boundaries', label: 'Boundaries', icon: '🛑' },
+  { id: 'interests', label: 'Books & Media', icon: '📚' },
+  { id: 'values', label: 'Causes & Quotes', icon: '💛' },
+  { id: 'more', label: 'More about you', icon: '✨' },
   { id: 'links', label: 'Links', icon: '🔗' },
   { id: 'preview', label: 'Preview', icon: '👁️' },
 ];
@@ -137,12 +140,36 @@ export function ProfileWizard({
             onNext={next} isPending={isPending} />
         )}
         {step === 6 && (
+          <ItemsStep title="Books & Media" description="Favourite books, movies, and series — the things that shaped you."
+            categories={['favourite_books', 'favourite_media']}
+            items={items.filter((i) => ['favourite_books', 'favourite_media'].includes(i.category))}
+            onAdd={(data) => { startTransition(async () => { await addProfileItem(data); router.refresh(); }); }}
+            onRemove={(id) => { startTransition(async () => { await removeProfileItem(id); router.refresh(); }); }}
+            onNext={next} isPending={isPending} />
+        )}
+        {step === 7 && (
+          <ItemsStep title="Causes & Quotes" description="What matters to you — charities, causes, and words that resonate."
+            categories={['causes', 'quotes']}
+            items={items.filter((i) => ['causes', 'quotes'].includes(i.category))}
+            onAdd={(data) => { startTransition(async () => { await addProfileItem(data); router.refresh(); }); }}
+            onRemove={(id) => { startTransition(async () => { await removeProfileItem(id); router.refresh(); }); }}
+            onNext={next} isPending={isPending} />
+        )}
+        {step === 8 && (
+          <ItemsStep title="More about you" description="What makes you proud, life hacks, questions you wish people asked."
+            categories={['proud_of', 'life_hacks', 'questions', 'billboard']}
+            items={items.filter((i) => ['proud_of', 'life_hacks', 'questions', 'billboard'].includes(i.category))}
+            onAdd={(data) => { startTransition(async () => { await addProfileItem(data); router.refresh(); }); }}
+            onRemove={(id) => { startTransition(async () => { await removeProfileItem(id); router.refresh(); }); }}
+            onNext={next} isPending={isPending} />
+        )}
+        {step === 9 && (
           <LinksStep links={links}
             onAdd={(data) => { startTransition(async () => { await addExternalLink(data); router.refresh(); }); }}
             onRemove={(id) => { startTransition(async () => { await removeExternalLink(id); router.refresh(); }); }}
             onNext={next} isPending={isPending} />
         )}
-        {step === 7 && (
+        {step === 10 && (
           <PreviewStep profile={profile} items={items} schools={schools} links={links}
             onPublish={() => { startTransition(async () => { await publishProfile(); router.refresh(); router.push('/dashboard'); }); }}
             isPending={isPending} />

--- a/supabase/migrations/20260330080000_add_missing_item_categories.sql
+++ b/supabase/migrations/20260330080000_add_missing_item_categories.sql
@@ -1,0 +1,12 @@
+-- KAN-137: Add missing profile item categories from original Python/Flask app
+-- Adds 8 new category values to the item_category enum type
+-- Applied to all 3 environments (dev, staging, production) on 30 March 2026
+
+ALTER TYPE item_category ADD VALUE IF NOT EXISTS 'favourite_books';
+ALTER TYPE item_category ADD VALUE IF NOT EXISTS 'favourite_media';
+ALTER TYPE item_category ADD VALUE IF NOT EXISTS 'causes';
+ALTER TYPE item_category ADD VALUE IF NOT EXISTS 'quotes';
+ALTER TYPE item_category ADD VALUE IF NOT EXISTS 'proud_of';
+ALTER TYPE item_category ADD VALUE IF NOT EXISTS 'life_hacks';
+ALTER TYPE item_category ADD VALUE IF NOT EXISTS 'questions';
+ALTER TYPE item_category ADD VALUE IF NOT EXISTS 'billboard';

--- a/tests/unit/profile-sections.test.js
+++ b/tests/unit/profile-sections.test.js
@@ -1,0 +1,121 @@
+/**
+ * Missing profile sections tests
+ * KAN-137: Restore missing profile section types from original Python/Flask app
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const root = path.join(__dirname, '../..');
+
+const NEW_CATEGORIES = [
+  'favourite_books', 'favourite_media', 'causes', 'quotes',
+  'proud_of', 'life_hacks', 'questions', 'billboard',
+];
+
+describe('KAN-137: Wizard supports new section categories', () => {
+  const wizardPath = path.join(root, 'src/app/dashboard/profile/wizard.tsx');
+  let wizardContent;
+
+  beforeAll(() => {
+    wizardContent = fs.readFileSync(wizardPath, 'utf8');
+  });
+
+  test('wizard file exists', () => {
+    expect(fs.existsSync(wizardPath)).toBe(true);
+  });
+
+  test('wizard has 11 steps (up from 8)', () => {
+    const stepMatches = wizardContent.match(/\{ id: '/g);
+    expect(stepMatches).not.toBeNull();
+    expect(stepMatches.length).toBe(11);
+  });
+
+  test('wizard includes Books & Media step', () => {
+    expect(wizardContent).toContain("'favourite_books'");
+    expect(wizardContent).toContain("'favourite_media'");
+    expect(wizardContent).toContain('Books & Media');
+  });
+
+  test('wizard includes Causes & Quotes step', () => {
+    expect(wizardContent).toContain("'causes'");
+    expect(wizardContent).toContain("'quotes'");
+    expect(wizardContent).toContain('Causes & Quotes');
+  });
+
+  test('wizard includes More about you step', () => {
+    expect(wizardContent).toContain("'proud_of'");
+    expect(wizardContent).toContain("'life_hacks'");
+    expect(wizardContent).toContain("'questions'");
+    expect(wizardContent).toContain("'billboard'");
+    expect(wizardContent).toContain('More about you');
+  });
+});
+
+describe('KAN-137: ItemsStep has labels for all categories', () => {
+  const itemsStepPath = path.join(root, 'src/app/dashboard/profile/steps/items-step.tsx');
+  let content;
+
+  beforeAll(() => {
+    content = fs.readFileSync(itemsStepPath, 'utf8');
+  });
+
+  test.each(NEW_CATEGORIES)('itemsStep has label for category: %s', (cat) => {
+    expect(content).toContain(`${cat}:`);
+  });
+});
+
+describe('KAN-137: Public profile page renders new categories', () => {
+  const profilePath = path.join(root, 'src/app/[slug]/page.tsx');
+  let content;
+
+  beforeAll(() => {
+    content = fs.readFileSync(profilePath, 'utf8');
+  });
+
+  test.each(NEW_CATEGORIES)('profile page has label for category: %s', (cat) => {
+    expect(content).toContain(`${cat}:`);
+  });
+
+  test.each(NEW_CATEGORIES)('profile page has icon for category: %s', (cat) => {
+    // Check it exists in categoryIcons
+    const iconSection = content.slice(
+      content.indexOf('const categoryIcons'),
+      content.indexOf('};', content.indexOf('const categoryIcons')) + 2
+    );
+    expect(iconSection).toContain(`${cat}:`);
+  });
+
+  test('categoryOrder includes new standard categories', () => {
+    expect(content).toContain("'favourite_books'");
+    expect(content).toContain("'favourite_media'");
+    expect(content).toContain("'causes'");
+    expect(content).toContain("'proud_of'");
+    expect(content).toContain("'life_hacks'");
+    expect(content).toContain("'questions'");
+  });
+
+  test('questions category has special Q&A rendering', () => {
+    expect(content).toContain("cat === 'questions'");
+    expect(content).toContain('border-l-3');
+  });
+
+  test('quotes have special styled rendering', () => {
+    expect(content).toContain("groupedItems['quotes']");
+    expect(content).toContain('italic');
+  });
+
+  test('billboard has special large-quote rendering', () => {
+    expect(content).toContain("groupedItems['billboard']");
+    expect(content).toContain('giant billboard');
+  });
+
+  test('billboard renders with sage green background', () => {
+    // Find the billboard section and check it uses sage bg
+    const billboardSection = content.slice(
+      content.indexOf("groupedItems['billboard']"),
+      content.indexOf("Links */")
+    );
+    expect(billboardSection).toContain('bg-[var(--color-sage)]');
+  });
+});


### PR DESCRIPTION
## What & Why
The original Python/Flask app had 14 profile section types. The Next.js wizard only had 6. This PR restores the 8 missing types. Part of KAN-131 epic.

## New categories added
`favourite_books`, `favourite_media`, `causes`, `quotes`, `proud_of`, `life_hacks`, `questions`, `billboard`

## Changes

### Database (already applied to all 3 envs)
- `item_category` enum extended with 8 new values
- Migration: `supabase/migrations/20260330080000_add_missing_item_categories.sql`

### Wizard (`wizard.tsx`, `items-step.tsx`)
- 3 new wizard steps added (11 total, up from 8):
  - Books & Media (favourite_books + favourite_media)
  - Causes & Quotes (causes + quotes)
  - More about you (proud_of + life_hacks + questions + billboard)
- Category labels updated for all 14 types

### Public profile (`[slug]/page.tsx`)
- Labels + icons for all 14 categories
- `categoryOrder` expanded to include new standard categories
- **Questions**: Q&A card rendering with left sage border
- **Quotes**: Italic block with attribution line
- **Billboard**: Large sage-green quote panel at bottom of profile

## Tests (34 new, 142 total)
- Wizard: step count, new step content verification
- ItemsStep: labels for all 8 new categories
- Profile page: labels, icons, categoryOrder, special renderers for questions/quotes/billboard

## Security Review
- Same XSS protection as existing sections (React auto-escapes)
- No new auth changes — uses existing profile ownership
- Enum values are additive only (no existing data affected)