### PR TITLE
diag: tee Vercel env audit to job log

### DIFF
--- a/.github/workflows/diagnose-vercel-env.yml
+++ b/.github/workflows/diagnose-vercel-env.yml
@@ -55,11 +55,12 @@ jobs:
             -H "Authorization: Bearer $VERCEL_TOKEN" \
             "https://api.vercel.com/v9/projects/$VERCEL_PROJECT_ID/env?teamId=$VERCEL_ORG_ID")
 
-          echo "$RESP" | python3 - <<'PY' >> "$GITHUB_STEP_SUMMARY"
+          printf '%s' "$RESP" > /tmp/vercel-envs.json
+          python3 <<'PY' >> "$GITHUB_STEP_SUMMARY"
           import json, os, sys, collections
 
-          raw = sys.stdin.read()
-          data = json.loads(raw)
+          with open('/tmp/vercel-envs.json') as f:
+              data = json.load(f)
           envs = data.get("envs", [])
 
           # Bucket every env-var entry by where it applies.
@@ -156,9 +157,11 @@ jobs:
             -H "Authorization: Bearer $VERCEL_TOKEN" \
             "https://api.vercel.com/v9/projects/$VERCEL_PROJECT_ID/custom-environments?teamId=$VERCEL_ORG_ID" \
             || echo '{"customEnvironments":[]}')
-          echo "$RESP" | python3 - <<'PY' >> "$GITHUB_STEP_SUMMARY"
-          import json, sys
-          data = json.loads(sys.stdin.read())
+          printf '%s' "$RESP" > /tmp/vercel-custom-envs.json
+          python3 <<'PY' >> "$GITHUB_STEP_SUMMARY"
+          import json
+          with open('/tmp/vercel-custom-envs.json') as f:
+              data = json.load(f)
           envs = data.get("customEnvironments") or data.get("environments") or []
           if not envs:
               print("_none defined_\n")

--- a/.github/workflows/diagnose-vercel-env.yml
+++ b/.github/workflows/diagnose-vercel-env.yml
@@ -181,3 +181,29 @@ jobs:
                   cid = e.get("id", "?")
                   print(f"| {name} | `{slug}` | `{branch}` | `{domain}` | `{cid}` |")
           PY
+      - name: Echo JSON to log (so non-UI clients can parse it)
+        run: |
+          set -euo pipefail
+          echo "=== ENV VARS (names + scope only) ==="
+          python3 -c "
+          import json
+          with open('/tmp/vercel-envs.json') as f:
+              data = json.load(f)
+          rows = sorted(
+              (e.get('key','?'),
+               ','.join(e.get('target') or []),
+               e.get('gitBranch') or '',
+               ','.join(e.get('customEnvironmentIds') or []))
+              for e in data.get('envs', [])
+          )
+          for k, t, gb, ce in rows:
+              print(f'{k}\t{t}\tgitBranch={gb}\tcustomEnvs={ce}')
+          "
+          echo ""
+          echo "=== CUSTOM ENVIRONMENTS ==="
+          cat /tmp/vercel-custom-envs.json | python3 -c "
+          import json, sys
+          d = json.load(sys.stdin)
+          for e in (d.get('customEnvironments') or d.get('environments') or []):
+              print(json.dumps(e, sort_keys=True))
+          "


### PR DESCRIPTION
Follow-up to PR #142 — add a step that prints env-var names to the job log so API clients (not just the UI summary view) can parse the result. Read-only.