### PR TITLE
BUGS-2: Fix pg_dump PATH — ensure v17 binary is found before v16

### DIFF
--- a/.github/workflows/backup-database.yml
+++ b/.github/workflows/backup-database.yml
@@ -18,6 +18,9 @@ jobs:
           sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
           curl -fsSL https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo gpg --dearmor -o /etc/apt/trusted.gpg.d/postgresql.gpg
           sudo apt-get update && sudo apt-get install -y postgresql-client-17
+          # Ensure v17 is found first on PATH (Ubuntu keeps v16 at /usr/bin/pg_dump)
+          echo "/usr/lib/postgresql/17/bin" >> $GITHUB_PATH
+          /usr/lib/postgresql/17/bin/pg_dump --version
 
       - name: Run pg_dump backup
         id: pgdump


### PR DESCRIPTION
## Problem
PR #23 installed postgresql-client-17, but `pg_dump` in the backup script still resolved to the system v16 at `/usr/bin/pg_dump`. The v17 binary is at `/usr/lib/postgresql/17/bin/pg_dump` — not on the default PATH.

Confirmed in backup run 23754582146: `pg_dump version: 16.13` despite v17 being installed.

## Fix
Prepend `/usr/lib/postgresql/17/bin` to PATH using `GITHUB_PATH` so subsequent steps find v17 first. Also logs `pg_dump --version` for verification.

## Tests
- 177 unit tests passing
- Real test: manual backup trigger after promotion to main