### PR TITLE
BUGS-2: Fix pg_dump version mismatch — install PostgreSQL 17 client

### DIFF
--- a/.github/workflows/backup-database.yml
+++ b/.github/workflows/backup-database.yml
@@ -11,8 +11,13 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - name: Install PostgreSQL client
-        run: sudo apt-get update && sudo apt-get install -y postgresql-client
+      - name: Install PostgreSQL 17 client
+        run: |
+          # Supabase runs Postgres 17 — pg_dump requires matching major version
+          # BUGS-2: Default apt postgresql-client installs v16, causing version mismatch
+          sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
+          curl -fsSL https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo gpg --dearmor -o /etc/apt/trusted.gpg.d/postgresql.gpg
+          sudo apt-get update && sudo apt-get install -y postgresql-client-17
 
       - name: Run pg_dump backup
         id: pgdump


### PR DESCRIPTION
## Bug
Backup workflow pg_dump fails: `server version: 17.6; pg_dump version: 16.13`

The GitHub Actions runner installs pg_dump 16 via `apt-get install postgresql-client`, but Supabase runs Postgres 17.6. pg_dump refuses to dump a newer server version. The REST API fallback works, so backups still complete — but pg_dump gives a more complete dump.

## Fix
Install `postgresql-client-17` from the official PostgreSQL apt repository instead of the default Ubuntu package.

Uses `gpg --dearmor` instead of the deprecated `apt-key add` method.

## Tests
- No code tests affected (CI workflow change only)
- 177 unit tests still passing
- The real test is the next scheduled backup run (Sunday 02:00 UTC) or a manual trigger

## Security Review
- Uses official PostgreSQL apt repository (apt.postgresql.org)
- GPG key verified via ACCC4CF8 (official PostgreSQL signing key)