### PR TITLE
fix(BUGS-16): merge-and-push — don't fetch into checked-out main

### DIFF
--- a/.github/workflows/promote-to-production.yml
+++ b/.github/workflows/promote-to-production.yml
@@ -157,8 +157,14 @@ jobs:
           BETA_SHORT: ${{ needs.verify-source.outputs.beta_short }}
         run: |
           set -euo pipefail
-          git fetch origin main:main beta
-          git checkout main
+          # The checkout step above lands us on a detached HEAD by default
+          # (refs/remotes/origin/main). Switch to a local 'main' branch
+          # tracking origin/main, then ensure we're up to date. We must NOT
+          # use `git fetch origin main:main` here — that errors with
+          # "refusing to fetch into branch refs/heads/main checked out at"
+          # because once we've created local main below, that ref is in use.
+          git fetch origin beta
+          git checkout -B main origin/main
           git pull origin main --ff-only
 
           # Standard fast-forward-able merge. If beta has main as a strict


### PR DESCRIPTION
Tiny follow-up to PR #182. The first real run of the new promote-to-production workflow errored on `git fetch origin main:main beta` because we're already on main (the checkout step landed us there). Drop `main:main` from the fetch and use `git checkout -B main origin/main` instead.

This needs to land on main directly so the in-flight test cycle can complete. Once verified, BUGS-11 + BUGS-16 close.