### PR TITLE
chore(dependabot): target npm bumps at develop

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,12 @@
 version: 2
 updates:
+  # npm deps target develop so they flow through the standard
+  # develop → staging → main pipeline. Workflow-file bumps below
+  # (github-actions ecosystem) still target main since workflow
+  # changes only take effect once on main (CLAUDE.md gotcha #1).
   - package-ecosystem: "npm"
     directory: "/"
+    target-branch: "develop"
     schedule:
       interval: "weekly"
       day: "monday"


### PR DESCRIPTION
Sets target-branch: develop for npm ecosystem so future Dependabot npm PRs flow through develop → staging → main instead of accumulating on main. github-actions ecosystem still targets main (workflow files only take effect once on main, per CLAUDE.md gotcha #1).