### PR TITLE
fix(beta): BUGS-13 vercel deploy --target=beta + pull beta env scope

### DIFF
--- a/.github/workflows/deploy-beta.yml
+++ b/.github/workflows/deploy-beta.yml
@@ -84,15 +84,21 @@ jobs:
           cache: 'npm'
       - name: Install Vercel CLI
         run: npm install -g vercel@latest
+      # BUGS-13: pull beta env (not preview) so build resolves IS_BETA_DEPLOY,
+      # NEXT_PUBLIC_SITE_URL=https://beta.checklyra.com, and PROD_SUPABASE_*
+      # from the beta custom environment. Without this, Vercel CLI defaults
+      # to preview scope and the resulting deployment is target=preview,
+      # which both serves stale content on beta.checklyra.com and trips the
+      # post-deploy SHA verification (which filters target=='beta').
       - name: Pull Vercel environment
-        run: vercel pull --yes --environment=preview --token=${{ secrets.VERCEL_TOKEN }}
+        run: vercel pull --yes --environment=beta --token=${{ secrets.VERCEL_TOKEN }}
       - name: Build project
-        run: vercel build --token=${{ secrets.VERCEL_TOKEN }}
+        run: vercel build --target=beta --token=${{ secrets.VERCEL_TOKEN }}
       - name: Deploy to Vercel
         id: deploy
         run: |
           set -euo pipefail
-          URL=$(vercel deploy --prebuilt --token=${{ secrets.VERCEL_TOKEN }})
+          URL=$(vercel deploy --prebuilt --target=beta --token=${{ secrets.VERCEL_TOKEN }})
           echo "deploy_url=$URL" >> $GITHUB_OUTPUT
           echo "Deployed to: $URL"
 

--- a/docs/HANDOVER_BETA_2026-05-11.md
+++ b/docs/HANDOVER_BETA_2026-05-11.md
@@ -4,6 +4,21 @@
 **For:** new chat session picking up the beta deploy after KAN-175 stand-up
 **Status:** infrastructure complete, ready for end-to-end smoke testing + first real promotion
 
+## 2026-05-11 — UPDATE after first real promotion attempt
+
+The first `promote-staging-to-beta.yml` run ([25653670221](https://github.com/luisa-sys/lyra/actions/runs/25653670221)) revealed **[BUGS-13](https://checklyra.atlassian.net/browse/BUGS-13)**: `deploy-beta.yml` has never actually produced a `target=beta` Vercel deployment because the deploy step is missing `--target=beta` and the env pull was scoped to `preview` instead of `beta`. All three CI deploy-beta runs since 2026-05-05 have failed at the same step — nobody noticed because the beta domain still resolves (serving an old 404 page).
+
+**What's true vs. what the rest of this doc says:**
+
+- `beta` branch exists, gets promoted, merges succeed — ✅ true
+- `deploy-beta.yml` runs lint, build, deploy steps — ✅ true
+- `beta.checklyra.com` returns HTTP 200 — ✅ true, but **the body is a stale 404 page**, not the beta homepage
+- Beta is gated by `is_beta_eligible` middleware — ✅ true in source, but **the gate has never actually served traffic** because no fresh deploy has landed
+- BUGS-11 will close on the next promotion — ❌ false, because `promote-staging-to-beta.yml` is a direct merge (no PR), so the auto-merge gate isn't exercised. BUGS-11 closes on the next `promote-to-production.yml` run, not the beta one.
+
+**Status now:** PR [#139](https://github.com/luisa-sys/lyra/pull/139) proposes the workflow fix. The Vercel-dashboard side (custom env named `beta` bound to the git branch, with the right env vars + `beta.checklyra.com` aliased to it) must be verified before that PR's effect can be confirmed end-to-end. See BUGS-13 step (b) for the dashboard checklist.
+
+
 ## Context (one paragraph)
 
 Lyra is a Next.js 16 + Supabase profile platform. Repo: `luisa-sys/lyra`. Pipeline is **develop → staging → beta → main**. Beta is a new env (KAN-175) just stood up — `beta.checklyra.com` is publicly reachable but gated by an in-app `is_beta_eligible` flag check in middleware. Non-eligible users redirect to `/waitlist`. Beta uses **production Supabase credentials** (shared `prod-lyra` project), so beta keys are valid prod keys via `mcp.checklyra.com`.


### PR DESCRIPTION
## Summary

- Make `deploy-beta.yml` actually deploy to the Vercel beta custom environment by passing `--target=beta` on `vercel deploy --prebuilt` (and matching `vercel build --target=beta`).
- Switch `vercel pull --environment=preview` → `--environment=beta` so the build resolves the beta env vars (`IS_BETA_DEPLOY=true`, `NEXT_PUBLIC_SITE_URL=https://beta.checklyra.com`, `PROD_SUPABASE_*`).

## Why

[BUGS-13](https://checklyra.atlassian.net/browse/BUGS-13): all three `deploy-beta.yml` runs since the env was stood up have failed at the same step (Post-Deploy Health Checks → Verify Vercel deployment matches commit SHA), because the deploy step never produces a `target=beta` deployment. As a side effect, `beta.checklyra.com` has been serving a stale 404 page — no CI deploy has actually landed on the beta alias.

Reproduced today during the first `promote-staging-to-beta.yml` run ([25653670221](https://github.com/luisa-sys/lyra/actions/runs/25653670221)). The merge to beta succeeded; the deploy ([25653679409](https://github.com/luisa-sys/lyra/actions/runs/25653679409)) failed with the same target mismatch.

## Vercel side — needs verification before this is fully usable

This workflow fix **alone is not sufficient**. Luisa should confirm in Vercel → project `lyra` → Settings → Environments:

- A custom environment named `beta` exists (the handover doc says it does)
- It is bound to the git branch `beta`
- It has `IS_BETA_DEPLOY=true`, `NEXT_PUBLIC_SITE_URL=https://beta.checklyra.com`, and `PROD_SUPABASE_*` keys set
- `beta.checklyra.com` is aliased to that environment, not to production

If the beta env doesn't exist, `vercel pull --environment=beta` will fail at that step — which is the right failure mode (loud, not silent like today).

## Test plan

- [ ] CI on this PR passes (PR Quality Gate, CodeQL)
- [ ] After merge to develop → staging → beta, the next `deploy-beta.yml` run completes all four jobs
- [ ] `curl https://beta.checklyra.com/` returns the homepage (not the stale 404)
- [ ] `curl <vercel-direct-url>/api/health` (with bypass header) returns `{"siteUrl":"https://beta.checklyra.com","isBetaDeploy":true,...}`
- [ ] Vercel API shows `target: 'beta'` for the merged SHA
- [ ] A subsequent `promote-staging-to-beta.yml` run completes without admin intervention

## Refs

- [BUGS-13](https://checklyra.atlassian.net/browse/BUGS-13)
- [KAN-175](https://checklyra.atlassian.net/browse/KAN-175) — closes the "promote cycle without admin intervention" AC
- Workflow: `.github/workflows/deploy-beta.yml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[BUGS-13]: https://checklyra.atlassian.net/browse/BUGS-13?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BUGS-13]: https://checklyra.atlassian.net/browse/BUGS-13?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ