### PR TITLE
KAN-126: Privacy policy and terms of service pages (blocks Google OAuth)

### DIFF
--- a/src/app/privacy/page.tsx
+++ b/src/app/privacy/page.tsx
@@ -1,0 +1,177 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+
+export const metadata: Metadata = {
+  title: "Privacy Policy — Lyra",
+  description: "How Lyra collects, uses, and protects your personal data.",
+};
+
+export default function PrivacyPage() {
+  return (
+    <main className="min-h-screen bg-stone-50">
+      <nav className="border-b border-stone-200/60 bg-stone-50/80 backdrop-blur-md">
+        <div className="max-w-3xl mx-auto px-6 h-16 flex items-center">
+          <Link href="/" className="font-[family-name:var(--font-serif)] text-2xl text-stone-800 tracking-tight">
+            lyra
+          </Link>
+        </div>
+      </nav>
+
+      <article className="max-w-3xl mx-auto px-6 py-12 prose prose-stone prose-sm">
+        <h1 className="font-[family-name:var(--font-serif)] text-3xl text-stone-800 mb-2">Privacy Policy</h1>
+        <p className="text-stone-500 text-sm mb-8">Last updated: 30 March 2026</p>
+
+        <div className="space-y-8 text-stone-700 leading-relaxed">
+
+          <section>
+            <h2 className="text-lg font-semibold text-stone-800">Who we are</h2>
+            <p>
+              Lyra is a personal profile platform operated from the United Kingdom. It allows you to
+              create a structured public profile sharing your preferences, interests, gift ideas, and
+              personal details — so the people (and AI assistants) in your life don&apos;t have to guess.
+            </p>
+            <p>
+              For data protection purposes, the data controller is Lyra (checklyra.com). If you have
+              questions about how your data is handled, contact us at <a href="mailto:privacy@checklyra.com" className="text-[var(--color-lyra-sage)] underline">privacy@checklyra.com</a>.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-lg font-semibold text-stone-800">What data we collect</h2>
+            <p>When you create a Lyra account and profile, we collect:</p>
+            <ul className="list-disc pl-5 space-y-1">
+              <li><strong>Account data:</strong> your email address and authentication credentials (managed via Google Sign-In or email/password).</li>
+              <li><strong>Profile data:</strong> display name, headline, city, country, bio, and any items you add to your profile (likes, dislikes, gift ideas, boundaries, school affiliations, external links, and other preference categories).</li>
+              <li><strong>Profile photo:</strong> if you upload one, your profile image is stored in our hosting infrastructure.</li>
+              <li><strong>Usage data:</strong> basic analytics about how you interact with the site (page views, session duration), collected by our hosting provider Vercel.</li>
+            </ul>
+            <p>We do not collect sensitive personal data (as defined by UK GDPR Article 9) unless you voluntarily include it in your profile content.</p>
+          </section>
+
+          <section>
+            <h2 className="text-lg font-semibold text-stone-800">How we use your data</h2>
+            <p>We use your data to:</p>
+            <ul className="list-disc pl-5 space-y-1">
+              <li>Provide and maintain your Lyra profile.</li>
+              <li>Display your published profile to visitors on the web and via our API.</li>
+              <li>Allow AI assistants to read your published profile data through our MCP (Model Context Protocol) server — this is a core feature of Lyra.</li>
+              <li>Send you essential service communications (account verification, security alerts).</li>
+              <li>Improve the platform based on aggregated, anonymised usage patterns.</li>
+            </ul>
+            <p>We do not sell your personal data. We do not use your data for advertising. We do not share your data with third parties for marketing purposes.</p>
+          </section>
+
+          <section>
+            <h2 className="text-lg font-semibold text-stone-800">Profile visibility and AI access</h2>
+            <p>
+              Lyra is designed to make your preferences accessible to people and AI assistants. When you
+              publish your profile:
+            </p>
+            <ul className="list-disc pl-5 space-y-1">
+              <li>Your profile is visible to anyone on the web at your public URL (checklyra.com/your-slug).</li>
+              <li>Your published profile data is accessible to AI assistants (such as Claude, ChatGPT, and others) via our MCP server. This means an AI companion can read your preferences to help someone choose a gift for you, for example.</li>
+              <li>Your profile appears in search results on Lyra&apos;s search/browse page.</li>
+            </ul>
+            <p>
+              Unpublished profiles are not visible to the public or to AI assistants. You control when to
+              publish and can unpublish at any time from your dashboard.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-lg font-semibold text-stone-800">Legal basis for processing</h2>
+            <p>Under UK GDPR, we process your data on the following legal bases:</p>
+            <ul className="list-disc pl-5 space-y-1">
+              <li><strong>Consent:</strong> you choose to create an account and publish your profile. You can withdraw consent by deleting your account.</li>
+              <li><strong>Legitimate interests:</strong> maintaining service security, preventing abuse, and improving the platform.</li>
+              <li><strong>Contract:</strong> providing the service you signed up for.</li>
+            </ul>
+          </section>
+
+          <section>
+            <h2 className="text-lg font-semibold text-stone-800">Where your data is stored</h2>
+            <p>
+              Your data is stored using Supabase (a PostgreSQL database service) with servers in the EU
+              (AWS eu-west-2, London region). Profile photos are stored in Supabase Storage, also in
+              the EU region. The website is served globally via Vercel&apos;s edge network and protected by
+              Cloudflare. Backups are stored in Cloudflare R2 with EU jurisdiction.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-lg font-semibold text-stone-800">Data retention</h2>
+            <p>
+              We retain your account and profile data for as long as your account is active. If you
+              delete your account, your data is removed from our active databases. Backups containing
+              your data may persist for up to 90 days after deletion before being automatically purged.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-lg font-semibold text-stone-800">Your rights</h2>
+            <p>Under UK GDPR, you have the right to:</p>
+            <ul className="list-disc pl-5 space-y-1">
+              <li><strong>Access:</strong> request a copy of the personal data we hold about you.</li>
+              <li><strong>Rectification:</strong> correct inaccurate data via your dashboard or by contacting us.</li>
+              <li><strong>Erasure:</strong> delete your account and all associated data.</li>
+              <li><strong>Portability:</strong> receive your data in a structured, machine-readable format.</li>
+              <li><strong>Object:</strong> object to processing based on legitimate interests.</li>
+              <li><strong>Restrict processing:</strong> request that we limit how we use your data.</li>
+            </ul>
+            <p>
+              To exercise any of these rights, contact us at <a href="mailto:privacy@checklyra.com" className="text-[var(--color-lyra-sage)] underline">privacy@checklyra.com</a>.
+              We will respond within one month as required by UK GDPR.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-lg font-semibold text-stone-800">Cookies</h2>
+            <p>
+              Lyra uses essential cookies only. These are required for authentication (keeping you
+              signed in) and security (CSRF protection). We do not use tracking cookies, advertising
+              cookies, or third-party analytics cookies. Vercel may collect anonymised performance
+              data through its edge network — see <a href="https://vercel.com/legal/privacy-policy" className="text-[var(--color-lyra-sage)] underline" target="_blank" rel="noopener noreferrer">Vercel&apos;s privacy policy</a> for details.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-lg font-semibold text-stone-800">Children</h2>
+            <p>
+              Lyra is not directed at children under 13. We do not knowingly collect personal data from
+              children under 13. If you believe a child under 13 has created an account, please contact
+              us at <a href="mailto:privacy@checklyra.com" className="text-[var(--color-lyra-sage)] underline">privacy@checklyra.com</a> and we will delete the account promptly.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-lg font-semibold text-stone-800">Changes to this policy</h2>
+            <p>
+              We may update this privacy policy from time to time. We will notify you of significant
+              changes by email or by posting a notice on the site. The &quot;last updated&quot; date at the
+              top of this page indicates when the policy was last revised.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-lg font-semibold text-stone-800">Contact and complaints</h2>
+            <p>
+              If you have questions or concerns about this privacy policy or how we handle your data,
+              contact us at <a href="mailto:privacy@checklyra.com" className="text-[var(--color-lyra-sage)] underline">privacy@checklyra.com</a>.
+            </p>
+            <p>
+              You also have the right to lodge a complaint with the Information Commissioner&apos;s Office
+              (ICO), the UK&apos;s data protection authority: <a href="https://ico.org.uk/make-a-complaint/" className="text-[var(--color-lyra-sage)] underline" target="_blank" rel="noopener noreferrer">ico.org.uk/make-a-complaint</a>.
+            </p>
+          </section>
+
+          <div className="border-t border-stone-200 pt-6 mt-8">
+            <p className="text-xs text-stone-400">
+              This is a working draft. It will be reviewed by a qualified solicitor before public beta launch.
+            </p>
+          </div>
+
+        </div>
+      </article>
+    </main>
+  );
+}

--- a/src/app/terms/page.tsx
+++ b/src/app/terms/page.tsx
@@ -1,0 +1,155 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+
+export const metadata: Metadata = {
+  title: "Terms of Service — Lyra",
+  description: "Terms and conditions for using the Lyra platform.",
+};
+
+export default function TermsPage() {
+  return (
+    <main className="min-h-screen bg-stone-50">
+      <nav className="border-b border-stone-200/60 bg-stone-50/80 backdrop-blur-md">
+        <div className="max-w-3xl mx-auto px-6 h-16 flex items-center">
+          <Link href="/" className="font-[family-name:var(--font-serif)] text-2xl text-stone-800 tracking-tight">
+            lyra
+          </Link>
+        </div>
+      </nav>
+
+      <article className="max-w-3xl mx-auto px-6 py-12 prose prose-stone prose-sm">
+        <h1 className="font-[family-name:var(--font-serif)] text-3xl text-stone-800 mb-2">Terms of Service</h1>
+        <p className="text-stone-500 text-sm mb-8">Last updated: 30 March 2026</p>
+
+        <div className="space-y-8 text-stone-700 leading-relaxed">
+
+          <section>
+            <h2 className="text-lg font-semibold text-stone-800">What Lyra is</h2>
+            <p>
+              Lyra is a personal profile platform. You create a profile that shares your preferences,
+              interests, gift ideas, boundaries, and other personal details. Your published profile is
+              visible on the web and accessible to AI assistants through our API, so the people in your
+              life can understand you better — without having to ask.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-lg font-semibold text-stone-800">Your account</h2>
+            <p>
+              To use Lyra, you need to create an account using a valid email address or Google Sign-In.
+              You are responsible for keeping your account credentials secure. If you suspect
+              unauthorised access to your account, contact us immediately at <a href="mailto:support@checklyra.com" className="text-[var(--color-lyra-sage)] underline">support@checklyra.com</a>.
+            </p>
+            <p>You must be at least 13 years old to create a Lyra account.</p>
+          </section>
+
+          <section>
+            <h2 className="text-lg font-semibold text-stone-800">Your content</h2>
+            <p>
+              You own the content you add to your Lyra profile. By publishing your profile, you grant
+              Lyra a licence to display that content on the web and make it accessible through our
+              MCP (Model Context Protocol) server to AI assistants. This licence exists only for as
+              long as your profile is published — if you unpublish or delete your profile, we stop
+              displaying and serving your content.
+            </p>
+            <p>You are responsible for the accuracy and legality of the content you add to your profile.</p>
+          </section>
+
+          <section>
+            <h2 className="text-lg font-semibold text-stone-800">Profile visibility</h2>
+            <p>When you publish your profile on Lyra, you understand and agree that:</p>
+            <ul className="list-disc pl-5 space-y-1">
+              <li>Your profile is publicly accessible at your unique URL (checklyra.com/your-slug).</li>
+              <li>Your published profile data can be read by AI assistants (such as Claude, ChatGPT, and others) through our MCP server. This is a core feature of Lyra — it&apos;s how AI companions learn about the people they help.</li>
+              <li>Your profile may appear in Lyra&apos;s search results.</li>
+              <li>Search engines may index your published profile.</li>
+            </ul>
+            <p>
+              You can unpublish your profile at any time from your dashboard. Unpublished profiles are
+              not visible to the public or to AI assistants.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-lg font-semibold text-stone-800">Acceptable use</h2>
+            <p>You agree not to use Lyra to:</p>
+            <ul className="list-disc pl-5 space-y-1">
+              <li>Impersonate another person or create a profile for someone without their consent.</li>
+              <li>Post content that is illegal, defamatory, abusive, threatening, or harassing.</li>
+              <li>Upload malware, spam, or content designed to exploit vulnerabilities.</li>
+              <li>Attempt to access other users&apos; accounts or data.</li>
+              <li>Use automated tools to scrape profiles or abuse the API beyond its intended purpose.</li>
+              <li>Post content that infringes copyright or other intellectual property rights.</li>
+            </ul>
+            <p>
+              We reserve the right to suspend or terminate accounts that violate these terms, with or
+              without notice depending on the severity of the violation.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-lg font-semibold text-stone-800">Deleting your account</h2>
+            <p>
+              You can delete your account at any time. When you delete your account, we remove your
+              profile and all associated data from our active databases. Backups may retain your data
+              for up to 90 days. See our <Link href="/privacy" className="text-[var(--color-lyra-sage)] underline">Privacy Policy</Link> for full details on data retention.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-lg font-semibold text-stone-800">Service availability</h2>
+            <p>
+              Lyra is provided on an &quot;as is&quot; and &quot;as available&quot; basis. We aim to keep the service
+              running reliably, but we do not guarantee uninterrupted or error-free access. We may
+              temporarily suspend the service for maintenance, updates, or security reasons.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-lg font-semibold text-stone-800">Limitation of liability</h2>
+            <p>
+              To the fullest extent permitted by law, Lyra is not liable for any indirect, incidental,
+              or consequential damages arising from your use of the service. Our total liability is
+              limited to the amount you have paid us (if any) in the 12 months preceding the claim.
+            </p>
+            <p>
+              Nothing in these terms limits our liability for death or personal injury caused by
+              negligence, fraud, or any other liability that cannot be excluded by law.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-lg font-semibold text-stone-800">Changes to these terms</h2>
+            <p>
+              We may update these terms from time to time. We will notify you of significant changes by
+              email or by posting a notice on the site. Continued use of Lyra after changes take effect
+              constitutes acceptance of the updated terms.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-lg font-semibold text-stone-800">Governing law</h2>
+            <p>
+              These terms are governed by the laws of England and Wales. Any disputes will be subject to
+              the exclusive jurisdiction of the courts of England and Wales.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-lg font-semibold text-stone-800">Contact</h2>
+            <p>
+              If you have questions about these terms, contact us at <a href="mailto:support@checklyra.com" className="text-[var(--color-lyra-sage)] underline">support@checklyra.com</a>.
+            </p>
+          </section>
+
+          <div className="border-t border-stone-200 pt-6 mt-8">
+            <p className="text-xs text-stone-400">
+              This is a working draft. It will be reviewed by a qualified solicitor before public beta launch.
+            </p>
+          </div>
+
+        </div>
+      </article>
+    </main>
+  );
+}

--- a/tests/unit/legal-pages.test.js
+++ b/tests/unit/legal-pages.test.js
@@ -1,0 +1,142 @@
+/**
+ * Privacy policy and terms of service page tests
+ * KAN-126: Create live privacy policy and terms of service pages
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const root = path.join(__dirname, '../..');
+
+describe('KAN-126: Privacy policy page', () => {
+  const filePath = path.join(root, 'src/app/privacy/page.tsx');
+  let content;
+
+  beforeAll(() => {
+    content = fs.readFileSync(filePath, 'utf8');
+  });
+
+  test('page file exists', () => {
+    expect(fs.existsSync(filePath)).toBe(true);
+  });
+
+  test('exports metadata with title', () => {
+    expect(content).toContain('Privacy Policy');
+    expect(content).toContain('metadata');
+  });
+
+  test('covers data collection', () => {
+    expect(content).toContain('What data we collect');
+    expect(content).toContain('email address');
+    expect(content).toContain('Profile data');
+  });
+
+  test('covers MCP/AI access to profiles', () => {
+    expect(content).toContain('MCP');
+    expect(content).toContain('AI assistant');
+  });
+
+  test('covers data storage location', () => {
+    expect(content).toContain('Supabase');
+    expect(content).toContain('EU');
+  });
+
+  test('covers UK GDPR rights', () => {
+    expect(content).toContain('UK GDPR');
+    expect(content).toContain('Access');
+    expect(content).toContain('Erasure');
+    expect(content).toContain('Portability');
+  });
+
+  test('covers cookies', () => {
+    expect(content).toContain('Cookies');
+    expect(content).toContain('essential cookies');
+  });
+
+  test('covers children policy', () => {
+    expect(content).toContain('under 13');
+  });
+
+  test('provides contact email', () => {
+    expect(content).toContain('privacy@checklyra.com');
+  });
+
+  test('references ICO for complaints', () => {
+    expect(content).toContain('ico.org.uk');
+  });
+
+  test('has solicitor review notice', () => {
+    expect(content).toContain('solicitor');
+  });
+});
+
+describe('KAN-126: Terms of service page', () => {
+  const filePath = path.join(root, 'src/app/terms/page.tsx');
+  let content;
+
+  beforeAll(() => {
+    content = fs.readFileSync(filePath, 'utf8');
+  });
+
+  test('page file exists', () => {
+    expect(fs.existsSync(filePath)).toBe(true);
+  });
+
+  test('exports metadata with title', () => {
+    expect(content).toContain('Terms of Service');
+    expect(content).toContain('metadata');
+  });
+
+  test('covers profile visibility and MCP access', () => {
+    expect(content).toContain('MCP');
+    expect(content).toContain('AI assistant');
+    expect(content).toContain('publish');
+  });
+
+  test('covers acceptable use', () => {
+    expect(content).toContain('Acceptable use');
+    expect(content).toContain('Impersonate');
+  });
+
+  test('covers content ownership', () => {
+    expect(content).toContain('You own the content');
+    expect(content).toContain('licence');
+  });
+
+  test('covers account deletion', () => {
+    expect(content).toContain('delete your account');
+  });
+
+  test('covers limitation of liability', () => {
+    expect(content).toContain('Limitation of liability');
+  });
+
+  test('governed by English law', () => {
+    expect(content).toContain('England and Wales');
+  });
+
+  test('has solicitor review notice', () => {
+    expect(content).toContain('solicitor');
+  });
+
+  test('provides contact email', () => {
+    expect(content).toContain('support@checklyra.com');
+  });
+});
+
+describe('KAN-126: Footer links exist on homepage', () => {
+  const filePath = path.join(root, 'src/app/page.tsx');
+  let content;
+
+  beforeAll(() => {
+    content = fs.readFileSync(filePath, 'utf8');
+  });
+
+  test('homepage footer links to /privacy', () => {
+    expect(content).toContain('href="/privacy"');
+  });
+
+  test('homepage footer links to /terms', () => {
+    expect(content).toContain('href="/terms"');
+  });
+});


### PR DESCRIPTION
## What & Why
Google OAuth verification requires live privacy policy and terms of service URLs. Both are already configured in the consent screen but currently 404. This PR creates both pages with real content — unblocking KAN-125 (Google OAuth Production mode).

## Pages Created

**Privacy Policy** (`/privacy`): data controller, data collected, usage, MCP/AI access, legal basis, storage (Supabase EU), retention (90-day backups), UK GDPR rights, cookies, children (13+), ICO complaints, contact.

**Terms of Service** (`/terms`): platform description, account requirements, content ownership + licence, profile visibility (web + MCP + search), acceptable use, deletion, liability, governing law (England & Wales).

Both pages include a visible note: *This is a working draft — will be reviewed by a qualified solicitor before public beta launch.*

## Tests (23 new, 200 total)
- Privacy: exists, metadata, data collection, MCP/AI coverage, storage location, UK GDPR rights, cookies, children, contact, ICO, solicitor notice
- Terms: exists, metadata, MCP/AI coverage, acceptable use, content ownership, deletion, liability, governing law, solicitor notice, contact
- Footer: homepage links to /privacy and /terms

## Security Review
- Public unauthenticated pages — no security concerns
- Content accurately describes actual data handling practices
- No claims of full GDPR compliance (flagged as draft)

## Architecture Impact
- Two new routes: /privacy, /terms
- No new env vars or dependencies
- Already in production smoke tests (checklyra.com/privacy and /terms)