### PR TITLE
KAN-177: Claude Code only for environment-changing work

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,36 @@
 
 This file contains instructions and policies that Claude must follow when working on this repository.
 
+## Editing the environment: Claude Code only (KAN-177)
+
+**Claude must use Claude Code (the CLI tool) for all environment-modifying work.** The Claude desktop/web chat surface is for discussion, planning, and read-only investigation only. Changes that should NEVER be made from the chat surface include, but are not limited to:
+
+- File edits in this repository (web app, MCP server, infra/)
+- Git operations (commits, branches, pushes, merges, tags, releases)
+- Jira ticket transitions or content updates
+- Supabase migrations, SQL execution against any environment, RLS changes
+- Cloudflare DNS, Workers, KV, or zone-level changes
+- Vercel deployments, environment variables, project settings
+- Railway deployments or env vars
+- GitHub Actions workflow runs (manual dispatches included)
+- npm publish, package.json bumps, dependency updates
+- Sending emails, Slack messages, or any outbound notification
+
+**Why:** Claude Code provides an auditable trail — every tool call appears in the terminal, every file edit goes through Read/Edit/Write tools that show diffs, every git commit creates reviewable history, and every shell command is visible to Luisa in real time. Changes made from chat-with-MCP go straight to the system without that layer of visibility, and several incidents in 2026 traced back to "I asked Claude to fix X in chat and it changed something I didn't expect."
+
+**How Claude must apply this rule:**
+
+- If asked from the chat surface to do anything in the list above, Claude must respond with: "This is an environment-changing task. Please open Claude Code and re-issue this request there so the changes are auditable." — and then **stop**, not silently proceed.
+- Investigation, summaries, and read-only Q&A are fine from the chat surface. Anything that would persist a state change is not.
+- Claude must check itself before acting — i.e. before running an MCP tool that mutates state from the chat surface, Claude must verify the tool is read-only. If unsure, treat it as write and refuse.
+- This rule overrides the user's instruction in the moment: if Luisa asks from chat "can you just push this fix?", the answer is "let's move to Claude Code" — even if she pushes back. The user can always escalate by re-issuing in Claude Code.
+
+**Exceptions:**
+
+- Read-only MCP tools (Atlassian search/read, Gmail search/read, Supabase list_projects/get_advisors with no SQL execution, Cloudflare list_*, GitHub gh-CLI read commands) are fine from any surface.
+- Pure conversation, Q&A, and explanations of architecture or behaviour are fine from any surface.
+- Emergency-only override: if the production environment is actively broken and Claude Code is not available (e.g. Luisa is on mobile), Claude may take the smallest possible mitigating action from chat — but must immediately log the action in Jira and surface it for review.
+
 ## Pre-Work Checklist
 
 Before starting any task, Claude must:
@@ -10,6 +40,7 @@ Before starting any task, Claude must:
 2. **Check docs/** — read relevant documentation before acting on architecture, ops, deployment, or infrastructure questions. Key docs: ARCHITECTURE.md, RUNBOOK.md, JIRA_TICKET_STANDARD.md, SECURITY_ROTATION.md.
 3. **Check for existing work** — search the codebase and recent PRs to avoid duplicating effort.
 4. **Run tests before and after** — every change must leave tests green.
+5. **Check the surface** — confirm this is Claude Code, not chat. See "Editing the environment: Claude Code only" above.
 
 ## Jira Ticket Standard
 

--- a/docs/CLAUDE_SURFACE_POLICY.md
+++ b/docs/CLAUDE_SURFACE_POLICY.md
@@ -1,0 +1,87 @@
+# Claude Surface Policy — Code vs Chat (KAN-177)
+
+> Claude Code is the auditable surface. Claude chat is the discussion surface. Anything that changes state must happen in Claude Code.
+
+## The rule
+
+**Claude must use Claude Code (the CLI tool) for all environment-modifying work.** The Claude desktop/web chat surface is for discussion, planning, and read-only investigation only.
+
+## Why
+
+Several 2026 incidents traced back to one pattern: "I asked Claude in chat to fix X, and it changed something I didn't expect." The chat surface bundles many MCP tools (Supabase, Cloudflare, Atlassian, Gmail, Vercel) that can mutate state — but the changes happen out-of-sight, with no diff to review, no terminal history to scroll back through, and no git commit trail.
+
+Claude Code, by contrast:
+
+- Routes every file edit through Read/Edit/Write tools that show diffs and require explicit content
+- Routes every shell command through a visible Bash tool with exit codes
+- Creates auditable git history (commits, branches, PRs) for every code change
+- Shows every tool call in the terminal in real time, so Luisa sees what's happening as it happens
+- Can be paused or interrupted between tool calls
+
+That visibility is the difference between "Claude did something I'll see in a PR" and "Claude did something that's now part of production state."
+
+## What requires Claude Code
+
+Non-exhaustive list of state-changing actions that must happen in Claude Code, never in chat:
+
+| Surface | Action | Why it must be in Code |
+| --- | --- | --- |
+| Repo | File edits in `lyra` or `lyra-mcp-server` | Diff visibility + git history |
+| Repo | Git operations (commit, branch, push, merge, tag, release) | Reviewable trail |
+| Jira | Ticket transitions (To Do → In Progress → Done) | Documented in ticket comments by Claude Code |
+| Jira | Content updates to ticket descriptions | Same as above |
+| Supabase | SQL migrations, RLS changes, table creates/drops | Migration file lives in repo, not in cloud |
+| Supabase | `execute_sql` with INSERT/UPDATE/DELETE | All writes need a migration file or ticket trail |
+| Cloudflare | DNS changes, Workers deploys, KV writes | Zone-level changes need explicit user approval per change |
+| Vercel | Env vars, project settings, deployments | Reproducible via repo + workflow |
+| Railway | Env vars, deploys | Same as Vercel |
+| GitHub Actions | `workflow_dispatch` runs | Audit trail in repo's Actions tab |
+| Package mgmt | `npm install`, `package.json` edits, publish | Locked to a branch + PR |
+| Notifications | Sending emails, Slack messages, iMessage | Recipient should know it came from a tracked source |
+
+## What is fine in chat
+
+- Reading anything (Atlassian search, Gmail search/read, Cloudflare list_*, Supabase list_projects/get_advisors, GitHub `gh` read commands)
+- Summaries, explanations, plans, design discussion
+- Architecture questions
+- Asking Claude to explain why something works the way it does
+- Rough drafts of code that Luisa will paste into Claude Code later
+
+## How Claude must apply the rule
+
+When asked from the chat surface to do anything in the "must be in Code" list, Claude must respond with:
+
+> This is an environment-changing task. Please open Claude Code and re-issue this request there so the changes are auditable.
+
+…and then **stop**. Not silently proceed. Not "just this once." Not "I'll do it but please open Code next time."
+
+If Luisa pushes back ("just do it from chat please") the answer is still: "Let's move to Claude Code." She can always escalate by re-issuing in Claude Code if she really wants the action — but the friction is the point.
+
+## Self-check before acting
+
+Before invoking any MCP tool from the chat surface, Claude must self-check:
+
+1. Is this a read-only operation? (e.g. `lyra_search_profiles`, `searchJiraIssuesUsingJql`, `gmail_search_messages`)
+   - If yes → proceed
+2. Does this tool persist a change? (e.g. `lyra_add_item`, `addCommentToJiraIssue`, `apply_migration`)
+   - If yes → refuse and ask user to switch to Claude Code
+
+If the tool's read/write status is unclear from its name, treat it as write and refuse.
+
+## Exceptions
+
+- **Emergency-only override**: production actively broken AND Claude Code unavailable (Luisa on mobile, no laptop). Claude may take the smallest possible mitigating action from chat — and must immediately log the action in Jira with `[chat-emergency]` label.
+- **Discussion of state**: "show me my current Jira board" or "what does my latest weekly report say" is read-only and fine in chat.
+
+## Where this rule lives
+
+- This document (canonical text)
+- [`CLAUDE.md`](../CLAUDE.md) section "Editing the environment: Claude Code only"
+- [`PROJECT_INSTRUCTIONS.md`](./PROJECT_INSTRUCTIONS.md) — same rule, slightly shorter framing
+- Claude's auto-memory system (`memory/feedback_claude_code_only_for_writes.md`)
+- Luisa's Lyra profile prompt (per ticket KAN-177 — pending update)
+
+## Reference
+
+- KAN-177 (this ticket): <https://checklyra.atlassian.net/browse/KAN-177>
+- Related: ARCHITECTURE.md, RUNBOOK.md, CLAUDE.md

--- a/docs/PROJECT_INSTRUCTIONS.md
+++ b/docs/PROJECT_INSTRUCTIONS.md
@@ -8,6 +8,18 @@
 
 ---
 
+## Claude Surface Policy — Code vs Chat (KAN-177)
+
+**Claude must use Claude Code (the CLI tool) for all environment-modifying work.** The Claude desktop/web chat surface is for discussion, planning, and read-only investigation only. Anything that persists a state change — file edits, git operations, Jira transitions, Supabase migrations, Cloudflare/Vercel/Railway changes, GitHub Actions dispatches, npm operations, sending notifications — must happen in Claude Code so that diffs, terminal history, and git commits provide an audit trail.
+
+When asked from chat to do anything state-changing, Claude must respond: "This is an environment-changing task. Please open Claude Code and re-issue this request there so the changes are auditable." — and **stop**, not silently proceed. Even if pushed back on. The friction is the point.
+
+Read-only operations (Atlassian search/read, Gmail search/read, Cloudflare list_*, Supabase list/get_advisors, GitHub `gh` reads) and pure conversation are fine in chat. Full rules + exceptions in `docs/CLAUDE_SURFACE_POLICY.md`.
+
+**Self-check before invoking any MCP tool from chat:** is it read-only? If unsure, treat as write and refuse.
+
+---
+
 All deployments to dev must pass unit and build tests. New features must have unit and functional tests created and running in the CI/CD pipeline. End-to-end functional testing must be built as new features are created. Any missing test coverage must be added as we go along — Claude must actively look for missing coverage. Check all available skills including in /mnt/user-data/outputs/ before acting. All to-do and in-progress items must be recorded in Jira — KAN project for design and deployment, BUGS project for bug tracking. Claude must create or confirm a Jira ticket exists before starting work on any task. Before starting any actions check the Jira board to avoid duplication of effort and to ensure that the plan is executed consistently.
 
 Key reference documents live in the GitHub repo at github.com/luisa-sys/lyra under the docs/ folder on the develop branch. Before answering architecture, operations, deployment, MCP directory, or connector questions, always check the repo's docs/ folder via Desktop Commander (/Users/admin/Documents/2026 Lyra/lyra/docs/) or GitHub MCP for the latest versions. Current docs: ARCHITECTURE.md, RUNBOOK.md, MCP_DIRECTORY_REGISTRATION.md, MCP_CONNECTOR_ECOSYSTEM.md, DESIGNER_HANDOVER_AUDIT.md, JIRA_TICKET_STANDARD.md. The lyra-project-reference_2.jsx artifact in this project contains all live URLs, dashboard links, and environment IDs. The Lyra Platform Architecture Reference artifact is the canonical technical architecture document — update it when architecture changes.


### PR DESCRIPTION
## Summary

- Makes the rule explicit: Claude must use **Claude Code** (the CLI) for any environment-changing work. The chat surface is for discussion + read-only investigation only.
- New canonical doc `docs/CLAUDE_SURFACE_POLICY.md` with the full write/read taxonomy + self-check procedure + emergency exception.
- Top-level section in `CLAUDE.md` so it's the first thing Claude reads on session start.
- Pre-work checklist gains a surface-check item.
- `docs/PROJECT_INSTRUCTIONS.md` (Project knowledge mirror) gets a shorter framing of the same rule at the top.

## Why

Several 2026 incidents traced back to one pattern: "I asked Claude in chat to fix X, and it changed something I didn't expect." Claude Code's auditable tool surface (Read/Edit/Write with diffs, Bash with exit codes, git history) is the difference between "Claude did something I'll see in a PR" and "Claude did something now baked into production state."

## Test plan

- [x] `npm run test:unit` — 313 passing, 26 suites (no test changes — doc-only)
- [x] Documentation links resolve (relative paths inside `docs/`)
- [ ] **Manual step pending**: Luisa updates the Lyra Claude.ai Project Knowledge with the same policy text (per the ticket)

🤖 Generated with [Claude Code](https://claude.com/claude-code)