### PR TITLE
KAN-135: Profile photo upload — Supabase Storage + upload API + display

### DIFF
--- a/src/app/[slug]/page.tsx
+++ b/src/app/[slug]/page.tsx
@@ -18,6 +18,7 @@ interface ProfileData {
   city: string | null;
   country: string | null;
   is_published: boolean;
+  avatar_url: string | null;
 }
 
 interface ProfileItem {
@@ -219,8 +220,12 @@ export default async function PublicProfilePage({ params }: Props) {
 
       {/* Profile header */}
       <div className="max-w-2xl mx-auto px-6 pt-10 pb-6 text-center">
-        <div className="w-20 h-20 rounded-full bg-[var(--color-sage)] mx-auto mb-4 flex items-center justify-center text-3xl text-white font-[family-name:var(--font-serif)]">
-          {typedProfile.display_name.charAt(0).toUpperCase()}
+        <div className="w-20 h-20 rounded-full bg-[var(--color-sage)] mx-auto mb-4 flex items-center justify-center text-3xl text-white font-[family-name:var(--font-serif)] overflow-hidden">
+          {typedProfile.avatar_url ? (
+            <img src={typedProfile.avatar_url} alt={typedProfile.display_name} className="w-full h-full object-cover" />
+          ) : (
+            typedProfile.display_name.charAt(0).toUpperCase()
+          )}
         </div>
         <h1 className="text-3xl font-[family-name:var(--font-serif)] text-[var(--color-ink)]">
           {typedProfile.display_name}

--- a/src/app/dashboard/profile/actions.ts
+++ b/src/app/dashboard/profile/actions.ts
@@ -194,3 +194,55 @@ export async function publishProfile(): Promise<ActionResult> {
   revalidatePath('/dashboard');
   return { success: true };
 }
+
+const ALLOWED_IMAGE_TYPES = ['image/jpeg', 'image/png', 'image/webp', 'image/gif'];
+const MAX_FILE_SIZE = 5 * 1024 * 1024; // 5MB
+
+export async function uploadAvatar(formData: FormData): Promise<ActionResult> {
+  const { user, supabase, error: authError } = await getAuthenticatedUser();
+  if (authError) return { success: false, error: authError };
+
+  const file = formData.get('avatar') as File | null;
+  if (!file || file.size === 0) return { success: false, error: 'No file provided' };
+
+  // Validate MIME type server-side
+  if (!ALLOWED_IMAGE_TYPES.includes(file.type)) {
+    return { success: false, error: 'Invalid file type. Allowed: JPEG, PNG, WebP, GIF' };
+  }
+
+  // Validate file size
+  if (file.size > MAX_FILE_SIZE) {
+    return { success: false, error: 'File too large. Maximum size is 5MB' };
+  }
+
+  // Determine extension from MIME type
+  const extMap: Record<string, string> = {
+    'image/jpeg': 'jpg', 'image/png': 'png', 'image/webp': 'webp', 'image/gif': 'gif',
+  };
+  const ext = extMap[file.type] || 'jpg';
+  const filePath = `${user!.id}/avatar.${ext}`;
+
+  // Upload to Supabase Storage (upsert to overwrite existing)
+  const { error: uploadError } = await supabase.storage
+    .from('profile-photos')
+    .upload(filePath, file, { upsert: true, contentType: file.type });
+
+  if (uploadError) return { success: false, error: uploadError.message };
+
+  // Get public URL
+  const { data: urlData } = supabase.storage
+    .from('profile-photos')
+    .getPublicUrl(filePath);
+
+  // Update profile with avatar URL
+  const { error: updateError } = await supabase
+    .from('profiles')
+    .update({ avatar_url: urlData.publicUrl })
+    .eq('user_id', user!.id);
+
+  if (updateError) return { success: false, error: updateError.message };
+
+  revalidatePath('/dashboard/profile');
+  revalidatePath('/dashboard');
+  return { success: true };
+}

--- a/src/app/dashboard/profile/steps/identity-step.tsx
+++ b/src/app/dashboard/profile/steps/identity-step.tsx
@@ -1,17 +1,49 @@
 'use client';
 
-import { useState } from 'react';
+import { useState, useRef } from 'react';
 import { Field, SaveButton, type WizardProfile } from './types';
 
-export function IdentityStep({ profile, onSave, isPending }: {
+export function IdentityStep({ profile, onSave, onUploadAvatar, isPending }: {
   profile: WizardProfile;
   onSave: (data: Record<string, string>) => void;
+  onUploadAvatar: (formData: FormData) => void;
   isPending: boolean;
 }) {
   const [name, setName] = useState(profile.display_name || '');
   const [headline, setHeadline] = useState(profile.headline || '');
   const [city, setCity] = useState(profile.city || '');
   const [country, setCountry] = useState(profile.country || 'GB');
+  const [preview, setPreview] = useState<string | null>(profile.avatar_url || null);
+  const [uploadError, setUploadError] = useState<string | null>(null);
+  const fileRef = useRef<HTMLInputElement>(null);
+
+  const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+
+    setUploadError(null);
+
+    // Client-side validation
+    const allowed = ['image/jpeg', 'image/png', 'image/webp', 'image/gif'];
+    if (!allowed.includes(file.type)) {
+      setUploadError('Please choose a JPEG, PNG, WebP, or GIF image.');
+      return;
+    }
+    if (file.size > 5 * 1024 * 1024) {
+      setUploadError('Image must be under 5MB.');
+      return;
+    }
+
+    // Show preview
+    const reader = new FileReader();
+    reader.onload = (ev) => setPreview(ev.target?.result as string);
+    reader.readAsDataURL(file);
+
+    // Upload
+    const fd = new FormData();
+    fd.append('avatar', file);
+    onUploadAvatar(fd);
+  };
 
   return (
     <div className="space-y-6">
@@ -19,6 +51,45 @@ export function IdentityStep({ profile, onSave, isPending }: {
         <h2 className="text-xl font-medium text-[var(--color-ink)]">Who are you?</h2>
         <p className="text-sm text-[var(--color-muted)] mt-1">The basics so people can find and recognise you.</p>
       </div>
+
+      {/* Avatar upload */}
+      <div className="flex items-center gap-4">
+        <button
+          type="button"
+          onClick={() => fileRef.current?.click()}
+          className="relative w-20 h-20 rounded-full overflow-hidden bg-[var(--color-sage)] flex items-center justify-center cursor-pointer hover:opacity-90 transition-opacity shrink-0"
+        >
+          {preview ? (
+            <img src={preview} alt="Profile photo" className="w-full h-full object-cover" />
+          ) : (
+            <span className="text-2xl text-white font-[family-name:var(--font-serif)]">
+              {name ? name.charAt(0).toUpperCase() : '?'}
+            </span>
+          )}
+          <div className="absolute inset-0 bg-black/0 hover:bg-black/20 transition-colors flex items-center justify-center">
+            <span className="text-white text-xs font-medium opacity-0 hover:opacity-100">Edit</span>
+          </div>
+        </button>
+        <div>
+          <button
+            type="button"
+            onClick={() => fileRef.current?.click()}
+            className="text-sm text-[var(--color-sage)] hover:underline cursor-pointer"
+          >
+            {preview ? 'Change photo' : 'Add a photo'}
+          </button>
+          <p className="text-xs text-[var(--color-muted)] mt-0.5">JPEG, PNG, WebP or GIF. Max 5MB.</p>
+          {uploadError && <p className="text-xs text-red-500 mt-0.5">{uploadError}</p>}
+        </div>
+        <input
+          ref={fileRef}
+          type="file"
+          accept="image/jpeg,image/png,image/webp,image/gif"
+          onChange={handleFileChange}
+          className="hidden"
+        />
+      </div>
+
       <div className="space-y-4">
         <Field label="Display name" value={name} onChange={setName} placeholder="Sarah Ashworth" />
         <Field label="Headline" value={headline} onChange={setHeadline} placeholder="Mum, teacher, coffee lover" />

--- a/src/app/dashboard/profile/steps/types.tsx
+++ b/src/app/dashboard/profile/steps/types.tsx
@@ -9,6 +9,7 @@ export interface WizardProfile {
   postcode_prefix: string | null;
   country: string | null;
   is_published: boolean;
+  avatar_url: string | null;
 }
 
 export interface WizardItem {

--- a/src/app/dashboard/profile/wizard.tsx
+++ b/src/app/dashboard/profile/wizard.tsx
@@ -12,6 +12,7 @@ import {
   addExternalLink,
   removeExternalLink,
   publishProfile,
+  uploadAvatar,
 } from './actions';
 import {
   IdentityStep, BioStep, SchoolStep, ItemsStep, LinksStep, PreviewStep,
@@ -90,6 +91,11 @@ export function ProfileWizard({
               await updateProfileFields(data);
               router.refresh();
               next();
+            });
+          }} onUploadAvatar={(formData: FormData) => {
+            startTransition(async () => {
+              await uploadAvatar(formData);
+              router.refresh();
             });
           }} isPending={isPending} />
         )}

--- a/src/app/search/page.tsx
+++ b/src/app/search/page.tsx
@@ -19,6 +19,7 @@ interface SearchProfile {
   headline: string | null;
   city: string | null;
   country: string | null;
+  avatar_url: string | null;
 }
 
 function ProfileCard({ profile }: { profile: SearchProfile }) {
@@ -28,8 +29,12 @@ function ProfileCard({ profile }: { profile: SearchProfile }) {
       className="block bg-white rounded-xl border border-stone-200 p-5 hover:shadow-sm hover:border-stone-300 transition-all group"
     >
       <div className="flex items-start gap-4">
-        <div className="w-12 h-12 rounded-full bg-[var(--color-sage)] flex items-center justify-center text-lg text-white font-[family-name:var(--font-serif)] shrink-0">
-          {profile.display_name.charAt(0).toUpperCase()}
+        <div className="w-12 h-12 rounded-full bg-[var(--color-sage)] flex items-center justify-center text-lg text-white font-[family-name:var(--font-serif)] shrink-0 overflow-hidden">
+          {profile.avatar_url ? (
+            <img src={profile.avatar_url} alt={profile.display_name} className="w-full h-full object-cover" />
+          ) : (
+            profile.display_name.charAt(0).toUpperCase()
+          )}
         </div>
         <div className="min-w-0">
           <h3 className="font-medium text-[var(--color-ink)] group-hover:text-[var(--color-sage)] transition-colors truncate">
@@ -64,7 +69,7 @@ export default async function SearchPage({
     const pattern = `%${query}%`;
     const { data } = await supabase
       .from('profiles')
-      .select('id, display_name, slug, headline, city, country')
+      .select('id, display_name, slug, headline, city, country, avatar_url')
       .eq('is_published', true)
       .or(`display_name.ilike.${pattern},headline.ilike.${pattern},city.ilike.${pattern},slug.ilike.${pattern}`)
       .order('display_name')

--- a/supabase/migrations/20260330120000_add_avatar_url_and_storage.sql
+++ b/supabase/migrations/20260330120000_add_avatar_url_and_storage.sql
@@ -1,0 +1,27 @@
+-- KAN-135: Add avatar_url column and profile-photos storage bucket with RLS
+-- Applied to all 3 environments (dev, staging, production) on 30 March 2026
+
+-- Storage bucket (created via SQL, not migration — bucket already exists)
+-- INSERT INTO storage.buckets (id, name, public, file_size_limit, allowed_mime_types)
+-- VALUES ('profile-photos', 'profile-photos', true, 5242880,
+--   ARRAY['image/jpeg', 'image/png', 'image/webp', 'image/gif']);
+
+-- Add avatar_url column
+ALTER TABLE public.profiles ADD COLUMN IF NOT EXISTS avatar_url text;
+
+-- Storage RLS policies
+CREATE POLICY "Users can upload their own avatar"
+ON storage.objects FOR INSERT TO authenticated
+WITH CHECK (bucket_id = 'profile-photos' AND (storage.foldername(name))[1] = auth.uid()::text);
+
+CREATE POLICY "Users can update their own avatar"
+ON storage.objects FOR UPDATE TO authenticated
+USING (bucket_id = 'profile-photos' AND (storage.foldername(name))[1] = auth.uid()::text);
+
+CREATE POLICY "Users can delete their own avatar"
+ON storage.objects FOR DELETE TO authenticated
+USING (bucket_id = 'profile-photos' AND (storage.foldername(name))[1] = auth.uid()::text);
+
+CREATE POLICY "Anyone can view profile photos"
+ON storage.objects FOR SELECT TO public
+USING (bucket_id = 'profile-photos');

--- a/tests/unit/photo-upload.test.js
+++ b/tests/unit/photo-upload.test.js
@@ -1,0 +1,147 @@
+/**
+ * Profile photo upload tests
+ * KAN-135: Profile photo upload — Supabase Storage + upload API + display
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const root = path.join(__dirname, '../..');
+
+describe('KAN-135: Upload action exists with validation', () => {
+  const actionsPath = path.join(root, 'src/app/dashboard/profile/actions.ts');
+  let content;
+
+  beforeAll(() => {
+    content = fs.readFileSync(actionsPath, 'utf8');
+  });
+
+  test('uploadAvatar function is exported', () => {
+    expect(content).toMatch(/export async function uploadAvatar/);
+  });
+
+  test('validates MIME type server-side', () => {
+    expect(content).toContain('ALLOWED_IMAGE_TYPES');
+    expect(content).toContain('image/jpeg');
+    expect(content).toContain('image/png');
+    expect(content).toContain('image/webp');
+    expect(content).toContain('image/gif');
+  });
+
+  test('validates file size (5MB max)', () => {
+    expect(content).toContain('MAX_FILE_SIZE');
+    expect(content).toContain('5 * 1024 * 1024');
+  });
+
+  test('uploads to profile-photos bucket', () => {
+    expect(content).toContain("'profile-photos'");
+    expect(content).toContain('.upload(');
+  });
+
+  test('updates profiles.avatar_url after upload', () => {
+    expect(content).toContain('avatar_url');
+    expect(content).toContain('publicUrl');
+  });
+
+  test('uses upsert to overwrite existing avatar', () => {
+    expect(content).toContain('upsert: true');
+  });
+});
+
+describe('KAN-135: WizardProfile includes avatar_url', () => {
+  const typesPath = path.join(root, 'src/app/dashboard/profile/steps/types.tsx');
+  let content;
+
+  beforeAll(() => {
+    content = fs.readFileSync(typesPath, 'utf8');
+  });
+
+  test('WizardProfile has avatar_url field', () => {
+    expect(content).toContain('avatar_url: string | null');
+  });
+});
+
+describe('KAN-135: Identity step has photo upload UI', () => {
+  const identityPath = path.join(root, 'src/app/dashboard/profile/steps/identity-step.tsx');
+  let content;
+
+  beforeAll(() => {
+    content = fs.readFileSync(identityPath, 'utf8');
+  });
+
+  test('accepts onUploadAvatar prop', () => {
+    expect(content).toContain('onUploadAvatar');
+  });
+
+  test('has file input for images', () => {
+    expect(content).toContain('type="file"');
+    expect(content).toContain('accept="image/jpeg,image/png,image/webp,image/gif"');
+  });
+
+  test('shows image preview', () => {
+    expect(content).toContain('preview');
+    expect(content).toContain('readAsDataURL');
+  });
+
+  test('validates file type client-side', () => {
+    expect(content).toContain('image/jpeg');
+    expect(content).toContain('Please choose a JPEG');
+  });
+
+  test('validates file size client-side', () => {
+    expect(content).toContain('5 * 1024 * 1024');
+    expect(content).toContain('under 5MB');
+  });
+});
+
+describe('KAN-135: Public profile shows avatar', () => {
+  const profilePath = path.join(root, 'src/app/[slug]/page.tsx');
+  let content;
+
+  beforeAll(() => {
+    content = fs.readFileSync(profilePath, 'utf8');
+  });
+
+  test('ProfileData interface includes avatar_url', () => {
+    expect(content).toContain('avatar_url: string | null');
+  });
+
+  test('profile header conditionally shows avatar image', () => {
+    expect(content).toContain('typedProfile.avatar_url');
+    expect(content).toContain('object-cover');
+  });
+});
+
+describe('KAN-135: Search page shows avatar in cards', () => {
+  const searchPath = path.join(root, 'src/app/search/page.tsx');
+  let content;
+
+  beforeAll(() => {
+    content = fs.readFileSync(searchPath, 'utf8');
+  });
+
+  test('SearchProfile includes avatar_url', () => {
+    expect(content).toContain('avatar_url: string | null');
+  });
+
+  test('search query selects avatar_url', () => {
+    expect(content).toContain('avatar_url');
+    expect(content).toContain('.select(');
+  });
+
+  test('ProfileCard conditionally shows avatar image', () => {
+    expect(content).toContain('profile.avatar_url');
+    expect(content).toContain('object-cover');
+  });
+});
+
+describe('KAN-135: Migration file exists', () => {
+  test('migration SQL file is present', () => {
+    const migrationPath = path.join(root, 'supabase/migrations/20260330120000_add_avatar_url_and_storage.sql');
+    expect(fs.existsSync(migrationPath)).toBe(true);
+    const content = fs.readFileSync(migrationPath, 'utf8');
+    expect(content).toContain('avatar_url');
+    expect(content).toContain('profile-photos');
+    expect(content).toContain('storage.objects');
+  });
+});


### PR DESCRIPTION
## What & Why
Profile photos existed in the original Python/Flask app but were completely missing from Next.js. This PR adds the full upload pipeline. Part of KAN-131 epic.

## Infrastructure (already applied to all 3 Supabase envs)
- `profile-photos` Storage bucket: public, 5MB limit, image MIME types only
- `avatar_url` column on `profiles` table
- 4 RLS policies on `storage.objects`: users upload/update/delete to own folder only, public read

## Code Changes
- **`actions.ts`**: New `uploadAvatar` server action — validates MIME + size, uploads to `{user_id}/avatar.{ext}` with upsert, updates `profiles.avatar_url`
- **`identity-step.tsx`**: Avatar upload UI with file input, live preview, client-side validation
- **`types.tsx`**: `avatar_url` added to `WizardProfile` interface
- **`wizard.tsx`**: Passes `onUploadAvatar` handler + imports `uploadAvatar`
- **`[slug]/page.tsx`**: Shows avatar image in profile header when available
- **`search/page.tsx`**: ProfileCard shows avatar, query includes `avatar_url`

## Tests (18 new, 177 total)
- Upload action: export, MIME validation, size validation, bucket name, upsert
- Types: avatar_url in WizardProfile
- Identity step: file input, preview, client-side validation
- Profile page: conditional avatar display
- Search page: avatar in interface, query, and card
- Migration file exists with correct content

## Security Review
- Server-side MIME type validation (not just extension)
- 5MB file size limit (server + client)
- RLS: users can only upload to `{their_user_id}/` folder
- Bucket restricts to image MIME types at storage level
- Public read is intentional (profile photos are public)