### PR TITLE
feat(KAN-165): weekly-report dashboard sections + email-as-prompt scaffold

### DIFF
--- a/.github/workflows/email-as-prompt.yml
+++ b/.github/workflows/email-as-prompt.yml
@@ -1,0 +1,187 @@
+name: Email as Prompt (scaffold)
+
+# KAN-165 Phase 2: scaffold for the "email-as-prompt" workflow.
+#
+# An inbound-email service (Resend inbound parsing or a Cloudflare Email
+# Worker — see docs/EMAIL_AS_PROMPT.md) POSTs to GitHub's repository_dispatch
+# API with event_type=email-prompt and a payload containing the email
+# subject and body. This workflow receives that dispatch, takes the body,
+# and posts it as a comment on a designated Jira ticket.
+#
+# This is a SCAFFOLD. The real inbound integration (parsing the email
+# from the actual inbox) is NOT wired up yet — see the follow-up
+# tickets noted in the PR description. Until then, the workflow can
+# also be triggered manually via `workflow_dispatch` for testing.
+#
+# Per KAN-167 workflow integrity policy: `set -euo pipefail` on every
+# multi-line `run:` block, fail-loud on every missing secret, never
+# silent-skip.
+
+on:
+  # Real production trigger: inbound-email service POSTs a dispatch.
+  repository_dispatch:
+    types: [email-prompt]
+  # Test trigger: kick off manually from the Actions UI with a
+  # synthetic subject + body to verify the Jira posting path end-to-end.
+  workflow_dispatch:
+    inputs:
+      subject:
+        description: 'Synthetic email subject (for manual testing)'
+        required: true
+        type: string
+        default: 'Test prompt from email-as-prompt scaffold'
+      body:
+        description: 'Synthetic email body (for manual testing)'
+        required: true
+        type: string
+        default: 'This is a test invocation of the email-as-prompt workflow scaffold.'
+      ticket_key:
+        description: 'Jira ticket key to comment on (default: KAN-165 for scaffold)'
+        required: false
+        type: string
+        default: 'KAN-165'
+
+defaults:
+  run:
+    shell: bash
+
+# Default GITHUB_TOKEN permissions: read-only repo metadata. This
+# workflow does not touch git refs.
+permissions:
+  contents: read
+  actions: read
+
+jobs:
+  post-to-jira:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Resolve trigger payload
+        id: payload
+        env:
+          # When triggered by repository_dispatch, the inbound service
+          # populates client_payload. When triggered manually for testing,
+          # inputs.* are populated instead. We unify them here.
+          DISPATCH_SUBJECT: ${{ github.event.client_payload.subject }}
+          DISPATCH_BODY: ${{ github.event.client_payload.body }}
+          DISPATCH_TICKET: ${{ github.event.client_payload.ticket_key }}
+          INPUT_SUBJECT: ${{ inputs.subject }}
+          INPUT_BODY: ${{ inputs.body }}
+          INPUT_TICKET: ${{ inputs.ticket_key }}
+        run: |
+          set -euo pipefail
+
+          if [ "${{ github.event_name }}" = "repository_dispatch" ]; then
+            SUBJECT="${DISPATCH_SUBJECT:-}"
+            BODY="${DISPATCH_BODY:-}"
+            TICKET="${DISPATCH_TICKET:-KAN-165}"
+          else
+            SUBJECT="${INPUT_SUBJECT:-}"
+            BODY="${INPUT_BODY:-}"
+            TICKET="${INPUT_TICKET:-KAN-165}"
+          fi
+
+          if [ -z "$SUBJECT" ]; then
+            echo "::error::Subject is empty — refusing to post a Jira comment without context."
+            exit 1
+          fi
+          if [ -z "$BODY" ]; then
+            echo "::error::Body is empty — refusing to post an empty Jira comment."
+            exit 1
+          fi
+          if [ -z "$TICKET" ]; then
+            echo "::error::Ticket key is empty — refusing to post to an unspecified ticket."
+            exit 1
+          fi
+
+          # Persist for the next step. Use the multi-line env var pattern
+          # so newlines in the body are preserved.
+          {
+            echo "SUBJECT=$SUBJECT"
+            echo "TICKET=$TICKET"
+            echo "BODY<<EOF_BODY_KAN_165"
+            printf '%s' "$BODY"
+            echo
+            echo "EOF_BODY_KAN_165"
+          } >> "$GITHUB_ENV"
+
+          echo "::notice::Resolved payload — ticket=$TICKET subject=\"$SUBJECT\" body_length=${#BODY}"
+
+      - name: Post comment to Jira via REST API
+        env:
+          ATLASSIAN_TOKEN: ${{ secrets.ATLASSIAN_API_TOKEN_READONLY }}
+          ATLASSIAN_EMAIL: ${{ secrets.ATLASSIAN_USER_EMAIL }}
+          ATLASSIAN_DOMAIN: ${{ secrets.ATLASSIAN_DOMAIN }}
+        run: |
+          set -euo pipefail
+
+          # Note: we re-use the read-only token name for now; in production
+          # this workflow needs a WRITE-scoped token (KAN-XXX follow-up).
+          # Until then, fail loud so the operator knows to provision it.
+          MISSING=()
+          [ -z "${ATLASSIAN_TOKEN:-}" ] && MISSING+=("ATLASSIAN_API_TOKEN_READONLY")
+          [ -z "${ATLASSIAN_EMAIL:-}" ] && MISSING+=("ATLASSIAN_USER_EMAIL")
+          [ -z "${ATLASSIAN_DOMAIN:-}" ] && MISSING+=("ATLASSIAN_DOMAIN")
+          if [ "${#MISSING[@]}" -gt 0 ]; then
+            echo "::error::Missing required secrets: ${MISSING[*]}. Cannot post Jira comment."
+            exit 1
+          fi
+
+          AUTH=$(printf '%s' "${ATLASSIAN_EMAIL}:${ATLASSIAN_TOKEN}" | base64 | tr -d '\n')
+
+          # Build the ADF (Atlassian Document Format) comment body. The
+          # email subject becomes the first paragraph (in bold) for easy
+          # scanning; the email body follows as plain text.
+          COMMENT_JSON=$(python3 <<'PY'
+          import json, os
+          subject = os.environ['SUBJECT']
+          body = os.environ['BODY']
+          adf = {
+              "body": {
+                  "type": "doc",
+                  "version": 1,
+                  "content": [
+                      {
+                          "type": "paragraph",
+                          "content": [
+                              {"type": "text", "text": "📧 Email-as-prompt: ", "marks": [{"type": "strong"}]},
+                              {"type": "text", "text": subject, "marks": [{"type": "strong"}]},
+                          ],
+                      },
+                      {
+                          "type": "paragraph",
+                          "content": [{"type": "text", "text": body}],
+                      },
+                      {
+                          "type": "paragraph",
+                          "content": [
+                              {
+                                  "type": "text",
+                                  "text": "(Auto-posted by .github/workflows/email-as-prompt.yml — KAN-165 scaffold.)",
+                                  "marks": [{"type": "em"}],
+                              }
+                          ],
+                      },
+                  ],
+              }
+          }
+          print(json.dumps(adf))
+          PY
+          )
+
+          RESPONSE=$(curl -s -w "\n__HTTP_CODE__%{http_code}" --max-time 20 \
+            -X POST "https://${ATLASSIAN_DOMAIN}/rest/api/3/issue/${TICKET}/comment" \
+            -H "Authorization: Basic ${AUTH}" \
+            -H "Accept: application/json" \
+            -H "Content-Type: application/json" \
+            -d "$COMMENT_JSON" 2>&1 || echo "__HTTP_CODE__000")
+
+          HTTP=$(echo "$RESPONSE" | grep -oE '__HTTP_CODE__[0-9]+' | sed 's/__HTTP_CODE__//')
+          BODY_OUT=$(echo "$RESPONSE" | sed 's/__HTTP_CODE__[0-9]*$//')
+
+          if [ "$HTTP" = "201" ] || [ "$HTTP" = "200" ]; then
+            COMMENT_ID=$(echo "$BODY_OUT" | python3 -c "import json,sys; print(json.load(sys.stdin).get('id','no-id'))" 2>/dev/null || echo "no-id")
+            echo "✓ Posted comment $COMMENT_ID to $TICKET"
+          else
+            echo "::error::Jira API returned HTTP $HTTP. Body: $(echo "$BODY_OUT" | head -c 400)"
+            exit 1
+          fi

--- a/.github/workflows/weekly-report.yml
+++ b/.github/workflows/weekly-report.yml
@@ -636,6 +636,299 @@ jobs:
             echo "::error::Section 13 — backup integrity check failed (rc=$INTEGRITY_RC). The latest backup contains placeholder data."
           fi
 
+      # ── Section 15: Release Cadence ────────────────────────
+      # KAN-165: extends the develop→main drift check from
+      # scripts/check-release-drift.sh (KAN-173) with the latest tag,
+      # tag date, and days-since-release. Drift status emoji 🟢/🟡/🔴
+      # comes straight from the script's bucket logic, then we hand the
+      # JSON to scripts/dashboard-shapers.py for rendering.
+      - name: Section 15 — Release Cadence
+        if: always()
+        run: |
+          set -euo pipefail
+          OUT="$RUNNER_TEMP/sections/15-release-cadence.md"
+
+          # Make sure we have develop and main refs locally (fetch-depth: 0
+          # gives us tags but the named branches may not be fetched).
+          git fetch --quiet origin develop main 2>/dev/null || true
+
+          # Drift fields from the existing script. set +e so a 'red' exit
+          # (rc=1) doesn't trip our pipefail — drift=red is data, not error.
+          set +e
+          DRIFT_OUT=$(bash scripts/check-release-drift.sh 2>"$RUNNER_TEMP/drift.err")
+          DRIFT_RC=$?
+          set -e
+
+          # Latest tag + its commit date. fetch-depth: 0 on checkout means
+          # tags are present. We still distinguish "no tags found" from
+          # "git error" rather than silent-defaulting to empty.
+          LATEST_TAG=""
+          LATEST_TAG_DATE=""
+          if LATEST_TAG=$(git describe --tags --abbrev=0 origin/main 2>"$RUNNER_TEMP/tag.err"); then
+            if [ -n "$LATEST_TAG" ]; then
+              LATEST_TAG_DATE=$(git log -1 --format=%cI "$LATEST_TAG" 2>/dev/null || echo "")
+            fi
+          else
+            echo "::warning::Section 15 — git describe failed: $(head -c 200 "$RUNNER_TEMP/tag.err")"
+          fi
+
+          # Parse the drift key=value output into JSON. We pipe DRIFT_OUT
+          # to Python on stdin (not via shell interpolation) so that any
+          # special characters in the script's summary line — quotes, $,
+          # newlines — can't break the heredoc or get expanded by bash.
+          DRIFT_FILE="$RUNNER_TEMP/drift-out.txt"
+          printf '%s' "$DRIFT_OUT" > "$DRIFT_FILE"
+          PAYLOAD=$(DRIFT_FILE="$DRIFT_FILE" LATEST_TAG="$LATEST_TAG" LATEST_TAG_DATE="$LATEST_TAG_DATE" python3 <<'PY'
+          import json, os, sys
+          drift = {}
+          with open(os.environ['DRIFT_FILE']) as fh:
+              for line in fh:
+                  line = line.strip()
+                  if '=' in line:
+                      k, v = line.split('=', 1)
+                      drift[k] = v
+          out = {
+              'latest_tag': os.environ.get('LATEST_TAG', ''),
+              'latest_tag_date': os.environ.get('LATEST_TAG_DATE', ''),
+              'drift': {
+                  'commits_ahead': drift.get('commits_ahead', 'DATA_UNAVAILABLE'),
+                  'days_since_last_commit': drift.get('days_since_last_commit', 'DATA_UNAVAILABLE'),
+                  'status': drift.get('status', 'unknown'),
+              },
+          }
+          print(json.dumps(out))
+          PY
+          )
+
+          # Render via shaper. stdout = markdown body, stderr = `section-15=<status>`.
+          echo "$PAYLOAD" | python3 scripts/dashboard-shapers.py release_cadence > "$OUT" 2> "$RUNNER_TEMP/shaper-15.err"
+          grep "^section-15=" "$RUNNER_TEMP/shaper-15.err" >> "$QUALITY_FILE"
+
+          echo "::notice::Section 15 — latest tag=$LATEST_TAG, drift rc=$DRIFT_RC"
+
+      # ── Section 16: In-Flight Work (Jira: In Progress) ─────
+      # KAN-165: pulls open "In Progress" Jira tickets via the REST API.
+      # Requires ATLASSIAN_API_TOKEN_READONLY + ATLASSIAN_USER_EMAIL +
+      # ATLASSIAN_DOMAIN secrets. If any is missing, the section emits
+      # `skipped_reason` so the shaper can render DATA UNAVAILABLE — never
+      # silent-skipped.
+      - name: Section 16 — In-Flight Work
+        if: always()
+        env:
+          ATLASSIAN_TOKEN: ${{ secrets.ATLASSIAN_API_TOKEN_READONLY }}
+          ATLASSIAN_EMAIL: ${{ secrets.ATLASSIAN_USER_EMAIL }}
+          ATLASSIAN_DOMAIN: ${{ secrets.ATLASSIAN_DOMAIN }}
+        run: |
+          set -euo pipefail
+          OUT="$RUNNER_TEMP/sections/16-in-flight.md"
+          PAYLOAD_FILE="$RUNNER_TEMP/in-flight-payload.json"
+
+          if [ -z "${ATLASSIAN_TOKEN:-}" ] || [ -z "${ATLASSIAN_EMAIL:-}" ] || [ -z "${ATLASSIAN_DOMAIN:-}" ]; then
+            echo "::warning::Section 16 (In-Flight) — Atlassian secrets not fully configured (ATLASSIAN_API_TOKEN_READONLY / ATLASSIAN_USER_EMAIL / ATLASSIAN_DOMAIN)"
+            # Emit a payload with error= so the shaper renders DATA
+            # UNAVAILABLE with the specific reason.
+            python3 -c "import json; print(json.dumps({'error': 'Atlassian secrets not configured (need ATLASSIAN_API_TOKEN_READONLY, ATLASSIAN_USER_EMAIL, ATLASSIAN_DOMAIN)'}))" > "$PAYLOAD_FILE"
+          else
+            JQL='project = KAN AND status = "In Progress"'
+            JQL_ENCODED=$(python3 -c "import urllib.parse,sys; print(urllib.parse.quote(sys.argv[1]))" "$JQL")
+            AUTH=$(printf '%s' "${ATLASSIAN_EMAIL}:${ATLASSIAN_TOKEN}" | base64 | tr -d '\n')
+            RESPONSE=$(curl -s -w "\n__HTTP_CODE__%{http_code}" --max-time 20 \
+              "https://${ATLASSIAN_DOMAIN}/rest/api/3/search?jql=${JQL_ENCODED}&fields=summary,status,updated,assignee&maxResults=50" \
+              -H "Authorization: Basic ${AUTH}" \
+              -H "Accept: application/json" 2>&1 || echo "__HTTP_CODE__000")
+            HTTP=$(echo "$RESPONSE" | grep -oE '__HTTP_CODE__[0-9]+' | sed 's/__HTTP_CODE__//')
+            BODY=$(echo "$RESPONSE" | sed 's/__HTTP_CODE__[0-9]*$//')
+            if [ "$HTTP" = "200" ]; then
+              # Re-shape Jira response into our payload format. Use stdin
+              # to avoid argv quoting issues with large/special-char bodies.
+              printf '%s' "$BODY" | python3 -c "
+          import json, sys
+          d = json.load(sys.stdin)
+          out = {'issues': d.get('issues', [])}
+          print(json.dumps(out))
+          " > "$PAYLOAD_FILE"
+            else
+              echo "::warning::Section 16 (In-Flight) — Jira API returned HTTP $HTTP"
+              HTTP="$HTTP" python3 -c "import json,os; print(json.dumps({'error': f\"Jira API returned HTTP {os.environ['HTTP']}\"}))" > "$PAYLOAD_FILE"
+            fi
+          fi
+
+          python3 scripts/dashboard-shapers.py in_flight < "$PAYLOAD_FILE" > "$OUT" 2> "$RUNNER_TEMP/shaper-16.err"
+          grep "^section-16=" "$RUNNER_TEMP/shaper-16.err" >> "$QUALITY_FILE"
+
+      # ── Section 17: PR Queue Health ────────────────────────
+      - name: Section 17 — PR Queue Health
+        if: always()
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          OUT="$RUNNER_TEMP/sections/17-pr-queue.md"
+          PAYLOAD_FILE="$RUNNER_TEMP/pr-queue-payload.json"
+
+          if PULLS_JSON=$(gh api "repos/${{ github.repository }}/pulls?state=open&per_page=100" 2>"$RUNNER_TEMP/pulls.err"); then
+            # Pipe JSON via stdin to avoid argv quoting issues.
+            printf '%s' "$PULLS_JSON" | python3 -c "
+          import json, sys
+          pulls = json.load(sys.stdin)
+          # Trim to only the fields the shaper needs (and that we want in logs).
+          slim = [
+              {
+                  'number': p.get('number'),
+                  'title': p.get('title', '')[:80],
+                  'base': {'ref': (p.get('base') or {}).get('ref')},
+                  'draft': bool(p.get('draft')),
+                  'created_at': p.get('created_at'),
+                  'user': {'login': (p.get('user') or {}).get('login')},
+              }
+              for p in pulls
+          ]
+          print(json.dumps({'pulls': slim}))
+          " > "$PAYLOAD_FILE"
+          else
+            ERR=$(head -c 200 "$RUNNER_TEMP/pulls.err")
+            echo "::warning::Section 17 — gh api /pulls failed: $ERR"
+            ERR="$ERR" python3 -c "import json,os; print(json.dumps({'error': os.environ['ERR']}))" > "$PAYLOAD_FILE"
+          fi
+
+          python3 scripts/dashboard-shapers.py pr_queue < "$PAYLOAD_FILE" > "$OUT" 2> "$RUNNER_TEMP/shaper-17.err"
+          grep "^section-17=" "$RUNNER_TEMP/shaper-17.err" >> "$QUALITY_FILE"
+
+      # ── Section 18: CI Flakiness (last 30 runs) ────────────
+      - name: Section 18 — CI Flakiness
+        if: always()
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          OUT="$RUNNER_TEMP/sections/18-ci-flakiness.md"
+          PAYLOAD_FILE="$RUNNER_TEMP/ci-flakiness-payload.json"
+
+          if RUNS_JSON=$(gh api "repos/${{ github.repository }}/actions/runs?per_page=30" 2>"$RUNNER_TEMP/runs.err"); then
+            # Pipe JSON via stdin to avoid argv quoting issues with large blobs.
+            printf '%s' "$RUNS_JSON" | python3 -c "
+          import json, sys
+          d = json.load(sys.stdin)
+          slim = [
+              {'name': r.get('name', 'unknown'), 'conclusion': r.get('conclusion')}
+              for r in d.get('workflow_runs', [])
+          ]
+          print(json.dumps({'runs': slim}))
+          " > "$PAYLOAD_FILE"
+          else
+            ERR=$(head -c 200 "$RUNNER_TEMP/runs.err")
+            echo "::warning::Section 18 — gh api /actions/runs failed: $ERR"
+            ERR="$ERR" python3 -c "import json,os; print(json.dumps({'error': os.environ['ERR']}))" > "$PAYLOAD_FILE"
+          fi
+
+          python3 scripts/dashboard-shapers.py ci_flakiness < "$PAYLOAD_FILE" > "$OUT" 2> "$RUNNER_TEMP/shaper-18.err"
+          grep "^section-18=" "$RUNNER_TEMP/shaper-18.err" >> "$QUALITY_FILE"
+
+      # ── Section 19: MCP Server Health (UptimeRobot) ────────
+      # KAN-165: if UPTIMEROBOT_API_KEY is not wired into this workflow,
+      # the section explicitly renders DATA UNAVAILABLE with the reason
+      # AND emits a workflow ::warning::. This is the documented-gap
+      # case from the ticket — not a silent skip.
+      - name: Section 19 — MCP Server Health
+        if: always()
+        env:
+          UPTIMEROBOT_API_KEY: ${{ secrets.UPTIMEROBOT_API_KEY }}
+        run: |
+          set -euo pipefail
+          OUT="$RUNNER_TEMP/sections/19-mcp-health.md"
+          PAYLOAD_FILE="$RUNNER_TEMP/mcp-health-payload.json"
+
+          if [ -z "${UPTIMEROBOT_API_KEY:-}" ]; then
+            echo "::warning::Section 19 (MCP Health) — UPTIMEROBOT_API_KEY secret not configured; UptimeRobot data is missing from the dashboard. See docs/UPTIMEROBOT_SETUP.md."
+            python3 -c "import json; print(json.dumps({'skipped_reason': 'UPTIMEROBOT_API_KEY secret not configured — see docs/UPTIMEROBOT_SETUP.md'}))" > "$PAYLOAD_FILE"
+          else
+            RESPONSE=$(curl -s -w "\n__HTTP_CODE__%{http_code}" --max-time 15 \
+              -X POST "https://api.uptimerobot.com/v2/getMonitors" \
+              -H "Content-Type: application/x-www-form-urlencoded" \
+              --data-urlencode "api_key=${UPTIMEROBOT_API_KEY}" \
+              --data-urlencode "format=json" \
+              --data-urlencode "all_time_uptime_ratio=1" 2>&1 || echo "__HTTP_CODE__000")
+            HTTP=$(echo "$RESPONSE" | grep -oE '__HTTP_CODE__[0-9]+' | sed 's/__HTTP_CODE__//')
+            BODY=$(echo "$RESPONSE" | sed 's/__HTTP_CODE__[0-9]*$//')
+            if [ "$HTTP" = "200" ]; then
+              # Pipe JSON via stdin to avoid argv quoting issues.
+              printf '%s' "$BODY" | python3 -c "
+          import json, sys
+          d = json.load(sys.stdin)
+          if d.get('stat') != 'ok':
+              print(json.dumps({'error': f\"UptimeRobot returned stat={d.get('stat')}\"}))
+          else:
+              slim = [
+                  {
+                      'friendly_name': m.get('friendly_name'),
+                      'status': m.get('status'),
+                      'all_time_uptime_ratio': m.get('all_time_uptime_ratio'),
+                  }
+                  for m in d.get('monitors', [])
+              ]
+              print(json.dumps({'monitors': slim}))
+          " > "$PAYLOAD_FILE"
+            else
+              echo "::warning::Section 19 — UptimeRobot API returned HTTP $HTTP"
+              HTTP="$HTTP" python3 -c "import json,os; print(json.dumps({'error': f\"UptimeRobot API HTTP {os.environ['HTTP']}\"}))" > "$PAYLOAD_FILE"
+            fi
+          fi
+
+          python3 scripts/dashboard-shapers.py mcp_health < "$PAYLOAD_FILE" > "$OUT" 2> "$RUNNER_TEMP/shaper-19.err"
+          grep "^section-19=" "$RUNNER_TEMP/shaper-19.err" >> "$QUALITY_FILE"
+
+      # ── Section 20: Cost Spotcheck (best-effort) ───────────
+      # KAN-165: optional. Each provider's API is probed; if the relevant
+      # token isn't set, the row renders DATA UNAVAILABLE with the missing
+      # var name. Never silent-skipped.
+      - name: Section 20 — Cost Spotcheck
+        if: always()
+        env:
+          VERCEL_API_TOKEN: ${{ secrets.VERCEL_API_TOKEN }}
+          SUPABASE_MANAGEMENT_TOKEN: ${{ secrets.SUPABASE_MANAGEMENT_TOKEN }}
+          RESEND_API_KEY: ${{ secrets.RESEND_API_KEY }}
+        run: |
+          set -euo pipefail
+          OUT="$RUNNER_TEMP/sections/20-cost-spotcheck.md"
+          PAYLOAD_FILE="$RUNNER_TEMP/cost-payload.json"
+
+          # Build a providers dict. We don't actually consume any of these
+          # APIs deeply yet — for this scaffold, "available" means the
+          # token is present and an HTTP HEAD to the API endpoint returns
+          # a 2xx/4xx (i.e. the API is reachable). Detailed usage parsing
+          # is a follow-up.
+          python3 <<'PY' > "$PAYLOAD_FILE"
+          import os, json, urllib.request, urllib.error
+          providers = {}
+
+          def probe(name, token_env, url, header):
+              tok = os.environ.get(token_env)
+              if not tok:
+                  providers[name] = {'available': False, 'detail': f'{token_env} not set'}
+                  return
+              try:
+                  req = urllib.request.Request(url, headers={header[0]: header[1].format(tok)})
+                  with urllib.request.urlopen(req, timeout=10) as r:
+                      providers[name] = {'available': True, 'detail': f'API reachable (HTTP {r.status}) — usage parsing TBD'}
+              except urllib.error.HTTPError as e:
+                  # 401/403 still means "we hit the API" — token may be scoped wrong.
+                  if e.code in (401, 403):
+                      providers[name] = {'available': False, 'detail': f'API returned HTTP {e.code} — token scope?'}
+                  else:
+                      providers[name] = {'available': True, 'detail': f'API reachable (HTTP {e.code})'}
+              except Exception as e:
+                  providers[name] = {'available': False, 'detail': f'unreachable: {type(e).__name__}'}
+
+          probe('Vercel', 'VERCEL_API_TOKEN', 'https://api.vercel.com/v2/user', ('Authorization', 'Bearer {}'))
+          probe('Supabase', 'SUPABASE_MANAGEMENT_TOKEN', 'https://api.supabase.com/v1/projects', ('Authorization', 'Bearer {}'))
+          probe('Resend', 'RESEND_API_KEY', 'https://api.resend.com/domains', ('Authorization', 'Bearer {}'))
+
+          print(json.dumps({'providers': providers}))
+          PY
+
+          python3 scripts/dashboard-shapers.py cost_spotcheck < "$PAYLOAD_FILE" > "$OUT" 2> "$RUNNER_TEMP/shaper-20.err"
+          grep "^section-20=" "$RUNNER_TEMP/shaper-20.err" >> "$QUALITY_FILE"
+
       # ── Compose final report (Data Quality Summary at top) ─
       - name: Compose final report
         if: always()
@@ -652,16 +945,19 @@ jobs:
             # ── Data Quality Summary ──
             echo "## 0. Data Quality Summary"
             echo ""
-            echo "This report is built from 8 data sources. Per KAN-167 Phase 3+4, each"
-            echo "source either succeeds with real data or shows DATA UNAVAILABLE with"
-            echo "the reason — never a silent placeholder. Section 13 actively checks"
-            echo "the most recent backup artifact for placeholder strings (Phase 4)."
+            echo "This report is built from 14 data sources. Per KAN-167 Phase 3+4 +"
+            echo "KAN-165 dashboard extension, each source either succeeds with real"
+            echo "data or shows DATA UNAVAILABLE with the reason — never a silent"
+            echo "placeholder. Section 13 actively checks the most recent backup"
+            echo "artifact for placeholder strings (Phase 4). Sections 15–20 are the"
+            echo "KAN-165 dashboard extension: release cadence, in-flight work,"
+            echo "PR queue, CI flakiness, MCP server health, and cost spotcheck."
             echo ""
             echo "| Section | Status |"
             echo "|---------|--------|"
 
             ALL_OK=1
-            for n in 1 2 3 4 5 6 7 13; do
+            for n in 1 2 3 4 5 6 7 13 15 16 17 18 19 20; do
               STATUS_LINE=$(grep "^section-$n=" "$QUALITY_FILE" 2>/dev/null || echo "section-$n=missing:section-did-not-run")
               STATUS=$(echo "$STATUS_LINE" | cut -d= -f2)
               case "$STATUS" in
@@ -705,13 +1001,19 @@ jobs:
                 6) NAME="Test Suite" ;;
                 7) NAME="Current Deployment" ;;
                 13) NAME="Backup Integrity" ;;
+                15) NAME="Release Cadence" ;;
+                16) NAME="In-Flight Work" ;;
+                17) NAME="PR Queue Health" ;;
+                18) NAME="CI Flakiness" ;;
+                19) NAME="MCP Server Health" ;;
+                20) NAME="Cost Spotcheck" ;;
               esac
               echo "| $n. $NAME | $ICON $REASON |"
             done
             echo ""
 
             if [ "$ALL_OK" -eq 1 ]; then
-              echo "**All 7 data sources reported clean.**"
+              echo "**All 14 data sources reported clean.**"
             else
               echo "**One or more data sources had issues — see Data Quality Summary above. The relevant section below will show DATA UNAVAILABLE with details.**"
             fi

--- a/docs/EMAIL_AS_PROMPT.md
+++ b/docs/EMAIL_AS_PROMPT.md
@@ -1,0 +1,133 @@
+# Email-as-Prompt — wiring up the inbound side
+
+**Status:** scaffold. The GitHub Actions workflow (`.github/workflows/email-as-prompt.yml`) is in place, but the inbound-email integration that fires it is not yet wired up. This doc covers the two viable options and the steps to choose and connect one.
+
+**Ticket:** KAN-165 Phase 2.
+
+## What the scaffold already does
+
+`email-as-prompt.yml` listens on two triggers:
+
+1. `repository_dispatch` with `event_type: "email-prompt"` — the production path. An external service POSTs a payload like:
+   ```json
+   {
+     "event_type": "email-prompt",
+     "client_payload": {
+       "subject": "Re: weekly report",
+       "body": "<the email body>",
+       "ticket_key": "KAN-165"
+     }
+   }
+   ```
+2. `workflow_dispatch` — a manual button in the GitHub Actions UI for testing the Jira-posting path end-to-end without needing the inbound side wired up. Use this to validate that the Atlassian secrets and ADF formatting are correct.
+
+When fired, the workflow posts the email subject + body as a comment on a designated Jira ticket (defaulting to `KAN-165` for the scaffold) using the Atlassian REST API.
+
+It does NOT yet:
+- Parse a real inbound email (the inbound service does that and sends only the body)
+- Choose the ticket dynamically based on the email (it uses a hardcoded `KAN-165` or whatever the dispatch payload specifies)
+- Authenticate the inbound dispatch against a known sender (any HMAC/signature check needs to be added — see [Security](#security))
+
+## Option A — Resend inbound parsing
+
+Resend doesn't currently expose inbound-email parsing as a first-class product, but they support webhook-style routing on a dedicated inbound subdomain. If/when they do:
+
+1. Add an MX record on a subdomain like `inbound.checklyra.com` pointing at Resend's inbound endpoint.
+2. Configure a Resend Webhook for incoming messages → POST to a small Cloudflare Worker (next section) that reformats the payload and dispatches the GitHub event.
+
+This option ties the project to Resend's roadmap. Right now (May 2026), it's not viable as a standalone path.
+
+## Option B — Cloudflare Email Worker (recommended)
+
+Cloudflare's Email Workers feature is mature and is the path we should take:
+
+1. **Set up Email Routing** on the `checklyra.com` zone (Cloudflare → Email → Email Routing). Enable Email Workers.
+2. **Create a Worker** named `lyra-inbound-prompt` from the dashboard. Sample code:
+
+   ```javascript
+   export default {
+     async email(message, env, ctx) {
+       // Read the email body.
+       const raw = await new Response(message.raw).text();
+       const body = extractPlainText(raw); // strip MIME headers; you can use postal-mime
+       const subject = message.headers.get('subject') ?? '(no subject)';
+       const from = message.headers.get('from') ?? '(unknown)';
+
+       // Allow-list check: only fire if the email is from an approved sender.
+       if (!isAllowedSender(from)) {
+         console.log('Rejected sender:', from);
+         return;
+       }
+
+       // Dispatch the GitHub event.
+       const r = await fetch(
+         'https://api.github.com/repos/luisa-sys/lyra/dispatches',
+         {
+           method: 'POST',
+           headers: {
+             'Authorization': `Bearer ${env.GITHUB_DISPATCH_PAT}`,
+             'Accept': 'application/vnd.github+json',
+             'Content-Type': 'application/json',
+             'User-Agent': 'lyra-inbound-prompt',
+           },
+           body: JSON.stringify({
+             event_type: 'email-prompt',
+             client_payload: {
+               subject,
+               body,
+               ticket_key: extractTicketFromSubject(subject) ?? 'KAN-165',
+             },
+           }),
+         }
+       );
+
+       if (!r.ok) {
+         console.error('GitHub dispatch failed:', r.status, await r.text());
+         throw new Error(`Dispatch failed: ${r.status}`);
+       }
+     },
+   };
+   ```
+
+3. **Bind the Worker as the destination** for one of the inbound addresses (e.g. `prompt@checklyra.com`) under Email → Email Routing → Routing rules.
+4. **Provide the Worker with a GitHub PAT**:
+   - Generate a fine-grained PAT (`LYRA_DISPATCH_PAT`) scoped to `luisa-sys/lyra` with `Actions: write` permission only.
+   - Set it as a Worker secret: `wrangler secret put GITHUB_DISPATCH_PAT`.
+   - Add it to `docs/SECURITY_ROTATION.md` with a 12-month rotation cadence.
+
+### Why Email Workers vs. an external SaaS
+
+- No third-party data dependency — the email never leaves Cloudflare's edge before being parsed.
+- Free tier covers Lyra's expected volume (a handful of emails a week).
+- Sender allow-listing happens before the GitHub dispatch fires, so a malicious inbound email can't trigger anything.
+
+## Security
+
+The inbound flow accepts an email and turns it into a Jira comment. Without controls, that's an SSRF-ish gadget — a stranger could spam Jira tickets by emailing the inbox. Mitigations:
+
+1. **Sender allow-list in the Worker.** Only `luisa@santos-stephens.com` (and any approved teammates) is allowed to trigger a dispatch. Hard-coded in the Worker; rejected senders are logged but no dispatch fires.
+2. **SPF + DKIM verification.** Cloudflare Email Workers receive the verification results — refuse any message that doesn't pass DMARC against an approved sender domain.
+3. **GitHub PAT scoping.** The PAT used by the Worker only has `Actions: write` on the lyra repo — nothing else.
+4. **Workflow rate-limit.** The workflow itself doesn't rate-limit, but Cloudflare Email Workers can be wrapped in a Durable Object that throttles dispatches to N/hour.
+5. **Atlassian token.** The workflow currently re-uses `ATLASSIAN_API_TOKEN_READONLY` which is read-only — posting comments via that token will 403. Before going live, provision a write-scoped Atlassian token (`ATLASSIAN_API_TOKEN_COMMENT`) restricted to comment creation, store as a separate secret, and update the workflow.
+
+## Follow-up tickets
+
+These are tracked separately and need to be filed when this scaffold lands:
+
+- **KAN-XXX** Provision an Atlassian write-scoped token (`ATLASSIAN_API_TOKEN_COMMENT`) and switch `email-as-prompt.yml` to use it.
+- **KAN-XXX** Build the Cloudflare Email Worker (`lyra-inbound-prompt`) and wire up the inbound route on a `prompt@checklyra.com` address.
+- **KAN-XXX** Add ticket-key extraction from the subject line (e.g. `Re: KAN-150 ... → ticket_key=KAN-150`).
+- **KAN-XXX** Add HMAC verification on the dispatch payload so the workflow refuses any dispatch that didn't come from the trusted Worker.
+- **KAN-XXX** Add `docs/RUNBOOK.md` entry under "Weekly status review" describing how Luisa replies to the Monday report and Claude picks up the comment.
+
+## Testing the scaffold today
+
+Without the inbound side wired up, you can still verify the Jira-posting path:
+
+1. Go to Actions → "Email as Prompt (scaffold)" → Run workflow.
+2. Fill in `subject` and `body` with a test value, leave `ticket_key` as `KAN-165`.
+3. Run.
+4. Check KAN-165 in Jira — there should be a new comment with the test content.
+
+If the comment doesn't appear, check the workflow run logs for the `::error::` annotation — the failure mode is always loud (no silent skips).

--- a/scripts/dashboard-shapers.py
+++ b/scripts/dashboard-shapers.py
@@ -1,0 +1,478 @@
+#!/usr/bin/env python3
+"""KAN-165: data-shaping helpers for the weekly dashboard sections.
+
+This is the pure-functional core of the new dashboard sections. Each
+function takes raw API JSON (already fetched by the workflow) plus a
+"now" timestamp and returns a markdown body string plus a status code
+(`ok` / `partial:...` / `failed:...` / `unavailable:...`) that the
+workflow appends to the data-quality file.
+
+Per KAN-167 workflow integrity policy:
+- Never silently swallow an error. If input JSON is malformed, return a
+  status of `failed:<reason>` and a markdown body that explicitly says
+  "DATA UNAVAILABLE — <reason>", rather than a clean-looking empty
+  table.
+- Distinguish "0 records" (legitimate green state) from "fetch failed"
+  (failure that needs investigating) in the rendered output.
+
+CLI usage:
+
+    python3 scripts/dashboard-shapers.py <shape>
+
+where <shape> is one of: in_flight, pr_queue, ci_flakiness, mcp_health,
+cost_spotcheck, release_cadence. Reads JSON from stdin, writes markdown
+body to stdout, and writes a single `section-<N>=<status>` line to
+stderr so the workflow can append it to the quality file.
+
+Tested in tests/unit/dashboard-shapers.test.js.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from datetime import datetime, timezone
+from typing import Any
+
+
+# ───────────────────────── helpers ─────────────────────────
+
+def _parse_iso(s: str) -> datetime | None:
+    """Parse a GitHub/Jira ISO timestamp into an aware datetime.
+
+    Handles the three formats we see in practice:
+      - GitHub:  "2026-05-10T07:00:00Z"
+      - Jira:    "2026-05-10T07:00:00.000+0000"  (no colon in offset)
+      - Generic: "2026-05-10T07:00:00.000+00:00"
+    """
+    if not s:
+        return None
+    try:
+        # Strip trailing Z (Python <3.11 doesn't parse it).
+        if s.endswith('Z'):
+            s = s[:-1] + '+00:00'
+        # Jira's offset has no colon (e.g. "+0000"); convert to "+00:00".
+        # Match a 4-digit offset at end of string.
+        import re
+        s = re.sub(r'([+-])(\d{2})(\d{2})$', r'\1\2:\3', s)
+        return datetime.fromisoformat(s)
+    except (ValueError, TypeError):
+        return None
+
+
+def _days_since(iso: str, now: datetime) -> int | None:
+    dt = _parse_iso(iso)
+    if dt is None:
+        return None
+    delta = now - dt
+    return max(0, int(delta.total_seconds() // 86400))
+
+
+# ───────────────────────── shape: release_cadence ─────────────────────────
+
+def shape_release_cadence(payload: dict[str, Any], now: datetime) -> tuple[str, str]:
+    """Render Section 15 — Release Cadence.
+
+    payload keys:
+      - latest_tag: str (e.g. "v0.1.40")
+      - latest_tag_date: ISO timestamp of the tag's commit
+      - drift: dict with `commits_ahead`, `days_since_last_commit`, `status` —
+        the same shape produced by scripts/check-release-drift.sh
+
+    Output: markdown body + section-15=<status>.
+    """
+    drift = payload.get('drift') or {}
+    tag = payload.get('latest_tag') or 'unknown'
+    tag_date = payload.get('latest_tag_date') or ''
+    commits_ahead = drift.get('commits_ahead', 'DATA_UNAVAILABLE')
+    days_since_commit = drift.get('days_since_last_commit', 'DATA_UNAVAILABLE')
+    drift_status = drift.get('status', 'unknown')
+
+    lines = ['## 15. Release Cadence', '']
+
+    # Compute days since release.
+    days_since_release: int | str
+    if tag_date:
+        d = _days_since(tag_date, now)
+        days_since_release = d if d is not None else 'DATA_UNAVAILABLE'
+    else:
+        days_since_release = 'DATA_UNAVAILABLE'
+
+    # Status emoji from the drift script's bucket (already computed there).
+    emoji = {
+        'green': '🟢',
+        'yellow': '🟡',
+        'red': '🔴',
+        'unknown': '❓',
+    }.get(drift_status, '❓')
+
+    lines.append('| Metric | Value |')
+    lines.append('|--------|-------|')
+    lines.append(f'| Latest tag | `{tag}` |')
+    lines.append(f'| Tag date | {tag_date or "DATA UNAVAILABLE"} |')
+    lines.append(f'| Days since last release | {days_since_release} |')
+    lines.append(f'| Unreleased commits on develop | {commits_ahead} |')
+    lines.append(f'| Days since last develop commit | {days_since_commit} |')
+    lines.append(f'| Drift status | {emoji} {drift_status} |')
+    lines.append('')
+
+    # Status logic for the quality summary.
+    if drift_status == 'unknown' or commits_ahead == 'DATA_UNAVAILABLE':
+        status = 'failed:drift-data-unavailable'
+    elif drift_status == 'red':
+        # Red means action needed, but the report itself isn't broken.
+        # Surface as partial so the quality summary flags it.
+        status = 'partial:drift-red'
+    else:
+        status = 'ok'
+
+    return '\n'.join(lines) + '\n', status
+
+
+# ───────────────────────── shape: in_flight ─────────────────────────
+
+def shape_in_flight(payload: dict[str, Any], now: datetime) -> tuple[str, str]:
+    """Render Section 16 — In-Flight Work.
+
+    payload keys:
+      - issues: list of Jira issues (each with `key`, `fields.summary`,
+        `fields.status.name`, `fields.updated`, `fields.assignee.displayName`)
+      - error: str | None — if set, render DATA UNAVAILABLE with the message.
+
+    "In progress" is determined by status.name == "In Progress".
+    """
+    lines = ['## 16. In-Flight Work (Jira: In Progress)', '']
+
+    err = payload.get('error')
+    if err:
+        lines.append(f'❌ DATA UNAVAILABLE — {err}')
+        lines.append('')
+        return '\n'.join(lines) + '\n', f'failed:jira-fetch:{err[:40]}'
+
+    issues = payload.get('issues')
+    if issues is None:
+        lines.append('❌ DATA UNAVAILABLE — Jira `issues` key missing from payload.')
+        lines.append('')
+        return '\n'.join(lines) + '\n', 'failed:jira-issues-key-missing'
+
+    if not issues:
+        lines.append('✅ No tickets currently In Progress.')
+        lines.append('')
+        return '\n'.join(lines) + '\n', 'ok'
+
+    # Sort oldest first (largest age).
+    rows: list[tuple[str, str, str, int, str]] = []
+    for it in issues:
+        key = it.get('key', 'UNKNOWN')
+        f = it.get('fields') or {}
+        summary = (f.get('summary') or '')[:80]
+        updated = f.get('updated') or ''
+        age = _days_since(updated, now)
+        age_val = age if age is not None else 0
+        assignee_obj = f.get('assignee') or {}
+        assignee = assignee_obj.get('displayName') or 'Unassigned'
+        rows.append((key, summary, updated, age_val, assignee))
+
+    rows.sort(key=lambda r: r[3], reverse=True)
+    oldest_age = rows[0][3]
+
+    lines.append(f'**Total In Progress:** {len(rows)} — oldest is {oldest_age} day(s) since last update.')
+    lines.append('')
+    lines.append('| Key | Summary | Days since update | Assignee |')
+    lines.append('|-----|---------|-------------------|----------|')
+    for key, summary, _, age, assignee in rows:
+        lines.append(f'| {key} | {summary} | {age} | {assignee} |')
+    lines.append('')
+
+    return '\n'.join(lines) + '\n', 'ok'
+
+
+# ───────────────────────── shape: pr_queue ─────────────────────────
+
+def shape_pr_queue(payload: dict[str, Any], now: datetime) -> tuple[str, str]:
+    """Render Section 17 — PR Queue Health.
+
+    payload keys:
+      - pulls: list of GitHub PR objects (each with `number`, `title`,
+        `base.ref`, `draft`, `created_at`, `user.login`)
+      - error: str | None
+    """
+    lines = ['## 17. PR Queue Health', '']
+
+    err = payload.get('error')
+    if err:
+        lines.append(f'❌ DATA UNAVAILABLE — {err}')
+        lines.append('')
+        return '\n'.join(lines) + '\n', f'failed:pr-fetch:{err[:40]}'
+
+    pulls = payload.get('pulls')
+    if pulls is None:
+        lines.append('❌ DATA UNAVAILABLE — `pulls` key missing from payload.')
+        lines.append('')
+        return '\n'.join(lines) + '\n', 'failed:pulls-key-missing'
+
+    if not pulls:
+        lines.append('✅ No open pull requests.')
+        lines.append('')
+        return '\n'.join(lines) + '\n', 'ok'
+
+    # Group by base ref.
+    by_base: dict[str, list[dict[str, Any]]] = {}
+    for pr in pulls:
+        base = ((pr.get('base') or {}).get('ref')) or 'unknown'
+        by_base.setdefault(base, []).append(pr)
+
+    # Oldest age across all PRs.
+    all_ages = [
+        _days_since(pr.get('created_at', ''), now) or 0
+        for pr in pulls
+    ]
+    oldest = max(all_ages) if all_ages else 0
+
+    # Author classification: dependabot vs human.
+    dep_count = sum(
+        1 for pr in pulls
+        if ((pr.get('user') or {}).get('login') or '').startswith('dependabot')
+    )
+    human_count = len(pulls) - dep_count
+
+    # Draft vs ready.
+    draft_count = sum(1 for pr in pulls if pr.get('draft'))
+    ready_count = len(pulls) - draft_count
+
+    lines.append(
+        f'**Total open:** {len(pulls)} — oldest {oldest} day(s) — '
+        f'{ready_count} ready / {draft_count} draft — '
+        f'{human_count} human / {dep_count} dependabot.'
+    )
+    lines.append('')
+
+    lines.append('| Base | Count | Oldest (days) |')
+    lines.append('|------|-------|---------------|')
+    for base in sorted(by_base.keys()):
+        prs = by_base[base]
+        ages = [_days_since(pr.get('created_at', ''), now) or 0 for pr in prs]
+        lines.append(f'| `{base}` | {len(prs)} | {max(ages) if ages else 0} |')
+    lines.append('')
+
+    return '\n'.join(lines) + '\n', 'ok'
+
+
+# ───────────────────────── shape: ci_flakiness ─────────────────────────
+
+def shape_ci_flakiness(payload: dict[str, Any], _now: datetime) -> tuple[str, str]:
+    """Render Section 18 — CI Flakiness (last 30 runs).
+
+    payload keys:
+      - runs: list of workflow-run objects (each with `name`, `conclusion`).
+              `conclusion` may be 'success', 'failure', 'cancelled',
+              'skipped', or null (in-progress).
+      - error: str | None
+    """
+    lines = ['## 18. CI Flakiness (last 30 runs grouped by workflow)', '']
+
+    err = payload.get('error')
+    if err:
+        lines.append(f'❌ DATA UNAVAILABLE — {err}')
+        lines.append('')
+        return '\n'.join(lines) + '\n', f'failed:ci-fetch:{err[:40]}'
+
+    runs = payload.get('runs')
+    if runs is None:
+        lines.append('❌ DATA UNAVAILABLE — `runs` key missing from payload.')
+        lines.append('')
+        return '\n'.join(lines) + '\n', 'failed:runs-key-missing'
+
+    if not runs:
+        lines.append('⚠️ No workflow runs in window — investigate, this should never be empty.')
+        lines.append('')
+        return '\n'.join(lines) + '\n', 'partial:no-runs-in-window'
+
+    by_wf: dict[str, dict[str, int]] = {}
+    for r in runs:
+        name = r.get('name') or 'unknown'
+        conclusion = r.get('conclusion') or 'in_progress'
+        agg = by_wf.setdefault(name, {'total': 0, 'success': 0, 'failure': 0, 'other': 0})
+        agg['total'] += 1
+        if conclusion == 'success':
+            agg['success'] += 1
+        elif conclusion == 'failure':
+            agg['failure'] += 1
+        else:
+            agg['other'] += 1
+
+    lines.append('| Workflow | Runs | Success rate | Failures |')
+    lines.append('|----------|------|--------------|----------|')
+    any_flaky = False
+    for wf in sorted(by_wf.keys()):
+        agg = by_wf[wf]
+        # Success rate computed against the non-in-progress denominator.
+        denom = agg['success'] + agg['failure']
+        if denom == 0:
+            rate_str = 'N/A (all in-progress/cancelled)'
+        else:
+            rate = 100.0 * agg['success'] / denom
+            rate_str = f'{rate:.0f}%'
+            if rate < 80.0:
+                any_flaky = True
+                rate_str = f'⚠️ {rate_str}'
+        lines.append(f'| {wf} | {agg["total"]} | {rate_str} | {agg["failure"]} |')
+    lines.append('')
+
+    status = 'partial:flaky-workflows' if any_flaky else 'ok'
+    return '\n'.join(lines) + '\n', status
+
+
+# ───────────────────────── shape: mcp_health ─────────────────────────
+
+def shape_mcp_health(payload: dict[str, Any], _now: datetime) -> tuple[str, str]:
+    """Render Section 19 — MCP Server Health.
+
+    payload keys:
+      - monitors: list of UptimeRobot monitor dicts (each with `friendly_name`,
+        `status`, `all_time_uptime_ratio` — strings/ints from the API).
+      - error: str | None
+      - skipped_reason: str | None — set if no API key was configured;
+        renders a header-level warning rather than a hard failure.
+    """
+    lines = ['## 19. MCP Server Health (UptimeRobot)', '']
+
+    skipped = payload.get('skipped_reason')
+    if skipped:
+        # KAN-167 fail-loud: a missing API key isn't silent — it's surfaced
+        # in the section header AND printed as a workflow warning by the
+        # caller. The section still appears in the email so the absence is
+        # visible to the reader.
+        lines.append(f'⚠️ DATA UNAVAILABLE — {skipped}')
+        lines.append('')
+        return '\n'.join(lines) + '\n', f'unavailable:{skipped[:60]}'
+
+    err = payload.get('error')
+    if err:
+        lines.append(f'❌ DATA UNAVAILABLE — {err}')
+        lines.append('')
+        return '\n'.join(lines) + '\n', f'failed:uptimerobot-fetch:{err[:40]}'
+
+    monitors = payload.get('monitors')
+    if monitors is None:
+        lines.append('❌ DATA UNAVAILABLE — `monitors` key missing from payload.')
+        lines.append('')
+        return '\n'.join(lines) + '\n', 'failed:monitors-key-missing'
+
+    if not monitors:
+        lines.append('⚠️ No UptimeRobot monitors found — bootstrap may not have run yet.')
+        lines.append('')
+        return '\n'.join(lines) + '\n', 'partial:no-monitors-configured'
+
+    # UptimeRobot monitor.status: 0=paused, 1=not_checked, 2=up, 8=seems-down, 9=down.
+    UR_STATUS = {0: '⏸ paused', 1: '… new', 2: '✅ up', 8: '⚠️ seems-down', 9: '❌ down'}
+    lines.append('| Monitor | Status | Uptime (all-time) |')
+    lines.append('|---------|--------|--------------------|')
+    any_down = False
+    for m in monitors:
+        name = m.get('friendly_name') or 'unknown'
+        st = m.get('status')
+        try:
+            st_int = int(st) if st is not None else -1
+        except (ValueError, TypeError):
+            st_int = -1
+        st_label = UR_STATUS.get(st_int, f'❓ unknown ({st})')
+        if st_int in (8, 9):
+            any_down = True
+        uptime = m.get('all_time_uptime_ratio')
+        uptime_str = f'{uptime}%' if uptime is not None else 'DATA UNAVAILABLE'
+        lines.append(f'| {name} | {st_label} | {uptime_str} |')
+    lines.append('')
+
+    status = 'partial:monitor-down' if any_down else 'ok'
+    return '\n'.join(lines) + '\n', status
+
+
+# ───────────────────────── shape: cost_spotcheck ─────────────────────────
+
+def shape_cost_spotcheck(payload: dict[str, Any], _now: datetime) -> tuple[str, str]:
+    """Render Section 20 — Cost Spotcheck.
+
+    payload shape: dict of {provider_name: {"available": bool, "detail": str}}.
+
+    Each entry is independently rendered. If the provider's API isn't
+    wired up (no token), `available=False` with a `detail` explaining
+    what's missing. Per KAN-167, the section is still rendered; the row
+    just says DATA UNAVAILABLE with the reason.
+    """
+    lines = ['## 20. Cost Spotcheck (best-effort)', '']
+    providers = payload.get('providers') or {}
+    if not providers:
+        lines.append('⚠️ DATA UNAVAILABLE — no providers configured.')
+        lines.append('')
+        return '\n'.join(lines) + '\n', 'unavailable:no-providers-configured'
+
+    lines.append('| Provider | Status | Detail |')
+    lines.append('|----------|--------|--------|')
+    any_unavailable = False
+    for name in sorted(providers.keys()):
+        info = providers[name] or {}
+        if info.get('available'):
+            lines.append(f'| {name} | ✅ ok | {info.get("detail", "—")} |')
+        else:
+            any_unavailable = True
+            lines.append(
+                f'| {name} | ⚠️ DATA UNAVAILABLE | {info.get("detail", "no detail")} |'
+            )
+    lines.append('')
+
+    status = 'partial:some-cost-providers-unavailable' if any_unavailable else 'ok'
+    return '\n'.join(lines) + '\n', status
+
+
+# ───────────────────────── CLI dispatch ─────────────────────────
+
+SHAPERS = {
+    'release_cadence': shape_release_cadence,
+    'in_flight': shape_in_flight,
+    'pr_queue': shape_pr_queue,
+    'ci_flakiness': shape_ci_flakiness,
+    'mcp_health': shape_mcp_health,
+    'cost_spotcheck': shape_cost_spotcheck,
+}
+
+SECTION_NUMBERS = {
+    'release_cadence': 15,
+    'in_flight': 16,
+    'pr_queue': 17,
+    'ci_flakiness': 18,
+    'mcp_health': 19,
+    'cost_spotcheck': 20,
+}
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) != 2 or argv[1] not in SHAPERS:
+        sys.stderr.write(
+            f'Usage: {argv[0]} <{ "|".join(SHAPERS) }>\n'
+            'Reads JSON payload from stdin; writes markdown to stdout '
+            'and `section-<N>=<status>` to stderr.\n'
+        )
+        return 2
+
+    shape = argv[1]
+    try:
+        payload = json.load(sys.stdin)
+    except json.JSONDecodeError as e:
+        # Loud, not silent. Emit a failed status so the workflow goes red.
+        sys.stdout.write(
+            f'## {SECTION_NUMBERS[shape]}. {shape.replace("_", " ").title()}\n\n'
+            f'❌ DATA UNAVAILABLE — payload was not valid JSON: {e}\n\n'
+        )
+        sys.stderr.write(f'section-{SECTION_NUMBERS[shape]}=failed:invalid-json\n')
+        return 1
+
+    now = datetime.now(timezone.utc)
+    body, status = SHAPERS[shape](payload, now)
+    sys.stdout.write(body)
+    sys.stderr.write(f'section-{SECTION_NUMBERS[shape]}={status}\n')
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main(sys.argv))

--- a/tests/unit/dashboard-shapers.test.js
+++ b/tests/unit/dashboard-shapers.test.js
@@ -1,0 +1,361 @@
+/**
+ * KAN-165: tests for scripts/dashboard-shapers.py.
+ *
+ * The shapers are the load-bearing piece of the new dashboard sections.
+ * Each test invokes the CLI in a subprocess with a JSON payload on stdin
+ * and asserts the markdown body + `section-<N>=<status>` line are correct.
+ *
+ * Per the test-integrity policy: these tests are exercising the pure
+ * data-shaping logic only. The actual API fetches happen in the workflow
+ * and are surfaced through these shapers via the `error` / `skipped_reason`
+ * fields, which we also test here.
+ */
+
+const { execFileSync } = require('node:child_process');
+const path = require('node:path');
+
+const SCRIPT = path.resolve(__dirname, '../../scripts/dashboard-shapers.py');
+
+function run(shape, payload) {
+  const json = JSON.stringify(payload);
+  let result;
+  try {
+    const out = execFileSync('python3', [SCRIPT, shape], {
+      input: json,
+      encoding: 'utf-8',
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+    result = { exitCode: 0, stdout: out, stderr: '' };
+  } catch (err) {
+    result = {
+      exitCode: err.status ?? 1,
+      stdout: err.stdout?.toString() ?? '',
+      stderr: err.stderr?.toString() ?? '',
+    };
+  }
+  // The shapers write `section-<N>=<status>` to stderr. execFileSync's
+  // success path doesn't expose stderr, so for ok paths we re-run with
+  // a try block. The simpler approach: assert the markdown body in
+  // stdout and assert the status line by parsing it out of stderr when
+  // available. For test purposes we run python3 separately for the
+  // status check.
+  return result;
+}
+
+function runCapturingStderr(shape, payload) {
+  // Spawn synchronously, capturing both streams via inheritable fds.
+  const { spawnSync } = require('node:child_process');
+  const r = spawnSync('python3', [SCRIPT, shape], {
+    input: JSON.stringify(payload),
+    encoding: 'utf-8',
+  });
+  return {
+    exitCode: r.status,
+    stdout: r.stdout,
+    stderr: r.stderr,
+  };
+}
+
+describe('dashboard-shapers.py — release_cadence', () => {
+  test('green when drift is green and tag date is recent', () => {
+    const today = new Date();
+    today.setDate(today.getDate() - 2);
+    const r = runCapturingStderr('release_cadence', {
+      latest_tag: 'v0.1.40',
+      latest_tag_date: today.toISOString(),
+      drift: {
+        commits_ahead: '2',
+        days_since_last_commit: '1',
+        status: 'green',
+      },
+    });
+    expect(r.exitCode).toBe(0);
+    expect(r.stdout).toMatch(/## 15. Release Cadence/);
+    expect(r.stdout).toMatch(/v0\.1\.40/);
+    expect(r.stdout).toMatch(/🟢 green/);
+    expect(r.stderr).toMatch(/section-15=ok/);
+  });
+
+  test('partial:drift-red when drift status is red', () => {
+    const r = runCapturingStderr('release_cadence', {
+      latest_tag: 'v0.1.20',
+      latest_tag_date: '2026-03-01T00:00:00Z',
+      drift: {
+        commits_ahead: '40',
+        days_since_last_commit: '15',
+        status: 'red',
+      },
+    });
+    expect(r.stdout).toMatch(/🔴 red/);
+    expect(r.stderr).toMatch(/section-15=partial:drift-red/);
+  });
+
+  test('failed:drift-data-unavailable when drift status is unknown', () => {
+    const r = runCapturingStderr('release_cadence', {
+      latest_tag: 'v0.1.40',
+      latest_tag_date: '',
+      drift: {
+        commits_ahead: 'DATA_UNAVAILABLE',
+        days_since_last_commit: 'DATA_UNAVAILABLE',
+        status: 'unknown',
+      },
+    });
+    expect(r.stderr).toMatch(/section-15=failed:drift-data-unavailable/);
+  });
+});
+
+describe('dashboard-shapers.py — in_flight', () => {
+  test('renders a sorted table by age (oldest first)', () => {
+    const now = new Date();
+    const tenDaysAgo = new Date(now.getTime() - 10 * 86400_000).toISOString();
+    const twoDaysAgo = new Date(now.getTime() - 2 * 86400_000).toISOString();
+    const r = runCapturingStderr('in_flight', {
+      issues: [
+        {
+          key: 'KAN-100',
+          fields: {
+            summary: 'newer ticket',
+            updated: twoDaysAgo,
+            assignee: { displayName: 'Luisa' },
+          },
+        },
+        {
+          key: 'KAN-50',
+          fields: {
+            summary: 'older ticket',
+            updated: tenDaysAgo,
+            assignee: null,
+          },
+        },
+      ],
+    });
+    expect(r.exitCode).toBe(0);
+    // Older should appear before newer in the table body.
+    const olderIdx = r.stdout.indexOf('KAN-50');
+    const newerIdx = r.stdout.indexOf('KAN-100');
+    expect(olderIdx).toBeGreaterThan(0);
+    expect(newerIdx).toBeGreaterThan(olderIdx);
+    expect(r.stdout).toMatch(/Unassigned/);
+    expect(r.stderr).toMatch(/section-16=ok/);
+  });
+
+  test('ok with empty issues list', () => {
+    const r = runCapturingStderr('in_flight', { issues: [] });
+    expect(r.stdout).toMatch(/No tickets currently In Progress/);
+    expect(r.stderr).toMatch(/section-16=ok/);
+  });
+
+  test('failed when error field is set', () => {
+    const r = runCapturingStderr('in_flight', {
+      error: 'JQL returned 403',
+    });
+    expect(r.stdout).toMatch(/DATA UNAVAILABLE — JQL returned 403/);
+    expect(r.stderr).toMatch(/section-16=failed:jira-fetch:/);
+  });
+
+  test('failed when issues key is missing entirely', () => {
+    const r = runCapturingStderr('in_flight', {});
+    expect(r.stdout).toMatch(/DATA UNAVAILABLE/);
+    expect(r.stderr).toMatch(/section-16=failed:jira-issues-key-missing/);
+  });
+
+  test('parses Jira no-colon timezone offset (e.g. +0000)', () => {
+    // Jira returns timestamps like "2026-05-01T00:00:00.000+0000" —
+    // Python <3.11's fromisoformat refuses that without normalization.
+    // Lock in that we handle this format and compute the correct age.
+    const ageDays = 7;
+    const target = new Date(Date.now() - ageDays * 86400_000);
+    // Build a Jira-style no-colon offset string.
+    const isoPlain = target.toISOString();
+    const jiraStyle = isoPlain.replace(/\.\d+Z$/, '.000+0000');
+    const r = runCapturingStderr('in_flight', {
+      issues: [
+        {
+          key: 'KAN-77',
+          fields: {
+            summary: 'jira-format check',
+            updated: jiraStyle,
+            assignee: { displayName: 'Luisa' },
+          },
+        },
+      ],
+    });
+    expect(r.exitCode).toBe(0);
+    // Should compute age ~7 days, not 0 (which would indicate parse-failure).
+    expect(r.stdout).toMatch(/oldest is [67] day\(s\)/);
+    expect(r.stderr).toMatch(/section-16=ok/);
+  });
+});
+
+describe('dashboard-shapers.py — pr_queue', () => {
+  test('groups PRs by base, counts draft vs ready, dependabot vs human', () => {
+    const fiveDaysAgo = new Date(Date.now() - 5 * 86400_000).toISOString();
+    const r = runCapturingStderr('pr_queue', {
+      pulls: [
+        {
+          number: 1,
+          title: 'A',
+          base: { ref: 'develop' },
+          draft: false,
+          created_at: fiveDaysAgo,
+          user: { login: 'luisa-sys' },
+        },
+        {
+          number: 2,
+          title: 'B',
+          base: { ref: 'develop' },
+          draft: true,
+          created_at: fiveDaysAgo,
+          user: { login: 'dependabot[bot]' },
+        },
+        {
+          number: 3,
+          title: 'C',
+          base: { ref: 'main' },
+          draft: false,
+          created_at: fiveDaysAgo,
+          user: { login: 'luisa-sys' },
+        },
+      ],
+    });
+    expect(r.exitCode).toBe(0);
+    expect(r.stdout).toMatch(/Total open:\*\* 3/);
+    expect(r.stdout).toMatch(/2 ready \/ 1 draft/);
+    expect(r.stdout).toMatch(/2 human \/ 1 dependabot/);
+    expect(r.stdout).toMatch(/`develop` \| 2/);
+    expect(r.stdout).toMatch(/`main` \| 1/);
+    expect(r.stderr).toMatch(/section-17=ok/);
+  });
+
+  test('ok with empty pulls list', () => {
+    const r = runCapturingStderr('pr_queue', { pulls: [] });
+    expect(r.stdout).toMatch(/No open pull requests/);
+    expect(r.stderr).toMatch(/section-17=ok/);
+  });
+
+  test('failed when error field is set', () => {
+    const r = runCapturingStderr('pr_queue', { error: 'gh api 502' });
+    expect(r.stdout).toMatch(/DATA UNAVAILABLE — gh api 502/);
+    expect(r.stderr).toMatch(/section-17=failed:pr-fetch:/);
+  });
+});
+
+describe('dashboard-shapers.py — ci_flakiness', () => {
+  test('computes success rate and flags <80% as partial', () => {
+    // pr-checks: 1 success, 4 failure → 20% → flaky
+    // deploy-dev: 5 success → 100%
+    const runs = [];
+    for (let i = 0; i < 4; i++) runs.push({ name: 'pr-checks', conclusion: 'failure' });
+    runs.push({ name: 'pr-checks', conclusion: 'success' });
+    for (let i = 0; i < 5; i++) runs.push({ name: 'deploy-dev', conclusion: 'success' });
+    const r = runCapturingStderr('ci_flakiness', { runs });
+    expect(r.exitCode).toBe(0);
+    expect(r.stdout).toMatch(/pr-checks/);
+    expect(r.stdout).toMatch(/deploy-dev/);
+    expect(r.stdout).toMatch(/⚠️ 20%/);
+    expect(r.stdout).toMatch(/100%/);
+    expect(r.stderr).toMatch(/section-18=partial:flaky-workflows/);
+  });
+
+  test('ok when every workflow ≥ 80%', () => {
+    const runs = [
+      { name: 'pr-checks', conclusion: 'success' },
+      { name: 'pr-checks', conclusion: 'success' },
+      { name: 'pr-checks', conclusion: 'success' },
+      { name: 'pr-checks', conclusion: 'success' },
+      { name: 'pr-checks', conclusion: 'failure' },
+    ];
+    const r = runCapturingStderr('ci_flakiness', { runs });
+    expect(r.stderr).toMatch(/section-18=ok/);
+  });
+
+  test('partial:no-runs when window is empty', () => {
+    const r = runCapturingStderr('ci_flakiness', { runs: [] });
+    expect(r.stderr).toMatch(/section-18=partial:no-runs-in-window/);
+  });
+});
+
+describe('dashboard-shapers.py — mcp_health', () => {
+  test('renders monitors with up status', () => {
+    const r = runCapturingStderr('mcp_health', {
+      monitors: [
+        { friendly_name: 'mcp.checklyra.com', status: 2, all_time_uptime_ratio: '99.97' },
+        { friendly_name: 'mcp-dev.checklyra.com', status: 2, all_time_uptime_ratio: '99.50' },
+      ],
+    });
+    expect(r.exitCode).toBe(0);
+    expect(r.stdout).toMatch(/✅ up/);
+    expect(r.stdout).toMatch(/99\.97%/);
+    expect(r.stderr).toMatch(/section-19=ok/);
+  });
+
+  test('partial:monitor-down when any monitor is seems-down or down', () => {
+    const r = runCapturingStderr('mcp_health', {
+      monitors: [
+        { friendly_name: 'mcp.checklyra.com', status: 9, all_time_uptime_ratio: '95.00' },
+      ],
+    });
+    expect(r.stdout).toMatch(/❌ down/);
+    expect(r.stderr).toMatch(/section-19=partial:monitor-down/);
+  });
+
+  test('unavailable when skipped_reason is set (no API key)', () => {
+    const r = runCapturingStderr('mcp_health', {
+      skipped_reason: 'UPTIMEROBOT_API_KEY secret not configured',
+    });
+    expect(r.stdout).toMatch(/DATA UNAVAILABLE — UPTIMEROBOT_API_KEY secret not configured/);
+    expect(r.stderr).toMatch(/section-19=unavailable:UPTIMEROBOT_API_KEY/);
+  });
+
+  test('failed when error is set', () => {
+    const r = runCapturingStderr('mcp_health', { error: 'http 500' });
+    expect(r.stderr).toMatch(/section-19=failed:uptimerobot-fetch:/);
+  });
+});
+
+describe('dashboard-shapers.py — cost_spotcheck', () => {
+  test('renders mixed available/unavailable providers', () => {
+    const r = runCapturingStderr('cost_spotcheck', {
+      providers: {
+        Vercel: { available: true, detail: 'Hobby plan — within free tier' },
+        Supabase: { available: false, detail: 'SUPABASE_MANAGEMENT_TOKEN not set' },
+      },
+    });
+    expect(r.stdout).toMatch(/Vercel \| ✅ ok/);
+    expect(r.stdout).toMatch(/Supabase \| ⚠️ DATA UNAVAILABLE/);
+    expect(r.stderr).toMatch(/section-20=partial:some-cost-providers-unavailable/);
+  });
+
+  test('ok when all providers available', () => {
+    const r = runCapturingStderr('cost_spotcheck', {
+      providers: {
+        Vercel: { available: true, detail: 'ok' },
+      },
+    });
+    expect(r.stderr).toMatch(/section-20=ok/);
+  });
+
+  test('unavailable when no providers configured', () => {
+    const r = runCapturingStderr('cost_spotcheck', { providers: {} });
+    expect(r.stderr).toMatch(/section-20=unavailable:no-providers-configured/);
+  });
+});
+
+describe('dashboard-shapers.py — CLI error paths', () => {
+  test('exits 2 on unknown shape name', () => {
+    const r = runCapturingStderr('not_a_real_shape', {});
+    expect(r.exitCode).toBe(2);
+    expect(r.stderr).toMatch(/Usage/);
+  });
+
+  test('exits 1 and emits failed status when stdin is malformed JSON', () => {
+    const { spawnSync } = require('node:child_process');
+    const r = spawnSync('python3', [SCRIPT, 'in_flight'], {
+      input: 'not-json',
+      encoding: 'utf-8',
+    });
+    expect(r.status).toBe(1);
+    expect(r.stdout).toMatch(/DATA UNAVAILABLE — payload was not valid JSON/);
+    expect(r.stderr).toMatch(/section-16=failed:invalid-json/);
+  });
+});


### PR DESCRIPTION
## Summary

Extends `weekly-report.yml` with six new dashboard sections so the Monday email becomes a real status dashboard, and scaffolds an `email-as-prompt` workflow that turns inbound emails into Jira comments. Closes KAN-165 Phase 1 + lays the foundation for Phase 2.

**New sections in weekly-report.yml**

| # | Section | Source | Fail-loud behaviour |
|---|---------|--------|---------------------|
| 15 | Release Cadence | `check-release-drift.sh` + `git describe` | Drift script's existing exit-2 path for missing refs |
| 16 | In-Flight Work | Jira REST (status="In Progress") | `::warning::` + DATA UNAVAILABLE if `ATLASSIAN_*` secrets missing |
| 17 | PR Queue Health | `gh api /pulls` | DATA UNAVAILABLE with curl error on fetch fail |
| 18 | CI Flakiness | `gh api /actions/runs?per_page=30` | DATA UNAVAILABLE; partial:flaky-workflows when any wf <80% |
| 19 | MCP Server Health | UptimeRobot `getMonitors` | `::warning::` + `unavailable:UPTIMEROBOT_API_KEY...` if key not wired (documented gap) |
| 20 | Cost Spotcheck | Vercel/Supabase/Resend API probe | Per-provider DATA UNAVAILABLE if token missing — never silent-skipped |

The Data Quality Summary at the top of the email now lists all 14 sources (was 8).

**Email-as-prompt scaffold**

`.github/workflows/email-as-prompt.yml` listens on `repository_dispatch` (`event_type: email-prompt`) and posts `client_payload.body` as a comment on a Jira ticket (default `KAN-165`) via the Atlassian REST API. Manual `workflow_dispatch` trigger included for testing.

Real inbound integration is **NOT wired up** — `docs/EMAIL_AS_PROMPT.md` walks through the Cloudflare Email Worker path (preferred) and the Resend inbound option, plus security controls (sender allow-list, SPF/DKIM, PAT scoping, rate limit).

**Why a new shapers module**

`scripts/dashboard-shapers.py` is the pure-functional core of the new sections — each function takes raw API JSON + a `now` timestamp and returns markdown + a section-status string. Splitting it out keeps the workflow shell thin and lets us unit-test the rendering logic (`tests/unit/dashboard-shapers.test.js`, 23 tests). Bonus: handles Jira's no-colon timezone offset (`+0000`) which Python <3.11's `fromisoformat` rejects — locked in by a regression test.

**Follow-up tickets to file**

- Provision a write-scoped Atlassian token (`ATLASSIAN_API_TOKEN_COMMENT`) and switch email-as-prompt to use it (currently re-uses read-only token name; comments will 403 until this lands).
- Build the Cloudflare Email Worker (`lyra-inbound-prompt`) and wire up a `prompt@checklyra.com` route.
- Add HMAC signature verification on the repository_dispatch payload so only the trusted Worker can fire the workflow.
- Wire `UPTIMEROBOT_API_KEY` into weekly-report.yml so Section 19 stops rendering DATA UNAVAILABLE.
- Add subject-line ticket-key extraction (e.g. `Re: KAN-150 ...` → `ticket_key=KAN-150`).

**Why extend rather than break out**

The new sections share the same compose step, data-quality file, and email-send pipeline as the existing 8 sections. Splitting them would mean duplicating the Resend integration or assembling the email from two artifacts. Extending is the smaller change.

## Test plan

- [ ] All 386 unit tests pass locally (`npm run test:unit`)
- [ ] `npm audit --audit-level=high` shows 0 vulnerabilities
- [ ] Both workflow YAML files parse cleanly (validated via `yaml.safe_load`)
- [ ] `scripts/check-workflow-integrity.sh` finds no issues
- [ ] After merge, manually trigger `workflow_dispatch` on weekly-report.yml and verify sections 15-20 appear with real data (or DATA UNAVAILABLE for unwired sources like UptimeRobot and Atlassian)
- [ ] After merge, manually trigger `workflow_dispatch` on email-as-prompt.yml with synthetic subject/body and verify a comment appears on KAN-165

🤖 Generated with [Claude Code](https://claude.com/claude-code)