### PR TITLE
feat(profile): KAN-154 — Manual of Me section (1/5)

### DIFF
--- a/src/app/[slug]/page.tsx
+++ b/src/app/[slug]/page.tsx
@@ -6,6 +6,10 @@ import type { Metadata } from 'next';
 import { env } from '@/lib/env';
 import { createClient as createSupabaseServerClient } from '@/lib/supabase-server';
 import { filterItemsByVisibility } from '@/app/dashboard/profile/visibility';
+import {
+  isManualOfMeEmpty,
+  type ManualOfMe,
+} from '@/app/dashboard/profile/manual-of-me-fields';
 
 // Create client per-request, not at module scope
 function getSupabase() {
@@ -90,6 +94,23 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   };
 }
 
+/** KAN-154: Display helper for a single Manual of Me field on the public
+ * profile. `value` is rendered as JSX text — React escapes it — and is also
+ * pre-sanitised on write via sanitiseText (which strips HTML tags and
+ * collapses whitespace). No dangerouslySetInnerHTML here. */
+function ManualOfMeFieldDisplay({ label, value }: { label: string; value: string }) {
+  return (
+    <div>
+      <p className="text-xs font-medium text-[var(--color-muted)] uppercase tracking-wide mb-1">
+        {label}
+      </p>
+      <p className="text-sm text-[var(--color-ink)] leading-relaxed">
+        {value}
+      </p>
+    </div>
+  );
+}
+
 export default async function PublicProfilePage({ params }: Props) {
   const { slug } = await params;
 
@@ -146,6 +167,16 @@ export default async function PublicProfilePage({ params }: Props) {
     .select('*')
     .eq('profile_id', typedProfile.id);
 
+  // KAN-154: Manual of Me (1-1 with profiles). Row may not exist for older
+  // profiles — treat that as "all fields empty" so the section is skipped.
+  const { data: manualOfMeRow } = await getSupabase()
+    .from('profile_manual_of_me')
+    .select('communication_style, working_preferences, energises_me, drains_me')
+    .eq('profile_id', typedProfile.id)
+    .maybeSingle();
+  const manualOfMe = (manualOfMeRow as ManualOfMe | null) ?? null;
+
+  // KAN-143: visibility-filtered items (see filterItemsByVisibility above).
   const typedItems = visibleItems;
   const typedSchools = (schools || []) as SchoolAffiliation[];
   const typedLinks = (links || []) as ExternalLink[];
@@ -272,6 +303,46 @@ export default async function PublicProfilePage({ params }: Props) {
         <div className="max-w-2xl mx-auto px-6 pb-6">
           <div className="bg-white rounded-xl border border-stone-200 p-5">
             <p className="text-[var(--color-ink)] leading-relaxed">{typedProfile.bio_short}</p>
+          </div>
+        </div>
+      )}
+
+      {/* KAN-154: Manual of Me — "How to work with me". Skip entirely if every
+          field is empty. All values are pre-sanitised on write (sanitiseText
+          strips HTML / normalises whitespace) AND rendered as JSX text content,
+          which React auto-escapes — no dangerouslySetInnerHTML here. */}
+      {!isManualOfMeEmpty(manualOfMe) && manualOfMe && (
+        <div className="max-w-2xl mx-auto px-6 pb-6">
+          <div className="bg-white rounded-xl border border-stone-200 p-5">
+            <h2 className="text-xs font-medium text-[var(--color-muted)] uppercase tracking-wide mb-4">
+              📖 How to work with me
+            </h2>
+            <div className="space-y-4">
+              {manualOfMe.communication_style && (
+                <ManualOfMeFieldDisplay
+                  label="Communication style"
+                  value={manualOfMe.communication_style}
+                />
+              )}
+              {manualOfMe.working_preferences && (
+                <ManualOfMeFieldDisplay
+                  label="Best ways to work with me"
+                  value={manualOfMe.working_preferences}
+                />
+              )}
+              {manualOfMe.energises_me && (
+                <ManualOfMeFieldDisplay
+                  label="What energises me"
+                  value={manualOfMe.energises_me}
+                />
+              )}
+              {manualOfMe.drains_me && (
+                <ManualOfMeFieldDisplay
+                  label="What drains me"
+                  value={manualOfMe.drains_me}
+                />
+              )}
+            </div>
           </div>
         </div>
       )}

--- a/src/app/dashboard/profile/manual-of-me-actions.ts
+++ b/src/app/dashboard/profile/manual-of-me-actions.ts
@@ -1,0 +1,107 @@
+'use server';
+
+/**
+ * KAN-154 — Server action for the "Manual of Me" profile section.
+ *
+ * Writes to the 1-1 `profile_manual_of_me` table (see migration
+ * 20260514120000_manual_of_me.sql).
+ *
+ * Security:
+ *   - Allowlist of writable fields (MANUAL_OF_ME_FIELDS) enforced before any
+ *     DB call, same pattern as updateProfileFields → prevents remote property
+ *     injection. (KAN-167 / CodeQL alert #2.)
+ *   - Every string field is run through sanitiseText (strips HTML, normalises
+ *     whitespace) with a per-field max length — defends in depth against
+ *     stored XSS even though React JSX auto-escapes. See KAN-171.
+ *   - The owning profile is resolved server-side from auth.uid() — caller
+ *     cannot supply a profile_id.
+ */
+
+import { createClient } from '@/lib/supabase-server';
+import { revalidatePath } from 'next/cache';
+import { sanitiseText, type ActionResult } from '@/lib/sanitise';
+import {
+  MANUAL_OF_ME_FIELDS,
+  MANUAL_OF_ME_MAX_LENGTHS,
+  isManualOfMeField,
+} from './manual-of-me-fields';
+
+/** Update (upsert) the user's Manual of Me row. Accepts a partial — any
+ * subset of allowlisted fields. Non-allowlisted keys cause wholesale
+ * rejection with a descriptive error.
+ *
+ * Null / empty-string values are written as null in the DB so the public-view
+ * "skip if empty" logic works correctly.
+ */
+export async function updateManualOfMe(
+  data: Record<string, string | null>
+): Promise<ActionResult> {
+  const supabase = await createClient();
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) return { success: false, error: 'Not authenticated' };
+
+  // 1. Allowlist enforcement — collect ALL rejected keys for a useful error.
+  const rejected: string[] = [];
+  const sanitised: Record<string, string | null> = {};
+  for (const [key, val] of Object.entries(data)) {
+    if (!isManualOfMeField(key)) {
+      rejected.push(key);
+      continue;
+    }
+    if (val === null || val === undefined) {
+      sanitised[key] = null;
+      continue;
+    }
+    if (typeof val !== 'string') {
+      // Defensive: this should not happen given the action signature, but
+      // a buggy caller passing a number/object would otherwise blow up
+      // sanitiseText. Reject explicitly.
+      rejected.push(key);
+      continue;
+    }
+    const maxLen = MANUAL_OF_ME_MAX_LENGTHS[key];
+    const cleaned = sanitiseText(val, maxLen);
+    // Treat post-sanitisation empty string as null so isManualOfMeEmpty works.
+    sanitised[key] = cleaned === '' ? null : cleaned;
+  }
+
+  if (rejected.length > 0) {
+    return {
+      success: false,
+      error: `Field(s) not permitted: ${rejected.join(', ')}`,
+    };
+  }
+
+  // 2. Resolve the owning profile (server-side, not client-supplied).
+  const { data: profile, error: profileErr } = await supabase
+    .from('profiles')
+    .select('id')
+    .eq('user_id', user.id)
+    .single();
+  if (profileErr || !profile) {
+    return { success: false, error: 'Profile not found' };
+  }
+
+  // 3. Empty input → no-op success (don't fire a meaningless UPDATE).
+  if (Object.keys(sanitised).length === 0) {
+    return { success: true };
+  }
+
+  // 4. Upsert (insert-or-update on profile_id PK). RLS enforces ownership.
+  const { error } = await supabase
+    .from('profile_manual_of_me')
+    .upsert(
+      { profile_id: profile.id, ...sanitised },
+      { onConflict: 'profile_id' }
+    );
+
+  if (error) return { success: false, error: error.message };
+
+  revalidatePath('/dashboard/profile');
+  return { success: true };
+}
+
+// Note: MANUAL_OF_ME_FIELDS is intentionally not re-exported from this file
+// (it would be a non-async export, rejected by Next.js 16+ at action-invocation
+// time — see CLAUDE.md gotcha #18). Callers should import it directly from
+// ./manual-of-me-fields.

--- a/src/app/dashboard/profile/manual-of-me-fields.ts
+++ b/src/app/dashboard/profile/manual-of-me-fields.ts
@@ -1,0 +1,59 @@
+/**
+ * KAN-154 — "Manual of Me" field allowlist + per-field max-length limits.
+ *
+ * Lives in this sibling module (rather than alongside the server action
+ * in `manual-of-me-actions.ts`) because Next.js 16+ rejects non-async-function
+ * exports from `'use server'` files at action-invocation time. See BUGS-12 /
+ * CLAUDE.md gotcha #18.
+ *
+ * v1 fields (4):
+ *   - communication_style   — how the user likes to be communicated with
+ *   - working_preferences   — best ways to work with this person (long text)
+ *   - energises_me          — what energises them at work
+ *   - drains_me             — what drains their energy
+ *
+ * Excluded for v1:
+ *   - "hot buttons"               (overlaps with dislikes/boundaries items)
+ *   - "how I handle disagreement" (niche, low demand)
+ *   - "preferred feedback style"  (possible v2)
+ */
+
+export const MANUAL_OF_ME_FIELDS = [
+  'communication_style',
+  'working_preferences',
+  'energises_me',
+  'drains_me',
+] as const;
+
+export type ManualOfMeField = typeof MANUAL_OF_ME_FIELDS[number];
+
+/** Per-field max length (passed to sanitiseText). working_preferences is
+ * intentionally longer because it's the "main" free-text field. */
+export const MANUAL_OF_ME_MAX_LENGTHS: Record<ManualOfMeField, number> = {
+  communication_style: 500,
+  working_preferences: 1000,
+  energises_me: 500,
+  drains_me: 500,
+};
+
+export function isManualOfMeField(key: string): key is ManualOfMeField {
+  return (MANUAL_OF_ME_FIELDS as readonly string[]).includes(key);
+}
+
+/** Shape returned by the loader and used by the wizard step + public view. */
+export interface ManualOfMe {
+  communication_style: string | null;
+  working_preferences: string | null;
+  energises_me: string | null;
+  drains_me: string | null;
+}
+
+/** True if every field is null or empty-after-trim. Public view uses this to
+ * decide whether to skip the entire "How to work with me" section. */
+export function isManualOfMeEmpty(m: ManualOfMe | null | undefined): boolean {
+  if (!m) return true;
+  return MANUAL_OF_ME_FIELDS.every((k) => {
+    const v = m[k];
+    return v === null || v === undefined || v.trim() === '';
+  });
+}

--- a/src/app/dashboard/profile/page.tsx
+++ b/src/app/dashboard/profile/page.tsx
@@ -1,10 +1,18 @@
 import { createClient } from '@/lib/supabase-server';
 import { redirect } from 'next/navigation';
 import { ProfileWizard } from './wizard';
+import type { ManualOfMe } from './manual-of-me-fields';
 
 export const metadata = {
   title: 'Edit your profile — Lyra',
   description: 'Set up your Lyra profile so people in your life can get to know you better.',
+};
+
+const EMPTY_MANUAL_OF_ME: ManualOfMe = {
+  communication_style: null,
+  working_preferences: null,
+  energises_me: null,
+  drains_me: null,
 };
 
 export default async function ProfilePage() {
@@ -36,12 +44,21 @@ export default async function ProfilePage() {
     .select('*')
     .eq('profile_id', profile.id);
 
+  // KAN-154: Manual of Me is a 1-1 table. If the user has never saved it,
+  // the row simply doesn't exist — render an empty form rather than failing.
+  const { data: manualOfMeRow } = await supabase
+    .from('profile_manual_of_me')
+    .select('communication_style, working_preferences, energises_me, drains_me')
+    .eq('profile_id', profile.id)
+    .maybeSingle();
+
   return (
     <ProfileWizard
       profile={profile}
       items={items || []}
       schools={schools || []}
       links={links || []}
+      manualOfMe={(manualOfMeRow as ManualOfMe | null) ?? EMPTY_MANUAL_OF_ME}
     />
   );
 }

--- a/src/app/dashboard/profile/steps/index.ts
+++ b/src/app/dashboard/profile/steps/index.ts
@@ -3,5 +3,6 @@ export { BioStep } from './bio-step';
 export { SchoolStep } from './school-step';
 export { ItemsStep } from './items-step';
 export { LinksStep } from './links-step';
+export { ManualOfMeStep } from './manual-of-me-step';
 export { PreviewStep } from './preview-step';
 export type { WizardProfile, WizardItem, WizardSchool, WizardLink } from './types';

--- a/src/app/dashboard/profile/steps/manual-of-me-step.tsx
+++ b/src/app/dashboard/profile/steps/manual-of-me-step.tsx
@@ -1,0 +1,139 @@
+'use client';
+
+import { useState } from 'react';
+import { SaveButton } from './types';
+import type { ManualOfMe } from '../manual-of-me-fields';
+import { MANUAL_OF_ME_MAX_LENGTHS } from '../manual-of-me-fields';
+
+/**
+ * KAN-154 — Wizard step for the "Manual of Me" profile section.
+ *
+ * Renders four optional text areas. All fields are independent — saving an
+ * empty field clears it; user can leave the whole step blank.
+ */
+export function ManualOfMeStep({
+  manualOfMe,
+  onSave,
+  isPending,
+}: {
+  manualOfMe: ManualOfMe;
+  onSave: (data: Record<string, string>) => void;
+  isPending: boolean;
+}) {
+  const [communicationStyle, setCommunicationStyle] = useState(
+    manualOfMe.communication_style || ''
+  );
+  const [workingPreferences, setWorkingPreferences] = useState(
+    manualOfMe.working_preferences || ''
+  );
+  const [energisesMe, setEnergisesMe] = useState(manualOfMe.energises_me || '');
+  const [drainsMe, setDrainsMe] = useState(manualOfMe.drains_me || '');
+
+  const handleSave = () => {
+    onSave({
+      communication_style: communicationStyle,
+      working_preferences: workingPreferences,
+      energises_me: energisesMe,
+      drains_me: drainsMe,
+    });
+  };
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h2 className="text-xl font-medium text-[var(--color-ink)]">
+          Manual of Me
+        </h2>
+        <p className="text-sm text-[var(--color-muted)] mt-1">
+          A short user-guide for working with you. All fields are optional —
+          fill in what feels useful.
+        </p>
+      </div>
+
+      <ManualOfMeField
+        label="Communication style"
+        helper="How do you prefer people communicate with you?"
+        placeholder="Async messages over meetings. Be direct — I'd rather hear it than guess."
+        value={communicationStyle}
+        onChange={setCommunicationStyle}
+        rows={3}
+        maxLength={MANUAL_OF_ME_MAX_LENGTHS.communication_style}
+      />
+
+      <ManualOfMeField
+        label="Best ways to work with me"
+        helper="What working preferences should people know?"
+        placeholder="Mornings are my deep-work time. I think out loud, so don't take rough drafts as final."
+        value={workingPreferences}
+        onChange={setWorkingPreferences}
+        rows={5}
+        maxLength={MANUAL_OF_ME_MAX_LENGTHS.working_preferences}
+      />
+
+      <ManualOfMeField
+        label="What energises me"
+        helper="What gives you energy?"
+        placeholder="Solving hard problems, making people laugh, walking meetings."
+        value={energisesMe}
+        onChange={setEnergisesMe}
+        rows={3}
+        maxLength={MANUAL_OF_ME_MAX_LENGTHS.energises_me}
+      />
+
+      <ManualOfMeField
+        label="What drains me"
+        helper="What pulls your energy down?"
+        placeholder="Back-to-back meetings with no breaks. Surprise context switches."
+        value={drainsMe}
+        onChange={setDrainsMe}
+        rows={3}
+        maxLength={MANUAL_OF_ME_MAX_LENGTHS.drains_me}
+      />
+
+      <SaveButton
+        onClick={handleSave}
+        isPending={isPending}
+        label="Save & continue"
+      />
+    </div>
+  );
+}
+
+/** Internal: labelled textarea with character-count footer. */
+function ManualOfMeField({
+  label,
+  helper,
+  placeholder,
+  value,
+  onChange,
+  rows,
+  maxLength,
+}: {
+  label: string;
+  helper: string;
+  placeholder: string;
+  value: string;
+  onChange: (v: string) => void;
+  rows: number;
+  maxLength: number;
+}) {
+  return (
+    <div>
+      <label className="block text-sm font-medium text-[var(--color-ink)] mb-1">
+        {label}
+      </label>
+      <p className="text-xs text-[var(--color-muted)] mb-1.5">{helper}</p>
+      <textarea
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        rows={rows}
+        maxLength={maxLength}
+        placeholder={placeholder}
+        className="w-full px-3 py-2 rounded-lg border border-stone-300 bg-white text-[var(--color-ink)] text-sm focus:outline-none focus:ring-2 focus:ring-[var(--color-sage)] focus:border-transparent resize-none"
+      />
+      <p className="text-xs text-[var(--color-muted)] mt-1">
+        {value.length}/{maxLength}
+      </p>
+    </div>
+  );
+}

--- a/src/app/dashboard/profile/wizard.tsx
+++ b/src/app/dashboard/profile/wizard.tsx
@@ -16,8 +16,10 @@ import {
   publishProfile,
   uploadAvatar,
 } from './actions';
+import { updateManualOfMe } from './manual-of-me-actions';
+import type { ManualOfMe } from './manual-of-me-fields';
 import {
-  IdentityStep, BioStep, SchoolStep, ItemsStep, LinksStep, PreviewStep,
+  IdentityStep, BioStep, SchoolStep, ItemsStep, LinksStep, ManualOfMeStep, PreviewStep,
   type WizardProfile, type WizardItem, type WizardSchool, type WizardLink,
 } from './steps';
 
@@ -25,6 +27,7 @@ const STEPS = [
   { id: 'identity', label: 'Identity', icon: '👤' },
   { id: 'school', label: 'School', icon: '🏫' },
   { id: 'bio', label: 'About you', icon: '✏️' },
+  { id: 'manual_of_me', label: 'Manual of Me', icon: '📖' },
   { id: 'likes', label: 'Likes & Dislikes', icon: '💚' },
   { id: 'gifts', label: 'Gift ideas', icon: '🎁' },
   { id: 'boundaries', label: 'Boundaries', icon: '🛑' },
@@ -40,11 +43,13 @@ export function ProfileWizard({
   items,
   schools,
   links,
+  manualOfMe,
 }: {
   profile: WizardProfile;
   items: WizardItem[];
   schools: WizardSchool[];
   links: WizardLink[];
+  manualOfMe: ManualOfMe;
 }) {
   const [step, setStep] = useState(0);
   const [isPending, startTransition] = useTransition();
@@ -124,6 +129,15 @@ export function ProfileWizard({
           }} isPending={isPending} />
         )}
         {step === 3 && (
+          <ManualOfMeStep manualOfMe={manualOfMe} onSave={(data: Record<string, string>) => {
+            startTransition(async () => {
+              await updateManualOfMe(data);
+              router.refresh();
+              next();
+            });
+          }} isPending={isPending} />
+        )}
+        {step === 4 && (
           <ItemsStep title="Likes & Dislikes" description="What do you love? What can't you stand?"
             categories={['likes', 'dislikes']}
             items={items.filter((i) => ['likes', 'dislikes'].includes(i.category))}
@@ -132,7 +146,7 @@ export function ProfileWizard({
             onUpdateVisibility={(id, visibility) => { startTransition(async () => { await updateProfileItemVisibility(id, visibility); router.refresh(); }); }}
             onNext={next} isPending={isPending} />
         )}
-        {step === 4 && (
+        {step === 5 && (
           <ItemsStep title="Gift ideas" description="Help people find the perfect gift for you."
             categories={['gift_ideas', 'gifts_to_avoid']}
             items={items.filter((i) => ['gift_ideas', 'gifts_to_avoid'].includes(i.category))}
@@ -141,7 +155,7 @@ export function ProfileWizard({
             onUpdateVisibility={(id, visibility) => { startTransition(async () => { await updateProfileItemVisibility(id, visibility); router.refresh(); }); }}
             onNext={next} isPending={isPending} />
         )}
-        {step === 5 && (
+        {step === 6 && (
           <ItemsStep title="Boundaries" description="Things people should know to respect your space."
             categories={['boundaries', 'helpful_to_know']}
             items={items.filter((i) => ['boundaries', 'helpful_to_know'].includes(i.category))}
@@ -150,7 +164,7 @@ export function ProfileWizard({
             onUpdateVisibility={(id, visibility) => { startTransition(async () => { await updateProfileItemVisibility(id, visibility); router.refresh(); }); }}
             onNext={next} isPending={isPending} />
         )}
-        {step === 6 && (
+        {step === 7 && (
           <ItemsStep title="Books & Media" description="Favourite books, movies, and series — the things that shaped you."
             categories={['favourite_books', 'favourite_media']}
             items={items.filter((i) => ['favourite_books', 'favourite_media'].includes(i.category))}
@@ -159,7 +173,7 @@ export function ProfileWizard({
             onUpdateVisibility={(id, visibility) => { startTransition(async () => { await updateProfileItemVisibility(id, visibility); router.refresh(); }); }}
             onNext={next} isPending={isPending} />
         )}
-        {step === 7 && (
+        {step === 8 && (
           <ItemsStep title="Causes & Quotes" description="What matters to you — charities, causes, and words that resonate."
             categories={['causes', 'quotes']}
             items={items.filter((i) => ['causes', 'quotes'].includes(i.category))}
@@ -168,7 +182,7 @@ export function ProfileWizard({
             onUpdateVisibility={(id, visibility) => { startTransition(async () => { await updateProfileItemVisibility(id, visibility); router.refresh(); }); }}
             onNext={next} isPending={isPending} />
         )}
-        {step === 8 && (
+        {step === 9 && (
           <ItemsStep title="More about you" description="What makes you proud, life hacks, questions you wish people asked."
             categories={['proud_of', 'life_hacks', 'questions', 'billboard']}
             items={items.filter((i) => ['proud_of', 'life_hacks', 'questions', 'billboard'].includes(i.category))}
@@ -177,13 +191,13 @@ export function ProfileWizard({
             onUpdateVisibility={(id, visibility) => { startTransition(async () => { await updateProfileItemVisibility(id, visibility); router.refresh(); }); }}
             onNext={next} isPending={isPending} />
         )}
-        {step === 9 && (
+        {step === 10 && (
           <LinksStep links={links}
             onAdd={(data) => { startTransition(async () => { await addExternalLink(data); router.refresh(); }); }}
             onRemove={(id) => { startTransition(async () => { await removeExternalLink(id); router.refresh(); }); }}
             onNext={next} isPending={isPending} />
         )}
-        {step === 10 && (
+        {step === 11 && (
           <PreviewStep profile={profile} items={items} schools={schools} links={links}
             onPublish={() => { startTransition(async () => { await publishProfile(); router.refresh(); router.push('/dashboard'); }); }}
             isPending={isPending} />

--- a/supabase/migrations/20260514120000_manual_of_me.sql
+++ b/supabase/migrations/20260514120000_manual_of_me.sql
@@ -1,0 +1,63 @@
+-- KAN-154: "Manual of Me" — profile section describing how to work / interact with the user
+--
+-- Decision: 1-1 table `profile_manual_of_me` (rather than columns on `profiles`).
+-- Rationale:
+--   1. Keeps `profiles` lean — already has ~12 columns; adding 4 more text fields would
+--      bloat every row read for callers that don't need this data.
+--   2. Mirrors the existing pattern for optional profile sections (profile_items,
+--      school_affiliations, external_links — all separate tables with profile_id FK).
+--   3. RLS policy is identical to other profile sections, easy to reason about.
+--   4. Easy to extend in v2 (additional fields) without touching the hot `profiles`
+--      table or any migration to add NULLable columns.
+--
+-- Fields (4, tighter subset chosen for v1):
+--   - communication_style   (max 500)  — how I like to be communicated with
+--   - working_preferences   (max 1000) — best ways to work with me (longer free text)
+--   - energises_me          (max 500)  — what gives me energy at work
+--   - drains_me             (max 500)  — what drains my energy
+--
+-- Excluded for v1 (can be added later if user demand exists):
+--   - "hot buttons"          — overlaps with existing `dislikes` and `boundaries` items
+--   - "how I handle disagreement" — niche; not enough demand signal
+--   - "preferred feedback style"  — possible v2 add
+--
+-- Rollback:
+--   DROP TABLE IF EXISTS public.profile_manual_of_me CASCADE;
+
+-- ============================================================
+-- TABLE: profile_manual_of_me (1-1 with profiles)
+-- ============================================================
+create table public.profile_manual_of_me (
+  profile_id uuid primary key references public.profiles(id) on delete cascade,
+  communication_style text,
+  working_preferences text,
+  energises_me text,
+  drains_me text,
+  created_at timestamptz default now(),
+  updated_at timestamptz default now()
+);
+
+-- Auto-update updated_at on row update
+create trigger on_profile_manual_of_me_updated
+  before update on public.profile_manual_of_me
+  for each row execute function public.handle_updated_at();
+
+-- ============================================================
+-- ROW LEVEL SECURITY
+-- Same pattern as other profile-section tables:
+--   - Owner can CRUD their own row
+--   - Anyone can read rows belonging to published profiles
+-- ============================================================
+alter table public.profile_manual_of_me enable row level security;
+
+create policy "Users can manage own manual_of_me"
+  on public.profile_manual_of_me for all
+  using (profile_id in (
+    select id from public.profiles where user_id = auth.uid()
+  ));
+
+create policy "Anyone can read manual_of_me from published profiles"
+  on public.profile_manual_of_me for select
+  using (profile_id in (
+    select id from public.profiles where is_published = true
+  ));

--- a/tests/unit/manual-of-me-actions.test.ts
+++ b/tests/unit/manual-of-me-actions.test.ts
@@ -1,0 +1,291 @@
+/**
+ * KAN-154 — updateManualOfMe server action tests.
+ *
+ * Mirrors the structure of profile-actions.test.ts. Coverage:
+ *   - Allowlist enforcement (rejects unknown fields → no DB write)
+ *   - sanitiseText is applied (HTML stripped, max-length per field)
+ *   - Empty / null inputs are normalised to null in the DB row
+ *   - profile_id is resolved server-side from auth.uid() — caller cannot inject
+ *   - Auth failure short-circuits before any DB call
+ *   - Helper isManualOfMeEmpty correctly detects all-empty rows
+ */
+
+// --- Mocks --------------------------------------------------------------
+
+const mockRevalidatePath = jest.fn();
+jest.mock('next/cache', () => ({
+  revalidatePath: (...args: unknown[]) => mockRevalidatePath(...args),
+}));
+
+// Captures upsert payload + onConflict argument
+const mockUpsertCapture = jest.fn();
+
+// Auth + profile-lookup are controllable per-test via these mocks.
+const mockGetUser = jest.fn();
+const mockProfileSelectSingle = jest.fn();
+
+jest.mock('@/lib/supabase-server', () => ({
+  createClient: jest.fn().mockImplementation(async () => ({
+    auth: {
+      getUser: mockGetUser,
+    },
+    from: jest.fn().mockImplementation((table: string) => {
+      if (table === 'profiles') {
+        return {
+          select: () => ({
+            eq: () => ({
+              single: mockProfileSelectSingle,
+            }),
+          }),
+        };
+      }
+      if (table === 'profile_manual_of_me') {
+        return {
+          upsert: (data: unknown, opts: unknown) => {
+            mockUpsertCapture(data, opts);
+            return Promise.resolve({ error: null });
+          },
+        };
+      }
+      throw new Error(`Unexpected table in test: ${table}`);
+    }),
+  })),
+}));
+
+import { updateManualOfMe } from '@/app/dashboard/profile/manual-of-me-actions';
+import {
+  MANUAL_OF_ME_FIELDS,
+  MANUAL_OF_ME_MAX_LENGTHS,
+  isManualOfMeField,
+  isManualOfMeEmpty,
+} from '@/app/dashboard/profile/manual-of-me-fields';
+
+beforeEach(() => {
+  mockUpsertCapture.mockClear();
+  mockRevalidatePath.mockClear();
+  // Default: authed user + their profile exists
+  mockGetUser.mockReset();
+  mockProfileSelectSingle.mockReset();
+  mockGetUser.mockResolvedValue({ data: { user: { id: 'user-1' } } });
+  mockProfileSelectSingle.mockResolvedValue({ data: { id: 'profile-1' }, error: null });
+});
+
+// --- Allowlist + sanitisation -------------------------------------------
+
+describe('updateManualOfMe — allowlist + sanitisation', () => {
+  test('accepts an allowlisted field and writes the sanitised value', async () => {
+    const result = await updateManualOfMe({
+      communication_style: 'Async <script>x</script> please',
+    });
+    expect(result).toEqual({ success: true });
+    expect(mockUpsertCapture).toHaveBeenCalledTimes(1);
+    const [payload, opts] = mockUpsertCapture.mock.calls[0];
+    expect(payload).toEqual({
+      profile_id: 'profile-1',
+      communication_style: 'Async x please',
+    });
+    expect(opts).toEqual({ onConflict: 'profile_id' });
+    expect(mockRevalidatePath).toHaveBeenCalledWith('/dashboard/profile');
+  });
+
+  test('accepts all four allowlisted fields at once', async () => {
+    const result = await updateManualOfMe({
+      communication_style: 'Direct',
+      working_preferences: 'Mornings',
+      energises_me: 'Hard problems',
+      drains_me: 'Back-to-back meetings',
+    });
+    expect(result).toEqual({ success: true });
+    const [payload] = mockUpsertCapture.mock.calls[0];
+    expect(payload).toMatchObject({
+      profile_id: 'profile-1',
+      communication_style: 'Direct',
+      working_preferences: 'Mornings',
+      energises_me: 'Hard problems',
+      drains_me: 'Back-to-back meetings',
+    });
+  });
+
+  test('truncates a too-long working_preferences to MANUAL_OF_ME_MAX_LENGTHS', async () => {
+    const long = 'A'.repeat(MANUAL_OF_ME_MAX_LENGTHS.working_preferences + 250);
+    await updateManualOfMe({ working_preferences: long });
+    const [payload] = mockUpsertCapture.mock.calls[0];
+    expect(payload.working_preferences.length).toBe(
+      MANUAL_OF_ME_MAX_LENGTHS.working_preferences
+    );
+  });
+
+  test('truncates a too-long communication_style to its specific limit', async () => {
+    const long = 'B'.repeat(MANUAL_OF_ME_MAX_LENGTHS.communication_style + 50);
+    await updateManualOfMe({ communication_style: long });
+    const [payload] = mockUpsertCapture.mock.calls[0];
+    expect(payload.communication_style.length).toBe(
+      MANUAL_OF_ME_MAX_LENGTHS.communication_style
+    );
+  });
+
+  test('REJECTS a non-allowlisted field with a clear error AND no DB write', async () => {
+    const result = await updateManualOfMe({
+      // Cast through `unknown` to bypass TS — simulates a malicious caller
+      // bypassing types. Function must defend at runtime.
+      bio_short: 'attack',
+    } as unknown as Record<string, string>);
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error).toContain('bio_short');
+      expect(result.error).toMatch(/not permitted/i);
+    }
+    expect(mockUpsertCapture).not.toHaveBeenCalled();
+    expect(mockRevalidatePath).not.toHaveBeenCalled();
+  });
+
+  test('REJECTS even a single bad key in an otherwise-valid payload (no partial write)', async () => {
+    const result = await updateManualOfMe({
+      communication_style: 'OK',
+      profile_id: 'attacker-profile',
+    } as unknown as Record<string, string>);
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error).toContain('profile_id');
+      expect(result.error).not.toContain('communication_style');
+    }
+    // CRITICAL: no partial DB write of the "OK" field
+    expect(mockUpsertCapture).not.toHaveBeenCalled();
+  });
+
+  test('REJECTS attempts to inject system columns', async () => {
+    for (const dangerous of ['id', 'profile_id', 'created_at', 'updated_at']) {
+      mockUpsertCapture.mockClear();
+      const result = await updateManualOfMe({
+        [dangerous]: 'attacker-value',
+      } as unknown as Record<string, string>);
+      expect(result.success).toBe(false);
+      expect(mockUpsertCapture).not.toHaveBeenCalled();
+    }
+  });
+
+  test('strips deeply-nested HTML tags (KAN-171 regression guard)', async () => {
+    // sanitiseText runs the strip-HTML loop until convergence — confirm a
+    // nested-tag bypass is fully neutralised end-to-end via updateManualOfMe.
+    // The key property: NO `<` characters survive, so no tag can re-form when
+    // the value is rendered as text. (stray `>` characters are harmless once
+    // there's no `<` to open a tag.)
+    await updateManualOfMe({
+      communication_style: '<scr<script>ipt>alert(1)</scr</script>ipt>',
+    });
+    const [payload] = mockUpsertCapture.mock.calls[0];
+    expect(payload.communication_style).not.toContain('<');
+    expect(payload.communication_style).not.toContain('<script');
+    expect(payload.communication_style).not.toContain('</script');
+  });
+});
+
+// --- Null / empty handling ----------------------------------------------
+
+describe('updateManualOfMe — null + empty handling', () => {
+  test('explicit null is written as null (clears the field)', async () => {
+    await updateManualOfMe({ communication_style: null });
+    const [payload] = mockUpsertCapture.mock.calls[0];
+    expect(payload).toEqual({
+      profile_id: 'profile-1',
+      communication_style: null,
+    });
+  });
+
+  test('empty-string input is stored as null (so isManualOfMeEmpty works)', async () => {
+    await updateManualOfMe({ drains_me: '   ' }); // whitespace only
+    const [payload] = mockUpsertCapture.mock.calls[0];
+    expect(payload.drains_me).toBeNull();
+  });
+
+  test('empty input object is a no-op success (no DB call)', async () => {
+    const result = await updateManualOfMe({});
+    expect(result).toEqual({ success: true });
+    expect(mockUpsertCapture).not.toHaveBeenCalled();
+  });
+});
+
+// --- Auth + profile lookup ----------------------------------------------
+
+describe('updateManualOfMe — auth + profile lookup', () => {
+  test('returns auth error when there is no user, no DB call', async () => {
+    mockGetUser.mockResolvedValueOnce({ data: { user: null } });
+    const result = await updateManualOfMe({ communication_style: 'hi' });
+    expect(result.success).toBe(false);
+    if (!result.success) expect(result.error).toMatch(/not authenticated/i);
+    expect(mockUpsertCapture).not.toHaveBeenCalled();
+  });
+
+  test('returns profile-not-found when the profile lookup is empty', async () => {
+    mockProfileSelectSingle.mockResolvedValueOnce({ data: null, error: null });
+    const result = await updateManualOfMe({ communication_style: 'hi' });
+    expect(result.success).toBe(false);
+    if (!result.success) expect(result.error).toMatch(/profile not found/i);
+    expect(mockUpsertCapture).not.toHaveBeenCalled();
+  });
+});
+
+// --- Helper assertions on the field metadata ----------------------------
+
+describe('MANUAL_OF_ME_FIELDS + helpers', () => {
+  test('exposes exactly the v1 four fields', () => {
+    expect(MANUAL_OF_ME_FIELDS).toEqual([
+      'communication_style',
+      'working_preferences',
+      'energises_me',
+      'drains_me',
+    ]);
+  });
+
+  test('every field has a max length set', () => {
+    for (const field of MANUAL_OF_ME_FIELDS) {
+      expect(typeof MANUAL_OF_ME_MAX_LENGTHS[field]).toBe('number');
+      expect(MANUAL_OF_ME_MAX_LENGTHS[field]).toBeGreaterThan(0);
+    }
+  });
+
+  test('isManualOfMeField guards correctly', () => {
+    expect(isManualOfMeField('communication_style')).toBe(true);
+    expect(isManualOfMeField('working_preferences')).toBe(true);
+    expect(isManualOfMeField('bio_short')).toBe(false);
+    expect(isManualOfMeField('profile_id')).toBe(false);
+    expect(isManualOfMeField('__proto__')).toBe(false);
+  });
+
+  test('isManualOfMeEmpty: true for null', () => {
+    expect(isManualOfMeEmpty(null)).toBe(true);
+  });
+
+  test('isManualOfMeEmpty: true for all-null row', () => {
+    expect(
+      isManualOfMeEmpty({
+        communication_style: null,
+        working_preferences: null,
+        energises_me: null,
+        drains_me: null,
+      })
+    ).toBe(true);
+  });
+
+  test('isManualOfMeEmpty: true for all-whitespace row', () => {
+    expect(
+      isManualOfMeEmpty({
+        communication_style: '   ',
+        working_preferences: '\n\t',
+        energises_me: '',
+        drains_me: null,
+      })
+    ).toBe(true);
+  });
+
+  test('isManualOfMeEmpty: false if any field has content', () => {
+    expect(
+      isManualOfMeEmpty({
+        communication_style: 'Direct',
+        working_preferences: null,
+        energises_me: null,
+        drains_me: null,
+      })
+    ).toBe(false);
+  });
+});

--- a/tests/unit/profile-sections.test.js
+++ b/tests/unit/profile-sections.test.js
@@ -25,10 +25,10 @@ describe('KAN-137: Wizard supports new section categories', () => {
     expect(fs.existsSync(wizardPath)).toBe(true);
   });
 
-  test('wizard has 11 steps (up from 8)', () => {
+  test('wizard has 12 steps (was 11; KAN-154 added Manual of Me)', () => {
     const stepMatches = wizardContent.match(/\{ id: '/g);
     expect(stepMatches).not.toBeNull();
-    expect(stepMatches.length).toBe(11);
+    expect(stepMatches.length).toBe(12);
   });
 
   test('wizard includes Books & Media step', () => {


### PR DESCRIPTION
## Summary

Implements the **Manual of Me** sub-feature of KAN-154 (1 of 5). A profile section where users describe how to work with them, displayed on their public profile.

The remaining four KAN-154 sub-features — homepage privacy trust signal, shareable invite text, conversation-starter questions, and "problems I'm trying to solve" — are deferred and remain TBD.

## Schema decision: 1-1 table

New table `profile_manual_of_me(profile_id PK FK, communication_style, working_preferences, energises_me, drains_me, …)` rather than adding columns to `profiles`.

**Why:**
- Keeps `profiles` lean (already ~12 cols; adding 4 more bloats every row read).
- Mirrors the existing pattern for optional sections (`profile_items`, `school_affiliations`, `external_links`).
- RLS policy is identical to the other tables — easy to reason about.
- Easy to extend in v2 with more fields without touching the hot `profiles` table.

Migration file: `supabase/migrations/20260514120000_manual_of_me.sql`. **Not executed** — Luisa applies it.

## Fields included (4 of 6 suggested)

- `communication_style` (max 500)
- `working_preferences` (max 1000 — the main free-text field)
- `energises_me` (max 500)
- `drains_me` (max 500)

**Excluded for v1** with rationale:
- *"Hot buttons"* — overlaps materially with existing `dislikes` and `boundaries` items.
- *"How I handle disagreement"* — niche; not enough demand signal to justify wizard real estate.
- *"Preferred feedback style"* — possible v2; conceptually similar to communication_style.

Four fields is enough to be meaningful without making the step intimidating.

## Security

- **Allowlist + sanitisation**: `updateManualOfMe` runs every key through an allowlist before any DB call (prevents remote property injection, KAN-167 / CodeQL alert #2). Every string value runs through `sanitiseText` (strips HTML tags via convergence loop — KAN-171 — and clamps to per-field max length).
- **profile_id is resolved server-side** from `auth.uid()` — caller cannot inject.
- **No `dangerouslySetInnerHTML`**: public view renders every Manual of Me field as JSX text, which React auto-escapes. Defence-in-depth on top of write-time sanitisation.
- **RLS**: owner CRUD; published profiles are publicly readable.

## Files touched

- New: `supabase/migrations/20260514120000_manual_of_me.sql`
- New: `src/app/dashboard/profile/manual-of-me-actions.ts` (`'use server'`)
- New: `src/app/dashboard/profile/manual-of-me-fields.ts` (constants live here per CLAUDE.md gotcha #18 / BUGS-12)
- New: `src/app/dashboard/profile/steps/manual-of-me-step.tsx`
- New: `tests/unit/manual-of-me-actions.test.ts` (+20 tests)
- Mod: `src/app/dashboard/profile/wizard.tsx` (step inserted after Bio)
- Mod: `src/app/dashboard/profile/page.tsx` (loads manual_of_me row)
- Mod: `src/app/dashboard/profile/steps/index.ts`
- Mod: `src/app/[slug]/page.tsx` (renders "How to work with me" section, skipped if empty)
- Mod: `tests/unit/profile-sections.test.js` — assertion updated from 11 → 12 steps to reflect the new wizard step (intentional content change for an explicitly-approved feature; no test was weakened)

## Test count

- Baseline (develop): 363 tests in 31 suites
- After this PR: **383 tests in 32 suites** (+20 net new)
- Lint, type-check, workflow-integrity, server-action-exports: all clean

## Test plan

- [ ] Apply migration on dev (`supabase/migrations/20260514120000_manual_of_me.sql`) once PR approved
- [ ] Walk the wizard end-to-end on dev preview — confirm new step appears between Bio and Likes & Dislikes, save & continue advances
- [ ] Leave all four fields blank on a fresh profile — public view should NOT show the "How to work with me" section
- [ ] Fill in 1+ field — public view should show the section with only the populated fields
- [ ] Confirm KAN-171 XSS regression test still passes (script-tag injection neutralised on write)
- [ ] Confirm `'use server'` exports stay clean — `bash scripts/check-server-action-exports.sh` returns 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)