### PR TITLE
KAN-104 follow-up: Sentry activation doc + rotation entries + parser fix

### DIFF
--- a/docs/SECURITY_ROTATION.md
+++ b/docs/SECURITY_ROTATION.md
@@ -17,6 +17,9 @@
 | Google OAuth client secret | Supabase Auth config (all 3 projects) | Annual or on suspicion | Google Cloud Console → APIs & Services → Credentials → OAuth 2.0 Client → Reset Secret → Update in all 3 Supabase project Auth settings. **Causes downtime**: all Google Sign-In sessions invalidated immediately. | Initial setup |
 | Railway API token | Local scripts only (not in CI) | 90 days | Railway → Account → Tokens → Create new → Update local env → Revoke old. | Initial setup |
 | SUPABASE_DB_URL (pg_dump) | GitHub secret | Annual | Supabase → Settings → Database → Connection string (Transaction Pooler, port 6543). Password changes if database password is reset. | Initial setup |
+| SENTRY_AUTH_TOKEN | Vercel env vars (each env) | Annual | Sentry → User Auth Tokens → Create new (scopes: org:read, project:read, project:write, project:releases) → Update in Vercel each env → redeploy → revoke old token. Build-time only — used by `next build` to upload source maps. Missing/wrong token doesn't fail the build (errorHandler swallows it), just means stack traces stay minified in Sentry. | 6 May 2026 |
+| Sentry DSN (NEXT_PUBLIC_SENTRY_DSN) | Vercel env vars (each env) | Only on suspicion | Sentry → Project → Settings → Client Keys (DSN) → "Generate new key". Public-by-design, doesn't expire. Rotate only if leaked into a context that matters (rare — DSN allows ingestion only, not data access). | 6 May 2026 |
+| UptimeRobot Main API key | Local only — never committed | Annual | UptimeRobot → My Settings → API Settings → Create Main API Key → use to re-run `npm run uptimerobot:bootstrap` if needed. Document scope: full account write. KAN-163 docs/UPTIMEROBOT_SETUP.md. | 5 May 2026 |
 
 ### User-Facing Secrets (user-controlled)
 

--- a/docs/SENTRY_SETUP.md
+++ b/docs/SENTRY_SETUP.md
@@ -1,0 +1,101 @@
+# Sentry Setup (KAN-104)
+
+> The SDK is scaffolded behind a two-flag gate. This doc walks through activating it on each environment.
+
+## What's already shipped (PR #136)
+
+- `@sentry/nextjs` installed
+- `instrumentation.ts` — server + edge runtime init, gated on `NEXT_PUBLIC_SENTRY_DSN` AND `IS_SENTRY_ENABLED='true'`
+- `instrumentation-client.ts` — browser init, same gate
+- `next.config.ts` wrapped with `withSentryConfig` (source-map upload + tunnel-route off + DE-region CSP)
+- 8 unit tests guarding the gate + CSP + auth-token-never-NEXT_PUBLIC
+
+Until both env vars are populated, the SDK is **completely inert** — no network calls, no event capture, no overhead.
+
+## Account snapshot (filled in on first activation)
+
+| Field | Value | Notes |
+|---|---|---|
+| Region | EU (de.sentry.io) | GDPR-friendly |
+| Org ID | `o4511340602523648` | Numeric, baked into DSN |
+| Project ID | `4511340621594704` | Numeric, baked into DSN |
+| Org slug | _(TBC — see below)_ | Needed for source-map upload only |
+| Project slug | _(TBC — see below)_ | Same |
+| DSN | `https://1d003e90bf6a072f57d3a7765f124a70@o4511340602523648.ingest.de.sentry.io/4511340621594704` | Public-by-design, safe in client bundle |
+
+## Activating Sentry on an environment
+
+Two steps per env. Recommend doing **dev** first, verifying, then promoting to staging/beta/prod.
+
+### Step 1: Vercel env vars
+
+Vercel → `lyra` project → Settings → Environment Variables. Add the following, scoped to your target env (Development / Preview / Production):
+
+| Variable | Value | Sensitive? | Purpose |
+|---|---|---|---|
+| `NEXT_PUBLIC_SENTRY_DSN` | `https://1d003e90bf6a072f57d3a7765f124a70@o4511340602523648.ingest.de.sentry.io/4511340621594704` | No | Where the SDK sends events. The `NEXT_PUBLIC_` prefix exposes it to the browser, which is correct — DSN is public-by-design. |
+| `IS_SENTRY_ENABLED` | `true` | No | The kill switch. Setting to `false` (or removing) disables Sentry entirely on that env without touching code. |
+
+After saving, redeploy that environment (push a commit or manually trigger via Vercel UI) so the new vars reach the build.
+
+### Step 2: Verify event flow (~30 seconds)
+
+Visit a deliberately-broken route on dev to trigger an error. Easy options:
+
+```bash
+# Server-side error: visit any route that throws
+curl https://dev.checklyra.com/api/__sentry-test  # 404 — captured as a Next.js NotFoundError
+
+# Client-side error: open dev.checklyra.com in browser, press F12, paste in console:
+throw new Error("KAN-104 verification ping " + new Date().toISOString())
+```
+
+Then check Sentry → Issues. The event should appear within ~30 seconds. If it doesn't:
+
+1. Hit the URL again and watch the browser DevTools Network tab — you should see a request to `https://*.ingest.de.sentry.io`. If you don't, the SDK didn't initialise — check both env vars are set on the right env.
+2. If the network request is there but events don't show in Sentry, the DSN is wrong (typo? rotated?) — check Sentry → Settings → Client Keys (DSN).
+3. If events show but the wrong env tag (e.g. dev events tagged `production`), check `VERCEL_ENV` is being set correctly — Vercel sets it automatically per environment.
+
+### Step 3 (optional, do once for source maps): activation for build-time integration
+
+Source maps turn `<minified>:42:13` into `Login.tsx:42:13` in the Sentry UI. This requires three more Vercel env vars set on **Production** (and ideally all envs):
+
+| Variable | Value | Sensitive? | Where to find it |
+|---|---|---|---|
+| `SENTRY_AUTH_TOKEN` | `sntrys_...` (long token) | **YES** — mark as encrypted in Vercel | Sentry top-right user icon → User Auth Tokens → Create New Token. Scopes: `org:read`, `project:read`, `project:write`, `project:releases` |
+| `SENTRY_ORG` | (your org slug) | No | Sentry URL bar when signed in: `https://sentry.io/organizations/[ORG_SLUG]/` |
+| `SENTRY_PROJECT` | `lyra` (probably) | No | Sentry → Settings → Projects → click project → URL becomes `/projects/[PROJECT_SLUG]/` |
+
+The token belongs in **Vercel** (where the build runs), not in GitHub Secrets. GitHub-Secrets-only would mean the token never reaches `next build` and source-map upload silently fails.
+
+If `SENTRY_AUTH_TOKEN` is missing or wrong, builds still succeed and events still flow — they just have minified stack traces. Source-map upload errors are caught and logged (not fatal) per the `errorHandler` in `next.config.ts`.
+
+## Rotation
+
+`SENTRY_AUTH_TOKEN` should be rotated annually (matching the LYRA_RELEASE_PAT cadence). Process:
+
+1. Sentry → User Auth Tokens → Create new token (same scopes)
+2. Update `SENTRY_AUTH_TOKEN` in Vercel env vars (each env)
+3. Trigger a redeploy on each env to pick up the new token
+4. Confirm a fresh deploy uploaded source maps (Sentry → Releases → newest release should show "Source Maps: 0 → N")
+5. Revoke the old token in Sentry
+
+The DSN itself doesn't expire and doesn't need rotation unless leaked.
+
+This rotation step is tracked in `docs/SECURITY_ROTATION.md`.
+
+## What's NOT enabled by default
+
+- **Session Replay** (replays of user interactions on errors). Off because:
+  - Cost — replay storage is the largest line item on most Sentry bills
+  - PII — replay can capture form input, password field values (if not masked), screen contents
+  - Enable per-incident only via `replaysSessionSampleRate` + `replaysOnErrorSampleRate` in `instrumentation-client.ts`
+- **Tunnel route**. Off because each tunnel-routed event becomes a serverless invocation on Vercel, eating quota fast on a free Sentry plan
+- **PII capture** (`sendDefaultPii`). Off — explicit opt-in per Lyra's privacy stance
+- **MCP server integration**. The `lyra-mcp-server` repo will get its own `@sentry/node` integration in a separate ticket. KAN-104 is web-app-only.
+
+## Reference
+
+- [@sentry/nextjs docs](https://docs.sentry.io/platforms/javascript/guides/nextjs/)
+- KAN-104 ticket: <https://checklyra.atlassian.net/browse/KAN-104>
+- Related: `docs/SECURITY_ROTATION.md` (rotation cadence), `docs/UPTIMEROBOT_SETUP.md` (the other monitoring layer — uptime, not error capture)

--- a/docs/lyra-project-reference.jsx
+++ b/docs/lyra-project-reference.jsx
@@ -82,14 +82,29 @@ const sections = [
     ],
   },
   {
-    title: "UptimeRobot (Monitoring) — KAN-163",
+    title: "UptimeRobot (Uptime monitoring) — KAN-163",
     icon: "📡",
     items: [
       { label: "Dashboard", link: "https://dashboard.uptimerobot.com/" },
       { label: "Setup guide", link: "https://github.com/luisa-sys/lyra/blob/develop/docs/UPTIMEROBOT_SETUP.md" },
       { label: "Plan", value: "Free — 50 monitors, 5-minute interval, SSL expiry monitoring" },
-      { label: "Alerts to", value: "luisa@santos-stephens.com, ben@santos-stephens.com" },
+      { label: "Alert recipient", value: "luisa@santos-stephens.com (free tier = 1 contact; ben@ via email forwarding TBD)" },
       { label: "Bootstrap script", value: "scripts/uptimerobot/bootstrap.js (idempotent, dry-run by default)" },
+      { label: "SSO-protected envs", value: "dev + stage have custom_http_statuses=200/401/403=UP (Vercel SSO returns 401)" },
+    ],
+  },
+  {
+    title: "Sentry (Error monitoring) — KAN-104",
+    icon: "🚨",
+    items: [
+      { label: "Dashboard", link: "https://sentry.io/" },
+      { label: "Setup guide", link: "https://github.com/luisa-sys/lyra/blob/develop/docs/SENTRY_SETUP.md" },
+      { label: "Region", value: "EU (de.sentry.io) — GDPR-friendly" },
+      { label: "DSN", value: "https://1d003e90bf6a072f57d3a7765f124a70@o4511340602523648.ingest.de.sentry.io/4511340621594704", copy: true },
+      { label: "Org ID", value: "o4511340602523648 (numeric, in DSN)" },
+      { label: "Project ID", value: "4511340621594704 (numeric, in DSN)" },
+      { label: "Activation", value: "Set NEXT_PUBLIC_SENTRY_DSN + IS_SENTRY_ENABLED=true on each Vercel env" },
+      { label: "Source-map upload", value: "Requires SENTRY_AUTH_TOKEN + SENTRY_ORG + SENTRY_PROJECT on Vercel (build time only)" },
     ],
   },
   {

--- a/scripts/check-secret-rotation.py
+++ b/scripts/check-secret-rotation.py
@@ -35,6 +35,18 @@ CADENCE_DAYS = {
     "quarterly": 90,
 }
 
+# Cadences meaning "no scheduled rotation" — rows with these are
+# informational only and skipped by the calendar reminder. Used for
+# credentials that rotate only on incident (e.g. Sentry DSN, which is
+# public-by-design and only rotates on leak).
+NO_SCHEDULE_CADENCES = {
+    "only on suspicion",
+    "on suspicion only",
+    "never",
+    "as needed",
+    "manual",
+}
+
 
 class SecretRow(NamedTuple):
     name: str
@@ -142,6 +154,11 @@ def main() -> int:
             unrotated.append(
                 f"  ⚠️  {row.name}: Last Rotated='Initial setup' — never rotated. Add a real date to SECURITY_ROTATION.md."
             )
+            continue
+        # No-schedule cadences (e.g. "Only on suspicion") are informational
+        # only — skip them entirely from the calendar reminder. They're
+        # tracked by incident response, not by date arithmetic.
+        if row.rotation.strip().lower() in NO_SCHEDULE_CADENCES:
             continue
         next_due = row.next_due()
         if next_due is None:

--- a/tests/unit/check-secret-rotation.test.ts
+++ b/tests/unit/check-secret-rotation.test.ts
@@ -59,4 +59,16 @@ describe('check-secret-rotation.py', () => {
     expect(r.stdout).not.toMatch(/OVERDUE/);
     expect(r.exitCode).toBe(0);
   });
+
+  test('skips rows with "Only on suspicion" cadence (no-schedule path)', () => {
+    // The Sentry DSN row uses "Only on suspicion" — should be skipped
+    // entirely (no warning, no error). Verify by looking at a date well
+    // past any annual rotation: the DSN row should NOT appear in any
+    // category, but the annual-cadence rows would. We assert the DSN row
+    // isn't flagged as overdue/in-window/unparseable.
+    const r = run(['--today', '2027-04-15', '--warn-days', '30']);
+    expect(r.stdout).not.toMatch(/Sentry DSN/);
+    // sanity check: scheduled-cadence rows still get flagged
+    expect(r.stdout).toMatch(/LYRA_RELEASE_PAT|LYRA_BACKUP_PAT/);
+  });
 });


### PR DESCRIPTION
## Summary

Follow-up to PR #136 (Sentry scaffold). The scaffold is shipped and inert until Vercel env vars are populated; this PR adds the operator-facing setup doc + rotation policy entries.

- `docs/SENTRY_SETUP.md` (new) — step-by-step activation per env, account snapshot (DSN, IDs, region), what's NOT enabled by default with rationale (Replay, PII, tunnel route, MCP), source-map upload prerequisites
- `docs/SECURITY_ROTATION.md` — added rows for SENTRY_AUTH_TOKEN (annual, Vercel), Sentry DSN (only on suspicion), UptimeRobot Main API key (annual, local-only)
- `docs/lyra-project-reference.jsx` — new "Sentry (Error monitoring)" section; renamed UptimeRobot section to "Uptime monitoring" so the two layers are visually distinct
- `scripts/check-secret-rotation.py` — handles "Only on suspicion" cadence as no-schedule (informational only, not warned/errored). Required because the Sentry DSN row would otherwise break the parser
- New unit test for the no-schedule path; 363 / 31 suites passing

## Operator next steps (per the new doc)

1. Vercel → set `NEXT_PUBLIC_SENTRY_DSN` + `IS_SENTRY_ENABLED=true` on Development env first
2. Trigger any error on dev to verify event flow (~30s)
3. Once happy, repeat for Preview + Production
4. Source-map upload requires `SENTRY_AUTH_TOKEN` + `SENTRY_ORG` + `SENTRY_PROJECT` in Vercel — non-blocking quality-of-life

## Test plan

- [x] `npm run test:unit` — 363 passing, 31 suites
- [x] `python3 scripts/check-secret-rotation.py --today 2026-05-06` returns exit 0 (no overdue/in-window flags after the new rows)
- [x] Lint + tsc clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)