### PR TITLE
fix(workflows): KAN-167 Pattern 4 — fail-loud shell defaults on 7 remaining workflows

### DIFF
--- a/.github/workflows/backup-restore-test.yml
+++ b/.github/workflows/backup-restore-test.yml
@@ -5,6 +5,10 @@ on:
     - cron: '0 5 * * 0'  # Sunday 05:00 UTC (after backups at 02:00-02:30, mutation at 04:00)
   workflow_dispatch:
 
+defaults:
+  run:
+    shell: bash
+
 jobs:
   restore-test:
     runs-on: ubuntu-latest
@@ -13,6 +17,7 @@ jobs:
 
       - name: Install PostgreSQL 17 client
         run: |
+          set -euo pipefail
           sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
           curl -fsSL https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo gpg --dearmor -o /etc/apt/trusted.gpg.d/postgresql.gpg
           sudo apt-get update && sudo apt-get install -y postgresql-client-17
@@ -22,6 +27,7 @@ jobs:
         env:
           SUPABASE_DB_URL: ${{ secrets.SUPABASE_DB_URL }}
         run: |
+          set -euo pipefail
           if [ -z "$SUPABASE_DB_URL" ]; then
             echo "SUPABASE_DB_URL not configured — skipping"
             exit 0
@@ -34,6 +40,7 @@ jobs:
         env:
           SUPABASE_DB_URL: ${{ secrets.SUPABASE_DB_URL }}
         run: |
+          set -euo pipefail
           if [ -z "$SUPABASE_DB_URL" ]; then
             echo "Skipping — no DB URL"
             exit 0

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -12,6 +12,10 @@ permissions:
   contents: read
   security-events: write
 
+defaults:
+  run:
+    shell: bash
+
 jobs:
   analyze:
     name: CodeQL Analysis

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -5,6 +5,11 @@ on:
 env:
   VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
   VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+
+defaults:
+  run:
+    shell: bash
+
 jobs:
   lint-and-test:
     name: Lint & Unit Tests
@@ -54,10 +59,12 @@ jobs:
       - name: Deploy to Vercel
         id: deploy
         run: |
+          set -euo pipefail
           URL=$(vercel deploy --prebuilt --token=${{ secrets.VERCEL_TOKEN }})
           echo "deploy_url=$URL" >> $GITHUB_OUTPUT
       - name: Post-deploy health check
         run: |
+          set -euo pipefail
           echo "Waiting 15s for deployment to propagate..."
           sleep 15
           STATUS=$(curl -so /dev/null -w "%{http_code}" --max-time 10 "${{ steps.deploy.outputs.deploy_url }}" || echo "000")
@@ -71,7 +78,7 @@ jobs:
           VERCEL_BYPASS: ${{ secrets.VERCEL_AUTOMATION_BYPASS }}
           DEPLOY_URL: ${{ steps.deploy.outputs.deploy_url }}
         run: |
-          set -uo pipefail
+          set -euo pipefail
           # KAN-175: Cloudflare bot challenge blocks CI runner IPs from
           # reaching dev.checklyra.com directly (returns 403 + JS challenge
           # page). Solution: hit the Vercel deployment URL directly

--- a/.github/workflows/health-check.yml
+++ b/.github/workflows/health-check.yml
@@ -8,6 +8,10 @@ permissions:
   contents: read
   issues: write
 
+defaults:
+  run:
+    shell: bash
+
 jobs:
   health-checks:
     name: All-Environment Health Checks
@@ -21,6 +25,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
+          set -euo pipefail
           gh issue create \
             --repo ${{ github.repository }} \
             --title "🔴 Health check failed — $(date -u '+%Y-%m-%d %H:%M UTC')" \

--- a/.github/workflows/mutation-testing.yml
+++ b/.github/workflows/mutation-testing.yml
@@ -5,6 +5,10 @@ on:
     - cron: '0 4 * * 0'  # Sunday 04:00 UTC (after backup at 02:00)
   workflow_dispatch:
 
+defaults:
+  run:
+    shell: bash
+
 jobs:
   mutation-test:
     runs-on: ubuntu-latest
@@ -38,6 +42,7 @@ jobs:
       - name: Summary
         if: always()
         run: |
+          set -euo pipefail
           if [ -f reports/mutation/mutation-report.json ]; then
             SCORE=$(cat reports/mutation/mutation-report.json | python3 -c "
           import json, sys

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
     branches: [develop, staging, main]
 
+defaults:
+  run:
+    shell: bash
+
 jobs:
   checks:
     name: PR Quality Gate
@@ -42,6 +46,7 @@ jobs:
         run: npm audit --audit-level=high
       - name: Check for lint/type bypasses without Jira reference
         run: |
+          set -euo pipefail
           echo "Scanning for eslint-disable, ts-ignore, ts-nocheck, ts-expect-error..."
           VIOLATIONS=""
           while IFS= read -r line; do
@@ -65,6 +70,7 @@ jobs:
           fi
       - name: Check architecture doc freshness
         run: |
+          set -euo pipefail
           # Get list of changed files in this PR
           CHANGED=$(git diff --name-only origin/${{ github.base_ref }}...HEAD 2>/dev/null || echo "")
           

--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -5,6 +5,10 @@ on:
     - cron: '0 7 * * 3'  # Wednesday 07:00 UTC
   workflow_dispatch:
 
+defaults:
+  run:
+    shell: bash
+
 jobs:
   audit:
     runs-on: ubuntu-latest
@@ -22,6 +26,7 @@ jobs:
       - name: Run npm audit
         id: audit
         run: |
+          set -euo pipefail
           npm audit --json > /tmp/audit-results.json 2>&1 || true
           echo "exit_code=$?" >> $GITHUB_OUTPUT
 
@@ -53,11 +58,13 @@ jobs:
       - name: Generate audit report
         id: report
         run: |
+          set -euo pipefail
           python3 scripts/audit-to-email.py /tmp/audit-results.json > /tmp/audit-email.json
           echo "has_vulns=$(python3 -c "import json; d=json.load(open('/tmp/audit-email.json')); print('true' if d.get('has_vulnerabilities') else 'false')")" >> $GITHUB_OUTPUT
 
       - name: Output to step summary
         run: |
+          set -euo pipefail
           echo "## 🔒 Weekly Security Audit" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "**Date:** $(date -u +%Y-%m-%dT%H:%M:%SZ)" >> $GITHUB_STEP_SUMMARY
@@ -102,6 +109,7 @@ jobs:
         env:
           RESEND_API_KEY: ${{ secrets.RESEND_API_KEY }}
         run: |
+          set -euo pipefail
           if [ -z "$RESEND_API_KEY" ]; then
             echo "⚠️ RESEND_API_KEY not configured — skipping email"
             exit 0
@@ -130,6 +138,7 @@ jobs:
       - name: Fail if high/critical vulnerabilities found
         if: steps.audit.outputs.high_critical_count != '0'
         run: |
+          set -euo pipefail
           echo "❌ ${{ steps.audit.outputs.high_critical_count }} high/critical vulnerabilities detected"
           echo "Run 'npm audit' locally and fix before next deploy"
           exit 1


### PR DESCRIPTION
## Summary

Adds the workflow-level `defaults.run.shell: bash` and the `set -euo pipefail` prefix to every multi-line `run: |` block in the 7 workflows that were still missing them, per the **Workflow & Backup Integrity Policy** in `CLAUDE.md`. Closes the last gap for [KAN-167](https://checklyra.atlassian.net/browse/KAN-167) Pattern 4.

## Why

Multi-line `run:` blocks without `set -euo pipefail` silently swallow pipe failures and report green. The policy mandates both the workflow-level shell default and the per-block fail-loud prefix on every multi-line block. The remaining 7 workflows were the last ones not yet compliant.

## Files changed

| File | Workflow-level `defaults` added | `run: |` blocks prefixed |
| --- | --- | --- |
| `.github/workflows/backup-restore-test.yml` | yes | 3 (install pg client, export schema, verify integrity) |
| `.github/workflows/codeql.yml` | yes | 0 (no multi-line blocks) |
| `.github/workflows/deploy-dev.yml` | yes | 3 (Deploy to Vercel, Post-deploy health check, /api/health smoke — last upgraded from `set -uo` → `set -euo`) |
| `.github/workflows/health-check.yml` | yes | 1 (Create issue on failure) |
| `.github/workflows/mutation-testing.yml` | yes | 1 (Summary) |
| `.github/workflows/pr-checks.yml` | yes | 2 (lint/type bypass check, architecture-doc freshness) |
| `.github/workflows/security-audit.yml` | yes | 5 (npm audit, generate report, step summary, Resend email, fail step) |

No command semantics changed. No new steps, jobs, or triggers were added. Each multi-line `run:` block now starts with `set -euo pipefail`; single-line `run:` commands were left alone per the task brief.

All 7 workflows use `runs-on: ubuntu-latest` exclusively — no Windows runners, no `shell: python` overrides — so the workflow-level bash default is universally safe.

## Verification

- `bash scripts/check-workflow-integrity.sh` — passes (no false-positive patterns)
- `npm run lint` — 0 errors (only 9 pre-existing warnings unrelated to this change)
- Grep verification: each workflow's `run: |` block count equals its `set -euo pipefail` count, and every workflow has `defaults.run.shell: bash`

## Test plan

- [ ] `scripts/check-workflow-integrity.sh` runs clean in CI
- [ ] PR Checks workflow passes on this PR (exercises the new `set -euo pipefail` in `pr-checks.yml` itself)
- [ ] No-op for scheduled workflows until they next run

Do **not** auto-merge — per task brief.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[KAN-167]: https://checklyra.atlassian.net/browse/KAN-167?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ