### PR TITLE
KAN-114: Add Playwright E2E tests to staging deploy pipeline

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -220,3 +220,66 @@ jobs:
           STATUS=$(curl -so /dev/null -w "%{http_code}" --max-time 15 "https://stage.checklyra.com")
           echo "Staging site: $STATUS"
           [ "$STATUS" = "200" ] || [ "$STATUS" = "401" ] || [ "$STATUS" = "403" ] || (echo "::error::Staging site unreachable" && exit 1)
+
+  e2e-tests:
+    name: Playwright E2E Tests on Staging
+    needs: [deploy-staging, post-deploy-checks]
+    runs-on: ubuntu-latest
+    # KAN-114: run the full Playwright suite against the just-deployed
+    # Vercel preview URL. We target the deployment URL directly (not
+    # stage.checklyra.com) because:
+    #   1. Cloudflare bot protection blocks GitHub runner IPs from
+    #      reaching stage.checklyra.com (gotcha #7).
+    #   2. Vercel SSO sits in front of stage.checklyra.com and would
+    #      return 401 for every Playwright request.
+    # The x-vercel-protection-bypass header on the direct deploy URL
+    # bypasses both — same pattern as the /api/health smoke step.
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - name: Setup Node.js
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
+        with:
+          node-version: '20'
+          cache: 'npm'
+      - name: Install dependencies
+        run: npm ci
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps chromium
+      - name: Resolve BASE_URL for Playwright
+        id: base_url
+        env:
+          DEPLOY_URL: ${{ needs.deploy-staging.outputs.deploy_url }}
+        run: |
+          set -euo pipefail
+          if [ -z "$DEPLOY_URL" ]; then
+            echo "::error::deploy_url output missing from deploy-staging job; cannot run E2E tests."
+            exit 1
+          fi
+          CLEAN="${DEPLOY_URL#https://}"
+          CLEAN="${CLEAN#http://}"
+          BASE_URL="https://$CLEAN"
+          echo "base_url=$BASE_URL" >> "$GITHUB_OUTPUT"
+          echo "Playwright BASE_URL: $BASE_URL"
+      - name: Run Playwright tests against staging deploy URL
+        env:
+          BASE_URL: ${{ steps.base_url.outputs.base_url }}
+          VERCEL_AUTOMATION_BYPASS: ${{ secrets.VERCEL_AUTOMATION_BYPASS }}
+          CI: 'true'
+        run: |
+          set -euo pipefail
+          # Fail loud if the bypass secret is missing — without it every
+          # request gets a Vercel SSO 401 and the whole suite would fail
+          # with a misleading error. Per the Workflow & Backup Integrity
+          # Policy: no silent-skip.
+          if [ -z "$VERCEL_AUTOMATION_BYPASS" ]; then
+            echo "::error::VERCEL_AUTOMATION_BYPASS secret is required for E2E tests against the protected staging deploy URL."
+            exit 1
+          fi
+          npx playwright test
+      - name: Upload Playwright report on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: playwright-report/
+          retention-days: 14

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,5 +1,14 @@
 import { defineConfig, devices } from '@playwright/test';
 
+// KAN-114: when running against a Vercel-protected deploy URL on CI we
+// need to send the bypass header on every request. Locally and in tests
+// against http://localhost:3000, the variable is unset and the header
+// object is empty — no behaviour change.
+const vercelBypass = process.env.VERCEL_AUTOMATION_BYPASS;
+const extraHTTPHeaders: Record<string, string> = vercelBypass
+  ? { 'x-vercel-protection-bypass': vercelBypass }
+  : {};
+
 export default defineConfig({
   testDir: './tests/e2e',
   fullyParallel: true,
@@ -9,6 +18,7 @@ export default defineConfig({
   reporter: [['html', { open: 'never' }], ['github'], ['list']],
   use: {
     baseURL: process.env.BASE_URL || 'http://localhost:3000',
+    extraHTTPHeaders,
     trace: 'on-first-retry',
     screenshot: 'only-on-failure',
   },

--- a/tests/e2e/public-pages.spec.ts
+++ b/tests/e2e/public-pages.spec.ts
@@ -1,0 +1,75 @@
+import { test, expect } from '@playwright/test';
+
+/**
+ * KAN-114: E2E coverage for public pages that don't require auth.
+ *
+ * These tests target pages that:
+ *   - render server-side without a Supabase session, AND
+ *   - are reachable both on stage.checklyra.com (via Vercel bypass header)
+ *     and on `npm run dev` for local runs.
+ *
+ * Each test asserts on at least one visible element (title, heading, or
+ * known body text) so a "page rendered an empty 200" regression is caught.
+ *
+ * Do NOT add auth-gated routes here — Vercel SSO would 401 them on staging.
+ */
+
+test.describe('Login page', () => {
+  test('renders the sign-in form', async ({ page }) => {
+    await page.goto('/login');
+    await expect(page).toHaveTitle(/Sign in to Lyra/i);
+    await expect(page.getByRole('heading', { name: /welcome back/i })).toBeVisible();
+    await expect(page.getByLabel(/email/i)).toBeVisible();
+    await expect(page.getByLabel(/password/i)).toBeVisible();
+  });
+});
+
+test.describe('Signup page', () => {
+  test('renders the create-account form', async ({ page }) => {
+    await page.goto('/signup');
+    await expect(page).toHaveTitle(/Create your Lyra profile/i);
+    await expect(page.getByRole('heading', { name: /create your profile/i })).toBeVisible();
+    await expect(page.getByLabel(/full name/i)).toBeVisible();
+  });
+});
+
+test.describe('Privacy policy', () => {
+  test('renders the GDPR privacy content', async ({ page }) => {
+    await page.goto('/privacy');
+    await expect(page).toHaveTitle(/Privacy Policy/i);
+    await expect(page.getByRole('heading', { name: /privacy policy/i, level: 1 })).toBeVisible();
+    // Content sanity-check: the GDPR section header must be present so
+    // we know the article body actually rendered, not just the nav.
+    await expect(page.getByRole('heading', { name: /your rights/i })).toBeVisible();
+  });
+});
+
+test.describe('Terms of service', () => {
+  test('renders the terms content', async ({ page }) => {
+    await page.goto('/terms');
+    await expect(page).toHaveTitle(/Terms of Service/i);
+    await expect(page.getByRole('heading', { name: /terms of service/i, level: 1 })).toBeVisible();
+    // Section 5 references MCP — a known stable phrase on this page.
+    await expect(page.getByText(/AI companion access/i)).toBeVisible();
+  });
+});
+
+test.describe('Public profile 404', () => {
+  test('shows the not-found page for an unknown slug', async ({ page }) => {
+    const response = await page.goto('/this-profile-does-not-exist-kan114');
+    // Next.js renders the [slug]/not-found.tsx — should be a 404 status
+    // and the friendly profile-not-found copy.
+    expect(response?.status()).toBe(404);
+    await expect(page.getByRole('heading', { name: '404' })).toBeVisible();
+    await expect(page.getByText(/This profile doesn['’]t exist/i)).toBeVisible();
+  });
+});
+
+test.describe('Waitlist page', () => {
+  test('renders the beta waitlist message', async ({ page }) => {
+    await page.goto('/waitlist');
+    await expect(page).toHaveTitle(/waitlist/i);
+    await expect(page.getByRole('heading', { name: /you['’]re on the list/i })).toBeVisible();
+    await expect(page.getByRole('link', { name: /go to lyra/i })).toBeVisible();
+  });
+});


### PR DESCRIPTION
## Summary

Closes [KAN-114](https://checklyra.atlassian.net/browse/KAN-114).

- Adds **6 new Playwright E2E tests** for public, no-auth-required pages in `tests/e2e/public-pages.spec.ts`. Each test asserts on a visible heading or known body text (not just a 200 status), so an "empty 200" regression is caught.
- Wires a new `e2e-tests` job into `.github/workflows/deploy-staging.yml` (`needs: [deploy-staging, post-deploy-checks]`) that installs Playwright + chromium and runs `npx playwright test` against the just-deployed staging URL.
- Updates `playwright.config.ts` to forward `VERCEL_AUTOMATION_BYPASS` into `extraHTTPHeaders` so every request carries `x-vercel-protection-bypass`. No change for local runs.

## New tests

| Spec | Route | Assertion |
|---|---|---|
| Login page | `/login` | Title + "Welcome back" heading + email/password labels |
| Signup page | `/signup` | Title + "Create your profile" heading + full-name label |
| Privacy policy | `/privacy` | "Privacy Policy" h1 + "Your rights" section heading |
| Terms of service | `/terms` | "Terms of Service" h1 + "AI companion access" copy |
| Public profile 404 | `/this-profile-does-not-exist-kan114` | HTTP 404 + "404" heading + not-found copy |
| Waitlist | `/waitlist` | Title + "You're on the list" heading + "Go to Lyra" link |

Total Playwright suite: 7 specs × 2 projects (Desktop Chrome + iPhone 14) = **14 runs**.

## SSO + bot-challenge bypass pattern

`stage.checklyra.com` sits behind **both** Cloudflare bot challenge (blocks GitHub runner IPs) **and** Vercel SSO (401s unauthenticated requests). Per the existing `/api/health` step in `deploy-staging.yml`, the way through is:

1. Target the **direct Vercel deploy URL** (e.g. `lyra-xxx.vercel.app`) — not proxied by Cloudflare.
2. Send `x-vercel-protection-bypass: \${{ secrets.VERCEL_AUTOMATION_BYPASS }}` on every request.

The new job forwards `needs.deploy-staging.outputs.deploy_url` into Playwright as `BASE_URL`, and `playwright.config.ts` injects the bypass header via `extraHTTPHeaders` when `VERCEL_AUTOMATION_BYPASS` is set.

## Integrity policy compliance

- No `continue-on-error: true`, no `if: env.X != ''` silent-skips, no `|| echo` swallowing.
- Missing `VERCEL_AUTOMATION_BYPASS` secret fails the job loud with `::error::`.
- All multi-line `run:` blocks start with `set -euo pipefail`.
- \`scripts/check-workflow-integrity.sh\`: **green**.

## Test plan

- [x] \`npx playwright test --list\` parses all 14 specs cleanly
- [x] \`npm run test:unit\` — 363/363 pass, no regressions
- [x] \`npm run lint\` — 0 errors
- [x] \`npm run type-check\` — clean
- [x] \`bash scripts/check-workflow-integrity.sh\` — passes
- [ ] **After merge:** promote to staging and confirm the new \`Playwright E2E Tests on Staging\` job runs green against the live deploy URL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[KAN-114]: https://checklyra.atlassian.net/browse/KAN-114?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ