### PR TITLE
KAN-170: automated secret rotation reminders + checker

### DIFF
--- a/.github/workflows/secret-rotation-reminder.yml
+++ b/.github/workflows/secret-rotation-reminder.yml
@@ -1,0 +1,82 @@
+name: Secret Rotation Reminder
+on:
+  schedule:
+    # Monthly on the 1st at 07:00 UTC (Mondays are weekly report; rotation
+    # reminders ride a separate cadence so they don't bury other signals).
+    - cron: "0 7 1 * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  check-rotations:
+    name: Check secret rotation due dates
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          fetch-depth: 1
+      - name: Run rotation checker (--warn-days 30)
+        id: check
+        run: |
+          set -euo pipefail
+          # Always run; capture exit code separately so we can decide
+          # email vs. silent. set +e is scoped to this command only.
+          set +e
+          python3 scripts/check-secret-rotation.py --warn-days 30 > "$RUNNER_TEMP/rotation.txt" 2>&1
+          EXIT=$?
+          set -e
+          cat "$RUNNER_TEMP/rotation.txt"
+          {
+            echo "## Secret rotation status"
+            echo ""
+            echo '```'
+            cat "$RUNNER_TEMP/rotation.txt"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+          # Stash for the email step, even on failure.
+          {
+            echo "exit_code=$EXIT"
+            echo "report_b64=$(base64 < "$RUNNER_TEMP/rotation.txt" | tr -d '\n')"
+          } >> "$GITHUB_OUTPUT"
+      - name: Email Luisa if any in-window or overdue (exit != 0)
+        if: ${{ steps.check.outputs.exit_code != '0' }}
+        env:
+          RESEND_API_KEY: ${{ secrets.RESEND_API_KEY }}
+          REPORT_B64: ${{ steps.check.outputs.report_b64 }}
+        run: |
+          set -euo pipefail
+          if [ -z "$RESEND_API_KEY" ]; then
+            echo "::error::RESEND_API_KEY missing — cannot send rotation reminder. Add it to repo secrets."
+            exit 1
+          fi
+          REPORT=$(echo "$REPORT_B64" | base64 -d)
+          # Resend's API rejects raw newlines in JSON; render the report
+          # as <pre> so Resend's HTML pipeline preserves it.
+          BODY_HTML=$(printf '<p>One or more Lyra infrastructure secrets are due for rotation within 30 days, or already overdue. Source: <code>docs/SECURITY_ROTATION.md</code>.</p><pre style="background:#f6f8fa;padding:12px;border-radius:6px;font-size:13px;font-family:Menlo,Consolas,monospace;white-space:pre-wrap;">%s</pre><p>Rotate via the procedure in <a href="https://github.com/luisa-sys/lyra/blob/develop/docs/SECURITY_ROTATION.md">SECURITY_ROTATION.md</a>. After rotating, update the "Last Rotated" column in that doc and commit so the next reminder arrives on the new schedule.</p>' "$(echo "$REPORT" | python3 -c "import html,sys; print(html.escape(sys.stdin.read()))")")
+          PAYLOAD=$(python3 -c "
+          import json, sys
+          payload = {
+            'from': 'Lyra Reports <reports@checklyra.com>',
+            'to': ['luisa@santos-stephens.com'],
+            'subject': '[Lyra] Secret rotation due within 30 days',
+            'html': sys.argv[1],
+          }
+          print(json.dumps(payload))
+          " "$BODY_HTML")
+          RESPONSE=$(curl -sf -X POST 'https://api.resend.com/emails' \
+            -H "Authorization: Bearer $RESEND_API_KEY" \
+            -H 'Content-Type: application/json' \
+            -d "$PAYLOAD")
+          EMAIL_ID=$(echo "$RESPONSE" | python3 -c "import json,sys; print(json.load(sys.stdin).get('id','no-id'))")
+          echo "::notice::Sent rotation reminder email (Resend id $EMAIL_ID)"
+      - name: Fail workflow if rotations are due (so dashboard surfaces it)
+        if: ${{ steps.check.outputs.exit_code != '0' }}
+        run: |
+          echo "::error::Secret rotation due — see step summary or email."
+          exit 1

--- a/docs/SECURITY_ROTATION.md
+++ b/docs/SECURITY_ROTATION.md
@@ -101,6 +101,22 @@ If you suspect ANY secret has been compromised:
 | On any security incident | Everything in the affected service chain |
 | When an employee/contractor leaves | All secrets they had access to |
 
+## Automated Rotation Reminders (KAN-170)
+
+The workflow [`.github/workflows/secret-rotation-reminder.yml`](../.github/workflows/secret-rotation-reminder.yml) runs on the 1st of every month at 07:00 UTC. It parses the **Infrastructure Secrets** table above and emails `luisa@santos-stephens.com` (via Resend) if any secret's `Last Rotated + Rotation cadence` date is within 30 days of today, or already overdue.
+
+The parser is [`scripts/check-secret-rotation.py`](../scripts/check-secret-rotation.py). Manual run:
+
+```bash
+python3 scripts/check-secret-rotation.py            # exit 1 if anything in window or overdue
+python3 scripts/check-secret-rotation.py --warn-days 7
+python3 scripts/check-secret-rotation.py --today 2027-04-01    # for testing
+```
+
+When you rotate a secret, **update the `Last Rotated` cell in the table above and commit** so the next reminder rides the new schedule. The parser reads dates in the format `28 April 2026` or `2026-04-28`.
+
+Rows with `Last Rotated: Initial setup` are flagged as advisory warnings (they have no anchor date so we can't compute next-due) but do NOT cause the reminder workflow to fail. Overdue and within-window rows DO cause failure and trigger the email.
+
 ## Lyra API Key Expiry (TODO)
 
 User-facing API keys (lyra_*) currently have no expiry. Future implementation:

--- a/scripts/check-secret-rotation.py
+++ b/scripts/check-secret-rotation.py
@@ -1,0 +1,187 @@
+#!/usr/bin/env python3
+"""KAN-170: scan docs/SECURITY_ROTATION.md for secrets due for rotation.
+
+Reads the "Infrastructure Secrets" Markdown table, computes the next-due
+date for each row from `Last Rotated` + `Rotation` cadence, and prints any
+rows whose next-due date is within --warn-days of today (default 30).
+
+Exits non-zero if any rows are within the warn window. The weekly report
+workflow consumes this exit code to decide whether to surface the warning
+in the Monday email.
+
+Strict by design: a secret without a parseable `Last Rotated` date is
+treated as a hard error. We'd rather fail loud than silently skip
+rotations like the silent-skip pattern KAN-167 was created to eliminate.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import re
+import sys
+from pathlib import Path
+from typing import List, NamedTuple, Optional
+
+DOC_PATH = Path(__file__).resolve().parent.parent / "docs" / "SECURITY_ROTATION.md"
+
+# Cadence string → days until next rotation.
+CADENCE_DAYS = {
+    "annual": 365,
+    "annual or on suspicion": 365,
+    "90 days": 90,
+    "60 days": 60,
+    "30 days": 30,
+    "quarterly": 90,
+}
+
+
+class SecretRow(NamedTuple):
+    name: str
+    rotation: str
+    last_rotated: str
+    location: str
+
+    def cadence_days(self) -> Optional[int]:
+        key = self.rotation.strip().lower()
+        return CADENCE_DAYS.get(key)
+
+    def last_rotated_date(self) -> Optional[dt.date]:
+        s = self.last_rotated.strip()
+        if not s or s.lower() == "initial setup":
+            return None
+        # Accept "29 April 2026" or "2026-04-29".
+        for fmt in ("%d %B %Y", "%Y-%m-%d", "%d %b %Y"):
+            try:
+                return dt.datetime.strptime(s, fmt).date()
+            except ValueError:
+                continue
+        return None
+
+    def next_due(self) -> Optional[dt.date]:
+        d = self.last_rotated_date()
+        days = self.cadence_days()
+        if d is None or days is None:
+            return None
+        return d + dt.timedelta(days=days)
+
+
+def parse_rotation_doc(path: Path) -> List[SecretRow]:
+    """
+    Parse the first Markdown table under '## Secrets Inventory' →
+    '### Infrastructure Secrets'. We deliberately do NOT parse the
+    user-facing table (different schema, user-controlled cadence).
+    """
+    text = path.read_text(encoding="utf-8")
+
+    # Find the Infrastructure Secrets section.
+    section_match = re.search(
+        r"###\s*Infrastructure Secrets[^\n]*\n(.*?)(?=\n###\s|\Z)",
+        text,
+        flags=re.DOTALL,
+    )
+    if not section_match:
+        raise SystemExit(
+            "::error::Could not find '### Infrastructure Secrets' section in SECURITY_ROTATION.md"
+        )
+    section = section_match.group(1)
+
+    # Find the markdown table — header line, separator line, then rows.
+    table_match = re.search(
+        r"\|\s*Secret\s*\|.*?\|\s*Last Rotated\s*\|\s*\n\|[-|\s]+\|\s*\n((?:\|.*?\|\s*\n)+)",
+        section,
+        flags=re.DOTALL,
+    )
+    if not table_match:
+        raise SystemExit(
+            "::error::Could not find Infrastructure Secrets table (expected | Secret | Location(s) | Rotation | How to Rotate | Last Rotated |)"
+        )
+
+    rows: List[SecretRow] = []
+    for line in table_match.group(1).strip().split("\n"):
+        cells = [c.strip() for c in line.strip().strip("|").split("|")]
+        if len(cells) < 5:
+            continue
+        rows.append(
+            SecretRow(
+                name=cells[0],
+                location=cells[1],
+                rotation=cells[2],
+                last_rotated=cells[4],
+            )
+        )
+    return rows
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--warn-days", type=int, default=30, help="Warn N days before due date.")
+    ap.add_argument("--doc", type=Path, default=DOC_PATH, help="Path to SECURITY_ROTATION.md")
+    ap.add_argument("--today", type=str, default=None, help="Override today's date (YYYY-MM-DD) for testing.")
+    args = ap.parse_args()
+
+    today = (
+        dt.date.fromisoformat(args.today) if args.today else dt.date.today()
+    )
+    rows = parse_rotation_doc(args.doc)
+
+    if not rows:
+        print("::error::Infrastructure Secrets table is empty")
+        return 1
+
+    warnings: List[str] = []
+    errors: List[str] = []
+    unrotated: List[str] = []
+
+    for row in rows:
+        # "Initial setup" means the secret has never been rotated since the
+        # project began. We can't compute next-due, but we should surface it
+        # so it doesn't sit forever. Distinct bucket from genuinely
+        # unparseable rows so a malformed table doesn't hide unrotated tokens.
+        if row.last_rotated.strip().lower() == "initial setup":
+            unrotated.append(
+                f"  ⚠️  {row.name}: Last Rotated='Initial setup' — never rotated. Add a real date to SECURITY_ROTATION.md."
+            )
+            continue
+        next_due = row.next_due()
+        if next_due is None:
+            errors.append(
+                f"  ❌ {row.name}: Last Rotated='{row.last_rotated}' or Rotation='{row.rotation}' is unparseable"
+            )
+            continue
+        days_until = (next_due - today).days
+        if days_until <= 0:
+            errors.append(
+                f"  🔴 {row.name}: rotation OVERDUE by {-days_until} days (was due {next_due.isoformat()})"
+            )
+        elif days_until <= args.warn_days:
+            warnings.append(
+                f"  ⚠️  {row.name}: rotation due {next_due.isoformat()} ({days_until} days)"
+            )
+
+    if errors:
+        print(f"❌ {len(errors)} secret(s) overdue or unparseable:")
+        for e in errors:
+            print(e)
+    if warnings:
+        print(f"⚠️  {len(warnings)} secret(s) due within {args.warn_days} days:")
+        for w in warnings:
+            print(w)
+    if unrotated:
+        print(f"⚠️  {len(unrotated)} secret(s) never rotated (still at 'Initial setup'):")
+        for u in unrotated:
+            print(u)
+    if not errors and not warnings and not unrotated:
+        print(f"✅ All {len(rows)} infrastructure secrets are >{args.warn_days} days from rotation.")
+        return 0
+
+    # Errors and "real" overdue → fail loud.
+    # Warnings (within window) → fail loud so the workflow surfaces them.
+    # 'Initial setup' rows alone → warning only, exit 0 (not a hard fail).
+    if errors or warnings:
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/unit/check-secret-rotation.test.ts
+++ b/tests/unit/check-secret-rotation.test.ts
@@ -1,0 +1,62 @@
+/**
+ * KAN-170: smoke tests for scripts/check-secret-rotation.py.
+ *
+ * The Python parser is the load-bearing piece. We invoke the script as
+ * a subprocess with synthetic --today values and assert the output
+ * categorises correctly: errors, warnings, "Initial setup" stragglers,
+ * and the all-clear path.
+ */
+
+import { execFileSync } from 'node:child_process';
+import { resolve } from 'node:path';
+
+const SCRIPT = resolve(__dirname, '../../scripts/check-secret-rotation.py');
+
+function run(args: string[]): { stdout: string; exitCode: number } {
+  try {
+    const stdout = execFileSync('python3', [SCRIPT, ...args], {
+      encoding: 'utf-8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    return { stdout, exitCode: 0 };
+  } catch (err) {
+    const e = err as { status?: number; stdout?: string };
+    return { stdout: e.stdout ?? '', exitCode: e.status ?? 1 };
+  }
+}
+
+describe('check-secret-rotation.py', () => {
+  test('with today set right after rotation: no errors, no in-window warnings, only Initial-setup advisories', () => {
+    const r = run(['--today', '2026-05-05', '--warn-days', '30']);
+    // Some "Initial setup" rows are present in the doc, so we assert their
+    // advisory line and that the script exits 0 (advisory only).
+    expect(r.stdout).toMatch(/never rotated/);
+    expect(r.stdout).not.toMatch(/rotation OVERDUE/);
+    expect(r.stdout).not.toMatch(/rotation due 20\d\d-/);
+    expect(r.exitCode).toBe(0);
+  });
+
+  test('within window of LYRA_RELEASE_PAT due date: warning + non-zero exit', () => {
+    // PATs were rotated 28-29 April 2026 with annual cadence → due 2027-04-28/29.
+    // 14 days before = 2027-04-15.
+    const r = run(['--today', '2027-04-15', '--warn-days', '30']);
+    expect(r.stdout).toMatch(/LYRA_RELEASE_PAT: rotation due 2027-04-29/);
+    expect(r.stdout).toMatch(/LYRA_BACKUP_PAT: rotation due 2027-04-28/);
+    expect(r.exitCode).toBe(1);
+  });
+
+  test('after due date: OVERDUE message + non-zero exit', () => {
+    const r = run(['--today', '2027-05-15', '--warn-days', '30']);
+    expect(r.stdout).toMatch(/LYRA_RELEASE_PAT: rotation OVERDUE by/);
+    expect(r.exitCode).toBe(1);
+  });
+
+  test('with --warn-days=0: no in-window warnings unless overdue', () => {
+    // The day OF rotation due is days_until=0 → marked overdue per script logic.
+    // The day BEFORE is days_until=1, which with --warn-days=0 is not in window.
+    const r = run(['--today', '2027-04-27', '--warn-days', '0']);
+    expect(r.stdout).not.toMatch(/rotation due/);
+    expect(r.stdout).not.toMatch(/OVERDUE/);
+    expect(r.exitCode).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary

- Adds a programmatic reminder for `LYRA_BACKUP_PAT` and every other secret in `docs/SECURITY_ROTATION.md` so we don't have to rely on a Google Calendar event in Luisa's account that's easy to lose.
- New monthly workflow `.github/workflows/secret-rotation-reminder.yml` runs on the 1st of each month at 07:00 UTC, parses the Infrastructure Secrets table, and emails Luisa via Resend if any secret is within 30 days of due or overdue. Workflow fails loud so the GitHub dashboard also surfaces it.
- New parser `scripts/check-secret-rotation.py` computes next-due dates from `Last Rotated` + `Rotation` cadence cells; supports `28 April 2026` and `2026-04-28` formats; flags `Last Rotated: Initial setup` rows as advisory only (they have no anchor date).
- 4 new unit tests via subprocess (`tests/unit/check-secret-rotation.test.ts`) — 317 total / 27 suites.
- Doc updated: SECURITY_ROTATION.md gains an "Automated Rotation Reminders" section.

## What this revealed

Six rows in the Infrastructure Secrets table currently show `Last Rotated: Initial setup` — Supabase keys (x2), Vercel deploy token, Google OAuth client secret, Railway API token, SUPABASE_DB_URL. These are all unrotated since project setup. The script flags them as advisory; suggest backfilling each row's date the next time you rotate, so future reminders ride the new schedule.

## Test plan

- [x] `npm run test:unit` — 317 passing, 27 suites
- [x] Manual: `python3 scripts/check-secret-rotation.py --today 2027-04-15` shows LYRA_RELEASE_PAT and LYRA_BACKUP_PAT in window
- [x] Manual: `python3 scripts/check-secret-rotation.py --today 2026-05-05` clean (only Initial-setup advisories)
- [x] YAML parses (`python3 -c "import yaml; yaml.safe_load(open(...))"`)
- [ ] Workflow run — will fire automatically on next 1st of month or via `gh workflow run secret-rotation-reminder.yml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)