### PR TITLE
deps: pin postcss >=8.5.10 via overrides (Dependabot alert #12)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8628,34 +8628,6 @@
         "tslib": "^2.8.0"
       }
     },
-    "node_modules/next/node_modules/postcss": {
-      "version": "8.4.31",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
-      "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/postcss/"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/postcss"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "nanoid": "^3.3.6",
-        "picocolors": "^1.0.0",
-        "source-map-js": "^1.0.2"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >=14"
-      }
-    },
     "node_modules/node-exports-info": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/node-exports-info/-/node-exports-info-1.6.0.tgz",
@@ -9194,10 +9166,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.8",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
-      "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
-      "dev": true,
+      "version": "8.5.14",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
+      "integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
       "funding": [
         {
           "type": "opencollective",

--- a/package.json
+++ b/package.json
@@ -41,5 +41,8 @@
     "tailwindcss": "^4",
     "ts-jest": "^29.4.6",
     "typescript": "^5"
+  },
+  "overrides": {
+    "postcss": "^8.5.10"
   }
 }


### PR DESCRIPTION
## Summary

Closes [Dependabot alert #12](https://github.com/luisa-sys/lyra/security/dependabot/12) — postcss <8.5.10 has a medium-severity XSS vulnerability via unescaped \`</style>\` in its CSS Stringify Output ([GHSA-qx2v-qp2m-jg93](https://github.com/advisories/GHSA-qx2v-qp2m-jg93)).

## Why an override and not a direct bump

Both postcss paths in the tree are transitive:
- `@tailwindcss/postcss@4.2.2 → postcss@8.5.8` (range \`^8.5.6\`, can be bumped)
- `next@16.2.3 → postcss@8.4.31` (pinned by Next.js — can't bump without a Next release)

Adding \`overrides: { postcss: "^8.5.10" }\` forces both paths to dedupe to a patched version (8.5.14). Cleaner than waiting for Next to release a postcss bump.

## Verified

- `npm ls postcss`: both paths resolve to **8.5.14** (deduped)
- `npx jest`: **290 tests pass** (22 suites; 1 pre-existing Playwright/Jest collision unrelated)
- `npm run build`: clean, all routes generate

## Tests Required

No new tests needed — this is a transitive dep override with no API surface change. Existing test suite + build verification covers regression risk.

## Security Review

Closes a known vulnerability. No new attack surface introduced. The override is a stricter floor on transitive dep version, not a new package.

## Architecture Impact

- Modified: `package.json` (added `overrides` block), `package-lock.json` (regenerated)
- No env vars, no workflow changes, no app code

## Acceptance Criteria

- [x] Dependabot alert #12 should close automatically when this lands on `main`
- [x] Tests + build green
- [x] No regression in Tailwind or Next.js CSS pipeline

## Refs

- Dependabot alert #12 / GHSA-qx2v-qp2m-jg93
- Cleared from "GitHub found 1 vulnerability" warning that was flagged on every push to develop/main since at least 2026-04-29