### PR TITLE
feat(KAN-139): port recommendation engine from original Python app

### DIFF
--- a/src/app/[slug]/page.tsx
+++ b/src/app/[slug]/page.tsx
@@ -10,6 +10,8 @@ import {
   isManualOfMeEmpty,
   type ManualOfMe,
 } from '@/app/dashboard/profile/manual-of-me-fields';
+import { getRecommendations } from '@/lib/recommend';
+import RecommendationsSection from './recommendations-section';
 
 // Create client per-request, not at module scope
 function getSupabase() {
@@ -180,6 +182,24 @@ export default async function PublicProfilePage({ params }: Props) {
   const typedItems = visibleItems;
   const typedSchools = (schools || []) as SchoolAffiliation[];
   const typedLinks = (links || []) as ExternalLink[];
+
+  // KAN-139: build gift / experience recommendations from the items the
+  // current viewer can see. Anonymous viewers therefore get recommendations
+  // computed against the public subset only — members_only items influence
+  // the engine only when a logged-in viewer is reading the profile, which
+  // matches the visibility intent (private signals stay private).
+  const recommendations = getRecommendations(
+    {
+      bio: typedProfile.bio_short,
+      headline: typedProfile.headline,
+      items: typedItems.map((i) => ({
+        category: i.category,
+        title: i.title,
+        description: i.description,
+      })),
+    },
+    { limit: 8 },
+  );
 
   const categoryLabels: Record<string, string> = {
     likes: 'Likes',
@@ -463,6 +483,14 @@ export default async function PublicProfilePage({ params }: Props) {
           </div>
         </div>
       )}
+
+      {/* KAN-139: gift recommendations based on profile data */}
+      <div className="max-w-2xl mx-auto px-6">
+        <RecommendationsSection
+          displayName={typedProfile.display_name}
+          recommendations={recommendations}
+        />
+      </div>
 
       {/* Footer */}
       <div className="max-w-2xl mx-auto px-6 py-8 text-center">

--- a/src/app/[slug]/recommendations-section.tsx
+++ b/src/app/[slug]/recommendations-section.tsx
@@ -1,0 +1,78 @@
+/**
+ * KAN-139: public-profile "Gift ideas based on this profile" section.
+ *
+ * Pure server component — receives pre-computed `RecommendationResult[]`
+ * from the parent profile page so the recommendation engine call (which
+ * touches potentially many keywords) happens once per request, not once
+ * per render.
+ *
+ * Renders nothing if no recommendations are produced (keeps the page
+ * clean for sparse profiles). For profiles with very few items the engine
+ * naturally returns 0 results, so this is the right behaviour.
+ */
+
+import type { RecommendationResult } from '@/lib/recommend';
+
+interface RecommendationsSectionProps {
+  /** Display name of the person whose profile this is — used in the heading. */
+  displayName: string;
+  recommendations: RecommendationResult[];
+}
+
+export default function RecommendationsSection({
+  displayName,
+  recommendations,
+}: RecommendationsSectionProps) {
+  if (recommendations.length === 0) return null;
+
+  const first = displayName.split(/\s+/)[0] ?? displayName;
+
+  return (
+    <section
+      aria-labelledby="recommendations-heading"
+      className="mt-16 pt-12 border-t border-stone-200"
+    >
+      <header className="mb-8">
+        <h2
+          id="recommendations-heading"
+          className="text-2xl font-medium text-[var(--color-ink)] font-[family-name:var(--font-serif)]"
+        >
+          Gift ideas based on {first}&rsquo;s profile
+        </h2>
+        <p className="text-sm text-[var(--color-muted)] mt-2">
+          Automatically generated from what {first} has shared. Not endorsements — just suggestions to spark ideas.
+        </p>
+      </header>
+
+      <ul className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+        {recommendations.map((rec) => (
+          <li
+            key={rec.title}
+            className="p-5 rounded-xl border border-stone-200 bg-white"
+          >
+            <div className="flex items-baseline justify-between gap-3 mb-1">
+              <h3 className="text-base font-medium text-[var(--color-ink)]">
+                {rec.title}
+              </h3>
+              <span className="text-xs uppercase tracking-wider text-[var(--color-muted)] shrink-0">
+                {rec.category}
+              </span>
+            </div>
+            <p className="text-sm text-[var(--color-muted)] leading-relaxed">
+              {rec.description}
+            </p>
+            {rec.reasons.length > 0 && (
+              <p className="text-xs text-stone-500 mt-3 italic">
+                Why: {rec.reasons[0]}
+              </p>
+            )}
+          </li>
+        ))}
+      </ul>
+
+      <p className="text-xs text-stone-500 mt-6">
+        Suggestions are produced automatically and may not always land — use them as a starting point, not a shopping list.
+      </p>
+    </section>
+  );
+}

--- a/src/app/api/recommendations/[slug]/route.ts
+++ b/src/app/api/recommendations/[slug]/route.ts
@@ -1,0 +1,114 @@
+/**
+ * KAN-139: GET /api/recommendations/[slug]
+ *
+ * Returns ranked gift / experience recommendations for a published
+ * profile. Read-only, no auth — the underlying profile data is already
+ * public (`is_published = true`). Members-only items are NOT considered
+ * here because the request is unauthenticated; if a future use-case
+ * needs auth'd-viewer recommendations the route can accept a cookie
+ * session and switch to the cookie-aware client.
+ *
+ * Response shape:
+ *
+ *   {
+ *     "slug": "luisa",
+ *     "displayName": "Luisa",
+ *     "recommendations": [
+ *       { "title": "...", "description": "...", "category": "Experiences",
+ *         "categoryKey": "experiences", "score": 12.4,
+ *         "reasons": ["..."], "tags": ["..."] },
+ *       ...
+ *     ],
+ *     "insights": {
+ *       "dietary": [...], "values": [...], "topInterests": [...],
+ *       "avoidThemes": [...], "preferredCategories": [...]
+ *     }
+ *   }
+ *
+ * Returns 404 if the slug doesn't match a published profile.
+ */
+
+import { NextResponse } from 'next/server';
+import { createClient } from '@supabase/supabase-js';
+import { env } from '@/lib/env';
+import { getRecommendations, getProfileInsights } from '@/lib/recommend';
+
+interface ProfileRow {
+  id: string;
+  display_name: string;
+  bio_short: string | null;
+  headline: string | null;
+  is_published: boolean;
+  is_suspended?: boolean | null;
+}
+
+interface ItemRow {
+  category: string;
+  title: string;
+  description: string | null;
+}
+
+function getServiceClient() {
+  return createClient(env.supabaseUrl(), env.supabaseServiceRoleKey());
+}
+
+export async function GET(
+  request: Request,
+  context: { params: Promise<{ slug: string }> },
+) {
+  const { slug } = await context.params;
+  const url = new URL(request.url);
+  const limit = Math.min(Math.max(Number(url.searchParams.get('limit') ?? '8') || 8, 1), 30);
+
+  const supabase = getServiceClient();
+
+  const { data: profile, error: profileError } = await supabase
+    .from('profiles')
+    .select('id, display_name, bio_short, headline, is_published')
+    .eq('slug', slug)
+    .maybeSingle<ProfileRow>();
+
+  if (profileError) {
+    return NextResponse.json({ error: 'lookup_failed' }, { status: 500 });
+  }
+  if (!profile || !profile.is_published) {
+    return NextResponse.json({ error: 'not_found' }, { status: 404 });
+  }
+
+  const { data: items, error: itemsError } = await supabase
+    .from('profile_items')
+    .select('category, title, description')
+    .eq('profile_id', profile.id)
+    .eq('visibility', 'public');
+
+  if (itemsError) {
+    return NextResponse.json({ error: 'items_lookup_failed' }, { status: 500 });
+  }
+
+  const recInput = {
+    bio: profile.bio_short,
+    headline: profile.headline,
+    items: (items ?? []) as ItemRow[],
+  };
+
+  const recommendations = getRecommendations(recInput, { limit });
+  const insights = getProfileInsights(recInput);
+
+  return NextResponse.json(
+    {
+      slug,
+      displayName: profile.display_name,
+      recommendations,
+      insights,
+    },
+    {
+      // Caches well — the underlying data only changes when the user
+      // updates their profile. 5-minute SWR balances freshness against
+      // load. Anyone hitting this URL more often is almost certainly
+      // automation; the cache will keep them off the DB.
+      headers: {
+        'Cache-Control': 'public, s-maxage=300, stale-while-revalidate=900',
+      },
+    },
+  );
+}

--- a/src/lib/recommend/categories.ts
+++ b/src/lib/recommend/categories.ts
@@ -1,0 +1,115 @@
+/**
+ * KAN-139: gift category taxonomy ported from the original Python
+ * /Users/admin/Documents/2026 Lyra/lyra-app/recommend.py (`GIFT_CATEGORIES`).
+ *
+ * Each category has a list of keyword stems that mark a profile item or
+ * recommendation as belonging to that category, plus a base weight that
+ * the scorer multiplies into the final match score. Keywords are
+ * lowercase substrings; matching is `text.includes(keyword)` after
+ * lower-casing — the same shape as the Python source so behaviour
+ * stays bit-for-bit identical on the same inputs.
+ */
+
+export type GiftCategoryKey =
+  | 'experiences'
+  | 'food_drink'
+  | 'books_reading'
+  | 'home_garden'
+  | 'arts_crafts'
+  | 'fashion_accessories'
+  | 'music_audio'
+  | 'sport_outdoors'
+  | 'charitable'
+  | 'stationery_writing';
+
+export interface GiftCategory {
+  keywords: readonly string[];
+  weight: number;
+}
+
+export const GIFT_CATEGORIES: Readonly<Record<GiftCategoryKey, GiftCategory>> = {
+  experiences: {
+    keywords: [
+      'experience', 'ticket', 'class', 'workshop', 'lesson', 'trip',
+      'spa', 'massage', 'voucher', 'membership', 'pass', 'entry',
+      'escape room', 'supper club', 'concert', 'show', 'festival',
+      'climbing', 'swimming', 'running', 'yoga', 'retreat',
+    ],
+    weight: 1.2,
+  },
+  food_drink: {
+    keywords: [
+      'chocolate', 'wine', 'coffee', 'tea', 'gin', 'negroni',
+      'food', 'cookbook', 'cooking', 'baking', 'flour', 'beans',
+      'restaurant', 'supper', 'cake', 'cocktail', 'matcha',
+      'sushi', 'ramen', 'cheese', 'olive oil', 'honey',
+    ],
+    weight: 1.0,
+  },
+  books_reading: {
+    keywords: [
+      'book', 'novel', 'fiction', 'waterstones', 'reading',
+      'kindle', 'library', 'author', 'poetry', 'magazine',
+      'literary', 'bookshop',
+    ],
+    weight: 1.0,
+  },
+  home_garden: {
+    keywords: [
+      'candle', 'plant', 'garden', 'seed', 'bulb', 'flower',
+      'pottery', 'mug', 'bowl', 'vase', 'homeware', 'cushion',
+      'blanket', 'throw', 'print', 'art', 'frame', 'succulent',
+      'herb', 'pot',
+    ],
+    weight: 1.0,
+  },
+  arts_crafts: {
+    keywords: [
+      'paint', 'watercolour', 'art', 'craft', 'draw', 'sketch',
+      'brush', 'canvas', 'gallery', 'museum', 'exhibition',
+      'design', 'photography', 'camera', 'calligraphy',
+    ],
+    weight: 1.0,
+  },
+  fashion_accessories: {
+    keywords: [
+      'clothing', 'jewellery', 'scarf', 'hat', 'bag', 'wallet',
+      'watch', 'sunglasses', 'socks', 'lululemon', 'cashmere',
+      'silk', 'linen',
+    ],
+    weight: 0.9,
+  },
+  music_audio: {
+    keywords: [
+      'music', 'vinyl', 'record', 'headphone', 'speaker',
+      'concert', 'jazz', 'guitar', 'instrument', 'playlist',
+      'album',
+    ],
+    weight: 1.0,
+  },
+  sport_outdoors: {
+    keywords: [
+      'running', 'cycling', 'walking', 'hiking', 'climbing',
+      'swimming', 'yoga', 'fitness', 'trail', 'gear', 'shoe',
+      'marathon', 'race',
+    ],
+    weight: 1.0,
+  },
+  charitable: {
+    keywords: [
+      'donation', 'charity', 'cause', 'shelter', 'trust',
+      'foundation', 'volunteer', 'ethical', 'sustainable',
+      'environment', 'woodland', 'wildlife',
+    ],
+    weight: 1.1,
+  },
+  stationery_writing: {
+    keywords: [
+      'notebook', 'journal', 'pen', 'stationery', 'letter',
+      'card', 'handwritten', 'note', 'diary', 'planner',
+    ],
+    weight: 0.9,
+  },
+};
+
+export const ALL_CATEGORY_KEYS = Object.keys(GIFT_CATEGORIES) as GiftCategoryKey[];

--- a/src/lib/recommend/index.ts
+++ b/src/lib/recommend/index.ts
@@ -1,0 +1,167 @@
+/**
+ * KAN-139: public API of the Lyra recommendation engine.
+ *
+ * Ported from the Python module at
+ * /Users/admin/Documents/2026 Lyra/lyra-app/recommend.py. Two top-level
+ * entry points:
+ *
+ *   - getRecommendations(profile, opts) — ranked list of gift / experience
+ *     suggestions for a profile, with diversification (max 3 per category).
+ *
+ *   - getProfileInsights(profile) — analyst summary of the profile
+ *     (top interests, things to avoid, gift style). Used by the MCP
+ *     `lyra_get_insights` tool and by the recommendations UI.
+ *
+ * Pure functions — DB access happens in the caller. See
+ * `src/app/api/recommendations/[slug]/route.ts` for the
+ * standard plumbing.
+ */
+
+import { RECOMMENDATION_POOL, type RecommendationTemplate } from './pool';
+import { buildPreferenceProfile, type ProfileInput, type PreferenceProfile } from './preferences';
+import { scoreRecommendation, type ScoredRecommendation } from './score';
+
+export interface RecommendationOptions {
+  /** Cap on returned recommendations (post-diversification). Default 10. */
+  limit?: number;
+  /**
+   * Optional title-keyed feedback: positive = upvote (+5), negative =
+   * downvote (-20). Mirrors the Python user feedback table. The DB
+   * schema for storing this is deferred to a follow-up ticket; the
+   * function accepts feedback inline so callers can wire it in later
+   * without changing this signature.
+   */
+  feedback?: Record<string, 1 | -1>;
+}
+
+export interface RecommendationResult {
+  title: string;
+  description: string;
+  category: string;
+  /** Stable category key (snake_case) — useful for filtering / analytics. */
+  categoryKey: RecommendationTemplate['category'];
+  score: number;
+  reasons: string[];
+  tags: readonly string[];
+}
+
+/**
+ * Returns up to `limit` ranked recommendations. Excludes any
+ * recommendation that scored ≤ 0 (i.e. net-negative match). Diversifies
+ * by capping each category at 3 entries so a fanatic gardener doesn't
+ * see only plant suggestions.
+ */
+export function getRecommendations(
+  profile: ProfileInput,
+  opts: RecommendationOptions = {},
+): RecommendationResult[] {
+  const limit = opts.limit ?? 10;
+  const feedback = opts.feedback ?? {};
+  const pref = buildPreferenceProfile(profile);
+
+  const scored: ScoredRecommendation[] = RECOMMENDATION_POOL.map((rec) => {
+    const out = scoreRecommendation(rec, pref);
+    const vote = feedback[rec.title];
+    if (vote === 1) {
+      out.score += 5;
+      out.reasons.unshift('You liked this suggestion');
+    } else if (vote === -1) {
+      out.score -= 20;
+      out.reasons.unshift('You disliked this suggestion');
+    }
+    return out;
+  });
+
+  // Sort by score descending; tie-break by pool order for stability.
+  scored.sort((a, b) => b.score - a.score);
+
+  // Filter positive-only + diversify (max 3 per category).
+  const out: RecommendationResult[] = [];
+  const perCat = new Map<string, number>();
+  for (const r of scored) {
+    if (r.score <= 0) continue;
+    const cat = r.template.category;
+    const count = perCat.get(cat) ?? 0;
+    if (count >= 3) continue;
+    perCat.set(cat, count + 1);
+    out.push({
+      title: r.template.title,
+      description: r.template.description,
+      category: cat.replace(/_/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase()),
+      categoryKey: cat,
+      score: r.score,
+      reasons: r.reasons,
+      tags: r.template.tags,
+    });
+    if (out.length >= limit) break;
+  }
+
+  return out;
+}
+
+export interface ProfileInsights {
+  /** Dietary constraints detected from boundary text. */
+  dietary: string[];
+  /** Inferred gift-giving values (experiences > things, charitable, handmade, minimal). */
+  values: string[];
+  /** Top 10 keywords from likes + gift ideas, longest-first. */
+  topInterests: string[];
+  /** Top 5 keywords from avoid items. */
+  avoidThemes: string[];
+  /** Top 3 preferred gift categories. */
+  preferredCategories: string[];
+}
+
+/**
+ * Returns a high-level summary of what the engine inferred about the
+ * profile. Used by the MCP `lyra_get_insights` tool and by the public
+ * recommendation UI to caption why suggestions are what they are.
+ */
+export function getProfileInsights(profile: ProfileInput): ProfileInsights {
+  const pref = buildPreferenceProfile(profile);
+
+  const combined = new Map<string, number>();
+  for (const k of pref.likes.keys()) {
+    combined.set(k, (combined.get(k) ?? 0) + pref.likes.get(k));
+  }
+  for (const k of pref.gifts.keys()) {
+    combined.set(k, (combined.get(k) ?? 0) + pref.gifts.get(k));
+  }
+  const topInterests = [...combined.entries()]
+    .sort((a, b) => b[1] - a[1])
+    .filter(([word]) => word.length > 3)
+    .slice(0, 10)
+    .map(([w]) => w);
+
+  const avoidThemes = pref.avoids
+    .mostCommon(5)
+    .filter(([word]) => word.length > 3)
+    .map(([w]) => w);
+
+  const values = giftStyleLabels(pref);
+
+  const preferredCategories = pref.preferredCategories
+    .mostCommon(3)
+    .map(([cat]) => cat.replace(/_/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase()));
+
+  return {
+    dietary: [...pref.dietary].sort(),
+    values,
+    topInterests,
+    avoidThemes,
+    preferredCategories,
+  };
+}
+
+function giftStyleLabels(pref: PreferenceProfile): string[] {
+  const out: string[] = [];
+  if (pref.valuesExperiences) out.push('Prefers experiences over physical gifts');
+  if (pref.valuesCharitable) out.push('Appreciates charitable donations');
+  if (pref.valuesHandmade) out.push('Values handmade and independent makers');
+  if (pref.valuesMinimal) out.push('Minimalist — avoid adding clutter');
+  return out;
+}
+
+// Re-export the building blocks so callers can compose / test in isolation.
+export type { ProfileInput, ProfileItemInput } from './preferences';
+export type { ScoredRecommendation } from './score';

--- a/src/lib/recommend/keywords.ts
+++ b/src/lib/recommend/keywords.ts
@@ -1,0 +1,80 @@
+/**
+ * KAN-139: keyword extraction + stopwords, ported from
+ * /Users/admin/Documents/2026 Lyra/lyra-app/recommend.py (`_extract_keywords`).
+ *
+ * Pulls "meaningful" words out of free text — strips stopwords, ignores
+ * short tokens (<3 chars), lowercases. Used by the preference profile
+ * builder and the scorer to compare a recommendation against a user's
+ * profile content.
+ */
+
+const STOPWORDS: ReadonlySet<string> = new Set([
+  'the', 'a', 'an', 'i', 'me', 'my', 'we', 'our', 'you', 'your',
+  'it', 'its', 'is', 'are', 'was', 'were', 'be', 'been', 'being',
+  'have', 'has', 'had', 'do', 'does', 'did', 'will', 'would', 'could',
+  'should', 'may', 'might', 'shall', 'can', 'to', 'of', 'in', 'for',
+  'on', 'with', 'at', 'by', 'from', 'as', 'into', 'through', 'during',
+  'before', 'after', 'above', 'below', 'between', 'out', 'off', 'over',
+  'under', 'again', 'further', 'then', 'once', 'here', 'there', 'when',
+  'where', 'why', 'how', 'all', 'both', 'each', 'few', 'more', 'most',
+  'other', 'some', 'such', 'no', 'nor', 'not', 'only', 'own', 'same',
+  'so', 'than', 'too', 'very', 'just', 'don', 'now', 'and', 'but',
+  'or', 'if', 'this', 'that', 'these', 'those', 'am', 'about', 'up',
+  'also', 'them', 'they', 'their', 'what', 'which', 'who', 'whom',
+  'him', 'her', 'his', 'she', 'he', 'thing', 'things', 'like', 'love',
+  'really', 'always', 'never', 'much', 'many', 'any', 'every',
+  'please', 'especially', 'prefer', 'anything', 'something', 'nothing',
+  'even', 'still', 'already', 'rather', 'quite', 'get', 'got',
+]);
+
+const WORD_RE = /[a-z]+/g;
+
+/**
+ * Returns the list of meaningful words in `text` — lowercased,
+ * stopwords removed, ≥3 chars. Idempotent on input (handles undefined
+ * / null as empty array so callers don't have to defend).
+ */
+export function extractKeywords(text: string | null | undefined): string[] {
+  if (!text) return [];
+  const matches = text.toLowerCase().match(WORD_RE);
+  if (!matches) return [];
+  return matches.filter((w) => w.length > 2 && !STOPWORDS.has(w));
+}
+
+/**
+ * A small `Counter`-equivalent so the rest of the recommend module can
+ * stay close in shape to the Python reference. Increments per term,
+ * exposes `entries()` and `get()` for the scorer.
+ */
+export class Counter {
+  private readonly counts = new Map<string, number>();
+
+  add(words: Iterable<string>): void {
+    for (const w of words) {
+      this.counts.set(w, (this.counts.get(w) ?? 0) + 1);
+    }
+  }
+
+  get(word: string): number {
+    return this.counts.get(word) ?? 0;
+  }
+
+  has(word: string): boolean {
+    return this.counts.has(word);
+  }
+
+  keys(): Iterable<string> {
+    return this.counts.keys();
+  }
+
+  /** Top-N by count, descending. Stable for equal counts (insertion order). */
+  mostCommon(n: number): Array<[string, number]> {
+    return [...this.counts.entries()]
+      .sort((a, b) => b[1] - a[1])
+      .slice(0, n);
+  }
+
+  size(): number {
+    return this.counts.size;
+  }
+}

--- a/src/lib/recommend/pool.ts
+++ b/src/lib/recommend/pool.ts
@@ -1,0 +1,90 @@
+/**
+ * KAN-139: recommendation pool ported from the original Python
+ * /Users/admin/Documents/2026 Lyra/lyra-app/recommend.py (`RECOMMENDATION_POOL`).
+ *
+ * Each template has a title, description, category, and tag set. The
+ * scorer combines these against a profile's preference model to rank
+ * matches. Curated by Luisa in 2026-Q1; new entries should go here
+ * (NOT in a database table) so the pool is reviewable in PR.
+ */
+
+import type { GiftCategoryKey } from './categories';
+
+export interface RecommendationTemplate {
+  title: string;
+  description: string;
+  category: GiftCategoryKey;
+  tags: readonly string[];
+}
+
+export const RECOMMENDATION_POOL: readonly RecommendationTemplate[] = [
+  // Experiences
+  { title: 'Cooking class at a local restaurant', description: 'A hands-on cooking experience trying new cuisines', category: 'experiences', tags: ['cooking', 'food', 'experience'] },
+  { title: 'Spa day or wellness voucher', description: 'A relaxing day of self-care and pampering', category: 'experiences', tags: ['spa', 'self-care', 'voucher'] },
+  { title: 'Theatre or concert tickets', description: 'A live performance at a local venue', category: 'experiences', tags: ['music', 'theatre', 'experience', 'ticket'] },
+  { title: 'Wine or cocktail tasting experience', description: 'A guided tasting at a local bar or vineyard', category: 'experiences', tags: ['wine', 'cocktail', 'experience', 'gin'] },
+  { title: 'Pottery or ceramics workshop', description: 'A hands-on session making something beautiful', category: 'experiences', tags: ['craft', 'pottery', 'experience', 'art'] },
+  { title: 'Escape room experience', description: 'A fun group activity for puzzle lovers', category: 'experiences', tags: ['experience', 'social', 'puzzle'] },
+  { title: 'National Trust membership', description: 'Annual access to gardens, houses, and landscapes', category: 'experiences', tags: ['nature', 'garden', 'membership', 'national trust'] },
+  { title: 'Art gallery membership or Art Fund pass', description: 'Access to exhibitions and galleries nationwide', category: 'experiences', tags: ['art', 'gallery', 'museum', 'pass'] },
+  { title: 'Trail running event entry', description: 'Entry to a scenic organised run', category: 'experiences', tags: ['running', 'trail', 'sport', 'race'] },
+  { title: 'Yoga retreat weekend', description: 'A restorative weekend of yoga and mindfulness', category: 'experiences', tags: ['yoga', 'retreat', 'self-care', 'wellness'] },
+  { title: 'Supper club or tasting menu', description: 'An intimate dining experience with curated courses', category: 'experiences', tags: ['food', 'dining', 'experience', 'supper'] },
+  { title: 'Rock climbing session', description: 'Indoor or outdoor climbing for adventure seekers', category: 'experiences', tags: ['climbing', 'sport', 'adventure'] },
+  { title: 'Garden tour or open garden visit', description: 'Explore beautiful private or historic gardens', category: 'experiences', tags: ['garden', 'nature', 'flowers'] },
+  { title: 'Live jazz evening at a small venue', description: 'An intimate night of live music', category: 'experiences', tags: ['jazz', 'music', 'live', 'experience'] },
+  { title: 'Swimming in the sea — wild swimming voucher', description: 'A guided sea or wild swimming experience', category: 'experiences', tags: ['swimming', 'nature', 'outdoors'] },
+
+  // Food & Drink
+  { title: 'Speciality coffee subscription', description: 'Monthly delivery of single-origin beans from small roasters', category: 'food_drink', tags: ['coffee', 'subscription', 'beans'] },
+  { title: 'Artisan chocolate box', description: 'High-quality dark chocolate from an independent maker', category: 'food_drink', tags: ['chocolate', 'dark', 'artisan'] },
+  { title: 'Loose leaf tea collection', description: 'A curated selection of fine teas', category: 'food_drink', tags: ['tea', 'loose leaf', 'darjeeling', 'earl grey'] },
+  { title: 'Natural wine selection', description: 'A box of interesting natural or biodynamic wines', category: 'food_drink', tags: ['wine', 'natural', 'red'] },
+  { title: 'Craft gin set', description: 'Small-batch gins with tonics and garnishes', category: 'food_drink', tags: ['gin', 'cocktail', 'negroni'] },
+  { title: 'Sourdough starter kit', description: 'Everything needed to start baking sourdough at home', category: 'food_drink', tags: ['baking', 'sourdough', 'bread'] },
+  { title: 'Ottolenghi or Meera Sodha cookbook', description: 'Beautiful vegetarian/vegan cookbook', category: 'food_drink', tags: ['cookbook', 'vegetarian', 'vegan', 'cooking'] },
+  { title: 'Olive oil and balsamic set', description: 'Premium Italian oils for the home cook', category: 'food_drink', tags: ['cooking', 'italian', 'food'] },
+  { title: 'Japanese pantry box', description: 'Miso, soy, dashi, and other Japanese essentials', category: 'food_drink', tags: ['japanese', 'cooking', 'food', 'miso'] },
+  { title: 'Hotel Chocolat tasting collection', description: 'An assortment of premium chocolates', category: 'food_drink', tags: ['chocolate', 'hotel chocolat'] },
+
+  // Books & Reading
+  { title: 'Waterstones gift card', description: 'Freedom to choose their next favourite read', category: 'books_reading', tags: ['book', 'waterstones', 'gift card'] },
+  { title: 'Independent bookshop voucher', description: 'Support local and let them discover something new', category: 'books_reading', tags: ['book', 'independent', 'bookshop'] },
+  { title: 'Book subscription (e.g., The Willoughby Book Club)', description: 'A surprise book delivery every month', category: 'books_reading', tags: ['book', 'subscription', 'surprise'] },
+  { title: 'Beautiful coffee table book', description: 'A visual feast on a subject they love', category: 'books_reading', tags: ['book', 'photography', 'design', 'art'] },
+
+  // Home & Garden
+  { title: 'Scented candle from The White Company', description: 'A luxurious home fragrance candle', category: 'home_garden', tags: ['candle', 'white company', 'homeware'] },
+  { title: 'Seasonal flower subscription', description: 'Fresh flowers delivered monthly', category: 'home_garden', tags: ['flower', 'subscription', 'seasonal'] },
+  { title: 'Indoor plant — potted succulent or herb', description: 'A living, low-maintenance gift', category: 'home_garden', tags: ['plant', 'succulent', 'herb'] },
+  { title: 'Sarah Raven seeds or bulbs', description: 'Beautiful flower or vegetable seeds for the garden', category: 'home_garden', tags: ['seeds', 'garden', 'flowers', 'sarah raven'] },
+  { title: 'Handmade pottery mug or bowl', description: 'A unique, artisan-crafted piece', category: 'home_garden', tags: ['pottery', 'handmade', 'mug', 'bowl'] },
+  { title: 'Luxury throw or blanket', description: 'A cosy, high-quality throw for the sofa', category: 'home_garden', tags: ['blanket', 'throw', 'cosy', 'homeware'] },
+  { title: 'Herb garden kit', description: 'A windowsill herb growing set', category: 'home_garden', tags: ['herb', 'garden', 'growing', 'plant'] },
+
+  // Arts & Crafts
+  { title: 'Winsor & Newton paint set', description: 'Professional watercolour or acrylic paints', category: 'arts_crafts', tags: ['paint', 'watercolour', 'art'] },
+  { title: 'Sketchbook and quality pen set', description: 'Beautiful tools for drawing and note-taking', category: 'arts_crafts', tags: ['sketch', 'pen', 'stationery', 'art'] },
+  { title: 'Art print from an independent artist', description: 'A beautiful print to hang at home', category: 'arts_crafts', tags: ['art', 'print', 'design'] },
+
+  // Music
+  { title: 'Vinyl record — a classic album', description: 'A carefully chosen record for their collection', category: 'music_audio', tags: ['vinyl', 'record', 'music'] },
+  { title: 'Record shop gift voucher', description: 'Let them find their own treasure', category: 'music_audio', tags: ['vinyl', 'record', 'music', 'gift card'] },
+
+  // Sport & Outdoors
+  { title: 'Running socks — Stance or Balega', description: 'High-quality running socks that any runner appreciates', category: 'sport_outdoors', tags: ['running', 'socks', 'sport'] },
+  { title: 'Yoga mat or accessories', description: 'A premium mat, blocks, or strap for their practice', category: 'sport_outdoors', tags: ['yoga', 'mat', 'sport'] },
+  { title: 'Hiking socks or trail snacks', description: 'Practical gifts for outdoor enthusiasts', category: 'sport_outdoors', tags: ['hiking', 'walking', 'trail', 'outdoors'] },
+
+  // Charitable
+  { title: 'Donation to their favourite charity', description: 'A meaningful gift that supports a cause they care about', category: 'charitable', tags: ['donation', 'charity', 'cause'] },
+  { title: 'Adopt an animal or tree in their name', description: 'A symbolic adoption supporting conservation', category: 'charitable', tags: ['donation', 'wildlife', 'woodland', 'nature'] },
+
+  // Stationery
+  { title: 'Luxury notebook — Leuchtturm or Moleskine', description: 'For lists, sketches, or journaling', category: 'stationery_writing', tags: ['notebook', 'journal', 'stationery'] },
+  { title: 'Handwritten letter kit', description: 'Beautiful writing paper and envelopes', category: 'stationery_writing', tags: ['letter', 'handwritten', 'card', 'stationery'] },
+
+  // Fashion
+  { title: 'Cashmere socks or scarf', description: 'A small luxury in natural fibres', category: 'fashion_accessories', tags: ['cashmere', 'scarf', 'socks', 'natural'] },
+  { title: 'Lululemon gift card', description: "For yoga or activewear they'll love", category: 'fashion_accessories', tags: ['lululemon', 'yoga', 'activewear', 'gift card'] },
+] as const;

--- a/src/lib/recommend/preferences.ts
+++ b/src/lib/recommend/preferences.ts
@@ -1,0 +1,184 @@
+/**
+ * KAN-139: build a preference profile from a user's profile data.
+ *
+ * Ported from `_build_preference_profile` in
+ * /Users/admin/Documents/2026 Lyra/lyra-app/recommend.py.
+ *
+ * Schema adaptation from the original Python/SQLite shape:
+ *
+ *   Python section_key  →  Next.js `item_category` enum
+ *   ──────────────────     ────────────────────────────
+ *   gift_ideas            gift_ideas         (identical)
+ *   things_i_like         likes              (renamed)
+ *   things_i_avoid        dislikes           (renamed)
+ *   boundaries            boundaries         (identical)
+ *   favourite_books       favourite_books    (identical, added in KAN-137)
+ *   favourite_media       favourite_media    (identical, added in KAN-137)
+ *   causes                causes             (identical, added in KAN-137)
+ *
+ * The "about" section body in the Python schema maps onto `profiles.bio`
+ * in Next.js (single string column rather than a `profile_sections` row).
+ *
+ * Pure function — no DB / network access. The caller fetches the rows
+ * and passes them in. This lets the same logic run from a Server
+ * Component, an API route, or the MCP server (eventually) without
+ * dragging Supabase into every consumer.
+ */
+
+import { extractKeywords, Counter } from './keywords';
+import { GIFT_CATEGORIES, type GiftCategoryKey, ALL_CATEGORY_KEYS } from './categories';
+
+/**
+ * Subset of `profile_items` columns the preference builder needs.
+ * Callers pass `select('category, title, description')` — anything
+ * else is irrelevant to scoring.
+ */
+export interface ProfileItemInput {
+  category: string;
+  title: string | null;
+  description: string | null;
+}
+
+export interface ProfileInput {
+  /**
+   * Short bio shown on the public profile. In the current schema this
+   * column is `profiles.bio_short`; the field is named `bio` here so the
+   * recommend module is decoupled from the column name and can be
+   * reused if that ever changes.
+   */
+  bio: string | null;
+  headline: string | null;
+  /** All non-draft items the viewer is allowed to see. */
+  items: ProfileItemInput[];
+}
+
+export interface PreferenceProfile {
+  likes: Counter;
+  avoids: Counter;
+  boundaries: Counter;
+  gifts: Counter;
+  all: Counter;
+  /** Lowercased + trimmed titles of items in the gift_ideas category. */
+  existingGiftTitles: Set<string>;
+  /** Detected dietary constraints from boundary items. */
+  dietary: Set<'vegan' | 'vegetarian' | 'gluten-free' | 'dairy-free' | 'no-pork'>;
+  /** How many gift items match each gift category — drives "preferred categories" boost. */
+  preferredCategories: Counter;
+  /** How many avoid items match each gift category — drives anti-category penalty. */
+  antiCategories: Counter;
+  valuesExperiences: boolean;
+  valuesCharitable: boolean;
+  valuesHandmade: boolean;
+  valuesMinimal: boolean;
+}
+
+/** Categories whose item text the scorer treats as "things I like". */
+const LIKE_CATEGORIES = new Set([
+  'likes',
+  'favourite_books',
+  'favourite_media',
+  'causes',
+  'helpful_to_know',
+  'proud_of',
+  'life_hacks',
+]);
+
+/** Returns true if the lowercased text contains any of the substrings. */
+function containsAny(text: string, needles: readonly string[]): boolean {
+  return needles.some((n) => text.includes(n));
+}
+
+/**
+ * Returns the gift-category keys that match `text` based on each
+ * category's keyword list. The same text can match multiple categories
+ * (e.g. "spa retreat voucher" matches both `experiences` and arguably
+ * `charitable` if it says donation). Mirrors the Python loop.
+ */
+function categoriesMatchingText(text: string): GiftCategoryKey[] {
+  const out: GiftCategoryKey[] = [];
+  for (const key of ALL_CATEGORY_KEYS) {
+    if (containsAny(text, GIFT_CATEGORIES[key].keywords)) {
+      out.push(key);
+    }
+  }
+  return out;
+}
+
+export function buildPreferenceProfile(profile: ProfileInput): PreferenceProfile {
+  const pref: PreferenceProfile = {
+    likes: new Counter(),
+    avoids: new Counter(),
+    boundaries: new Counter(),
+    gifts: new Counter(),
+    all: new Counter(),
+    existingGiftTitles: new Set(),
+    dietary: new Set(),
+    preferredCategories: new Counter(),
+    antiCategories: new Counter(),
+    valuesExperiences: false,
+    valuesCharitable: false,
+    valuesHandmade: false,
+    valuesMinimal: false,
+  };
+
+  for (const item of profile.items) {
+    const title = item.title ?? '';
+    const desc = item.description ?? '';
+    const text = `${title} ${desc}`.toLowerCase();
+    const words = extractKeywords(text);
+
+    if (item.category === 'gift_ideas') {
+      pref.gifts.add(words);
+      pref.existingGiftTitles.add(title.toLowerCase().trim());
+
+      // Preference signals from the kinds of gift ideas they list.
+      if (containsAny(text, ['experience', 'ticket', 'entry', 'class', 'workshop'])) {
+        pref.valuesExperiences = true;
+      }
+      if (containsAny(text, ['donation', 'charity', 'cause'])) {
+        pref.valuesCharitable = true;
+      }
+      if (containsAny(text, ['handmade', 'independent', 'artisan', 'small'])) {
+        pref.valuesHandmade = true;
+      }
+
+      for (const cat of categoriesMatchingText(text)) {
+        pref.preferredCategories.add([cat]);
+      }
+    } else if (item.category === 'dislikes' || item.category === 'gifts_to_avoid') {
+      pref.avoids.add(words);
+      for (const cat of categoriesMatchingText(text)) {
+        pref.antiCategories.add([cat]);
+      }
+    } else if (item.category === 'boundaries') {
+      pref.boundaries.add(words);
+      if (containsAny(text, ['vegan'])) pref.dietary.add('vegan');
+      if (containsAny(text, ['vegetarian'])) pref.dietary.add('vegetarian');
+      if (containsAny(text, ['gluten-free', 'coeliac', 'celiac'])) pref.dietary.add('gluten-free');
+      if (containsAny(text, ['dairy', 'lactose'])) pref.dietary.add('dairy-free');
+      if (containsAny(text, ['pork', 'halal'])) pref.dietary.add('no-pork');
+    } else if (LIKE_CATEGORIES.has(item.category)) {
+      pref.likes.add(words);
+    }
+
+    pref.all.add(words);
+
+    // Minimalism signal: applies regardless of which category the
+    // signal appears in (the Python original scanned all items).
+    if (containsAny(text, ['minimal', 'clutter', 'fewer', 'less stuff', 'simple'])) {
+      pref.valuesMinimal = true;
+    }
+  }
+
+  // Treat the profile bio as additional "likes" / "all" signal —
+  // matches the Python behaviour of reading the about section body.
+  for (const field of [profile.bio, profile.headline]) {
+    if (field) {
+      const w = extractKeywords(field);
+      pref.likes.add(w);
+      pref.all.add(w);
+    }
+  }
+
+  return pref;
+}

--- a/src/lib/recommend/score.ts
+++ b/src/lib/recommend/score.ts
@@ -1,0 +1,179 @@
+/**
+ * KAN-139: score a single recommendation template against a
+ * preference profile. Higher score = better match.
+ *
+ * Ported from `_score_recommendation` in
+ * /Users/admin/Documents/2026 Lyra/lyra-app/recommend.py. Same weights,
+ * same penalties, same reason strings — bit-for-bit identical scoring
+ * on the same inputs.
+ */
+
+import { extractKeywords } from './keywords';
+import { GIFT_CATEGORIES } from './categories';
+import type { PreferenceProfile } from './preferences';
+import type { RecommendationTemplate } from './pool';
+
+export interface ScoredRecommendation {
+  template: RecommendationTemplate;
+  score: number;
+  reasons: string[];
+}
+
+/** "Soft reject" sentinel returned for items too similar to existing gift ideas. */
+const SIMILARITY_VETO = -100;
+
+/**
+ * Returns the union of two iterables as a set — used for cheap
+ * keyword overlap checks against Counter keys.
+ */
+function intersect(a: Iterable<string>, b: ReadonlySet<string>): string[] {
+  const out: string[] = [];
+  for (const v of a) if (b.has(v)) out.push(v);
+  return out;
+}
+
+/**
+ * Title-cased label for a category, used in reason strings ("Matches
+ * preferred category: Food Drink").
+ */
+function categoryLabel(cat: string): string {
+  return cat.replace(/_/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase());
+}
+
+export function scoreRecommendation(
+  rec: RecommendationTemplate,
+  pref: PreferenceProfile,
+): ScoredRecommendation {
+  const recText = `${rec.title} ${rec.description}`.toLowerCase();
+  const recWords = new Set([...extractKeywords(recText), ...rec.tags.map((t) => t.toLowerCase())]);
+  const titleWords = new Set(extractKeywords(rec.title));
+
+  // 0. Similarity veto — if more than half the title words overlap an
+  // existing gift idea title, skip. Stops the engine recommending
+  // "Cashmere scarf" when the user already wrote "Cashmere socks or scarf".
+  for (const existing of pref.existingGiftTitles) {
+    const existingWords = new Set(extractKeywords(existing));
+    if (titleWords.size === 0 || existingWords.size === 0) continue;
+    let shared = 0;
+    for (const w of titleWords) if (existingWords.has(w)) shared++;
+    const overlap = shared / titleWords.size;
+    if (overlap > 0.5) {
+      return {
+        template: rec,
+        score: SIMILARITY_VETO,
+        reasons: ['Too similar to an existing gift idea'],
+      };
+    }
+  }
+
+  let score = 0;
+  const reasons: string[] = [];
+
+  // 1. Category match — boost if they've listed gifts in this category.
+  const catCount = pref.preferredCategories.get(rec.category);
+  if (catCount > 0) {
+    score += catCount * 2.0;
+    reasons.push(`Matches preferred category: ${categoryLabel(rec.category)}`);
+  }
+
+  // 2. Anti-category penalty.
+  if (pref.antiCategories.get(rec.category) > 0) {
+    score -= 10;
+    reasons.push('Conflicts with things they avoid');
+  }
+
+  // 3. Keyword overlap with likes.
+  const likesKeys = new Set(pref.likes.keys());
+  const likeOverlap = intersect(recWords, likesKeys);
+  if (likeOverlap.length > 0) {
+    const bonus = likeOverlap.reduce((sum, w) => sum + pref.likes.get(w), 0) * 1.5;
+    score += bonus;
+    reasons.push(`Matches interests: ${likeOverlap.slice(0, 3).sort().join(', ')}`);
+  }
+
+  // 4. Keyword overlap with existing gift ideas (mild positive — they
+  // clearly like this theme even though we've vetoed near-duplicates).
+  const giftsKeys = new Set(pref.gifts.keys());
+  const giftOverlap = intersect(recWords, giftsKeys);
+  if (giftOverlap.length > 0) {
+    const bonus = giftOverlap.reduce((sum, w) => sum + pref.gifts.get(w), 0) * 1.0;
+    score += bonus;
+    reasons.push('Similar to gifts they want');
+  }
+
+  // 5. Keyword overlap with avoids = strong penalty.
+  const avoidsKeys = new Set(pref.avoids.keys());
+  const avoidOverlap = intersect(recWords, avoidsKeys);
+  if (avoidOverlap.length > 0) {
+    const penalty = avoidOverlap.reduce((sum, w) => sum + pref.avoids.get(w), 0) * 3.0;
+    score -= penalty;
+    reasons.push(`May conflict: ${avoidOverlap.slice(0, 2).sort().join(', ')}`);
+  }
+
+  // 6. Experience bonus — they prefer experiences over things.
+  if (pref.valuesExperiences && rec.category === 'experiences') {
+    score += 3.0;
+    reasons.push('They value experiences over objects');
+  }
+
+  // 7. Charitable bonus.
+  if (pref.valuesCharitable && rec.category === 'charitable') {
+    score += 3.0;
+    reasons.push('They value charitable giving');
+  }
+
+  // 8. Minimalism — boost experiences, penalise physical clutter.
+  if (pref.valuesMinimal) {
+    if (rec.category === 'experiences') {
+      score += 2.0;
+    } else if (
+      rec.category === 'home_garden'
+      || rec.category === 'fashion_accessories'
+      || rec.category === 'stationery_writing'
+    ) {
+      score -= 1.5;
+    }
+  }
+
+  // 9. Dietary filtering on food/drink recs.
+  if (rec.category === 'food_drink' && pref.dietary.size > 0) {
+    if (pref.dietary.has('vegan')) {
+      const fineForVegans = ['chocolate', 'wine', 'gin', 'coffee', 'tea', 'cocktail'];
+      const animalProducts = ['cheese', 'honey', 'cream'];
+      if (!fineForVegans.some((w) => recText.includes(w))
+          && animalProducts.some((w) => recText.includes(w))) {
+        score -= 10;
+        reasons.push('Conflicts with vegan diet');
+      }
+    }
+    if (pref.dietary.has('gluten-free')) {
+      const glutenous = ['sourdough', 'bread', 'flour', 'baking'];
+      if (glutenous.some((w) => recText.includes(w))) {
+        score -= 10;
+        reasons.push('Conflicts with gluten-free diet');
+      }
+    }
+  }
+
+  // 10. Category base weight.
+  score *= GIFT_CATEGORIES[rec.category].weight;
+
+  // 11. Faint general signal — every keyword the rec shares with anything
+  // in the profile nudges the score slightly. Prevents zero-scoring on
+  // light-data profiles by giving partial credit.
+  const allKeys = new Set(pref.all.keys());
+  const allOverlap = intersect(recWords, allKeys);
+  if (allOverlap.length > 0) {
+    score += allOverlap.length * 0.3;
+  }
+
+  if (reasons.length === 0) {
+    reasons.push('General match based on profile analysis');
+  }
+
+  return {
+    template: rec,
+    score: Math.round(score * 100) / 100,
+    reasons,
+  };
+}

--- a/tests/unit/recommend.test.ts
+++ b/tests/unit/recommend.test.ts
@@ -1,0 +1,232 @@
+/**
+ * KAN-139: behaviour tests for the recommendation engine.
+ *
+ * Locks in the rules that have user-visible consequences:
+ *  - similarity veto (don't suggest near-duplicates of existing gifts)
+ *  - dietary filtering (vegan / gluten-free)
+ *  - anti-category penalty (avoid items reduce that category's score)
+ *  - diversification (max 3 per category)
+ *  - feedback boost / penalty
+ *  - empty-profile safety
+ */
+
+import { getRecommendations, getProfileInsights, type ProfileInput } from '@/lib/recommend';
+import { buildPreferenceProfile } from '@/lib/recommend/preferences';
+import { scoreRecommendation } from '@/lib/recommend/score';
+import { RECOMMENDATION_POOL } from '@/lib/recommend/pool';
+import { extractKeywords, Counter } from '@/lib/recommend/keywords';
+
+function profileWith(items: ProfileInput['items']): ProfileInput {
+  return { bio: null, headline: null, items };
+}
+
+describe('KAN-139 recommend — extractKeywords', () => {
+  test('drops stopwords and short tokens', () => {
+    expect(extractKeywords('I love the smell of fresh coffee in the morning'))
+      .toEqual(['smell', 'fresh', 'coffee', 'morning']);
+  });
+
+  test('handles null / empty gracefully', () => {
+    expect(extractKeywords(null)).toEqual([]);
+    expect(extractKeywords(undefined)).toEqual([]);
+    expect(extractKeywords('')).toEqual([]);
+  });
+
+  test('lowercases consistently', () => {
+    expect(extractKeywords('SOURDOUGH bread BAKING')).toEqual(['sourdough', 'bread', 'baking']);
+  });
+});
+
+describe('KAN-139 recommend — Counter', () => {
+  test('counts repeats and ranks by frequency', () => {
+    const c = new Counter();
+    c.add(['coffee', 'tea', 'coffee', 'wine', 'coffee']);
+    expect(c.get('coffee')).toBe(3);
+    expect(c.get('tea')).toBe(1);
+    expect(c.get('not-there')).toBe(0);
+    expect(c.mostCommon(2)).toEqual([['coffee', 3], ['tea', 1]]);
+  });
+});
+
+describe('KAN-139 recommend — buildPreferenceProfile', () => {
+  test('classifies items into the right buckets by category', () => {
+    const pref = buildPreferenceProfile(profileWith([
+      { category: 'gift_ideas', title: 'Cashmere scarf', description: null },
+      { category: 'likes', title: 'Strong coffee in the morning', description: null },
+      { category: 'dislikes', title: 'Scented candles', description: 'Migraine triggers' },
+      { category: 'boundaries', title: 'Vegan diet', description: 'No animal products' },
+    ]));
+    expect(pref.gifts.get('cashmere')).toBe(1);
+    expect(pref.likes.get('coffee')).toBe(1);
+    expect(pref.avoids.get('scented')).toBe(1);
+    expect(pref.boundaries.get('vegan')).toBe(1);
+    expect(pref.dietary.has('vegan')).toBe(true);
+    expect(pref.existingGiftTitles.has('cashmere scarf')).toBe(true);
+  });
+
+  test('detects value signals from gift idea wording', () => {
+    const pref = buildPreferenceProfile(profileWith([
+      { category: 'gift_ideas', title: 'Cooking class', description: 'A workshop with a chef' },
+      { category: 'gift_ideas', title: 'Donation to woodland trust', description: null },
+    ]));
+    expect(pref.valuesExperiences).toBe(true);
+    expect(pref.valuesCharitable).toBe(true);
+    expect(pref.valuesMinimal).toBe(false);
+  });
+
+  test('detects minimalism signal regardless of category', () => {
+    const pref = buildPreferenceProfile(profileWith([
+      { category: 'helpful_to_know', title: 'I am minimal about possessions', description: null },
+    ]));
+    expect(pref.valuesMinimal).toBe(true);
+  });
+
+  test('maps gifts_to_avoid into the anti-category bucket', () => {
+    const pref = buildPreferenceProfile(profileWith([
+      { category: 'gifts_to_avoid', title: 'Scented candles and plants', description: null },
+    ]));
+    expect(pref.antiCategories.get('home_garden')).toBeGreaterThan(0);
+  });
+});
+
+describe('KAN-139 recommend — scoreRecommendation', () => {
+  test('vetoes a near-duplicate of an existing gift idea title', () => {
+    const pref = buildPreferenceProfile(profileWith([
+      { category: 'gift_ideas', title: 'Waterstones gift card', description: null },
+    ]));
+    const waterstones = RECOMMENDATION_POOL.find((r) => r.title.includes('Waterstones'))!;
+    const out = scoreRecommendation(waterstones, pref);
+    expect(out.score).toBeLessThan(-50);
+    expect(out.reasons[0]).toMatch(/Too similar/);
+  });
+
+  test('boosts experiences when the user values experiences', () => {
+    const expExperiences = buildPreferenceProfile(profileWith([
+      { category: 'gift_ideas', title: 'Pottery workshop', description: 'A class' },
+    ]));
+    const expThings = buildPreferenceProfile(profileWith([
+      { category: 'gift_ideas', title: 'Cashmere socks', description: null },
+    ]));
+    const concert = RECOMMENDATION_POOL.find((r) => r.title.includes('Theatre or concert'))!;
+    expect(scoreRecommendation(concert, expExperiences).score)
+      .toBeGreaterThan(scoreRecommendation(concert, expThings).score);
+  });
+
+  test('penalises food/drink recommendations that conflict with vegan diet', () => {
+    const pref = buildPreferenceProfile(profileWith([
+      { category: 'boundaries', title: 'Strict vegan diet', description: 'No animal products' },
+      { category: 'gift_ideas', title: 'Italian cookbook', description: null },
+    ]));
+    // Cheese is the canonical conflicter — there's no cheese template in
+    // the pool, so synthesise one for this assertion.
+    const cheese = { title: 'Artisan cheese box', description: 'Aged cheddar selection', category: 'food_drink' as const, tags: ['cheese', 'dairy'] };
+    const result = scoreRecommendation(cheese, pref);
+    expect(result.reasons).toContain('Conflicts with vegan diet');
+  });
+
+  test('penalises sourdough kit when user is gluten-free', () => {
+    const pref = buildPreferenceProfile(profileWith([
+      { category: 'boundaries', title: 'Gluten-free / coeliac', description: null },
+    ]));
+    const sourdough = RECOMMENDATION_POOL.find((r) => r.title.includes('Sourdough'))!;
+    const result = scoreRecommendation(sourdough, pref);
+    expect(result.reasons).toContain('Conflicts with gluten-free diet');
+    expect(result.score).toBeLessThan(0);
+  });
+
+  test('rewards keyword overlap with likes', () => {
+    const coffeeFan = buildPreferenceProfile(profileWith([
+      { category: 'likes', title: 'Single-origin coffee', description: 'I drink it every morning' },
+    ]));
+    const noSignal = buildPreferenceProfile(profileWith([]));
+    const coffee = RECOMMENDATION_POOL.find((r) => r.title.includes('coffee subscription'))!;
+    expect(scoreRecommendation(coffee, coffeeFan).score)
+      .toBeGreaterThan(scoreRecommendation(coffee, noSignal).score);
+  });
+});
+
+describe('KAN-139 recommend — getRecommendations', () => {
+  test('returns at most `limit` results', () => {
+    const out = getRecommendations(profileWith([
+      { category: 'likes', title: 'Coffee, wine, books, yoga, gardens', description: null },
+    ]), { limit: 5 });
+    expect(out.length).toBeLessThanOrEqual(5);
+  });
+
+  test('diversifies — no category appears more than 3 times', () => {
+    // A wide-net profile that matches many categories.
+    const out = getRecommendations(profileWith([
+      { category: 'likes', title: 'Wine coffee tea chocolate', description: 'Books gardens art music' },
+      { category: 'gift_ideas', title: 'Wine subscription', description: null },
+      { category: 'gift_ideas', title: 'Coffee subscription', description: null },
+    ]), { limit: 30 });
+    const counts: Record<string, number> = {};
+    for (const r of out) counts[r.categoryKey] = (counts[r.categoryKey] ?? 0) + 1;
+    for (const c of Object.values(counts)) expect(c).toBeLessThanOrEqual(3);
+  });
+
+  test('excludes net-negative recommendations', () => {
+    const out = getRecommendations(profileWith([]), { limit: 20 });
+    for (const r of out) expect(r.score).toBeGreaterThan(0);
+  });
+
+  test('handles an empty profile without throwing', () => {
+    expect(() => getRecommendations(profileWith([]))).not.toThrow();
+  });
+
+  test('upvote feedback rises the score, downvote lowers it', () => {
+    const profile = profileWith([
+      { category: 'likes', title: 'Coffee in the morning', description: null },
+    ]);
+    const target = 'Speciality coffee subscription';
+    const base = getRecommendations(profile, { limit: 20 }).find((r) => r.title === target)!;
+    const upvoted = getRecommendations(profile, { limit: 20, feedback: { [target]: 1 } })
+      .find((r) => r.title === target)!;
+    expect(upvoted.score).toBeGreaterThan(base.score);
+    expect(upvoted.reasons[0]).toMatch(/You liked/);
+
+    const downvoted = getRecommendations(profile, { limit: 20, feedback: { [target]: -1 } });
+    // -20 should knock it out of the positive-only list entirely.
+    expect(downvoted.find((r) => r.title === target)).toBeUndefined();
+  });
+});
+
+describe('KAN-139 recommend — getProfileInsights', () => {
+  test('returns dietary, values and top interests', () => {
+    const insights = getProfileInsights(profileWith([
+      { category: 'boundaries', title: 'Vegan', description: null },
+      { category: 'gift_ideas', title: 'Cooking class', description: 'A workshop with a chef' },
+      { category: 'likes', title: 'Coffee, gardens, running', description: null },
+    ]));
+    expect(insights.dietary).toContain('vegan');
+    expect(insights.values).toContain('Prefers experiences over physical gifts');
+    expect(insights.topInterests.length).toBeGreaterThan(0);
+  });
+
+  test('handles a profile with no items', () => {
+    const insights = getProfileInsights(profileWith([]));
+    expect(insights.dietary).toEqual([]);
+    expect(insights.values).toEqual([]);
+    expect(insights.topInterests).toEqual([]);
+    expect(insights.avoidThemes).toEqual([]);
+    expect(insights.preferredCategories).toEqual([]);
+  });
+});
+
+describe('KAN-139 recommend — pool integrity', () => {
+  test('every recommendation has a valid category', () => {
+    const validCats = new Set([
+      'experiences', 'food_drink', 'books_reading', 'home_garden',
+      'arts_crafts', 'fashion_accessories', 'music_audio',
+      'sport_outdoors', 'charitable', 'stationery_writing',
+    ]);
+    for (const r of RECOMMENDATION_POOL) {
+      expect(validCats.has(r.category)).toBe(true);
+    }
+  });
+
+  test('no duplicate titles (curation hygiene)', () => {
+    const titles = RECOMMENDATION_POOL.map((r) => r.title);
+    expect(new Set(titles).size).toBe(titles.length);
+  });
+});


### PR DESCRIPTION
## Summary

Ports the Lyra recommendation engine from the original Flask app (`recommend.py` — 543 LOC) into a typed, modular Next.js library. Closes Priority 2 of the KAN-131 feature gap audit — a core value proposition (gift / experience suggestions on every published profile) that was missing in the Next.js rewrite.

## What's ported

- **`src/lib/recommend/`** — 6 modules:
  - `categories.ts` — 10 gift categories + keyword stems + per-category weights (verbatim from `GIFT_CATEGORIES`)
  - `pool.ts` — 50 curated recommendation templates (verbatim)
  - `keywords.ts` — `extractKeywords()` + `Counter` class
  - `preferences.ts` — `buildPreferenceProfile()` with dietary + value-signal detection
  - `score.ts` — `scoreRecommendation()` with the 11 numbered rules from the Python source
  - `index.ts` — public API: `getRecommendations()` (ranked + diversified) and `getProfileInsights()`
- Pure functions, no DB / network access — callers fetch the rows and pass them in.

## Integration

- **Public profile** (`src/app/[slug]/page.tsx`) renders a new "Gift ideas based on this profile" section below the items grid. Returns null for sparse profiles.
- **API route** `GET /api/recommendations/[slug]` returns recs + insights as JSON with 5-minute SWR cache. Public-only (anonymous request, public items).

## Tests

22 behaviour tests in `tests/unit/recommend.test.ts` covering keyword extraction, Counter, preference profile classification, similarity veto, dietary filtering (vegan + gluten-free), experience-value boost, like-keyword overlap, diversification cap, empty-profile safety, upvote/downvote feedback, and pool integrity. All pass.

## What's NOT in this PR

- Feedback storage (upvote/downvote DB table) — the engine accepts feedback as an optional `Record<title, ±1>` param so this can be wired later without API change.
- MCP server tools (`lyra_recommend_gifts`, `lyra_get_insights`) currently return placeholder data — wiring them to the new API belongs in a separate PR on `lyra-mcp-server`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)