### PR TITLE
KAN-163: SSO-aware UptimeRobot monitors (fix dev/stage false-DOWN)

### DIFF
--- a/scripts/uptimerobot/bootstrap.js
+++ b/scripts/uptimerobot/bootstrap.js
@@ -104,10 +104,17 @@ async function main() {
     log(`  ✅ ${u.friendlyName} (id ${u.id})`);
   }
   for (const u of monitorDiff.toUpdate) {
-    log(`  ⚠️  ${u.friendlyName} (id ${u.id}) URL drift: have=${u.currentUrl} want=${u.desiredUrl} — review manually`);
+    if (u.reason === 'url-mismatch') {
+      log(`  ⚠️  ${u.friendlyName} (id ${u.id}) URL drift: have=${u.currentUrl} want=${u.desiredUrl} — review manually`);
+    } else if (u.reason === 'custom-http-statuses-mismatch') {
+      log(`  🔧 ${u.friendlyName} (id ${u.id}) custom_http_statuses drift: have='${u.currentCustomHttpStatuses}' want='${u.desiredCustomHttpStatuses}' — will reconcile on --apply`);
+    } else {
+      log(`  ⚠️  ${u.friendlyName} (id ${u.id}) needs update (reason: ${u.reason})`);
+    }
   }
   for (const c of monitorDiff.toCreate) {
-    log(`  ➕ would create: ${c.friendlyName} → ${c.url}`);
+    const extras = c.customHttpStatuses ? ` (custom_http_statuses=${c.customHttpStatuses})` : '';
+    log(`  ➕ would create: ${c.friendlyName} → ${c.url}${extras}`);
   }
 
   if (APPLY) {
@@ -115,33 +122,61 @@ async function main() {
     // Throttle locally + retry on 429 with longer backoff so the script
     // is reliable end-to-end without operator intervention.
     const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
-    for (let i = 0; i < monitorDiff.toCreate.length; i++) {
-      const c = monitorDiff.toCreate[i];
+    const callWithRetry = async (fn, label) => {
       let attempt = 0;
       while (true) {
         try {
-          const res = await client.newMonitor({
-            friendlyName: c.friendlyName,
-            url: c.url,
-            alertContacts: alertContactsParam,
-          });
-          const id = res.monitor?.id;
-          log(`  + created monitor ${c.friendlyName} (id ${id})`);
-          break;
+          return await fn();
         } catch (err) {
           attempt++;
           const msg = err instanceof Error ? err.message : String(err);
           if (msg.includes('429') && attempt <= 4) {
             const wait = 10000 * attempt;
-            log(`  ⏳ 429 from UptimeRobot, sleeping ${wait}ms before retry ${attempt}/4`);
+            log(`  ⏳ 429 from UptimeRobot on ${label}, sleeping ${wait}ms before retry ${attempt}/4`);
             await sleep(wait);
             continue;
           }
           throw err;
         }
       }
-      // Pre-emptive 4s pause between calls.
+    };
+
+    for (let i = 0; i < monitorDiff.toCreate.length; i++) {
+      const c = monitorDiff.toCreate[i];
+      const res = await callWithRetry(
+        () =>
+          client.newMonitor({
+            friendlyName: c.friendlyName,
+            url: c.url,
+            alertContacts: alertContactsParam,
+            customHttpStatuses: c.customHttpStatuses,
+          }),
+        `newMonitor(${c.friendlyName})`
+      );
+      log(`  + created monitor ${c.friendlyName} (id ${res.monitor?.id})`);
       if (i < monitorDiff.toCreate.length - 1) {
+        await sleep(4000);
+      }
+    }
+
+    // Reconcile custom_http_statuses drift (e.g. SSO env was added later
+    // and existing monitors don't have the override). URL drift stays a
+    // manual review — that's intentional per planMonitorDiff's contract.
+    const statusUpdates = monitorDiff.toUpdate.filter(
+      (u) => u.reason === 'custom-http-statuses-mismatch'
+    );
+    for (let i = 0; i < statusUpdates.length; i++) {
+      const u = statusUpdates[i];
+      await callWithRetry(
+        () =>
+          client.editMonitor({
+            id: u.id,
+            customHttpStatuses: u.desiredCustomHttpStatuses,
+          }),
+        `editMonitor(${u.friendlyName} custom_http_statuses)`
+      );
+      log(`  ✏️  edited ${u.friendlyName} (id ${u.id}) custom_http_statuses → ${u.desiredCustomHttpStatuses}`);
+      if (i < statusUpdates.length - 1) {
         await sleep(4000);
       }
     }

--- a/scripts/uptimerobot/lib.d.ts
+++ b/scripts/uptimerobot/lib.d.ts
@@ -34,6 +34,13 @@ export const FIVE_MINUTES: 300;
 export interface MonitorSpec {
   readonly friendlyName: string;
   readonly url: string;
+  /**
+   * Optional override for UptimeRobot's default 200-299=up / 300-599=down
+   * classification. Format: `<code>:<1|0>_...` where 1=up, 0=down. e.g.
+   * `"200:1_401:1_403:1"` accepts 401 (Vercel SSO) and 403 (Cloudflare
+   * bot challenge) as "up" — used on dev/stage/SSO-protected envs.
+   */
+  readonly customHttpStatuses?: string;
 }
 export const LYRA_MONITORS: readonly MonitorSpec[];
 
@@ -78,7 +85,13 @@ export interface UptimeRobotClient {
   }): Promise<{ stat: 'ok'; alertcontact?: { id: number } }>;
   getMonitors(search?: string): Promise<{
     stat: 'ok';
-    monitors?: Array<{ id: number; friendly_name: string; url: string; status?: number }>;
+    monitors?: Array<{
+      id: number;
+      friendly_name: string;
+      url: string;
+      status?: number;
+      custom_http_statuses?: string;
+    }>;
   }>;
   newMonitor(input: {
     friendlyName: string;
@@ -89,12 +102,14 @@ export interface UptimeRobotClient {
     sslExpirationReminder?: number;
     timeout?: number;
     httpMethodType?: number;
+    customHttpStatuses?: string;
   }): Promise<{ stat: 'ok'; monitor?: { id: number } }>;
   editMonitor(input: {
     id: number;
     alertContacts?: string;
     interval?: number;
     sslExpirationReminder?: number;
+    customHttpStatuses?: string;
   }): Promise<{ stat: 'ok' }>;
 }
 
@@ -104,17 +119,28 @@ export interface ExistingMonitor {
   id: number;
   friendly_name: string;
   url: string;
+  custom_http_statuses?: string;
 }
+
+export type MonitorDiffEntry =
+  | {
+      id: number;
+      friendlyName: string;
+      currentUrl: string;
+      desiredUrl: string;
+      reason: 'url-mismatch';
+    }
+  | {
+      id: number;
+      friendlyName: string;
+      currentCustomHttpStatuses: string;
+      desiredCustomHttpStatuses: string;
+      reason: 'custom-http-statuses-mismatch';
+    };
 
 export interface MonitorDiff {
   toCreate: MonitorSpec[];
-  toUpdate: Array<{
-    id: number;
-    friendlyName: string;
-    currentUrl: string;
-    desiredUrl: string;
-    reason: 'url-mismatch';
-  }>;
+  toUpdate: MonitorDiffEntry[];
   unchanged: Array<{ id: number; friendlyName: string }>;
 }
 

--- a/scripts/uptimerobot/lib.js
+++ b/scripts/uptimerobot/lib.js
@@ -96,6 +96,7 @@ function makeClient({ apiKey, httpClient = (typeof fetch === 'function' ? fetch 
       sslExpirationReminder = 1,
       timeout = 30,
       httpMethodType = 1,
+      customHttpStatuses,
     }) =>
       call('newMonitor', {
         friendly_name: friendlyName,
@@ -106,13 +107,15 @@ function makeClient({ apiKey, httpClient = (typeof fetch === 'function' ? fetch 
         ssl_expiration_reminder: sslExpirationReminder,
         timeout,
         http_method_type: httpMethodType,
+        custom_http_statuses: customHttpStatuses,
       }),
-    editMonitor: ({ id, alertContacts, interval, sslExpirationReminder = 1 }) =>
+    editMonitor: ({ id, alertContacts, interval, sslExpirationReminder = 1, customHttpStatuses }) =>
       call('editMonitor', {
         id,
         alert_contacts: alertContacts,
         interval,
         ssl_expiration_reminder: sslExpirationReminder,
+        custom_http_statuses: customHttpStatuses,
       }),
   };
 }
@@ -123,14 +126,31 @@ function makeClient({ apiKey, httpClient = (typeof fetch === 'function' ? fetch 
  * the world against weekly-report Section 1.
  *
  * Each entry: a `friendlyName` we use as the idempotency key (search by
- * exact match before creating) and the URL the monitor should poll.
+ * exact match before creating), the URL the monitor should poll, and
+ * optionally `customHttpStatuses` to override the default "200-299 = up,
+ * 300-599 = down" classification.
+ *
+ * The `customHttpStatuses` format is UptimeRobot's: `<code>:<1|0>_<code>:<1|0>...`
+ * where 1 = consider as "up", 0 = consider as "down".
+ *
+ * Why we override status mapping on dev/stage:
+ * - dev.checklyra.com and stage.checklyra.com sit behind Vercel SSO,
+ *   which returns 401 for unauthenticated traffic. UptimeRobot's free
+ *   scraper has no way to authenticate, so it always sees 401. Without
+ *   the override, both monitors stay falsely DOWN forever.
+ * - The 401 means "Vercel SSO is alive and refusing me", which is
+ *   exactly the signal we want for "the deployment is up". A real
+ *   outage on those envs would return 502/503/timeout, which we still
+ *   want to alert on.
+ * - 403 is also accepted-as-up because Cloudflare bot challenge
+ *   sometimes returns 403 to UptimeRobot's IPs (CLAUDE.md gotcha #7).
  */
 const LYRA_MONITORS = Object.freeze([
   { friendlyName: 'Lyra prod — checklyra.com',         url: 'https://checklyra.com/' },
   { friendlyName: 'Lyra prod — privacy',               url: 'https://checklyra.com/privacy' },
   { friendlyName: 'Lyra beta — beta.checklyra.com',    url: 'https://beta.checklyra.com/' },
-  { friendlyName: 'Lyra stage — stage.checklyra.com',  url: 'https://stage.checklyra.com/' },
-  { friendlyName: 'Lyra dev — dev.checklyra.com',      url: 'https://dev.checklyra.com/' },
+  { friendlyName: 'Lyra stage — stage.checklyra.com',  url: 'https://stage.checklyra.com/', customHttpStatuses: '200:1_401:1_403:1' },
+  { friendlyName: 'Lyra dev — dev.checklyra.com',      url: 'https://dev.checklyra.com/',   customHttpStatuses: '200:1_401:1_403:1' },
   { friendlyName: 'Lyra MCP prod — mcp.checklyra.com', url: 'https://mcp.checklyra.com/health' },
   { friendlyName: 'Lyra MCP dev — mcp-dev.checklyra.com', url: 'https://mcp-dev.checklyra.com/health' },
 ]);
@@ -167,9 +187,26 @@ function planMonitorDiff(existing, desired) {
         desiredUrl: want.url,
         reason: 'url-mismatch',
       });
-    } else {
-      unchanged.push({ id: have.id, friendlyName: want.friendlyName });
+      continue;
     }
+    // Reconcile customHttpStatuses if it differs. UptimeRobot's API
+    // returns `custom_http_statuses` as a string like "200-1_401-1_403-1"
+    // (yes, with hyphens between code and flag, even though the API
+    // accepts underscores on input). Normalise both sides for compare.
+    const normalise = (s) => (s || '').replace(/[-_]/g, ':').replace(/(\d):/g, '$1:');
+    const haveStatuses = normalise(have.custom_http_statuses);
+    const wantStatuses = normalise(want.customHttpStatuses);
+    if (haveStatuses !== wantStatuses) {
+      toUpdate.push({
+        id: have.id,
+        friendlyName: want.friendlyName,
+        currentCustomHttpStatuses: have.custom_http_statuses || '',
+        desiredCustomHttpStatuses: want.customHttpStatuses || '',
+        reason: 'custom-http-statuses-mismatch',
+      });
+      continue;
+    }
+    unchanged.push({ id: have.id, friendlyName: want.friendlyName });
   }
   return { toCreate, toUpdate, unchanged };
 }

--- a/tests/scripts/uptimerobot.test.ts
+++ b/tests/scripts/uptimerobot.test.ts
@@ -56,6 +56,24 @@ describe('LYRA_MONITORS canonical list', () => {
     expect(urls).toContain('https://mcp-dev.checklyra.com/health');
   });
 
+  test('SSO-protected envs (dev, stage) carry the customHttpStatuses override', () => {
+    // dev and stage sit behind Vercel SSO and return 401 to UR's scraper.
+    // Without the 401:1 override they'd stay falsely DOWN forever.
+    // Verified live 2026-05-06 — alert path was triggered via these false
+    // positives within 2 min of monitor creation; the override stops the
+    // alert spam from recurring on every scrape.
+    const dev = LYRA_MONITORS.find((m) => m.friendlyName === 'Lyra dev — dev.checklyra.com');
+    const stage = LYRA_MONITORS.find((m) => m.friendlyName === 'Lyra stage — stage.checklyra.com');
+    expect(dev?.customHttpStatuses).toBe('200:1_401:1_403:1');
+    expect(stage?.customHttpStatuses).toBe('200:1_401:1_403:1');
+    // Public envs should NOT have the override — we want real 401/403
+    // there to fail the monitor.
+    const prod = LYRA_MONITORS.find((m) => m.friendlyName === 'Lyra prod — checklyra.com');
+    const beta = LYRA_MONITORS.find((m) => m.friendlyName === 'Lyra beta — beta.checklyra.com');
+    expect(prod?.customHttpStatuses).toBeUndefined();
+    expect(beta?.customHttpStatuses).toBeUndefined();
+  });
+
   test('canonical list is frozen — runtime mutation rejected', () => {
     expect(() => {
       // Cast away readonly to attempt a real mutation; Object.freeze should reject.
@@ -75,16 +93,48 @@ describe('planMonitorDiff', () => {
     expect(out.toUpdate.length).toBe(0);
   });
 
-  test('matches by friendly_name and reports unchanged when url already correct', () => {
+  test('matches by friendly_name and reports unchanged when url + custom_http_statuses already correct', () => {
+    // Mirror the canonical list including customHttpStatuses where set.
+    // UptimeRobot's API returns the field as `custom_http_statuses` with
+    // hyphens between code and flag (e.g. "200-1_401-1_403-1") even
+    // though it accepts underscores on input — the diff planner
+    // normalises both sides, so the test mirrors the API output shape.
     const existing = LYRA_MONITORS.map((m, i) => ({
       id: 1000 + i,
       friendly_name: m.friendlyName,
       url: m.url,
+      custom_http_statuses: m.customHttpStatuses
+        ? m.customHttpStatuses.replace(/:/g, '-')
+        : '',
     }));
     const out = planMonitorDiff(existing, LYRA_MONITORS);
     expect(out.toCreate).toEqual([]);
     expect(out.toUpdate).toEqual([]);
     expect(out.unchanged.length).toBe(LYRA_MONITORS.length);
+  });
+
+  test('flags custom_http_statuses drift as toUpdate (so apply path can edit it)', () => {
+    // dev's canonical entry includes customHttpStatuses; an existing
+    // monitor created without it (older bootstrap version) should be
+    // flagged for reconcile. URL is correct in both cases.
+    const dev = LYRA_MONITORS.find((m) => m.friendlyName === 'Lyra dev — dev.checklyra.com');
+    const existing = [
+      {
+        id: 999,
+        friendly_name: dev!.friendlyName,
+        url: dev!.url,
+        custom_http_statuses: '', // older monitor created without override
+      },
+    ];
+    const out = planMonitorDiff(existing, [dev!]);
+    expect(out.toUpdate).toHaveLength(1);
+    expect(out.toUpdate[0]).toMatchObject({
+      id: 999,
+      friendlyName: dev!.friendlyName,
+      reason: 'custom-http-statuses-mismatch',
+      currentCustomHttpStatuses: '',
+      desiredCustomHttpStatuses: '200:1_401:1_403:1',
+    });
   });
 
   test('flags url drift via toUpdate (manual review) instead of silent overwrite', () => {


### PR DESCRIPTION
## Summary

Within ~2 min of yesterday's bootstrap, dev and stage UptimeRobot monitors fired DOWN alerts to Luisa's inbox — alert path proved itself, but the underlying status was a **false positive**: both envs sit behind Vercel SSO and return 401, which UR classifies as "down" by default. Without the override they'd alert every 5 minutes forever.

The 401 actually means "Vercel SSO is alive and refusing me" — exactly the signal we want for "deployment is up". Real outages return 502/503/timeout which we still alert on.

- Canonical `LYRA_MONITORS` list: dev + stage gain `customHttpStatuses: '200:1_401:1_403:1'` (1 = up, 0 = down)
- 403 also accepted as up — Cloudflare bot challenge can hit UR's IPs (CLAUDE.md gotcha #7)
- prod and beta intentionally have NO override; we want real 401/403 there to fail
- newMonitor + editMonitor + planMonitorDiff updated end-to-end
- 2 new unit tests (19 total in `tests/scripts/uptimerobot.test.ts`)

## Live state

Live monitor edits applied via API at 02:32 UTC. Verifying via background watcher that dev + stage flip DOWN → UP on next scrape.

## Test plan

- [x] `npm run test:unit` passes (existing 351 tests + 2 new)
- [x] Lint + tsc clean
- [x] Live API edit returned `stat:ok` for both dev and stage monitors
- [ ] Confirm dev + stage flip to UP after next scrape (in progress)
- [ ] Confirm "back UP" alert email lands in Gmail

🤖 Generated with [Claude Code](https://claude.com/claude-code)