### PR TITLE
chore(deps): group react/react-dom in dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,6 +15,16 @@ updates:
       - "dependencies"
     commit-message:
       prefix: "deps"
+    # Group react/react-dom (+ @types) so they always bump together.
+    # react-dom@X peer-depends on react@^X and package.json pins exact
+    # versions — solo react-dom bumps fail install (see PR #91).
+    groups:
+      react:
+        patterns:
+          - "react"
+          - "react-dom"
+          - "@types/react"
+          - "@types/react-dom"
 
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
## Summary

Adds a `groups` entry to the npm section of `.github/dependabot.yml` so that `react`, `react-dom`, `@types/react`, and `@types/react-dom` are always bumped in a single combined PR.

**Motivation: PR #91**

Dependabot opened PR #91 to bump `react-dom` alone from 19.2.4 → 19.2.5/6. Because `react-dom@X` peer-depends on `react@^X` and our `package.json` pins exact versions, `npm install` fails with `ERESOLVE` whenever react-dom is bumped without a matching react bump. The PR has been stuck unmergeable since it opened.

With this grouping in place, Dependabot will open one combined react-family PR going forward, which installs cleanly and can flow through `develop → staging → main` normally. PR #91 will be closed and superseded by the next Dependabot Monday run.

Only the npm ecosystem block is affected — the `github-actions` block is untouched.

## Test plan

- [ ] Workflow integrity check passes (`bash scripts/check-workflow-integrity.sh`)
- [ ] YAML parses cleanly (verified locally with `python3 -c 'import yaml; yaml.safe_load(...)'`)
- [ ] After merge, watch next Monday's Dependabot run — confirm any react-family bumps come through as a single grouped PR rather than separate `react` / `react-dom` PRs

🤖 Generated with [Claude Code](https://claude.com/claude-code)