### PR TITLE
fix(release): use mergedAt instead of removed gh `merged` field (BUGS-10)

### DIFF
--- a/.github/workflows/promote-to-production.yml
+++ b/.github/workflows/promote-to-production.yml
@@ -232,10 +232,11 @@ jobs:
             sleep $INTERVAL
             ELAPSED=$((ELAPSED + INTERVAL))
 
+            # BUGS-8: gh CLI removed the boolean `merged` field; derive it from `mergedAt`.
             PR_STATE=$(gh pr view "$PR_NUMBER" \
               --repo "${{ github.repository }}" \
-              --json state,merged,mergeCommit,mergeable,statusCheckRollup \
-              -q '{state, merged, sha: .mergeCommit.oid, mergeable, checks: [.statusCheckRollup[] | {name: .name, conclusion: .conclusion}]}')
+              --json state,mergedAt,mergeCommit,mergeable,statusCheckRollup \
+              -q '{state, merged: (.mergedAt != null), sha: .mergeCommit.oid, mergeable, checks: [.statusCheckRollup[] | {name: .name, conclusion: .conclusion}]}')
 
             STATE=$(echo "$PR_STATE" | python3 -c "import json,sys; print(json.load(sys.stdin)['state'])")
             MERGED=$(echo "$PR_STATE" | python3 -c "import json,sys; print(json.load(sys.stdin)['merged'])")


### PR DESCRIPTION
## What & Why

gh CLI removed the boolean `merged` field from `gh pr view --json`. When `wait-for-merge` in `promote-to-production.yml` asked for that field, the runner's gh returned an "Available fields:" error and exited 1, silently breaking every promotion run.

Discovered during the 2026-05-04 production promotion attempt — [run 25325422468](https://github.com/luisa-sys/lyra/actions/runs/25325422468) failed at `wait-for-merge` even though all status checks on the underlying PR were green.

## Fix

Replace `merged` (no longer in the available fields) with `mergedAt`, then derive merged-ness via jq: `merged: (.mergedAt != null)`. The downstream python check `if [ "$MERGED" = "True" ]` is unchanged because jq emits a boolean → python prints `True`/`False`.

## Tests Required

Workflow change only — verified by re-running `promote-to-production.yml` after merge. The bootstrap pattern means this change must be on `main` before it takes effect (per CLAUDE.md gotcha #1).

## Security Review

No surface change. Read-only `gh pr view` call.

## Architecture Impact

None. Workflow file only.

## Acceptance Criteria

- [ ] `wait-for-merge` step polls PR status without crashing
- [ ] Production promotion completes end-to-end with smoke tests + tag creation

## Refs

- [BUGS-10](https://checklyra.atlassian.net/browse/BUGS-10) — workflow merged-field bug (originally referenced as BUGS-8 in commit `54a99ee`; that key was already taken by an unrelated LYRA_RELEASE_PAT scope ticket, so the back-fill ticket landed as BUGS-10)
- Follow-up: back-merge BUGS-4/6/7 bootstrap commits from main into develop so future release branches aren't BEHIND main

[BUGS-10]: https://checklyra.atlassian.net/browse/BUGS-10?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ