### PR TITLE
KAN-163: UptimeRobot bootstrap script + setup doc + tests

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,7 +45,7 @@ The pipeline is: **develop → staging → main** (promotion-based).
 - New features must have unit and functional tests in the same PR/commit — never defer to a separate ticket
 - E2E functional testing must be built as new features are created
 - Claude must actively look for missing coverage and flag it
-- Current test floor: **254 tests** (20 suites) in lyra, **64 tests** (2 suites) in lyra-mcp-server
+- Current test floor: **330 tests** (27 suites) in lyra, **64 tests** (2 suites) in lyra-mcp-server
 
 ## Test Integrity Policy
 

--- a/docs/RUNBOOK.md
+++ b/docs/RUNBOOK.md
@@ -252,9 +252,26 @@ All scheduled workflows also support `workflow_dispatch` for manual runs.
 - Workflow fails (red status) when high/critical vulns detected — visible in GitHub UI
 - Manual trigger: GitHub → Actions → "Weekly Security Audit" → Run workflow
 
+## Incident Response
+
+**Primary signal:** UptimeRobot (5-minute interval, KAN-163). Email alerts to luisa@santos-stephens.com and ben@santos-stephens.com when any monitored endpoint goes down or an SSL cert is within 30 days of expiry.
+
+**Secondary signal:** the 6-hourly GitHub Actions health-check workflow. Slower (up to 6h delay) but redundant; useful when UptimeRobot itself is degraded.
+
+**Tertiary signal:** weekly report Monday 07:00 UTC — Section 1 endpoint health is a 7-day summary, not a live signal, but it cross-checks UptimeRobot.
+
+When an alert fires:
+1. Check the affected endpoint manually with `curl -I` to confirm it's a real outage rather than a probe blocking issue (Cloudflare bot protection occasionally trips on UptimeRobot's IP — gotcha #7 in CLAUDE.md).
+2. Check Vercel deployment status for the affected env.
+3. Check Cloudflare for DNS, Workers, or zone-level issues.
+4. If MCP-side: check Railway logs.
+5. Roll back the deploy if a recent promotion looks responsible — see "Deployment Rollback" above.
+
+UptimeRobot setup, monitor list, and bootstrap procedure: [`docs/UPTIMEROBOT_SETUP.md`](./UPTIMEROBOT_SETUP.md).
+
 ## Emergency Contacts
 
-ServiceDashboardSupportVercel[vercel.com/luisa-sys-projects/lyra](http://vercel.com/luisa-sys-projects/lyra)[vercel.com/help](http://vercel.com/help)Supabase[supabase.com/dashboard/project/ilprytcrnqyrsbsrfujj](http://supabase.com/dashboard/project/ilprytcrnqyrsbsrfujj)[supabase.com/support](http://supabase.com/support)Cloudflare[dash.cloudflare.com](http://dash.cloudflare.com)[cloudflare.com/support](http://cloudflare.com/support)GitHub[github.com/luisa-sys/lyra](http://github.com/luisa-sys/lyra)[support.github.com](http://support.github.com)Railwayrailway.app (Lyra project)railway.app/help
+ServiceDashboardSupportVercel[vercel.com/luisa-sys-projects/lyra](http://vercel.com/luisa-sys-projects/lyra)[vercel.com/help](http://vercel.com/help)Supabase[supabase.com/dashboard/project/ilprytcrnqyrsbsrfujj](http://supabase.com/dashboard/project/ilprytcrnqyrsbsrfujj)[supabase.com/support](http://supabase.com/support)Cloudflare[dash.cloudflare.com](http://dash.cloudflare.com)[cloudflare.com/support](http://cloudflare.com/support)GitHub[github.com/luisa-sys/lyra](http://github.com/luisa-sys/lyra)[support.github.com](http://support.github.com)Railwayrailway.app (Lyra project)railway.app/helpUptimeRobot[dashboard.uptimerobot.com](https://dashboard.uptimerobot.com/)[uptimerobot.com/help](https://uptimerobot.com/help)
 
 ## MCP Server Operations
 

--- a/docs/UPTIMEROBOT_SETUP.md
+++ b/docs/UPTIMEROBOT_SETUP.md
@@ -1,0 +1,108 @@
+# UptimeRobot Monitoring Setup (KAN-163)
+
+This is the one-time setup procedure for Lyra's external uptime monitoring. Once complete, UptimeRobot becomes the **primary signal** for environment availability and SSL-certificate expiry across all four envs (prod, beta, stage, dev) plus both MCP servers. The 6-hourly GitHub Actions health-check stays as a redundant secondary signal.
+
+Total time: ~10 minutes for the human steps; the automated bootstrap below provisions the actual monitors.
+
+## 1. Sign up for UptimeRobot
+
+Go to <https://uptimerobot.com/> and create an account on the **Free** plan. The free plan covers everything Lyra needs:
+
+- Up to 50 monitors at a 5-minute interval
+- HTTPS keyword & SSL expiry monitoring on every monitor
+- Email alerts (no SMS, no Slack on free — that's fine for now)
+- 2 months of detailed log retention
+
+Use **`luisa@santos-stephens.com`** as the account email. Enable 2FA immediately under **My Settings → Two-Factor Authentication** — this is in the security review for KAN-163 and the account becomes a single-point-of-failure for outage detection if it gets compromised.
+
+After signup, store the account credentials in 1Password under the existing "Lyra services" vault.
+
+## 2. Generate a Main API key
+
+1. In UptimeRobot, click your avatar (top right) → **My Settings**.
+2. Scroll to **API Settings**.
+3. Click **Create Main API Key**. Give it a label like `Lyra bootstrap (Claude)`.
+4. Copy the key (it starts with `ur-`). Treat this like a password — it has full read/write on every monitor in the account.
+
+The Main API key is what the bootstrap script needs. There's also a Read-Only API key option — don't use that one; the script needs to create monitors and alert contacts.
+
+## 3. Hand the key over to Claude
+
+Paste the key in the chat in this exact form so I can pick it up without ambiguity:
+
+```
+UPTIMEROBOT_API_KEY=ur-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+```
+
+I'll run the bootstrap immediately, verify the monitors are created, and confirm the first scrape completed successfully. After that, the key is no longer needed in chat — UptimeRobot does its job from the dashboard, and you can rotate the key at any time without affecting running monitors.
+
+If you'd rather not paste the key in chat, the alternative is to set it locally and run the script yourself — see "Run the bootstrap manually" below.
+
+## 4. Bootstrap the monitors (Claude does this automatically)
+
+The bootstrap is idempotent — running it once or 100 times produces the same end state. It creates two things:
+
+**Alert contacts** (one per email, type=email):
+- `luisa@santos-stephens.com`
+- `ben@santos-stephens.com`
+
+**Monitors** (HTTP, 5-minute interval, SSL expiry reminder enabled):
+
+| Friendly name | URL |
+| --- | --- |
+| Lyra prod — checklyra.com | <https://checklyra.com/> |
+| Lyra prod — privacy | <https://checklyra.com/privacy> |
+| Lyra beta — beta.checklyra.com | <https://beta.checklyra.com/> |
+| Lyra stage — stage.checklyra.com | <https://stage.checklyra.com/> |
+| Lyra dev — dev.checklyra.com | <https://dev.checklyra.com/> |
+| Lyra MCP prod — mcp.checklyra.com | <https://mcp.checklyra.com/health> |
+| Lyra MCP dev — mcp-dev.checklyra.com | <https://mcp-dev.checklyra.com/health> |
+
+The canonical list is in [`scripts/uptimerobot/lib.js`](../scripts/uptimerobot/lib.js) under `LYRA_MONITORS` — it's deliberately kept tiny and pure-data so the weekly report can cross-check UptimeRobot's view of the world against its own Section 1 endpoint health (KAN-165 follow-up).
+
+## 5. Verify the alert path
+
+Once the bootstrap reports green, induce a deliberate failure on `dev.checklyra.com` (the safest env to test) by temporarily renaming the Vercel project or pausing the deployment. UptimeRobot should fire an email alert to both addresses within ~10 minutes. Restore the deployment immediately after the alert lands.
+
+This step is required by the KAN-163 acceptance criteria and confirms the email path actually works end-to-end (deliverability, not just config).
+
+## 6. Add the dashboard link to lyra-project-reference
+
+Once the bootstrap is done, replace the placeholder in [`docs/lyra-project-reference.jsx`](./lyra-project-reference.jsx) under the `monitoring` block with your real UptimeRobot dashboard URL (visible in the address bar after sign-in — typically `https://dashboard.uptimerobot.com/monitors`).
+
+## Run the bootstrap manually (alternative path)
+
+If you don't want to paste the API key in chat, run the bootstrap yourself from the lyra repo:
+
+```bash
+# Dry-run first — prints the diff but writes nothing.
+UPTIMEROBOT_API_KEY=ur-xxxxxxxx \
+ALERT_EMAILS=luisa@santos-stephens.com,ben@santos-stephens.com \
+  node scripts/uptimerobot/bootstrap.js
+
+# Apply once the dry-run looks right.
+UPTIMEROBOT_API_KEY=ur-xxxxxxxx \
+ALERT_EMAILS=luisa@santos-stephens.com,ben@santos-stephens.com \
+  node scripts/uptimerobot/bootstrap.js --apply
+```
+
+The script:
+- Verifies the API key works (calls `getAccountDetails`)
+- Lists existing alert contacts and creates any missing ones (matches by email value, case-insensitive)
+- Lists existing monitors and creates any missing ones (matches by `friendly_name`, exact)
+- Flags URL drift on existing monitors as a manual review item rather than silently overwriting
+- Defaults to dry-run; pass `--apply` to commit changes
+
+Re-running with `--apply` against a configured account is a no-op.
+
+## Rotation and offboarding
+
+The Main API key has full write access. Rotate it under the same conditions as `LYRA_BACKUP_PAT` (KAN-170): annually, plus immediately if you ever paste it anywhere it shouldn't be (chat history, screenshots, public commits). Rotation is non-disruptive — generating a new key and revoking the old one in **My Settings → API Settings** does not affect running monitors or alerts.
+
+If Ben leaves the project, remove `ben@santos-stephens.com` from the alert contacts and re-run the bootstrap (or remove via dashboard). The script does not delete contacts — only adds — so removal is always a deliberate manual step.
+
+## Reference
+
+- UptimeRobot API v2: <https://uptimerobot.com/api/>
+- KAN-163 ticket: <https://checklyra.atlassian.net/browse/KAN-163>
+- Related: KAN-84 (production launch), KAN-63 (autonomous monitoring epic), KAN-165 (status dashboard).

--- a/docs/lyra-project-reference.jsx
+++ b/docs/lyra-project-reference.jsx
@@ -82,6 +82,17 @@ const sections = [
     ],
   },
   {
+    title: "UptimeRobot (Monitoring) — KAN-163",
+    icon: "📡",
+    items: [
+      { label: "Dashboard", link: "https://dashboard.uptimerobot.com/" },
+      { label: "Setup guide", link: "https://github.com/luisa-sys/lyra/blob/develop/docs/UPTIMEROBOT_SETUP.md" },
+      { label: "Plan", value: "Free — 50 monitors, 5-minute interval, SSL expiry monitoring" },
+      { label: "Alerts to", value: "luisa@santos-stephens.com, ben@santos-stephens.com" },
+      { label: "Bootstrap script", value: "scripts/uptimerobot/bootstrap.js (idempotent, dry-run by default)" },
+    ],
+  },
+  {
     title: "Jira (Project Management)",
     icon: "📋",
     items: [

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -11,6 +11,14 @@ const eslintConfig = defineConfig([
       "@typescript-eslint/no-require-imports": "off",
     },
   },
+  {
+    // scripts/ are runnable Node entry points — CommonJS is the natural fit
+    // (no transpile step). Allow require()/module.exports here.
+    files: ["scripts/**/*.js"],
+    rules: {
+      "@typescript-eslint/no-require-imports": "off",
+    },
+  },
   // Override default ignores of eslint-config-next.
   globalIgnores([
     // Default ignores of eslint-config-next:

--- a/package.json
+++ b/package.json
@@ -8,11 +8,13 @@
     "start": "next start",
     "lint": "eslint",
     "type-check": "tsc --noEmit",
-    "test:unit": "npx jest --testPathPatterns=tests/unit",
+    "test:unit": "npx jest --testPathPatterns='tests/(unit|scripts)'",
     "test:integration": "npx jest --testPathPatterns=tests/integration",
     "test:e2e": "npx playwright test",
     "test:all": "npm run test:unit && npm run test:integration && npm run test:e2e",
-    "db:migrate": "echo 'No migrations configured yet'"
+    "test:scripts": "npx jest --testPathPatterns=tests/scripts",
+    "db:migrate": "echo 'No migrations configured yet'",
+    "uptimerobot:bootstrap": "node scripts/uptimerobot/bootstrap.js"
   },
   "dependencies": {
     "@supabase/ssr": "^0.10.2",

--- a/scripts/uptimerobot/bootstrap.js
+++ b/scripts/uptimerobot/bootstrap.js
@@ -111,14 +111,39 @@ async function main() {
   }
 
   if (APPLY) {
-    for (const c of monitorDiff.toCreate) {
-      const res = await client.newMonitor({
-        friendlyName: c.friendlyName,
-        url: c.url,
-        alertContacts: alertContactsParam,
-      });
-      const id = res.monitor?.id;
-      log(`  + created monitor ${c.friendlyName} (id ${id})`);
+    // UptimeRobot throttles newMonitor (~1 req/3s on free tier).
+    // Throttle locally + retry on 429 with longer backoff so the script
+    // is reliable end-to-end without operator intervention.
+    const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+    for (let i = 0; i < monitorDiff.toCreate.length; i++) {
+      const c = monitorDiff.toCreate[i];
+      let attempt = 0;
+      while (true) {
+        try {
+          const res = await client.newMonitor({
+            friendlyName: c.friendlyName,
+            url: c.url,
+            alertContacts: alertContactsParam,
+          });
+          const id = res.monitor?.id;
+          log(`  + created monitor ${c.friendlyName} (id ${id})`);
+          break;
+        } catch (err) {
+          attempt++;
+          const msg = err instanceof Error ? err.message : String(err);
+          if (msg.includes('429') && attempt <= 4) {
+            const wait = 10000 * attempt;
+            log(`  ⏳ 429 from UptimeRobot, sleeping ${wait}ms before retry ${attempt}/4`);
+            await sleep(wait);
+            continue;
+          }
+          throw err;
+        }
+      }
+      // Pre-emptive 4s pause between calls.
+      if (i < monitorDiff.toCreate.length - 1) {
+        await sleep(4000);
+      }
     }
   }
 

--- a/scripts/uptimerobot/bootstrap.js
+++ b/scripts/uptimerobot/bootstrap.js
@@ -1,0 +1,132 @@
+#!/usr/bin/env node
+/**
+ * KAN-163: bootstrap UptimeRobot monitors for all Lyra environments.
+ *
+ *   UPTIMEROBOT_API_KEY=ur-xxxxxx                                       \
+ *   ALERT_EMAILS=luisa@santos-stephens.com,ben@santos-stephens.com      \
+ *     node scripts/uptimerobot/bootstrap.js [--apply]
+ *
+ * Default mode is DRY-RUN: no writes happen, the script prints the diff
+ * between desired state and what's already in UptimeRobot. Pass `--apply`
+ * to actually create the missing monitors and alert contacts.
+ *
+ * Idempotent: re-running with --apply against an already-configured
+ * account is a no-op (matched by friendly_name / email value).
+ */
+
+'use strict';
+
+const {
+  ALERT_CONTACT_TYPE,
+  LYRA_MONITORS,
+  makeClient,
+  planContactDiff,
+  planMonitorDiff,
+} = require('./lib');
+
+const APPLY = process.argv.includes('--apply');
+
+function log(msg) {
+  console.log(msg);
+}
+
+async function main() {
+  const apiKey = process.env.UPTIMEROBOT_API_KEY;
+  const alertEmails = (process.env.ALERT_EMAILS || '')
+    .split(',')
+    .map((s) => s.trim())
+    .filter(Boolean);
+
+  if (!apiKey) {
+    log('::error::UPTIMEROBOT_API_KEY is not set in env. Refusing to run.');
+    log('See docs/UPTIMEROBOT_SETUP.md for how to obtain and pass the key.');
+    process.exit(1);
+  }
+  if (alertEmails.length === 0) {
+    log('::error::ALERT_EMAILS is empty. Pass a comma-separated list of recipient emails.');
+    process.exit(1);
+  }
+
+  const client = makeClient({ apiKey });
+
+  log(APPLY ? '⚙️  Mode: APPLY (will write to UptimeRobot)' : '🧪 Mode: DRY-RUN (no writes; pass --apply to commit)');
+  log('');
+
+  // Sanity-check the API key works AND returns a free-or-better account.
+  const account = await client.getAccountDetails();
+  const acct = account.account || {};
+  log(`Account: ${acct.email || '(no email)'}  monitor limit: ${acct.monitor_limit ?? '?'}  used: ${acct.up_monitors ?? '?'}+${acct.down_monitors ?? '?'}+${acct.paused_monitors ?? '?'}`);
+  log('');
+
+  // Alert contacts first — newMonitor needs their IDs.
+  const contactsResp = await client.getAlertContacts();
+  const contactDiff = planContactDiff(contactsResp.alert_contacts || [], alertEmails);
+
+  log(`Alert contacts: ${contactDiff.present.length} present, ${contactDiff.toCreate.length} to create`);
+  for (const p of contactDiff.present) {
+    log(`  ✅ ${p.value} (id ${p.id}, status ${p.status})`);
+  }
+  for (const c of contactDiff.toCreate) {
+    log(`  ➕ would create: ${c.value}`);
+  }
+
+  const createdContactIds = [];
+  if (APPLY) {
+    for (const c of contactDiff.toCreate) {
+      const res = await client.newAlertContact({
+        friendlyName: c.value,
+        type: ALERT_CONTACT_TYPE.EMAIL,
+        value: c.value,
+      });
+      const id = res.alertcontact?.id;
+      log(`  + created contact ${c.value} (id ${id})`);
+      createdContactIds.push(id);
+    }
+  }
+
+  // Build the contact-id list to attach to monitors. Format required by
+  // UptimeRobot is `id_threshold_recurrence-id_threshold_recurrence-...`
+  // — for plain email alerts, threshold=0 (immediate) and recurrence=0
+  // (no re-alerting) is what we want.
+  const allContactIds = [
+    ...contactDiff.present.map((p) => p.id),
+    ...createdContactIds,
+  ];
+  const alertContactsParam = allContactIds.map((id) => `${id}_0_0`).join('-');
+  log('');
+
+  // Monitors next.
+  const monitorsResp = await client.getMonitors();
+  const monitorDiff = planMonitorDiff(monitorsResp.monitors || [], LYRA_MONITORS);
+
+  log(`Monitors: ${monitorDiff.unchanged.length} unchanged, ${monitorDiff.toUpdate.length} need update, ${monitorDiff.toCreate.length} to create`);
+  for (const u of monitorDiff.unchanged) {
+    log(`  ✅ ${u.friendlyName} (id ${u.id})`);
+  }
+  for (const u of monitorDiff.toUpdate) {
+    log(`  ⚠️  ${u.friendlyName} (id ${u.id}) URL drift: have=${u.currentUrl} want=${u.desiredUrl} — review manually`);
+  }
+  for (const c of monitorDiff.toCreate) {
+    log(`  ➕ would create: ${c.friendlyName} → ${c.url}`);
+  }
+
+  if (APPLY) {
+    for (const c of monitorDiff.toCreate) {
+      const res = await client.newMonitor({
+        friendlyName: c.friendlyName,
+        url: c.url,
+        alertContacts: alertContactsParam,
+      });
+      const id = res.monitor?.id;
+      log(`  + created monitor ${c.friendlyName} (id ${id})`);
+    }
+  }
+
+  log('');
+  log(APPLY ? '✅ Done.' : 'ℹ️  Dry-run complete. Re-run with --apply to commit changes.');
+}
+
+main().catch((err) => {
+  log(`::error::Bootstrap failed: ${err.message}`);
+  process.exit(1);
+});

--- a/scripts/uptimerobot/lib.d.ts
+++ b/scripts/uptimerobot/lib.d.ts
@@ -1,0 +1,141 @@
+/**
+ * KAN-163: TypeScript declarations for the UptimeRobot bootstrap library.
+ *
+ * The runtime is plain JavaScript (CommonJS) so `node scripts/uptimerobot/
+ * bootstrap.js` works without compilation. These declarations exist purely
+ * so jest + ESLint can typecheck the test file. Keep in sync with lib.js.
+ */
+
+export const API_BASE: string;
+
+export const MONITOR_TYPE: {
+  readonly HTTP: 1;
+  readonly KEYWORD: 2;
+  readonly PING: 3;
+  readonly PORT: 4;
+  readonly HEARTBEAT: 5;
+};
+
+export const ALERT_CONTACT_TYPE: {
+  readonly SMS: 1;
+  readonly EMAIL: 2;
+  readonly TWITTER: 3;
+  readonly WEBHOOK: 5;
+  readonly PUSHBULLET: 6;
+  readonly ZAPIER: 7;
+  readonly PUSHOVER: 9;
+  readonly HTTP_NOTIFICATION: 10;
+  readonly VOICE_CALL: 11;
+  readonly SLACK: 11;
+};
+
+export const FIVE_MINUTES: 300;
+
+export interface MonitorSpec {
+  readonly friendlyName: string;
+  readonly url: string;
+}
+export const LYRA_MONITORS: readonly MonitorSpec[];
+
+export function makeFormBody(obj: Record<string, unknown>): string;
+
+export interface MockResponse {
+  ok: boolean;
+  status: number;
+  statusText: string;
+  json: () => Promise<unknown>;
+}
+
+export type HttpClient = (
+  url: string,
+  init: { method: string; headers: Record<string, string>; body: string }
+) => Promise<MockResponse>;
+
+export interface MakeClientArgs {
+  apiKey?: string;
+  httpClient?: HttpClient;
+}
+
+export interface UptimeRobotClient {
+  getAccountDetails(): Promise<{
+    stat: 'ok';
+    account: {
+      email?: string;
+      monitor_limit?: number;
+      up_monitors?: number;
+      down_monitors?: number;
+      paused_monitors?: number;
+    };
+  }>;
+  getAlertContacts(): Promise<{
+    stat: 'ok';
+    alert_contacts?: Array<{ id: number; type: number; value: string; status: number }>;
+  }>;
+  newAlertContact(input: {
+    friendlyName: string;
+    type: number;
+    value: string;
+  }): Promise<{ stat: 'ok'; alertcontact?: { id: number } }>;
+  getMonitors(search?: string): Promise<{
+    stat: 'ok';
+    monitors?: Array<{ id: number; friendly_name: string; url: string; status?: number }>;
+  }>;
+  newMonitor(input: {
+    friendlyName: string;
+    url: string;
+    alertContacts: string;
+    type?: number;
+    interval?: number;
+    sslExpirationReminder?: number;
+    timeout?: number;
+    httpMethodType?: number;
+  }): Promise<{ stat: 'ok'; monitor?: { id: number } }>;
+  editMonitor(input: {
+    id: number;
+    alertContacts?: string;
+    interval?: number;
+    sslExpirationReminder?: number;
+  }): Promise<{ stat: 'ok' }>;
+}
+
+export function makeClient(args: MakeClientArgs): UptimeRobotClient;
+
+export interface ExistingMonitor {
+  id: number;
+  friendly_name: string;
+  url: string;
+}
+
+export interface MonitorDiff {
+  toCreate: MonitorSpec[];
+  toUpdate: Array<{
+    id: number;
+    friendlyName: string;
+    currentUrl: string;
+    desiredUrl: string;
+    reason: 'url-mismatch';
+  }>;
+  unchanged: Array<{ id: number; friendlyName: string }>;
+}
+
+export function planMonitorDiff(
+  existing: ExistingMonitor[] | null | undefined,
+  desired: readonly MonitorSpec[]
+): MonitorDiff;
+
+export interface ExistingContact {
+  id: number;
+  type: number;
+  value: string;
+  status: number;
+}
+
+export interface ContactDiff {
+  toCreate: Array<{ value: string }>;
+  present: Array<{ id: number; value: string; status: number }>;
+}
+
+export function planContactDiff(
+  existing: ExistingContact[] | null | undefined,
+  desiredEmails: string[]
+): ContactDiff;

--- a/scripts/uptimerobot/lib.js
+++ b/scripts/uptimerobot/lib.js
@@ -1,0 +1,211 @@
+/**
+ * KAN-163: UptimeRobot API v2 client.
+ *
+ * Pure functions for the API surface we actually use. Designed to be
+ * trivially mockable: the only side-effect is `httpClient(url, init)`, which
+ * defaults to global `fetch` but can be injected for tests.
+ *
+ * UptimeRobot API reference: https://uptimerobot.com/api/
+ * - All requests are POST with form-urlencoded body.
+ * - `api_key` and `format=json` are required on every call.
+ * - Free tier supports 50 monitors at a 5-minute minimum interval (300s).
+ */
+
+'use strict';
+
+const API_BASE = 'https://api.uptimerobot.com/v2';
+
+const MONITOR_TYPE = {
+  HTTP: 1,
+  KEYWORD: 2,
+  PING: 3,
+  PORT: 4,
+  HEARTBEAT: 5,
+};
+
+const ALERT_CONTACT_TYPE = {
+  SMS: 1,
+  EMAIL: 2,
+  TWITTER: 3,
+  WEBHOOK: 5,
+  PUSHBULLET: 6,
+  ZAPIER: 7,
+  PUSHOVER: 9,
+  HTTP_NOTIFICATION: 10,
+  VOICE_CALL: 11,
+  SLACK: 11,
+};
+
+const FIVE_MINUTES = 300;
+
+function makeFormBody(obj) {
+  const params = new URLSearchParams();
+  for (const [k, v] of Object.entries(obj)) {
+    if (v === undefined || v === null) continue;
+    params.append(k, String(v));
+  }
+  return params.toString();
+}
+
+function makeClient({ apiKey, httpClient = (typeof fetch === 'function' ? fetch : null) } = {}) {
+  if (!apiKey) {
+    throw new Error('UPTIMEROBOT_API_KEY is required (set it in env or pass apiKey).');
+  }
+  if (!httpClient) {
+    throw new Error('No fetch available — pass httpClient or run on Node 18+.');
+  }
+
+  async function call(path, body = {}) {
+    const fullBody = makeFormBody({ api_key: apiKey, format: 'json', ...body });
+    const res = await httpClient(`${API_BASE}/${path}`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/x-www-form-urlencoded',
+        'Cache-Control': 'no-cache',
+      },
+      body: fullBody,
+    });
+    if (!res.ok) {
+      throw new Error(`UptimeRobot ${path}: HTTP ${res.status} ${res.statusText}`);
+    }
+    const json = await res.json();
+    if (json.stat !== 'ok') {
+      const errMsg = json.error?.message || json.error?.type || JSON.stringify(json.error);
+      throw new Error(`UptimeRobot ${path} returned non-ok: ${errMsg}`);
+    }
+    return json;
+  }
+
+  return {
+    getAccountDetails: () => call('getAccountDetails'),
+    getAlertContacts: () => call('getAlertContacts'),
+    newAlertContact: ({ friendlyName, type, value }) =>
+      call('newAlertContact', {
+        friendly_name: friendlyName,
+        type,
+        value,
+      }),
+    getMonitors: (search) =>
+      call('getMonitors', search ? { search } : {}),
+    newMonitor: ({
+      friendlyName,
+      url,
+      type = MONITOR_TYPE.HTTP,
+      interval = FIVE_MINUTES,
+      alertContacts,
+      sslExpirationReminder = 1,
+      timeout = 30,
+      httpMethodType = 1,
+    }) =>
+      call('newMonitor', {
+        friendly_name: friendlyName,
+        url,
+        type,
+        interval,
+        alert_contacts: alertContacts,
+        ssl_expiration_reminder: sslExpirationReminder,
+        timeout,
+        http_method_type: httpMethodType,
+      }),
+    editMonitor: ({ id, alertContacts, interval, sslExpirationReminder = 1 }) =>
+      call('editMonitor', {
+        id,
+        alert_contacts: alertContacts,
+        interval,
+        ssl_expiration_reminder: sslExpirationReminder,
+      }),
+  };
+}
+
+/**
+ * Canonical Lyra monitor list. Single source of truth — used by both the
+ * bootstrap script and any cross-check that compares UptimeRobot's view of
+ * the world against weekly-report Section 1.
+ *
+ * Each entry: a `friendlyName` we use as the idempotency key (search by
+ * exact match before creating) and the URL the monitor should poll.
+ */
+const LYRA_MONITORS = Object.freeze([
+  { friendlyName: 'Lyra prod — checklyra.com',         url: 'https://checklyra.com/' },
+  { friendlyName: 'Lyra prod — privacy',               url: 'https://checklyra.com/privacy' },
+  { friendlyName: 'Lyra beta — beta.checklyra.com',    url: 'https://beta.checklyra.com/' },
+  { friendlyName: 'Lyra stage — stage.checklyra.com',  url: 'https://stage.checklyra.com/' },
+  { friendlyName: 'Lyra dev — dev.checklyra.com',      url: 'https://dev.checklyra.com/' },
+  { friendlyName: 'Lyra MCP prod — mcp.checklyra.com', url: 'https://mcp.checklyra.com/health' },
+  { friendlyName: 'Lyra MCP dev — mcp-dev.checklyra.com', url: 'https://mcp-dev.checklyra.com/health' },
+]);
+
+/**
+ * Compute the diff between desired monitors and what UptimeRobot already
+ * has. Pure function — given the existing monitor list and the desired
+ * list, returns the actions to take. Tested without any HTTP.
+ *
+ * Match key: `friendly_name` (exact). UptimeRobot allows any URL change
+ * later via editMonitor, but renaming is a manual concern.
+ */
+function planMonitorDiff(existing, desired) {
+  const existingByName = new Map();
+  for (const m of existing || []) {
+    existingByName.set(m.friendly_name, m);
+  }
+  const toCreate = [];
+  const toUpdate = [];
+  const unchanged = [];
+  for (const want of desired) {
+    const have = existingByName.get(want.friendlyName);
+    if (!have) {
+      toCreate.push(want);
+      continue;
+    }
+    // We don't reconcile the URL automatically — surface a manual flag
+    // instead, because URL change usually means a real config decision.
+    if (have.url !== want.url) {
+      toUpdate.push({
+        id: have.id,
+        friendlyName: want.friendlyName,
+        currentUrl: have.url,
+        desiredUrl: want.url,
+        reason: 'url-mismatch',
+      });
+    } else {
+      unchanged.push({ id: have.id, friendlyName: want.friendlyName });
+    }
+  }
+  return { toCreate, toUpdate, unchanged };
+}
+
+/**
+ * Compute the diff between desired alert contacts and existing. Same shape
+ * as planMonitorDiff. Match key: email value (case-insensitive).
+ */
+function planContactDiff(existing, desiredEmails) {
+  const existingByValue = new Map();
+  for (const c of existing || []) {
+    if (c.type === ALERT_CONTACT_TYPE.EMAIL) {
+      existingByValue.set(String(c.value).toLowerCase(), c);
+    }
+  }
+  const toCreate = [];
+  const present = [];
+  for (const email of desiredEmails) {
+    const have = existingByValue.get(email.toLowerCase());
+    if (have) {
+      present.push({ id: have.id, value: have.value, status: have.status });
+    } else {
+      toCreate.push({ value: email });
+    }
+  }
+  return { toCreate, present };
+}
+
+module.exports = {
+  API_BASE,
+  MONITOR_TYPE,
+  ALERT_CONTACT_TYPE,
+  FIVE_MINUTES,
+  LYRA_MONITORS,
+  makeClient,
+  makeFormBody,
+  planMonitorDiff,
+  planContactDiff,
+};

--- a/tests/scripts/uptimerobot.test.ts
+++ b/tests/scripts/uptimerobot.test.ts
@@ -1,0 +1,187 @@
+/**
+ * KAN-163 unit tests for the UptimeRobot bootstrap library. Pure-function
+ * tests for the diff planners + a fetch-mock smoke test for the client.
+ */
+
+import {
+  ALERT_CONTACT_TYPE,
+  FIVE_MINUTES,
+  LYRA_MONITORS,
+  makeClient,
+  makeFormBody,
+  planContactDiff,
+  planMonitorDiff,
+  type HttpClient,
+  type MockResponse,
+} from '../../scripts/uptimerobot/lib';
+
+describe('makeFormBody', () => {
+  test('encodes simple key/values', () => {
+    expect(makeFormBody({ a: 1, b: 'hello' })).toBe('a=1&b=hello');
+  });
+
+  test('skips null and undefined', () => {
+    expect(makeFormBody({ a: 1, b: null, c: undefined, d: 0 })).toBe('a=1&d=0');
+  });
+
+  test('url-encodes special characters', () => {
+    expect(makeFormBody({ url: 'https://example.com/?q=1&r=2' }))
+      .toBe('url=https%3A%2F%2Fexample.com%2F%3Fq%3D1%26r%3D2');
+  });
+});
+
+describe('LYRA_MONITORS canonical list', () => {
+  test('contains exactly 7 monitors covering all environments + MCP', () => {
+    expect(LYRA_MONITORS.length).toBe(7);
+  });
+
+  test('every monitor has a friendlyName and an https url', () => {
+    for (const m of LYRA_MONITORS) {
+      expect(m.friendlyName).toMatch(/^Lyra /);
+      expect(m.url).toMatch(/^https:\/\//);
+    }
+  });
+
+  test('covers prod, beta, stage, dev, prod-mcp, dev-mcp', () => {
+    const urls = LYRA_MONITORS.map((m) => m.url).join('|');
+    expect(urls).toMatch(/checklyra\.com\//);
+    expect(urls).toMatch(/beta\.checklyra\.com/);
+    expect(urls).toMatch(/stage\.checklyra\.com/);
+    expect(urls).toMatch(/dev\.checklyra\.com/);
+    expect(urls).toMatch(/mcp\.checklyra\.com\/health/);
+    expect(urls).toMatch(/mcp-dev\.checklyra\.com\/health/);
+  });
+
+  test('canonical list is frozen — runtime mutation rejected', () => {
+    expect(() => {
+      // Cast away readonly to attempt a real mutation; Object.freeze should reject.
+      (LYRA_MONITORS as unknown as Array<{ friendlyName: string; url: string }>).push({
+        friendlyName: 'rogue',
+        url: 'https://x',
+      });
+    }).toThrow();
+  });
+});
+
+describe('planMonitorDiff', () => {
+  test('marks all monitors for create when account is empty', () => {
+    const out = planMonitorDiff([], LYRA_MONITORS);
+    expect(out.toCreate.length).toBe(LYRA_MONITORS.length);
+    expect(out.unchanged.length).toBe(0);
+    expect(out.toUpdate.length).toBe(0);
+  });
+
+  test('matches by friendly_name and reports unchanged when url already correct', () => {
+    const existing = LYRA_MONITORS.map((m, i) => ({
+      id: 1000 + i,
+      friendly_name: m.friendlyName,
+      url: m.url,
+    }));
+    const out = planMonitorDiff(existing, LYRA_MONITORS);
+    expect(out.toCreate).toEqual([]);
+    expect(out.toUpdate).toEqual([]);
+    expect(out.unchanged.length).toBe(LYRA_MONITORS.length);
+  });
+
+  test('flags url drift via toUpdate (manual review) instead of silent overwrite', () => {
+    const drifted = [
+      {
+        id: 42,
+        friendly_name: 'Lyra prod — checklyra.com',
+        url: 'https://wrong.example.com/',
+      },
+    ];
+    const out = planMonitorDiff(drifted, LYRA_MONITORS);
+    expect(out.toUpdate).toHaveLength(1);
+    expect(out.toUpdate[0]).toMatchObject({
+      id: 42,
+      friendlyName: 'Lyra prod — checklyra.com',
+      currentUrl: 'https://wrong.example.com/',
+      desiredUrl: 'https://checklyra.com/',
+      reason: 'url-mismatch',
+    });
+  });
+});
+
+describe('planContactDiff', () => {
+  test('case-insensitive match on email value', () => {
+    const out = planContactDiff(
+      [{ id: 5, type: ALERT_CONTACT_TYPE.EMAIL, value: 'Luisa@Santos-Stephens.COM', status: 2 }],
+      ['luisa@santos-stephens.com', 'ben@santos-stephens.com']
+    );
+    expect(out.present.map((p) => p.id)).toEqual([5]);
+    expect(out.toCreate.map((c) => c.value)).toEqual(['ben@santos-stephens.com']);
+  });
+
+  test('ignores non-email contact types', () => {
+    const out = planContactDiff(
+      [{ id: 7, type: ALERT_CONTACT_TYPE.WEBHOOK, value: 'luisa@santos-stephens.com', status: 2 }],
+      ['luisa@santos-stephens.com']
+    );
+    expect(out.present).toEqual([]);
+    expect(out.toCreate).toEqual([{ value: 'luisa@santos-stephens.com' }]);
+  });
+});
+
+describe('makeClient', () => {
+  function makeMockResponse(body: unknown, ok = true, status = 200): MockResponse {
+    return {
+      ok,
+      status,
+      statusText: ok ? 'OK' : 'Error',
+      json: async () => body,
+    };
+  }
+
+  test('throws when no api key', () => {
+    expect(() => makeClient({})).toThrow(/UPTIMEROBOT_API_KEY/);
+  });
+
+  test('sends api_key + format=json on every call and parses ok response', async () => {
+    const calls: Array<{ url: string; body: string }> = [];
+    const httpClient: HttpClient = async (url, init) => {
+      calls.push({ url, body: init.body });
+      return makeMockResponse({ stat: 'ok', account: { email: 'luisa@santos-stephens.com' } });
+    };
+    const client = makeClient({ apiKey: 'ur-test', httpClient });
+    const out = await client.getAccountDetails();
+    expect(out.account.email).toBe('luisa@santos-stephens.com');
+    expect(calls).toHaveLength(1);
+    expect(calls[0].url).toBe('https://api.uptimerobot.com/v2/getAccountDetails');
+    const params = new URLSearchParams(calls[0].body);
+    expect(params.get('api_key')).toBe('ur-test');
+    expect(params.get('format')).toBe('json');
+  });
+
+  test('throws on stat=fail (preserves the API error message)', async () => {
+    const httpClient: HttpClient = async () =>
+      makeMockResponse({ stat: 'fail', error: { type: 'invalid_parameter', message: 'api_key invalid' } });
+    const client = makeClient({ apiKey: 'ur-bad', httpClient });
+    await expect(client.getAccountDetails()).rejects.toThrow(/api_key invalid/);
+  });
+
+  test('throws on non-2xx HTTP', async () => {
+    const httpClient: HttpClient = async () => makeMockResponse({}, false, 503);
+    const client = makeClient({ apiKey: 'ur-test', httpClient });
+    await expect(client.getMonitors()).rejects.toThrow(/HTTP 503/);
+  });
+
+  test('newMonitor passes our defaults (5-min interval, ssl_expiration_reminder=1)', async () => {
+    let captured = '';
+    const httpClient: HttpClient = async (_url, init) => {
+      captured = init.body;
+      return makeMockResponse({ stat: 'ok', monitor: { id: 999 } });
+    };
+    const client = makeClient({ apiKey: 'ur-test', httpClient });
+    await client.newMonitor({
+      friendlyName: 'test',
+      url: 'https://example.com/',
+      alertContacts: '5_0_0',
+    });
+    const params = new URLSearchParams(captured);
+    expect(params.get('interval')).toBe(String(FIVE_MINUTES));
+    expect(params.get('ssl_expiration_reminder')).toBe('1');
+    expect(params.get('alert_contacts')).toBe('5_0_0');
+    expect(params.get('type')).toBe('1'); // HTTP
+  });
+});

--- a/tests/scripts/uptimerobot.test.ts
+++ b/tests/scripts/uptimerobot.test.ts
@@ -43,13 +43,17 @@ describe('LYRA_MONITORS canonical list', () => {
   });
 
   test('covers prod, beta, stage, dev, prod-mcp, dev-mcp', () => {
-    const urls = LYRA_MONITORS.map((m) => m.url).join('|');
-    expect(urls).toMatch(/checklyra\.com\//);
-    expect(urls).toMatch(/beta\.checklyra\.com/);
-    expect(urls).toMatch(/stage\.checklyra\.com/);
-    expect(urls).toMatch(/dev\.checklyra\.com/);
-    expect(urls).toMatch(/mcp\.checklyra\.com\/health/);
-    expect(urls).toMatch(/mcp-dev\.checklyra\.com\/health/);
+    // Substring `toContain` rather than unanchored regex matchers — CodeQL
+    // flags regex-on-URL patterns as high security-severity (the pattern
+    // could match attacker-controlled hosts if lifted into production input
+    // validation). toContain has no regex semantics so it can't be misused.
+    const urls = LYRA_MONITORS.map((m) => m.url);
+    expect(urls).toContain('https://checklyra.com/');
+    expect(urls).toContain('https://beta.checklyra.com/');
+    expect(urls).toContain('https://stage.checklyra.com/');
+    expect(urls).toContain('https://dev.checklyra.com/');
+    expect(urls).toContain('https://mcp.checklyra.com/health');
+    expect(urls).toContain('https://mcp-dev.checklyra.com/health');
   });
 
   test('canonical list is frozen — runtime mutation rejected', () => {


### PR DESCRIPTION
## Summary

- Adds an idempotent UptimeRobot bootstrap (`scripts/uptimerobot/bootstrap.js`) that creates the 7 Lyra monitors + 2 alert contacts in one run, and is a no-op on subsequent runs.
- Documents the human-side setup procedure in `docs/UPTIMEROBOT_SETUP.md` so the API key handover is unambiguous.
- 17 new unit tests (now 330 total / 27 suites in lyra) covering encoding, the canonical monitor list, both diff planners, and the API client.
- Adds a new "Incident Response" section to `docs/RUNBOOK.md` naming UptimeRobot as the primary signal and updates emergency contacts.
- Adds the monitoring section to `docs/lyra-project-reference.jsx` with the dashboard placeholder.

The bootstrap is **dry-run by default**; `--apply` writes. It refuses to run without `UPTIMEROBOT_API_KEY` and `ALERT_EMAILS` set in env. Running with `--apply` against an already-configured account is a safe no-op.

This PR ships only the prep work. Account signup + API key generation are human-side steps documented in `docs/UPTIMEROBOT_SETUP.md`. Once the key is provided, `npm run uptimerobot:bootstrap -- --apply` creates everything.

## Test plan

- [x] `npm run test:unit` — 330/330 passing, 27/27 suites
- [x] `npm run test:scripts` — 17/17 passing
- [x] `npx eslint scripts/uptimerobot/ tests/scripts/uptimerobot.test.ts` — clean
- [x] `npx tsc --noEmit` — clean
- [ ] Manual: bootstrap dry-run against real API key (waits on user's UptimeRobot signup)
- [ ] Manual: bootstrap --apply, verify 7 monitors + 2 contacts created, first scrape green
- [ ] Manual: induced 503 on dev triggers an email alert within 10 minutes (KAN-163 acceptance criterion)

🤖 Generated with [Claude Code](https://claude.com/claude-code)