### PR TITLE
fix(KAN-104): activate-sentry --scopes=all expanded development entry

### DIFF
--- a/.github/workflows/activate-sentry.yml
+++ b/.github/workflows/activate-sentry.yml
@@ -65,9 +65,11 @@ jobs:
           requested="${{ github.event.inputs.scopes }}"
           if [[ "$requested" == "all" ]]; then
             # Order matters: dev → staging → beta → production.
-            # Each entry is "label:target:gitBranch". Empty gitBranch
-            # means the entry isn't branch-scoped.
-            echo "list=development::,preview:preview:develop,preview:preview:staging,preview:preview:beta,production:production:" >> "$GITHUB_OUTPUT"
+            # Each entry is "label:target:gitBranch". The Vercel REST
+            # API rejects an empty `target`, so unbranched scopes need
+            # the label and target equal (development:development:,
+            # production:production:). gitBranch is empty for those.
+            echo "list=development:development:,preview:preview:develop,preview:preview:staging,preview:preview:beta,production:production:" >> "$GITHUB_OUTPUT"
           else
             echo "list=$requested" >> "$GITHUB_OUTPUT"
           fi


### PR DESCRIPTION
Trivial fix to the `all` shortcut in `activate-sentry.yml` — `development` was expanding to `development::` which Vercel REST rejected (`target` empty). Now `development:development:` which matches what worked manually. Verified upstream via run 25958275609. 🤖 Generated with [Claude Code](https://claude.com/claude-code)