### PR TITLE
fix(promote-beta): BUGS-13 — promote workflow's own verify uses alias too

### DIFF
--- a/.github/workflows/promote-staging-to-beta.yml
+++ b/.github/workflows/promote-staging-to-beta.yml
@@ -218,13 +218,25 @@ jobs:
               "https://api.vercel.com/v6/deployments?projectId=$VERCEL_PROJECT_ID&teamId=$VERCEL_ORG_ID&limit=10" \
               | python3 -c "
           import json, sys
+          # BUGS-13: custom-env "beta" deployments come back from Vercel
+          # with target=null. Match on alias-list OR branch ref OR target.
           target_sha = '$EXPECTED_SHA'
           data = json.load(sys.stdin)
           for d in data.get('deployments', []):
               meta = d.get('meta', {}) or {}
               sha = meta.get('githubCommitSha') or ''
+              if sha != target_sha:
+                  continue
               dep_target = d.get('target') or ''
-              if sha == target_sha and dep_target == 'beta':
+              alias_field = d.get('alias')
+              aliases = alias_field if isinstance(alias_field, list) else []
+              branch = meta.get('githubCommitRef') or ''
+              is_beta = (
+                  dep_target == 'beta'
+                  or any('beta.checklyra.com' in (a or '') for a in aliases)
+                  or branch == 'beta'
+              )
+              if is_beta:
                   print(f\"{d.get('uid')}|{d.get('readyState')}|{sha}\")
                   break
           else:


### PR DESCRIPTION
Final BUGS-13 piece. Last staging→beta run got further than ever — wait-for-deploy passed ✅ — but the workflow's own post-deploy-health (separate from deploy-beta.yml's) still had the old target=='beta' check. Same fix applied.