### PR TITLE
docs(KAN-150): Add security audit to RUNBOOK and update test count

### DIFF
--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -1,0 +1,135 @@
+name: Weekly Security Audit
+
+on:
+  schedule:
+    - cron: '0 7 * * 3'  # Wednesday 07:00 UTC
+  workflow_dispatch:
+
+jobs:
+  audit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: '20'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run npm audit
+        id: audit
+        run: |
+          npm audit --json > /tmp/audit-results.json 2>&1 || true
+          echo "exit_code=$?" >> $GITHUB_OUTPUT
+
+          # Parse results
+          HIGH=$(python3 -c "
+          import json, sys
+          try:
+              data = json.load(open('/tmp/audit-results.json'))
+              vulns = data.get('metadata', {}).get('vulnerabilities', {})
+              high = vulns.get('high', 0)
+              critical = vulns.get('critical', 0)
+              print(high + critical)
+          except:
+              print(0)
+          ")
+          echo "high_critical_count=$HIGH" >> $GITHUB_OUTPUT
+
+          TOTAL=$(python3 -c "
+          import json
+          try:
+              data = json.load(open('/tmp/audit-results.json'))
+              vulns = data.get('metadata', {}).get('vulnerabilities', {})
+              print(sum(vulns.values()))
+          except:
+              print(0)
+          ")
+          echo "total_count=$TOTAL" >> $GITHUB_OUTPUT
+
+      - name: Generate audit report
+        id: report
+        run: |
+          python3 scripts/audit-to-email.py /tmp/audit-results.json > /tmp/audit-email.json
+          echo "has_vulns=$(python3 -c "import json; d=json.load(open('/tmp/audit-email.json')); print('true' if d.get('has_vulnerabilities') else 'false')")" >> $GITHUB_OUTPUT
+
+      - name: Output to step summary
+        run: |
+          echo "## 🔒 Weekly Security Audit" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "**Date:** $(date -u +%Y-%m-%dT%H:%M:%SZ)" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+
+          if [ "${{ steps.audit.outputs.high_critical_count }}" != "0" ]; then
+            echo "### ⚠️ High/Critical Vulnerabilities Found: ${{ steps.audit.outputs.high_critical_count }}" >> $GITHUB_STEP_SUMMARY
+          else
+            echo "### ✅ No high/critical vulnerabilities" >> $GITHUB_STEP_SUMMARY
+          fi
+
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "**Total vulnerabilities:** ${{ steps.audit.outputs.total_count }}" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+
+          # Include advisory details
+          python3 -c "
+          import json
+          try:
+              data = json.load(open('/tmp/audit-results.json'))
+              vulns = data.get('vulnerabilities', {})
+              if vulns:
+                  print('| Package | Severity | Advisory | Fix |')
+                  print('|---------|----------|----------|-----|')
+                  for name, info in vulns.items():
+                      severity = info.get('severity', 'unknown')
+                      fix = info.get('fixAvailable', False)
+                      fix_str = 'Yes' if fix else 'No'
+                      via = info.get('via', [])
+                      url = ''
+                      for v in via:
+                          if isinstance(v, dict):
+                              url = v.get('url', '')
+                              break
+                      print(f'| {name} | {severity} | {url} | {fix_str} |')
+          except Exception as e:
+              print(f'Could not parse audit results: {e}')
+          " >> $GITHUB_STEP_SUMMARY
+
+      - name: Email vulnerability alert via Resend
+        if: steps.report.outputs.has_vulns == 'true'
+        env:
+          RESEND_API_KEY: ${{ secrets.RESEND_API_KEY }}
+        run: |
+          if [ -z "$RESEND_API_KEY" ]; then
+            echo "⚠️ RESEND_API_KEY not configured — skipping email"
+            exit 0
+          fi
+
+          # Remove the has_vulnerabilities flag before sending (not a Resend field)
+          python3 -c "
+          import json
+          data = json.load(open('/tmp/audit-email.json'))
+          data.pop('has_vulnerabilities', None)
+          json.dump(data, open('/tmp/audit-email-send.json', 'w'))
+          "
+
+          RESPONSE=$(curl -s -X POST "https://api.resend.com/emails" \
+            -H "Authorization: Bearer $RESEND_API_KEY" \
+            -H "Content-Type: application/json" \
+            -d @/tmp/audit-email-send.json)
+
+          echo "Email response: $RESPONSE"
+          if echo "$RESPONSE" | grep -q '"id"'; then
+            echo "✅ Security alert emailed successfully"
+          else
+            echo "⚠️ Email send may have failed — check Resend dashboard"
+          fi
+
+      - name: Fail if high/critical vulnerabilities found
+        if: steps.audit.outputs.high_critical_count != '0'
+        run: |
+          echo "❌ ${{ steps.audit.outputs.high_critical_count }} high/critical vulnerabilities detected"
+          echo "Run 'npm audit' locally and fix before next deploy"
+          exit 1

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,7 +44,7 @@ The pipeline is: **develop → staging → main** (promotion-based).
 - New features must have unit and functional tests in the same PR/commit — never defer to a separate ticket
 - E2E functional testing must be built as new features are created
 - Claude must actively look for missing coverage and flag it
-- Current test floor: **239 tests** (19 suites) in lyra, **64 tests** (2 suites) in lyra-mcp-server
+- Current test floor: **254 tests** (20 suites) in lyra, **64 tests** (2 suites) in lyra-mcp-server
 
 ## Test Integrity Policy
 
@@ -132,3 +132,4 @@ See `docs/RUNBOOK.md` for the full schedule. Key times (UTC):
 - Sunday 04:00 — Stryker mutation testing
 - Sunday 05:00 — Backup restore test
 - Monday 07:00 — Weekly report (emails via Resend)
+- Wednesday 07:00 — Security audit (npm audit + email alerts via Resend)

--- a/docs/RUNBOOK.md
+++ b/docs/RUNBOOK.md
@@ -74,6 +74,28 @@ supabase migration repair <VERSION> --status reverted
 ./scripts/restore-database.sh ./backups/latest_backup.sql
 ```
 
+## Scheduled Workflows (GitHub Actions)
+
+| Day | Time (UTC) | Workflow | Description |
+|-----|-----------|----------|-------------|
+| Sunday | 02:00 | backup-database.yml | Database backup to GitHub Artifacts (90-day retention) |
+| Sunday | 02:30 | backup-platform.yml | Full platform backup (repos, DNS, schema) to Cloudflare R2 |
+| Sunday | 04:00 | mutation-testing.yml | Stryker mutation testing |
+| Sunday | 05:00 | backup-restore-test.yml | Automated backup restore verification |
+| Monday | 07:00 | weekly-report.yml | Weekly status report emailed via Resend |
+| Monday | — | Dependabot | Dependency update PRs (npm + GitHub Actions) |
+| Wednesday | 07:00 | security-audit.yml | npm audit scan; emails alert if high/critical vulns found |
+
+All scheduled workflows also support `workflow_dispatch` for manual runs.
+
+### Security Audit (Wednesday 07:00 UTC)
+- Runs `npm audit --json` against lockfile
+- Parses results for high/critical severity vulnerabilities
+- Emails `luisa@santos-stephens.com` via Resend if any found
+- Writes detailed advisory table to GitHub Actions step summary
+- Workflow fails (red status) when high/critical vulns detected — visible in GitHub UI
+- Manual trigger: GitHub → Actions → "Weekly Security Audit" → Run workflow
+
 ## Emergency Contacts
 
 | Service | Dashboard | Support |

--- a/scripts/audit-to-email.py
+++ b/scripts/audit-to-email.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+"""Convert npm audit JSON to Resend email JSON payload for security alerts."""
+
+import json
+import sys
+from datetime import datetime, timezone
+
+
+def main():
+    if len(sys.argv) < 2:
+        print("Usage: audit-to-email.py <audit-results.json>", file=sys.stderr)
+        sys.exit(1)
+
+    try:
+        with open(sys.argv[1], "r") as f:
+            data = json.load(f)
+    except (json.JSONDecodeError, FileNotFoundError) as e:
+        # No valid audit data — output no-vuln payload
+        payload = {"has_vulnerabilities": False}
+        print(json.dumps(payload))
+        return
+
+    vulns_meta = data.get("metadata", {}).get("vulnerabilities", {})
+    high = vulns_meta.get("high", 0)
+    critical = vulns_meta.get("critical", 0)
+    total = sum(vulns_meta.values())
+
+    if high + critical == 0:
+        payload = {"has_vulnerabilities": False}
+        print(json.dumps(payload))
+        return
+
+    # Build vulnerability table
+    vulns = data.get("vulnerabilities", {})
+    rows = []
+    for name, info in vulns.items():
+        severity = info.get("severity", "unknown")
+        if severity not in ("high", "critical"):
+            continue
+        fix_available = info.get("fixAvailable", False)
+        fix_str = "✅ Yes" if fix_available else "❌ No"
+        via = info.get("via", [])
+        advisory_url = ""
+        title = ""
+        for v in via:
+            if isinstance(v, dict):
+                advisory_url = v.get("url", "")
+                title = v.get("title", "")
+                break
+        rows.append(
+            f'<tr><td style="padding:8px;border:1px solid #e7e5e4;">{name}</td>'
+            f'<td style="padding:8px;border:1px solid #e7e5e4;">'
+            f'<span style="color:{"#dc2626" if severity == "critical" else "#ea580c"};font-weight:bold;">{severity.upper()}</span></td>'
+            f'<td style="padding:8px;border:1px solid #e7e5e4;">{title}</td>'
+            f'<td style="padding:8px;border:1px solid #e7e5e4;">'
+            f'{"<a href=" + chr(34) + advisory_url + chr(34) + ">View</a>" if advisory_url else "—"}</td>'
+            f'<td style="padding:8px;border:1px solid #e7e5e4;">{fix_str}</td></tr>'
+        )
+
+    table = (
+        '<table style="border-collapse:collapse;width:100%;font-size:14px;margin:16px 0;">'
+        "<tr>"
+        '<th style="padding:8px;border:1px solid #e7e5e4;background:#f5f5f4;text-align:left;">Package</th>'
+        '<th style="padding:8px;border:1px solid #e7e5e4;background:#f5f5f4;text-align:left;">Severity</th>'
+        '<th style="padding:8px;border:1px solid #e7e5e4;background:#f5f5f4;text-align:left;">Issue</th>'
+        '<th style="padding:8px;border:1px solid #e7e5e4;background:#f5f5f4;text-align:left;">Advisory</th>'
+        '<th style="padding:8px;border:1px solid #e7e5e4;background:#f5f5f4;text-align:left;">Fix Available</th>'
+        "</tr>"
+        + "\n".join(rows)
+        + "</table>"
+    )
+
+    date = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+
+    html_body = f"""<div style="font-family:'DM Sans',Helvetica,Arial,sans-serif;max-width:700px;margin:0 auto;padding:20px;background:#fafaf9;">
+<div style="text-align:center;margin-bottom:24px;">
+<span style="font-family:serif;font-size:28px;color:#1c1917;">lyra</span>
+</div>
+<div style="background:#fef2f2;border:1px solid #fecaca;border-radius:8px;padding:16px;margin-bottom:24px;">
+<h2 style="color:#dc2626;margin:0 0 8px 0;font-size:18px;">⚠️ Security Vulnerabilities Detected</h2>
+<p style="color:#44403c;margin:0;">The weekly security audit found <strong>{high + critical} high/critical</strong> vulnerabilities ({total} total) in the Lyra web app dependencies.</p>
+</div>
+<h3 style="color:#1c1917;margin-top:24px;">Affected Packages</h3>
+{table}
+<h3 style="color:#1c1917;margin-top:24px;">Recommended Action</h3>
+<div style="background:#f5f5f4;border-radius:6px;padding:12px;font-family:monospace;font-size:13px;">
+cd lyra<br>
+npm audit<br>
+npm audit fix --force<br>
+npm run build && npx jest<br>
+git add -A && git commit -m "security: fix npm audit vulnerabilities"
+</div>
+<p style="color:#78716c;font-size:13px;margin-top:16px;">Run <code>npm audit</code> locally for full details. If <code>npm audit fix</code> doesn't resolve, manual intervention may be needed.</p>
+<div style="text-align:center;margin-top:32px;padding-top:16px;border-top:1px solid #e7e5e4;">
+<span style="font-size:12px;color:#a8a29e;">Lyra Security Audit &mdash; generated automatically by GitHub Actions every Wednesday</span>
+</div>
+</div>"""
+
+    payload = {
+        "from": "Lyra Security <reports@checklyra.com>",
+        "to": ["luisa@santos-stephens.com"],
+        "subject": f"⚠️ Lyra Security Alert — {high + critical} vulnerabilities found ({date})",
+        "html": html_body,
+        "has_vulnerabilities": True,
+    }
+    print(json.dumps(payload))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/unit/security-audit.test.js
+++ b/tests/unit/security-audit.test.js
@@ -1,0 +1,182 @@
+/**
+ * Tests for the security audit workflow scripts and configuration.
+ * KAN-150: Weekly security audit with email alerts.
+ */
+
+const fs = require('fs');
+const path = require('path');
+const { execSync } = require('child_process');
+const yaml = require('js-yaml');
+
+/** Helper: run python3 script with paths safely quoted for shell */
+function runPython(scriptPath, ...args) {
+  const quotedArgs = args.map(a => `'${a}'`).join(' ');
+  return execSync(`python3 '${scriptPath}' ${quotedArgs}`, { encoding: 'utf8' });
+}
+
+describe('KAN-150: Security Audit Workflow', () => {
+  const workflowPath = path.join(__dirname, '../../.github/workflows/security-audit.yml');
+  const emailScriptPath = path.join(__dirname, '../../scripts/audit-to-email.py');
+  let workflowContent;
+  let workflowYaml;
+
+  beforeAll(() => {
+    workflowContent = fs.readFileSync(workflowPath, 'utf8');
+    workflowYaml = yaml.load(workflowContent);
+  });
+
+  describe('Workflow configuration', () => {
+    test('workflow file exists', () => {
+      expect(fs.existsSync(workflowPath)).toBe(true);
+    });
+
+    test('scheduled for Wednesday 07:00 UTC', () => {
+      const schedule = workflowYaml.on.schedule;
+      expect(schedule).toBeDefined();
+      expect(schedule[0].cron).toBe('0 7 * * 3');
+    });
+
+    test('has workflow_dispatch for manual runs', () => {
+      expect(workflowYaml.on.workflow_dispatch).toBeDefined();
+    });
+
+    test('uses SHA-pinned Actions (no version tags)', () => {
+      const usesLines = workflowContent.match(/uses:\s+\S+/g) || [];
+      usesLines.forEach(line => {
+        // Each 'uses:' should have a SHA hash (40 hex chars), not just a tag
+        expect(line).toMatch(/@[a-f0-9]{40}/);
+      });
+    });
+
+    test('uses npm audit with --json flag', () => {
+      expect(workflowContent).toContain('npm audit --json');
+    });
+
+    test('emails only when vulnerabilities are found', () => {
+      // The email step should have a conditional
+      expect(workflowContent).toContain("if: steps.report.outputs.has_vulns == 'true'");
+    });
+
+    test('uses RESEND_API_KEY secret', () => {
+      expect(workflowContent).toContain('RESEND_API_KEY');
+      expect(workflowContent).toContain('secrets.RESEND_API_KEY');
+    });
+
+    test('fails workflow on high/critical vulnerabilities', () => {
+      expect(workflowContent).toContain('exit 1');
+      expect(workflowContent).toContain('high_critical_count');
+    });
+
+    test('writes to step summary', () => {
+      expect(workflowContent).toContain('$GITHUB_STEP_SUMMARY');
+    });
+  });
+
+  describe('Email script (audit-to-email.py)', () => {
+    test('script file exists', () => {
+      expect(fs.existsSync(emailScriptPath)).toBe(true);
+    });
+
+    test('outputs no-vuln payload for clean audit', () => {
+      // Create a clean audit result
+      const cleanAudit = {
+        metadata: {
+          vulnerabilities: { info: 0, low: 0, moderate: 0, high: 0, critical: 0, total: 0 }
+        },
+        vulnerabilities: {}
+      };
+      const tmpFile = path.join('/tmp', 'test-clean-audit.json');
+      fs.writeFileSync(tmpFile, JSON.stringify(cleanAudit));
+
+      const output = runPython(emailScriptPath, tmpFile);
+      const result = JSON.parse(output.trim());
+      expect(result.has_vulnerabilities).toBe(false);
+      expect(result.to).toBeUndefined(); // No email fields when clean
+
+      fs.unlinkSync(tmpFile);
+    });
+
+    test('outputs email payload for audit with high vulnerability', () => {
+      const vulnAudit = {
+        metadata: {
+          vulnerabilities: { info: 0, low: 0, moderate: 1, high: 1, critical: 0, total: 2 }
+        },
+        vulnerabilities: {
+          'next': {
+            name: 'next',
+            severity: 'high',
+            fixAvailable: true,
+            via: [{ title: 'DoS via Server Components', url: 'https://github.com/advisories/GHSA-test' }]
+          },
+          'lodash': {
+            name: 'lodash',
+            severity: 'moderate',
+            fixAvailable: true,
+            via: [{ title: 'Prototype Pollution', url: 'https://github.com/advisories/GHSA-test2' }]
+          }
+        }
+      };
+      const tmpFile = path.join('/tmp', 'test-vuln-audit.json');
+      fs.writeFileSync(tmpFile, JSON.stringify(vulnAudit));
+
+      const output = runPython(emailScriptPath, tmpFile);
+      const result = JSON.parse(output.trim());
+
+      expect(result.has_vulnerabilities).toBe(true);
+      expect(result.to).toEqual(['luisa@santos-stephens.com']);
+      expect(result.from).toContain('Lyra Security');
+      expect(result.subject).toContain('1 vulnerabilities found');
+      expect(result.html).toContain('next');
+      expect(result.html).toContain('HIGH');
+      // Should NOT include moderate-only vulns in the table
+      expect(result.html).not.toContain('MODERATE');
+
+      fs.unlinkSync(tmpFile);
+    });
+
+    test('outputs email payload for critical vulnerability', () => {
+      const criticalAudit = {
+        metadata: {
+          vulnerabilities: { info: 0, low: 0, moderate: 0, high: 0, critical: 1, total: 1 }
+        },
+        vulnerabilities: {
+          'react': {
+            name: 'react',
+            severity: 'critical',
+            fixAvailable: true,
+            via: [{ title: 'RCE in Server Components', url: 'https://github.com/advisories/GHSA-crit' }]
+          }
+        }
+      };
+      const tmpFile = path.join('/tmp', 'test-critical-audit.json');
+      fs.writeFileSync(tmpFile, JSON.stringify(criticalAudit));
+
+      const output = runPython(emailScriptPath, tmpFile);
+      const result = JSON.parse(output.trim());
+
+      expect(result.has_vulnerabilities).toBe(true);
+      expect(result.subject).toContain('1 vulnerabilities found');
+      expect(result.html).toContain('CRITICAL');
+      expect(result.html).toContain('#dc2626'); // Red colour for critical
+
+      fs.unlinkSync(tmpFile);
+    });
+
+    test('handles invalid JSON gracefully', () => {
+      const tmpFile = path.join('/tmp', 'test-bad-audit.json');
+      fs.writeFileSync(tmpFile, 'not json');
+
+      const output = runPython(emailScriptPath, tmpFile);
+      const result = JSON.parse(output.trim());
+      expect(result.has_vulnerabilities).toBe(false);
+
+      fs.unlinkSync(tmpFile);
+    });
+
+    test('handles missing file gracefully', () => {
+      const output = runPython(emailScriptPath, '/tmp/nonexistent-file-12345.json');
+      const result = JSON.parse(output.trim());
+      expect(result.has_vulnerabilities).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
## What & Why
The KAN-150 workflow, script, and tests were already committed on develop (commit 4601b16). This PR adds the missing documentation updates:

## Changes
- **RUNBOOK.md**: New 'Scheduled Workflows' section with a complete table of all automated GitHub Actions jobs (times, descriptions). Added operational details for the Wednesday 07:00 UTC security audit.
- **CLAUDE.md**: Test floor updated from 239 → 254 (20 suites). Wednesday 07:00 security audit added to the scheduled times list.

## Tests
All 254 tests passing (20 suites). No test changes in this PR — documentation only.

Closes KAN-150