### PR TITLE
fix(beta): BUGS-13 follow-up — verify-SHA matches alias, not target

### DIFF
--- a/.github/workflows/deploy-beta.yml
+++ b/.github/workflows/deploy-beta.yml
@@ -110,11 +110,15 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - name: Wait for deployment propagation
         run: sleep 20
-      # BUGS-4 / KAN-175: verify Vercel actually deployed our SHA before
-      # health-checking. Custom env "beta" is queried by name in target=beta.
-      # If Vercel API rejects custom env names in this filter, fall back to
-      # listing deployments without the target filter and matching on SHA
-      # AND deployment.target=='beta' Python-side.
+      # BUGS-13 fix: custom-env "beta" deployments come back with target=null
+      # from Vercel's API (custom envs don't populate the legacy target field
+      # the way `production` / `staging` do). The reliable signals are:
+      #   - alias contains "beta.checklyra.com"  (the verified beta alias),
+      #   - meta.githubCommitRef == "beta"       (the git branch we pushed),
+      #   - source == "cli"                      (deployed by this workflow).
+      # We match on SHA + (alias OR branch), which is robust across both the
+      # auto-target case (if Vercel ever populates target='beta') and the
+      # observed custom-env-null case.
       - name: Verify Vercel deployment matches commit SHA
         env:
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
@@ -129,8 +133,6 @@ jobs:
           DEPLOY_UID=""
           while [ $ATTEMPT -lt $MAX_ATTEMPTS ]; do
             ATTEMPT=$((ATTEMPT + 1))
-            # Pull last 10 deployments without target filter, then filter
-            # Python-side on both SHA and target=='beta' for robustness.
             DEPLOY_INFO=$(curl -sf \
               -H "Authorization: Bearer $VERCEL_TOKEN" \
               "https://api.vercel.com/v6/deployments?projectId=$VERCEL_PROJECT_ID&teamId=$VERCEL_ORG_ID&limit=10" \
@@ -141,12 +143,23 @@ jobs:
           for d in data.get('deployments', []):
               meta = d.get('meta', {}) or {}
               sha = meta.get('githubCommitSha') or ''
+              if sha != target_sha:
+                  continue
               dep_target = d.get('target') or ''
-              if sha == target_sha and dep_target == 'beta':
-                  print(f\"{d.get('uid')}|{d.get('readyState')}|{sha}\")
+              aliases = d.get('alias') or d.get('aliasAssigned') or []
+              if isinstance(aliases, str):
+                  aliases = [aliases]
+              branch = meta.get('githubCommitRef') or ''
+              is_beta = (
+                  dep_target == 'beta'
+                  or any('beta.checklyra.com' in (a or '') for a in aliases)
+                  or branch == 'beta'
+              )
+              if is_beta:
+                  print(f\"{d.get('uid')}|{d.get('readyState')}|{sha}|{dep_target or 'null'}\")
                   break
           else:
-              print('NONE||')
+              print('NONE|||')
           ")
             DEPLOY_UID=$(echo "$DEPLOY_INFO" | cut -d'|' -f1)
             STATE=$(echo "$DEPLOY_INFO" | cut -d'|' -f2)


### PR DESCRIPTION
## Summary

Follow-up to [PR #139](https://github.com/luisa-sys/lyra/pull/139). Today's promote-staging-to-beta run reproduced the failure with the new \`--target=beta\` flag in place. Pulled the actual deployment via Vercel MCP — it's READY, aliased to beta.checklyra.com, but \`target: null\`.

So Vercel's API does **not** populate the legacy \`target\` field for custom-env deployments. The verification step needs to use a different signal.

## Change

\`post-deploy-checks.Verify Vercel deployment matches commit SHA\` now matches on (any of):

- \`target == 'beta'\` (future-proof if Vercel ever populates it)
- \`alias\` contains \`beta.checklyra.com\` (the verified alias)
- \`meta.githubCommitRef == 'beta'\` (the branch we pushed)

## Verified state (right now, pre-PR)

Vercel deployment \`dpl_3JtsLMRh99URTNUsSds7ge81qCtX\` for SHA \`4f72af3b\`:
\`\`\`
state: READY
alias: ["beta.checklyra.com", "lyra-env-beta-luisa-sys-projects.vercel.app"]
target: null
meta.githubCommitRef: "beta"
\`\`\`

\`curl https://beta.checklyra.com/\` returns the Vercel SSO page ("Authentication Required") — expected per the handover doc, and confirms the deployment is genuinely serving (vs. the stale 404 we had pre-PR-139).

## Test plan

- [ ] CI passes
- [ ] Land on develop → staging → beta; the next deploy-beta run verifies cleanly
- [ ] promote-staging-to-beta exits 0 end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)