### PR TITLE
KAN-173: hybrid release automation + drift policy

### DIFF
--- a/.github/workflows/auto-promote-to-staging.yml
+++ b/.github/workflows/auto-promote-to-staging.yml
@@ -1,0 +1,157 @@
+name: Auto-promote develop → staging (weekly)
+on:
+  schedule:
+    # Sunday 23:00 UTC. Lands in time for the Monday 07:00 UTC weekly
+    # report so the drift counter and last-auto-promote status are fresh.
+    - cron: "0 23 * * 0"
+  workflow_dispatch:
+    inputs:
+      force:
+        description: "Force-promote even if soak/CI checks would normally skip (for hotfixes only)"
+        required: false
+        default: "false"
+
+permissions:
+  contents: write
+  actions: read
+  pull-requests: write
+
+defaults:
+  run:
+    shell: bash
+
+env:
+  SOAK_HOURS: "24"
+
+jobs:
+  preconditions:
+    name: Check preconditions for auto-promote
+    runs-on: ubuntu-latest
+    outputs:
+      should_promote: ${{ steps.check.outputs.should_promote }}
+      skip_reason: ${{ steps.check.outputs.skip_reason }}
+      develop_sha: ${{ steps.check.outputs.develop_sha }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          fetch-depth: 0
+          ref: develop
+      - name: Evaluate preconditions
+        id: check
+        env:
+          GH_TOKEN: ${{ github.token }}
+          FORCE: ${{ inputs.force }}
+        run: |
+          set -euo pipefail
+          DEVELOP_SHA=$(git rev-parse HEAD)
+          DEVELOP_SHORT="${DEVELOP_SHA:0:8}"
+          echo "develop HEAD: $DEVELOP_SHA"
+          echo "develop_sha=$DEVELOP_SHA" >> "$GITHUB_OUTPUT"
+
+          # KAN-173 / KAN-167: every skip path emits a clear ::warning:: with
+          # a reason, and writes the reason into the workflow output so the
+          # weekly report can surface it. Skip is NOT the same as failure —
+          # we still exit 0 — but the reason MUST be surfaced.
+          should_skip() {
+            local reason="$1"
+            echo "::warning::auto-promote skipped: $reason"
+            echo "should_promote=false" >> "$GITHUB_OUTPUT"
+            echo "skip_reason=$reason" >> "$GITHUB_OUTPUT"
+            echo "## Skipped" >> "$GITHUB_STEP_SUMMARY"
+            echo "Reason: $reason" >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          }
+
+          # Precondition 1: develop CI must be green at this exact SHA.
+          # Filtered by headSha (BUGS-4 lesson) to avoid matching a stale run.
+          # If FORCE is set, we still check but only warn — never skip on it.
+          RUN_INFO=$(gh run list \
+            --repo "${{ github.repository }}" \
+            --branch develop \
+            --workflow deploy-dev.yml \
+            --limit 10 \
+            --json status,conclusion,headSha \
+            | python3 -c "
+          import json, sys
+          target = '$DEVELOP_SHA'
+          for r in json.load(sys.stdin):
+              if r['headSha'] == target:
+                  print(f\"{r['status']}|{r['conclusion'] or 'pending'}\")
+                  break
+          else:
+              print('NONE|')
+          ")
+          STATUS=$(echo "$RUN_INFO" | cut -d'|' -f1)
+          CONCLUSION=$(echo "$RUN_INFO" | cut -d'|' -f2)
+          echo "Develop CI for $DEVELOP_SHORT: $STATUS / $CONCLUSION"
+
+          if [ "$FORCE" = "true" ]; then
+            echo "::notice::FORCE=true — skipping precondition checks"
+          else
+            if [ "$STATUS" != "completed" ] || [ "$CONCLUSION" != "success" ]; then
+              should_skip "develop CI not green at $DEVELOP_SHORT (status=$STATUS conclusion=$CONCLUSION)"
+            fi
+
+            # Precondition 2: soak time. The most recent commit must be at
+            # least SOAK_HOURS old. Stops us promoting a commit that just
+            # landed and hasn't had a chance to fail in dev.
+            COMMIT_TS=$(git log -1 --format=%ct "$DEVELOP_SHA")
+            NOW_TS=$(date +%s)
+            AGE_HOURS=$(( (NOW_TS - COMMIT_TS) / 3600 ))
+            echo "develop HEAD age: $AGE_HOURS hours"
+            if [ "$AGE_HOURS" -lt "$SOAK_HOURS" ]; then
+              should_skip "develop HEAD only $AGE_HOURS hours old (need $SOAK_HOURS hours soak time)"
+            fi
+
+            # Precondition 3: develop must be fast-forward into staging.
+            # If staging has commits not on develop, someone hand-edited
+            # staging — needs human attention. We refuse to merge.
+            git fetch origin staging
+            BEHIND=$(git rev-list --count origin/staging..origin/develop || echo 0)
+            AHEAD=$(git rev-list --count origin/develop..origin/staging || echo 0)
+            echo "develop is $BEHIND ahead of staging, $AHEAD behind"
+            if [ "$AHEAD" -gt 0 ]; then
+              should_skip "staging has $AHEAD commits not on develop (manual edit?) — needs human review"
+            fi
+            if [ "$BEHIND" -eq 0 ]; then
+              should_skip "no new commits on develop since last staging promotion (nothing to do)"
+            fi
+          fi
+
+          echo "::notice::All preconditions met — proceeding with promotion"
+          echo "should_promote=true" >> "$GITHUB_OUTPUT"
+          {
+            echo "## Preconditions OK"
+            echo "- develop SHA: $DEVELOP_SHORT"
+            echo "- develop CI: $STATUS / $CONCLUSION"
+            echo "- HEAD age: ${AGE_HOURS:-FORCE-bypassed} hours"
+            echo "- behind/ahead vs staging: $BEHIND/$AHEAD (force=$FORCE)"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  promote:
+    name: Run promote-to-staging
+    needs: preconditions
+    if: ${{ needs.preconditions.outputs.should_promote == 'true' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger promote-to-staging.yml
+        env:
+          GH_TOKEN: ${{ secrets.LYRA_RELEASE_PAT }}
+          DEVELOP_SHA: ${{ needs.preconditions.outputs.develop_sha }}
+        run: |
+          set -euo pipefail
+          if [ -z "$GH_TOKEN" ]; then
+            echo "::error::LYRA_RELEASE_PAT is required for cross-workflow dispatch"
+            exit 1
+          fi
+          # Dispatch the existing manual workflow with confirm=promote.
+          # We use LYRA_RELEASE_PAT so the dispatched run can in turn
+          # trigger downstream deploy-staging.yml (GITHUB_TOKEN suppresses
+          # those triggers — gotcha #16).
+          gh workflow run promote-to-staging.yml \
+            --repo "${{ github.repository }}" \
+            --ref main \
+            -f confirm=promote
+          echo "::notice::Dispatched promote-to-staging.yml for develop $DEVELOP_SHA"
+          echo "## Promotion dispatched" >> "$GITHUB_STEP_SUMMARY"
+          echo "Watch the run at: ${{ github.server_url }}/${{ github.repository }}/actions/workflows/promote-to-staging.yml" >> "$GITHUB_STEP_SUMMARY"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,11 +33,12 @@ Full details: `docs/JIRA_TICKET_STANDARD.md`
 The pipeline is: **develop → staging → main** (promotion-based).
 
 - All feature work goes to `develop` via PR
-- Promotion to staging: `gh workflow run promote-to-staging.yml -f confirm=promote`
-- Promotion to production: `gh workflow run promote-to-production.yml -f confirm=PRODUCTION`
+- Promotion to staging: `gh workflow run promote-to-staging.yml -f confirm=promote` (also auto-runs Sunday 23:00 UTC — see KAN-173 / `docs/RELEASE_POLICY.md`)
+- Promotion to production: `gh workflow run promote-to-production.yml -f confirm=PRODUCTION` (always manual — never automated)
 - **Never push directly to staging or main**
 - All environments must be kept in sync
 - Commit and push only after verifying code compiles and tests pass
+- Cadence: at least one release/week to flush the chain (see `docs/RELEASE_POLICY.md`)
 
 ## Testing Requirements
 

--- a/docs/RELEASE_POLICY.md
+++ b/docs/RELEASE_POLICY.md
@@ -1,0 +1,75 @@
+# Lyra Release Policy (KAN-173)
+
+> Pipelines rot when not exercised. Drift breeds incidents. Force at least one release per week to flush the entire chain.
+
+## Cadence
+
+| Stage | Cadence | Trigger | Why |
+|---|---|---|---|
+| `develop` → `staging` | **Weekly, automatic** | Sunday 23:00 UTC | Forces the staging chain to run every week so `deploy-staging.yml` doesn't go a month without exercise. |
+| `staging` → `beta` | Manual | When ready to expose changes to beta testers | Beta hits real prod data, so the move beyond staging is a deliberate decision. |
+| `beta` → `main` | Manual | When beta has been exercised against real users | Highest blast radius. Always human-supervised. |
+
+**The chain MUST be exercised at least weekly.** If `auto-promote-to-staging.yml` skips for any reason, the weekly report flags it red — see "Skip behaviour" below.
+
+## Drift thresholds
+
+The weekly report's drift counter (Section 15, KAN-173 follow-up) reports `git rev-list --count main..develop` and the days since the most recent develop commit:
+
+| Status | Commits ahead of main | Days since last develop commit | Action |
+|---|---|---|---|
+| 🟢 Green | < 5 | < 3 | None |
+| 🟡 Yellow | 5–14 | 3–6 | Plan a promotion this week |
+| 🔴 Red | ≥ 15 OR ≥ 7 days | Promote now |
+
+If we hit red, the weekly report adds a "drift exceeded threshold" line and Luisa schedules a manual promotion the same day.
+
+## Security SLA
+
+A high or critical CodeQL/Dependabot alert that lands on develop must reach **production within 24 hours**, including any necessary review. This is the entire point of forcing a weekly cadence — security fixes can never be allowed to sit on develop indefinitely.
+
+When the security alert is filed:
+1. Fix on a branch off `develop` (per Test Integrity + Workflow Integrity policies).
+2. Land via PR to develop.
+3. Promote develop → staging → beta → main without waiting for the weekly cron — manually via `gh workflow run promote-to-staging.yml -f confirm=promote`.
+4. Confirm the alert is closed in GitHub Security tab and the corresponding KAN/BUGS ticket is closed.
+
+## When NOT to release
+
+Don't auto-promote (suspend the cron) and don't manually promote when:
+- Open Highest-priority bug ticket against the system being released
+- Smoke tests already failing on staging or production
+- Mid-incident — use a hotfix branch directly to main via PR if needed; don't pile a release on top of an active investigation
+- Friday afternoon UK time — no support window for the weekend
+- Beta testers have flagged a regression that hasn't been triaged yet
+
+The `auto-promote-to-staging.yml` workflow has a hard precondition that develop CI is green — it won't promote a red develop. But the human conditions above are NOT machine-checkable and require operator judgement to suspend the cron via GitHub UI.
+
+## Skip behaviour
+
+`auto-promote-to-staging.yml` skips (no promotion, no failure) when:
+- Develop CI for the latest develop commit is not green or not yet completed
+- HEAD of develop is < 24 hours old (soak time so the latest commits get a chance to fail in dev first)
+- Develop is not fast-forward into staging (someone manually changed staging — needs a human)
+
+A skip is reported as `::warning::` in the workflow run and is surfaced in the weekly report Section 15 ("Last auto-promote-to-staging: skipped — reason: …").
+
+A skip is **not the same as a failure**. We never want a green-looking workflow that didn't actually do the promotion (KAN-167 lessons applied). If three consecutive weekly auto-promotes skip, the weekly report escalates to red and Luisa investigates manually.
+
+## What stays manual
+
+- **`staging` → `beta`** — `gh workflow run promote-staging-to-beta.yml -f confirm=promote`. No cron. Decision made when beta-testable changes have soaked on staging.
+- **`beta` → `main` (production)** — `gh workflow run promote-to-production.yml -f confirm=PRODUCTION`. No cron, ever. This is the highest-blast-radius decision in the entire project.
+
+The reasoning is asymmetric:
+- Auto-promote to **staging** is safe — staging is gated by Vercel SSO, no real users see it
+- Auto-promote to **production** has the same false-positive risk class KAN-167 spent days dismantling — a "green" CI run that's actually broken would auto-ship to users
+
+## Reference
+
+- KAN-173 (this policy): <https://checklyra.atlassian.net/browse/KAN-173>
+- KAN-167 (workflow integrity, the prior art for false-positive prevention): <https://checklyra.atlassian.net/browse/KAN-167>
+- BUGS-11 (auto-merge BLOCKED, the failure mode that triggered the rebase fix): <https://checklyra.atlassian.net/browse/BUGS-11>
+- `docs/RUNBOOK.md` — operational procedures
+- `.github/workflows/promote-to-staging.yml` — the manual workflow (auto-promote calls the same logic)
+- `.github/workflows/auto-promote-to-staging.yml` — the scheduled wrapper

--- a/docs/RUNBOOK.md
+++ b/docs/RUNBOOK.md
@@ -29,7 +29,7 @@ Real-user beta testing happens on `beta.checklyra.com` with prod credentials, so
 
 ## Release Procedure
 
-Promotions follow develop → staging → main with manual triggers and automated verification.
+Promotions follow develop → staging → beta → main with manual triggers (and one weekly auto-promote to staging — see `docs/RELEASE_POLICY.md`). The full policy + cadence + when-NOT-to-release rules live in `docs/RELEASE_POLICY.md`; this section covers the operational mechanics.
 
 ### Promote develop → staging
 

--- a/scripts/check-release-drift.sh
+++ b/scripts/check-release-drift.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# scripts/check-release-drift.sh
+#
+# KAN-173: compute develop→main drift and produce a one-line status
+# (🟢/🟡/🔴) plus a structured key=value output that the weekly report's
+# Section 15 can ingest without re-doing the math.
+#
+# Output format (stdout):
+#   commits_ahead=<N>
+#   days_since_last_commit=<D>
+#   status=<green|yellow|red>
+#   summary=<one-line human-readable summary>
+#
+# Exit codes:
+#   0  green or yellow
+#   1  red (drift exceeded threshold)
+#   2  unable to compute (e.g. main not fetched)
+#
+# The KAN-167 lesson applies: this script must distinguish "could not
+# compute" (exit 2, status=unknown) from "0 commits ahead" (exit 0,
+# status=green) — never silently report a clean zero.
+
+set -euo pipefail
+
+DEVELOP_REF="${DEVELOP_REF:-origin/develop}"
+MAIN_REF="${MAIN_REF:-origin/main}"
+
+# Verify both refs exist before computing anything.
+if ! git rev-parse --verify "$DEVELOP_REF" >/dev/null 2>&1; then
+  echo "commits_ahead=DATA_UNAVAILABLE"
+  echo "days_since_last_commit=DATA_UNAVAILABLE"
+  echo "status=unknown"
+  echo "summary=$DEVELOP_REF not found — fetch develop before running"
+  exit 2
+fi
+if ! git rev-parse --verify "$MAIN_REF" >/dev/null 2>&1; then
+  echo "commits_ahead=DATA_UNAVAILABLE"
+  echo "days_since_last_commit=DATA_UNAVAILABLE"
+  echo "status=unknown"
+  echo "summary=$MAIN_REF not found — fetch main before running"
+  exit 2
+fi
+
+COMMITS_AHEAD=$(git rev-list --count "$MAIN_REF..$DEVELOP_REF")
+LAST_COMMIT_TS=$(git log -1 --format=%ct "$DEVELOP_REF")
+NOW_TS=$(date +%s)
+DAYS_SINCE=$(( (NOW_TS - LAST_COMMIT_TS) / 86400 ))
+
+# Threshold logic from KAN-173 description:
+#   green  : < 5 commits ahead AND < 3 days since last commit
+#   yellow : < 15 commits ahead AND < 7 days since last commit
+#   red    : ≥ 15 commits ahead OR ≥ 7 days since last commit
+if [ "$COMMITS_AHEAD" -ge 15 ] || [ "$DAYS_SINCE" -ge 7 ]; then
+  STATUS="red"
+  EXIT=1
+elif [ "$COMMITS_AHEAD" -ge 5 ] || [ "$DAYS_SINCE" -ge 3 ]; then
+  STATUS="yellow"
+  EXIT=0
+else
+  STATUS="green"
+  EXIT=0
+fi
+
+SUMMARY="develop is $COMMITS_AHEAD commits / $DAYS_SINCE days ahead of main ($STATUS)"
+
+echo "commits_ahead=$COMMITS_AHEAD"
+echo "days_since_last_commit=$DAYS_SINCE"
+echo "status=$STATUS"
+echo "summary=$SUMMARY"
+
+exit $EXIT

--- a/tests/unit/release-drift.test.ts
+++ b/tests/unit/release-drift.test.ts
@@ -1,0 +1,143 @@
+/**
+ * KAN-173: tests for scripts/check-release-drift.sh.
+ *
+ * The script's logic — threshold buckets and the "DATA_UNAVAILABLE on
+ * missing refs" case — is the load-bearing piece. We invoke the script
+ * in a throwaway git repo with synthetic ref histories and assert it
+ * categorises correctly + emits the expected key=value output.
+ */
+
+import { execFileSync, execSync } from 'node:child_process';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+
+const SCRIPT = resolve(__dirname, '../../scripts/check-release-drift.sh');
+
+interface DriftResult {
+  exitCode: number;
+  stdout: string;
+  fields: Record<string, string>;
+}
+
+function parseFields(stdout: string): Record<string, string> {
+  const fields: Record<string, string> = {};
+  for (const line of stdout.split('\n')) {
+    const m = line.match(/^([a-z_]+)=(.*)$/);
+    if (m) fields[m[1]] = m[2];
+  }
+  return fields;
+}
+
+function runScript(cwd: string, env: Record<string, string> = {}): DriftResult {
+  try {
+    const stdout = execFileSync('bash', [SCRIPT], {
+      cwd,
+      encoding: 'utf-8',
+      env: { ...process.env, ...env, PATH: process.env.PATH ?? '' },
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    return { exitCode: 0, stdout, fields: parseFields(stdout) };
+  } catch (err) {
+    const e = err as { status?: number; stdout?: string };
+    const stdout = e.stdout ?? '';
+    return { exitCode: e.status ?? 1, stdout, fields: parseFields(stdout) };
+  }
+}
+
+function gitRun(cwd: string, args: string[]): string {
+  return execSync(`git ${args.join(' ')}`, { cwd, encoding: 'utf-8' }).trim();
+}
+
+function makeRepo(): string {
+  const dir = mkdtempSync(join(tmpdir(), 'lyra-drift-'));
+  gitRun(dir, ['init', '-q', '-b', 'main']);
+  gitRun(dir, ['config', 'user.email', 'test@example.com']);
+  gitRun(dir, ['config', 'user.name', 'test']);
+  return dir;
+}
+
+function commit(cwd: string, file: string, contents: string, msg: string, dateIso?: string): string {
+  writeFileSync(join(cwd, file), contents);
+  gitRun(cwd, ['add', '.']);
+  if (dateIso) {
+    execSync(`GIT_COMMITTER_DATE='${dateIso}' git commit -q -m '${msg}' --date='${dateIso}'`, { cwd });
+  } else {
+    gitRun(cwd, ['commit', '-q', '-m', `'${msg}'`]);
+  }
+  return gitRun(cwd, ['rev-parse', 'HEAD']);
+}
+
+describe('check-release-drift.sh', () => {
+  let repo: string;
+
+  beforeEach(() => {
+    repo = makeRepo();
+    // Bootstrap: one commit on main; no develop yet.
+    commit(repo, 'README', 'main\n', 'initial');
+  });
+
+  afterEach(() => {
+    rmSync(repo, { recursive: true, force: true });
+  });
+
+  test('green when 0 commits ahead and 0 days since last commit', () => {
+    // Make develop = main (no drift). Use a recent date.
+    gitRun(repo, ['branch', 'develop']);
+    const r = runScript(repo, { DEVELOP_REF: 'develop', MAIN_REF: 'main' });
+    expect(r.fields.status).toBe('green');
+    expect(r.fields.commits_ahead).toBe('0');
+    expect(parseInt(r.fields.days_since_last_commit, 10)).toBeLessThanOrEqual(1);
+    expect(r.exitCode).toBe(0);
+  });
+
+  test('yellow when 5–14 commits ahead', () => {
+    gitRun(repo, ['checkout', '-q', '-b', 'develop']);
+    for (let i = 0; i < 6; i++) {
+      commit(repo, `f${i}`, String(i), `commit ${i}`);
+    }
+    const r = runScript(repo, { DEVELOP_REF: 'develop', MAIN_REF: 'main' });
+    expect(r.fields.status).toBe('yellow');
+    expect(r.fields.commits_ahead).toBe('6');
+    expect(r.exitCode).toBe(0);
+  });
+
+  test('red when ≥ 15 commits ahead', () => {
+    gitRun(repo, ['checkout', '-q', '-b', 'develop']);
+    for (let i = 0; i < 16; i++) {
+      commit(repo, `f${i}`, String(i), `commit ${i}`);
+    }
+    const r = runScript(repo, { DEVELOP_REF: 'develop', MAIN_REF: 'main' });
+    expect(r.fields.status).toBe('red');
+    expect(r.fields.commits_ahead).toBe('16');
+    expect(r.exitCode).toBe(1);
+  });
+
+  test('red when develop HEAD ≥ 7 days old (even with few commits)', () => {
+    gitRun(repo, ['checkout', '-q', '-b', 'develop']);
+    // Commit dated 10 days ago.
+    const tenDaysAgoTs = Math.floor(Date.now() / 1000) - 10 * 86400;
+    const iso = new Date(tenDaysAgoTs * 1000).toISOString();
+    commit(repo, 'old', 'stale', 'stale commit', iso);
+    const r = runScript(repo, { DEVELOP_REF: 'develop', MAIN_REF: 'main' });
+    expect(r.fields.status).toBe('red');
+    expect(parseInt(r.fields.days_since_last_commit, 10)).toBeGreaterThanOrEqual(10);
+    expect(r.exitCode).toBe(1);
+  });
+
+  test('exits 2 with DATA_UNAVAILABLE when develop ref missing', () => {
+    // Don't create develop; DEVELOP_REF=develop won't resolve.
+    const r = runScript(repo, { DEVELOP_REF: 'develop', MAIN_REF: 'main' });
+    expect(r.fields.status).toBe('unknown');
+    expect(r.fields.commits_ahead).toBe('DATA_UNAVAILABLE');
+    expect(r.fields.days_since_last_commit).toBe('DATA_UNAVAILABLE');
+    expect(r.exitCode).toBe(2);
+  });
+
+  test('emits a human-readable summary line for every status', () => {
+    gitRun(repo, ['checkout', '-q', '-b', 'develop']);
+    commit(repo, 'one', '1', 'one');
+    const r = runScript(repo, { DEVELOP_REF: 'develop', MAIN_REF: 'main' });
+    expect(r.fields.summary).toMatch(/^develop is \d+ commits \/ \d+ days ahead of main \(green|yellow|red\)$/);
+  });
+});


### PR DESCRIPTION
## Summary

Forces at least one release per week to flush the entire chain. Without this, develop accumulates fixes for weeks (15+ commit gap was real on 2026-04-29) — security alerts sit unreleased, the pipeline rots from disuse, and zero-day patches don't reach prod until someone notices.

- `docs/RELEASE_POLICY.md` — single source of truth: cadence, drift thresholds (🟢/🟡/🔴), security SLA (24h for high/critical alerts), when NOT to release, and the asymmetric reasoning for auto-promote-to-staging vs manual-only-to-production
- `.github/workflows/auto-promote-to-staging.yml` — scheduled Sunday 23:00 UTC. Three preconditions enforced loud-fail-or-skip per KAN-167: develop CI green at HEAD, HEAD ≥24h old (soak), develop fast-forward into staging. Skips are explicit `::warning::` annotations, never silent
- `scripts/check-release-drift.sh` — pure-data drift counter for the weekly report Section 15 follow-up
- `tests/unit/release-drift.test.ts` — 6 tests covering green/yellow/red bands, the ≥7-days-stale path, and the DATA_UNAVAILABLE path

## Asymmetric automation

Auto-promote to **staging** is safe — staging is gated by Vercel SSO, no real users see it. Auto-promote to **production** has the same false-positive risk class KAN-167 spent days dismantling — that stays manual permanently.

## Out of scope (deliberately deferred)

- Weekly report Section 15+16 — script is in place, hooking into `weekly-report.yml` is a follow-up ticket
- Auto-promote to production — never going to be automated

## Test plan

- [x] `npm run test:unit` — 319 passing, 27 suites
- [x] `bash scripts/check-release-drift.sh` against current repo — works (reports 14/0/yellow)
- [x] YAML parses (`python3 -c "import yaml; yaml.safe_load(open(...))"`)
- [ ] First scheduled run: Sunday 23:00 UTC after this lands. Watch for either successful staging dispatch OR a clear `::warning::` skip with reason

🤖 Generated with [Claude Code](https://claude.com/claude-code)