### PR TITLE
docs: trivial no-op for BUGS-16 end-to-end validation

### DIFF
--- a/docs/RELEASE_POLICY.md
+++ b/docs/RELEASE_POLICY.md
@@ -69,7 +69,9 @@ The reasoning is asymmetric:
 
 - KAN-173 (this policy): <https://checklyra.atlassian.net/browse/KAN-173>
 - KAN-167 (workflow integrity, the prior art for false-positive prevention): <https://checklyra.atlassian.net/browse/KAN-167>
-- BUGS-11 (auto-merge BLOCKED, the failure mode that triggered the rebase fix): <https://checklyra.atlassian.net/browse/BUGS-11>
+- BUGS-11 (auto-merge BLOCKED, originally attributed to strict-ancestry): <https://checklyra.atlassian.net/browse/BUGS-11>
+- BUGS-16 (auto-merge real root cause — phantom Vercel check_suite): <https://checklyra.atlassian.net/browse/BUGS-16>
 - `docs/RUNBOOK.md` — operational procedures
 - `.github/workflows/promote-to-staging.yml` — the manual workflow (auto-promote calls the same logic)
+- `.github/workflows/promote-to-production.yml` — direct-merge flow as of 2026-05-15 (BUGS-16 fix)
 - `.github/workflows/auto-promote-to-staging.yml` — the scheduled wrapper


### PR DESCRIPTION
Adds BUGS-16 + direct-merge workflow reference rows to docs/RELEASE_POLICY.md. Real purpose: put a commit on develop so we can run the full promote chain and prove the new promote-to-production workflow completes without admin intervention.