### PR TITLE
feat(KAN-154): homepage privacy trust signal + dashboard share invite (A + B of 5)

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -30,6 +30,12 @@ const eslintConfig = defineConfig([
     // doesn't drown in errors from snapshots of older code. CI never
     // sees `.claude/`; this is purely a local-DX fix.
     ".claude/**",
+    // KAN-154: test-artifact directories created by `jest --coverage`
+    // and Playwright runs. Pure local-DX — CI starts from a clean
+    // checkout so these never appear in CI lint runs.
+    "coverage/**",
+    "playwright-report/**",
+    "test-results/**",
   ]),
 ]);
 

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -3,6 +3,7 @@ import { redirect } from 'next/navigation';
 import Link from 'next/link';
 import Image from 'next/image';
 import { signOut } from '../(auth)/actions';
+import ShareProfile from './share-profile';
 
 export const metadata = {
   title: 'Dashboard — Lyra',
@@ -102,6 +103,16 @@ export default async function DashboardPage() {
             <Link href="/dashboard/profile" className="mt-6 block w-full py-3 rounded-lg bg-[var(--color-sage)] text-white text-base font-medium hover:opacity-90 transition-opacity text-center">
               Set up your profile →
             </Link>
+          )}
+
+          {/* KAN-154-B: shareable invite. Only shown once the profile has
+              a slug — before that there's nothing to share, and the
+              fallback CTA would just point at the public landing page. */}
+          {profile?.slug && (
+            <ShareProfile
+              profileUrl={`${process.env.NEXT_PUBLIC_SITE_URL || 'https://checklyra.com'}/${profile.slug}`}
+              displayName={profile.display_name}
+            />
           )}
         </div>
       </div>

--- a/src/app/dashboard/share-profile.tsx
+++ b/src/app/dashboard/share-profile.tsx
@@ -1,0 +1,98 @@
+'use client';
+
+import { useState } from 'react';
+import { buildInviteText } from '@/lib/invite-text';
+
+/**
+ * KAN-154-B: client component for the dashboard "Share your invite" card.
+ *
+ * Renders a textarea pre-filled with the invite message (so the user can
+ * tweak the greeting before copying) and a Copy button that writes the
+ * current textarea contents to the clipboard. Two-second "Copied!" toast
+ * gives feedback without library overhead.
+ *
+ * The textarea is the source of truth — `buildInviteText` only seeds the
+ * initial value. This means edits the user makes locally before clicking
+ * Copy are preserved in the clipboard write.
+ *
+ * Accessibility:
+ *   - Textarea has a real label
+ *   - Copy button has aria-live region for the success message
+ *   - Falls back to a manual "select all" hint if clipboard API is
+ *     unavailable (older browsers, file:// contexts)
+ */
+export default function ShareProfile({
+  profileUrl,
+  displayName,
+}: {
+  profileUrl?: string | null;
+  displayName?: string | null;
+}) {
+  const initialText = buildInviteText({
+    profileUrl,
+    greeting: displayName ? `Hi! It's ${displayName}.` : undefined,
+  });
+
+  const [text, setText] = useState(initialText);
+  const [status, setStatus] = useState<'idle' | 'copied' | 'error'>('idle');
+
+  async function handleCopy() {
+    try {
+      // Modern path — works in all green-padlock contexts (HTTPS / localhost).
+      if (typeof navigator !== 'undefined' && navigator.clipboard) {
+        await navigator.clipboard.writeText(text);
+        setStatus('copied');
+        setTimeout(() => setStatus('idle'), 2000);
+        return;
+      }
+      setStatus('error');
+    } catch {
+      // Clipboard write can throw e.g. on focus-loss or permission-denied.
+      // We don't surface the raw error — the user just needs to know to
+      // copy manually.
+      setStatus('error');
+    }
+  }
+
+  return (
+    <div className="mt-6 pt-6 border-t border-stone-200">
+      <h3 className="text-lg font-medium text-[var(--color-ink)] mb-1">
+        Share Lyra with a friend
+      </h3>
+      <p className="text-sm text-[var(--color-muted)] mb-4">
+        Tweak the message below if you like, then copy and paste it
+        wherever feels right — WhatsApp, text, email.
+      </p>
+
+      <label htmlFor="invite-text" className="sr-only">
+        Invite message
+      </label>
+      <textarea
+        id="invite-text"
+        value={text}
+        onChange={(e) => setText(e.target.value)}
+        rows={7}
+        className="w-full p-3 text-sm rounded-lg border border-stone-300 bg-white text-[var(--color-ink)] focus:outline-none focus:ring-2 focus:ring-[var(--color-lyra-sage)] focus:border-transparent resize-y"
+      />
+
+      <div className="mt-3 flex items-center gap-3">
+        <button
+          type="button"
+          onClick={handleCopy}
+          className="px-5 py-2.5 rounded-full bg-[var(--color-lyra-sage)] text-white text-sm font-medium hover:bg-[var(--color-lyra-sage-hover)] transition-colors"
+        >
+          Copy message
+        </button>
+        <span
+          role="status"
+          aria-live="polite"
+          className="text-sm text-[var(--color-muted)]"
+        >
+          {status === 'copied' && 'Copied!'}
+          {status === 'error' &&
+            'Copy not available — select the text and copy manually.'}
+        </span>
+      </div>
+    </div>
+  );
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -221,8 +221,15 @@ function UseCases() {
 }
 
 function WhatLyraIsNot() {
-  // KAN-156: anti-social features expanded.
+  // KAN-156: anti-social features.
+  // KAN-154-A: explicit privacy trust signal — surfaces the no-contact-display
+  // promise alongside the existing anti-social "no" list. Sits at the top of
+  // the list because contact-detail privacy is the question most new visitors
+  // arrive with ("is my number going to be on this?"). Pairs with KAN-153's
+  // opt-in hashed discovery: phone/postcode are NEVER displayed, only used
+  // server-side for opt-in match lookup if the user explicitly enables it.
   const items = [
+    "No display of email, phone, or contact details (opt-in discovery only)",
     "No likes, followers, or feeds",
     "No friend requests, direct or group messages",
     "No algorithms deciding what you see",

--- a/src/lib/invite-text.ts
+++ b/src/lib/invite-text.ts
@@ -1,0 +1,58 @@
+/**
+ * KAN-154-B: build the shareable invite text a user can copy from the
+ * dashboard and paste into WhatsApp / SMS / email.
+ *
+ * Kept in a sibling .ts module (NOT in 'use server' files) so it can be
+ * imported by both the Server Component (dashboard/page.tsx) AND the
+ * client share button (dashboard/share-profile.tsx) without colliding
+ * with the use-server export rule (CLAUDE.md gotcha #18).
+ *
+ * Personalisation: the user's profile URL is embedded so recipients land
+ * on the inviter's profile. The text is deliberately gentle and explicit
+ * about the time cost ("a couple of minutes") to defuse the common
+ * objection "I don't have time for another app".
+ */
+
+const PRODUCT_BLURB =
+  "I'm using Lyra to help people around me know what I'd appreciate — gift ideas, things I love, things I don't, that sort of thing.";
+
+const COMMITMENT_BLURB =
+  "It only takes a couple of minutes — even just adding a few gift ideas helps.";
+
+const SITE_LANDING =
+  process.env.NEXT_PUBLIC_SITE_URL || "https://checklyra.com";
+
+/**
+ * Returns the full invite message a user can paste into any channel.
+ *
+ * @param opts.profileUrl - The inviter's published profile URL
+ *                          (e.g. https://checklyra.com/<slug>). Omit /
+ *                          pass undefined if the inviter has no slug yet —
+ *                          we fall back to the public landing page.
+ * @param opts.greeting   - Optional opener (e.g. "Hi Sarah!"). Falls back
+ *                          to a neutral "Hi!" so the text stays useful
+ *                          even when copied without personalisation.
+ */
+export function buildInviteText(opts: {
+  profileUrl?: string | null;
+  greeting?: string;
+}): string {
+  const greeting = (opts.greeting ?? "Hi!").trim();
+  const myProfileLine = opts.profileUrl
+    ? `Mine's here if you want to take a look: ${opts.profileUrl}`
+    : null;
+  const ctaLine = `Here's where you can create yours: ${SITE_LANDING}`;
+
+  return [
+    greeting,
+    "",
+    PRODUCT_BLURB,
+    "",
+    COMMITMENT_BLURB,
+    "",
+    myProfileLine,
+    ctaLine,
+  ]
+    .filter((line): line is string => line !== null)
+    .join("\n");
+}

--- a/tests/unit/invite-text.test.ts
+++ b/tests/unit/invite-text.test.ts
@@ -1,0 +1,76 @@
+/**
+ * KAN-154-B: buildInviteText behaviour guards.
+ *
+ * Invite text is user-facing — small changes (wrong link, missing
+ * personalisation, broken newline structure when pasted into WhatsApp)
+ * are visible and trust-damaging. These tests pin the contract.
+ */
+
+import { buildInviteText } from '@/lib/invite-text';
+
+describe('KAN-154-B buildInviteText', () => {
+  test('includes the inviter profile URL when provided', () => {
+    const out = buildInviteText({
+      profileUrl: 'https://checklyra.com/luisa',
+    });
+    expect(out).toContain('https://checklyra.com/luisa');
+  });
+
+  test('always includes the public landing URL as the create-yours CTA', () => {
+    const out = buildInviteText({
+      profileUrl: 'https://checklyra.com/luisa',
+    });
+    // The CTA line points recipients at the homepage; this is THE
+    // call-to-action and must always appear.
+    expect(out).toMatch(/Here['']s where you can create yours: https?:\/\//);
+  });
+
+  test('falls back to default greeting when none is provided', () => {
+    const out = buildInviteText({ profileUrl: null });
+    // The default opener has to keep working for users who copy the
+    // textarea without editing it.
+    expect(out.split('\n')[0]).toBe('Hi!');
+  });
+
+  test('uses provided greeting verbatim when supplied', () => {
+    const out = buildInviteText({
+      profileUrl: null,
+      greeting: "Hi! It's Luisa.",
+    });
+    expect(out.split('\n')[0]).toBe("Hi! It's Luisa.");
+  });
+
+  test('omits the "mine is here" line when no profileUrl', () => {
+    // Users who haven't picked a slug yet should still get a useful
+    // invite — just one without a profile preview.
+    const out = buildInviteText({ profileUrl: undefined });
+    expect(out).not.toContain("Mine's here");
+  });
+
+  test('keeps blank-line structure intact for WhatsApp / SMS readability', () => {
+    // Pasting into WhatsApp respects newlines — losing them would turn
+    // the message into a single dense paragraph. Lock the structure.
+    const out = buildInviteText({
+      profileUrl: 'https://checklyra.com/luisa',
+      greeting: 'Hi Sarah!',
+    });
+    const lines = out.split('\n');
+    // Greeting, blank, blurb, blank, commitment, blank, mine-line, cta
+    expect(lines[0]).toBe('Hi Sarah!');
+    expect(lines[1]).toBe('');
+    expect(lines[3]).toBe('');
+    expect(lines[5]).toBe('');
+    // The last two non-empty lines are the profile + landing URLs.
+    expect(lines[lines.length - 2]).toContain('https://checklyra.com/luisa');
+    expect(lines[lines.length - 1]).toMatch(/Here['']s where you can create yours:/);
+  });
+
+  test('mentions gift ideas in the body (commitment to the low-friction onboarding promise)', () => {
+    // KAN-154 ticket explicitly calls out "even just adding a few gift
+    // ideas helps" as the low-friction commitment. If a future refactor
+    // changes this to something heavier ("set up your full profile"),
+    // we want to know.
+    const out = buildInviteText({ profileUrl: null });
+    expect(out.toLowerCase()).toContain('gift idea');
+  });
+});


### PR DESCRIPTION
## Summary

Ships KAN-154 sub-features **A** (homepage privacy trust signal) and **B** (dashboard share invite). The remaining D (conversation starters) and E (current problems) need their own design + migration work and will go in separate sub-tickets. C (Manual of Me) shipped 2026-05-14.

### A) Homepage privacy trust signal
- Adds "No display of email, phone, or contact details (opt-in discovery only)" as the first item in the "What Lyra is not" list on `src/app/page.tsx`. Pairs with KAN-153's opt-in hashed discovery.

### B) Dashboard share invite
- `src/lib/invite-text.ts` — pure module, `buildInviteText(opts)` generates personalised invite text. Can be imported by both Server Component (dashboard page) and Client Component (share button) safely (no use-server collision per CLAUDE.md gotcha #18).
- `src/app/dashboard/share-profile.tsx` — client component with editable pre-filled textarea, Copy Message button using `navigator.clipboard.writeText`, aria-live status, and a graceful "select manually" fallback.
- Wired into `src/app/dashboard/page.tsx`, rendered only when `profile.slug` is set (no slug = nothing to share).
- 7 unit tests pinning URL inclusion, CTA line, greeting fallback, line structure for WhatsApp/SMS readability, and the "gift ideas" commitment phrase the ticket calls out.

### Bonus
- `eslint.config.mjs` — adds `coverage/`, `playwright-report/`, `test-results/` to global ignores so local `npm run lint` after a test run isn't a 3000-warning wall.

## Test plan

- [x] Lint clean on changed files (`npx eslint <files>` no findings)
- [x] 7 unit tests pass (`tests/unit/invite-text.test.ts`)
- [ ] PR Quality Gate passes
- [ ] Manual: load `/dashboard`, confirm share card renders below "Edit profile" CTA, message looks right, Copy button gives "Copied!" toast
- [ ] Manual: load homepage, confirm new privacy line appears first in "What Lyra is not"

🤖 Generated with [Claude Code](https://claude.com/claude-code)