### PR TITLE
fix(tests): wrap CodeQL-flagged regex alternation in a non-capturing group

### DIFF
--- a/tests/unit/release-drift.test.ts
+++ b/tests/unit/release-drift.test.ts
@@ -138,6 +138,11 @@ describe('check-release-drift.sh', () => {
     gitRun(repo, ['checkout', '-q', '-b', 'develop']);
     commit(repo, 'one', '1', 'one');
     const r = runScript(repo, { DEVELOP_REF: 'develop', MAIN_REF: 'main' });
-    expect(r.fields.summary).toMatch(/^develop is \d+ commits \/ \d+ days ahead of main \(green|yellow|red\)$/);
+    // The alternation must be wrapped in a group — without it the regex
+    // parses as three top-level alternatives ("…(green" OR "yellow" OR
+    // "red)$") and the test passes for the wrong reasons (any string
+    // containing "yellow" satisfies the middle alternative). CodeQL
+    // flagged this — see js/regex/missing-regexp-anchor.
+    expect(r.fields.summary).toMatch(/^develop is \d+ commits \/ \d+ days ahead of main \((?:green|yellow|red)\)$/);
   });
 });


### PR DESCRIPTION
CodeQL caught a regex bug in `tests/unit/release-drift.test.ts:141`: the alternation wasn't grouped, so the test passed for any string containing 'yellow' or ending in 'red)'. Wrapped in `(?:...)` so the alternation is local to the colour choice.

Test still passes (6/6); behaviour now matches what KAN-173 intended.

CodeQL rule: `js/regex/missing-regexp-anchor`.