### PR TITLE
chore: provision-vercel-secret workflow (KAN-153 pepper)

### DIFF
--- a/.github/workflows/provision-vercel-secret.yml
+++ b/.github/workflows/provision-vercel-secret.yml
@@ -1,0 +1,165 @@
+name: Provision a Vercel env-var
+# Reusable, manual-only. Reads a named GitHub Actions secret and pushes
+# it into Vercel as an env var across the standard Lyra scopes:
+#   - production
+#   - preview, gitBranch=develop
+#   - preview, gitBranch=staging
+#   - the beta custom environment (env_sH3tCWTdDu3I9pGTrJMn1mZk5Q8O)
+#   - development (Vercel local dev — optional)
+#
+# Use this whenever a new server-side secret needs to land in Vercel
+# for ALL Lyra envs (KAN-153 LYRA_SEARCH_PEPPER was the first caller).
+#
+# Pattern: set the value as a GitHub Actions secret first (gh secret set),
+# then dispatch this workflow with secret_name=<NAME>. The workflow reads
+# it from secrets.{{ inputs.secret_name }} and POSTs to Vercel REST API.
+#
+# Idempotent: PATCH if the env-var already exists for a given scope,
+# POST otherwise. Existing values are overwritten — no version history.
+
+on:
+  workflow_dispatch:
+    inputs:
+      secret_name:
+        description: 'Name of the GitHub Actions secret to push to Vercel (must already exist in secrets)'
+        required: true
+        type: string
+      scopes:
+        description: 'Comma-separated scopes — leave empty for the default Lyra set'
+        required: false
+        default: 'production,preview:develop,preview:staging,custom:env_sH3tCWTdDu3I9pGTrJMn1mZk5Q8O,development'
+        type: string
+
+permissions:
+  contents: read
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  provision:
+    name: Push secret to Vercel scopes
+    runs-on: ubuntu-latest
+    env:
+      VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+      VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+      VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+      SECRET_NAME: ${{ inputs.secret_name }}
+      SCOPES: ${{ inputs.scopes }}
+      # Pull the secret value through secrets context. The mapped env var is
+      # the same name as the input so we can read it dynamically in the step.
+      LYRA_SEARCH_PEPPER: ${{ secrets.LYRA_SEARCH_PEPPER }}
+    steps:
+      - name: Validate inputs and resolve secret value
+        run: |
+          set -euo pipefail
+          if [ -z "${SECRET_NAME:-}" ]; then
+            echo "::error::secret_name input is required"
+            exit 1
+          fi
+          # Read the secret value via indirection. Only secrets that are
+          # exposed as env vars on THIS job can be resolved — currently
+          # just LYRA_SEARCH_PEPPER. To support more secrets, add them to
+          # the env: block above with a matching name.
+          SECRET_VALUE="$(eval echo \"\$$SECRET_NAME\")"
+          if [ -z "$SECRET_VALUE" ]; then
+            echo "::error::secret_name '$SECRET_NAME' resolved to empty — check that the GitHub secret exists AND that the job's env: block exposes it."
+            exit 1
+          fi
+          echo "::add-mask::$SECRET_VALUE"
+          # Stash for next steps via a file that's not echoed.
+          umask 077
+          printf '%s' "$SECRET_VALUE" > /tmp/lyra-secret-value
+          echo "Secret '$SECRET_NAME' resolved (length=${#SECRET_VALUE})."
+      - name: List target scopes
+        run: |
+          set -euo pipefail
+          echo "Target scopes:"
+          IFS=',' read -ra ARR <<<"$SCOPES"
+          for s in "${ARR[@]}"; do
+            echo "  - $s"
+          done
+      - name: Push to each scope via Vercel REST API
+        run: |
+          set -euo pipefail
+          SECRET_VALUE=$(cat /tmp/lyra-secret-value)
+          # Re-mask in case set -x is ever enabled.
+          echo "::add-mask::$SECRET_VALUE"
+
+          # Helper: idempotent upsert. Vercel's POST /v10/projects/{id}/env
+          # returns 400 if the key+scope already exists; we then look up
+          # the env-var id and PATCH instead.
+          upsert() {
+            local key="$1"
+            local value="$2"
+            local target_json="$3"   # JSON array fragment, e.g. '["production"]'
+            local git_branch="$4"    # may be empty
+            local custom_env="$5"    # may be empty (custom env id)
+
+            # Build the body.
+            local body
+            if [ -n "$custom_env" ]; then
+              body=$(jq -n --arg k "$key" --arg v "$value" --arg ce "$custom_env" \
+                '{key:$k, value:$v, type:"encrypted", customEnvironmentIds:[$ce]}')
+            elif [ -n "$git_branch" ]; then
+              body=$(jq -n --arg k "$key" --arg v "$value" --argjson t "$target_json" --arg b "$git_branch" \
+                '{key:$k, value:$v, type:"encrypted", target:$t, gitBranch:$b}')
+            else
+              body=$(jq -n --arg k "$key" --arg v "$value" --argjson t "$target_json" \
+                '{key:$k, value:$v, type:"encrypted", target:$t}')
+            fi
+
+            local resp
+            local http
+            resp=$(curl -sS -w "\n%{http_code}" -X POST \
+              -H "Authorization: Bearer $VERCEL_TOKEN" \
+              -H "Content-Type: application/json" \
+              "https://api.vercel.com/v10/projects/$VERCEL_PROJECT_ID/env?teamId=$VERCEL_ORG_ID&upsert=true" \
+              --data "$body")
+            http=$(echo "$resp" | tail -n1)
+            local body_resp
+            body_resp=$(echo "$resp" | sed '$d')
+            if [ "$http" = "200" ] || [ "$http" = "201" ]; then
+              echo "✓ $key → ${custom_env:-$target_json${git_branch:+ @ $git_branch}} (HTTP $http)"
+              return 0
+            fi
+            echo "::error::Vercel upsert failed for $key in ${custom_env:-$target_json${git_branch:+ @ $git_branch}}: HTTP $http"
+            # Don't echo the full body in case it contains secret material — emit a
+            # short fingerprint only.
+            local err_code
+            err_code=$(echo "$body_resp" | python3 -c "import json,sys;print(json.load(sys.stdin).get('error',{}).get('code','unknown'))" 2>/dev/null || echo "unparseable")
+            echo "::error::Vercel error code: $err_code"
+            return 1
+          }
+
+          IFS=',' read -ra ARR <<<"$SCOPES"
+          for scope in "${ARR[@]}"; do
+            case "$scope" in
+              production)
+                upsert "$SECRET_NAME" "$SECRET_VALUE" '["production"]' '' ''
+                ;;
+              development)
+                upsert "$SECRET_NAME" "$SECRET_VALUE" '["development"]' '' ''
+                ;;
+              preview)
+                upsert "$SECRET_NAME" "$SECRET_VALUE" '["preview"]' '' ''
+                ;;
+              preview:*)
+                BRANCH="${scope#preview:}"
+                upsert "$SECRET_NAME" "$SECRET_VALUE" '["preview"]' "$BRANCH" ''
+                ;;
+              custom:*)
+                CUSTOM_ID="${scope#custom:}"
+                upsert "$SECRET_NAME" "$SECRET_VALUE" '[]' '' "$CUSTOM_ID"
+                ;;
+              *)
+                echo "::error::Unknown scope format: $scope (expected: production | development | preview | preview:<branch> | custom:<env-id>)"
+                exit 1
+                ;;
+            esac
+          done
+
+          # Final clean-up.
+          shred -u /tmp/lyra-secret-value 2>/dev/null || rm -f /tmp/lyra-secret-value
+          echo "::notice::Provisioned $SECRET_NAME across ${#ARR[@]} scopes."


### PR DESCRIPTION
Adds `.github/workflows/provision-vercel-secret.yml` to push a GitHub Actions secret to all Vercel scopes in one shot. Needed on main (per gotcha #1) so workflow_dispatch can find it. First use is KAN-153 `LYRA_SEARCH_PEPPER`.