### PR TITLE
KAN-144: Cookie policy page at /cookies

### DIFF
--- a/src/app/(legal)/cookies/page.tsx
+++ b/src/app/(legal)/cookies/page.tsx
@@ -1,0 +1,74 @@
+import Link from 'next/link';
+
+export const metadata = {
+  title: 'Cookie Policy — Lyra',
+  description: 'How Lyra uses cookies and similar technologies.',
+};
+
+export default function CookiePolicyPage() {
+  return (
+    <main className="min-h-screen bg-stone-50">
+      <nav className="border-b border-stone-200/60">
+        <div className="max-w-3xl mx-auto px-6 h-14 flex items-center">
+          <Link href="/" className="font-[family-name:var(--font-serif)] text-xl text-[var(--color-ink)]">lyra</Link>
+        </div>
+      </nav>
+
+      <article className="max-w-3xl mx-auto px-6 py-10 prose prose-stone prose-sm">
+        <h1 className="text-2xl font-[family-name:var(--font-serif)] text-[var(--color-ink)]">Cookie Policy</h1>
+        <p className="text-sm text-[var(--color-muted)]">Last updated: 31 March 2026</p>
+
+        <h2>What are cookies?</h2>
+        <p>Cookies are small text files stored on your device when you visit a website. They help websites remember your preferences and keep you signed in.</p>
+
+        <h2>Cookies we use</h2>
+        <p>Lyra uses only <strong>essential cookies</strong> that are strictly necessary for the site to function. We do not use any advertising, tracking, or analytics cookies.</p>
+
+        <table>
+          <thead>
+            <tr>
+              <th>Cookie</th>
+              <th>Purpose</th>
+              <th>Duration</th>
+              <th>Type</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><code>sb-*-auth-token</code></td>
+              <td>Keeps you signed in to your Lyra account. Set by Supabase Auth after you log in.</td>
+              <td>Session / up to 7 days</td>
+              <td>Essential</td>
+            </tr>
+            <tr>
+              <td><code>sb-*-auth-token-code-verifier</code></td>
+              <td>Used during the OAuth sign-in flow (e.g. Google Sign-In) to prevent cross-site request forgery.</td>
+              <td>Session</td>
+              <td>Essential</td>
+            </tr>
+          </tbody>
+        </table>
+
+        <h2>Third-party cookies</h2>
+        <p>When you sign in with Google, Google may set its own cookies as part of the authentication process. These are governed by <a href="https://policies.google.com/privacy" target="_blank" rel="noopener noreferrer" className="text-[var(--color-sage)]">Google&apos;s Privacy Policy</a>. Lyra does not control these cookies.</p>
+        <p>Vercel, our hosting provider, may collect anonymised performance data. See <a href="https://vercel.com/legal/privacy-policy" target="_blank" rel="noopener noreferrer" className="text-[var(--color-sage)]">Vercel&apos;s Privacy Policy</a> for details. Cloudflare, which protects and routes our traffic, may set a <code>__cf_bm</code> cookie for bot detection. See <a href="https://developers.cloudflare.com/fundamentals/reference/policies-compliances/cloudflare-cookies/" target="_blank" rel="noopener noreferrer" className="text-[var(--color-sage)]">Cloudflare&apos;s cookie documentation</a>.</p>
+
+        <h2>Managing cookies</h2>
+        <p>Since Lyra only uses essential cookies, disabling them will prevent the site from working correctly (you won&apos;t be able to stay signed in). You can clear cookies at any time through your browser settings:</p>
+        <ul>
+          <li><strong>Chrome:</strong> Settings → Privacy and security → Clear browsing data</li>
+          <li><strong>Firefox:</strong> Settings → Privacy &amp; Security → Cookies and Site Data → Clear Data</li>
+          <li><strong>Safari:</strong> Settings → Safari → Clear History and Website Data</li>
+          <li><strong>Edge:</strong> Settings → Privacy, search, and services → Clear browsing data</li>
+        </ul>
+
+        <h2>Changes to this policy</h2>
+        <p>If we add new types of cookies (for example, analytics), we will update this page and notify you. We will never add advertising or tracking cookies.</p>
+
+        <h2>Contact</h2>
+        <p>Questions about cookies: <a href="mailto:privacy@checklyra.com" className="text-[var(--color-sage)]">privacy@checklyra.com</a></p>
+        <p>See also our <Link href="/privacy" className="text-[var(--color-sage)]">Privacy Policy</Link> and <Link href="/terms" className="text-[var(--color-sage)]">Terms of Service</Link>.</p>
+      </article>
+    </main>
+  );
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -308,6 +308,7 @@ function Footer() {
         <div className="flex items-center gap-4 text-sm text-stone-400">
           <Link href="/privacy" className="hover:text-stone-600 transition-colors">Privacy</Link>
           <Link href="/terms" className="hover:text-stone-600 transition-colors">Terms</Link>
+          <Link href="/cookies" className="hover:text-stone-600 transition-colors">Cookies</Link>
           <span>&copy; {new Date().getFullYear()} Lyra</span>
         </div>
       </div>

--- a/tests/unit/legal-pages.test.js
+++ b/tests/unit/legal-pages.test.js
@@ -133,4 +133,60 @@ describe('KAN-126: Footer links exist on homepage', () => {
   test('homepage footer links to /terms', () => {
     expect(content).toContain('href="/terms"');
   });
+
+  test('homepage footer links to /cookies', () => {
+    expect(content).toContain('href="/cookies"');
+  });
+});
+
+describe('KAN-144: Cookie policy page', () => {
+  const filePath = path.join(root, 'src/app/(legal)/cookies/page.tsx');
+  let content;
+
+  beforeAll(() => {
+    content = fs.readFileSync(filePath, 'utf8');
+  });
+
+  test('page file exists', () => {
+    expect(fs.existsSync(filePath)).toBe(true);
+  });
+
+  test('exports metadata with title', () => {
+    expect(content).toContain('Cookie Policy');
+    expect(content).toContain('metadata');
+  });
+
+  test('explains what cookies are', () => {
+    expect(content).toContain('What are cookies');
+  });
+
+  test('lists specific cookies used', () => {
+    expect(content).toContain('sb-');
+    expect(content).toContain('auth-token');
+    expect(content).toContain('Essential');
+  });
+
+  test('mentions third-party cookies (Google, Cloudflare)', () => {
+    expect(content).toContain('Google');
+    expect(content).toContain('Cloudflare');
+  });
+
+  test('explains how to manage cookies', () => {
+    expect(content).toContain('Managing cookies');
+    expect(content).toContain('browser settings');
+  });
+
+  test('commits to no advertising cookies', () => {
+    expect(content).toContain('advertising');
+    expect(content).toContain('tracking');
+  });
+
+  test('provides contact email', () => {
+    expect(content).toContain('privacy@checklyra.com');
+  });
+
+  test('links to privacy policy and terms', () => {
+    expect(content).toContain('href="/privacy"');
+    expect(content).toContain('href="/terms"');
+  });
 });


### PR DESCRIPTION
## What & Why
Adds a dedicated cookie policy page. Good practice for UK compliance and may help with Google OAuth verification. Origin: KAN-131 feature gap audit.

## Changes
- New `src/app/(legal)/cookies/page.tsx`: essential cookies table, third-party cookies (Google/Cloudflare), management instructions, no-tracking commitment
- Footer: added Cookies link alongside Privacy and Terms

## Tests (10 new, 208 total)
Cookie page: exists, metadata, explains cookies, lists specific cookies, third-party, management, no-advertising, contact, links to privacy/terms. Footer: links to /cookies.