### PR TITLE
feat(KAN-141): admin dashboard, reports, and moderation tools

### DIFF
--- a/src/app/[slug]/page.tsx
+++ b/src/app/[slug]/page.tsx
@@ -12,6 +12,7 @@ import {
 } from '@/app/dashboard/profile/manual-of-me-fields';
 import { getRecommendations } from '@/lib/recommend';
 import RecommendationsSection from './recommendations-section';
+import ReportButton from './report-button';
 
 // Create client per-request, not at module scope
 function getSupabase() {
@@ -20,6 +21,7 @@ function getSupabase() {
 
 interface ProfileData {
   id: string;
+  user_id: string;
   display_name: string;
   slug: string;
   headline: string | null;
@@ -493,10 +495,17 @@ export default async function PublicProfilePage({ params }: Props) {
       </div>
 
       {/* Footer */}
-      <div className="max-w-2xl mx-auto px-6 py-8 text-center">
+      <div className="max-w-2xl mx-auto px-6 py-8 text-center space-y-3">
         <p className="text-sm text-[var(--color-muted)]">
           This is a <Link href="/" className="text-[var(--color-sage)] hover:underline">Lyra</Link> profile
         </p>
+        {/* KAN-141: inline report button — never shown for the profile's owner */}
+        {viewer?.id !== typedProfile.user_id && (
+          <ReportButton
+            profileSlug={typedProfile.slug}
+            isAuthenticated={isAuthenticated}
+          />
+        )}
       </div>
     </main>
     </>

--- a/src/app/[slug]/report-button.tsx
+++ b/src/app/[slug]/report-button.tsx
@@ -1,0 +1,199 @@
+'use client';
+
+import { useState } from 'react';
+import Link from 'next/link';
+
+/**
+ * KAN-141: inline "Report this profile" button for the public profile page.
+ *
+ * Opens a small modal with reason dropdown + optional note. On submit
+ * POSTs to /api/reports. Anonymous viewers see "Sign in to report" (no
+ * client-side fetch — anonymous reporting is too easy to abuse and the
+ * API rejects it anyway, but failing softly here is friendlier than a
+ * 401 in DevTools).
+ *
+ * Three failure modes are surfaced to the user:
+ *   - 401  — sign in required
+ *   - 429  — already reported this profile recently (24h rate limit)
+ *   - 4xx/5xx other — generic "something went wrong"
+ */
+
+const REASONS = [
+  { value: 'spam', label: 'Spam or fake' },
+  { value: 'harassment', label: 'Harassment or abuse' },
+  { value: 'impersonation', label: 'Impersonation' },
+  { value: 'inappropriate', label: 'Inappropriate content' },
+  { value: 'other', label: 'Something else' },
+] as const;
+
+type Status = 'idle' | 'submitting' | 'success' | 'error' | 'rate-limited' | 'unauthorized';
+
+export default function ReportButton({
+  profileSlug,
+  isAuthenticated,
+}: {
+  profileSlug: string;
+  isAuthenticated: boolean;
+}) {
+  const [open, setOpen] = useState(false);
+  const [reason, setReason] = useState<typeof REASONS[number]['value']>('spam');
+  const [note, setNote] = useState('');
+  const [status, setStatus] = useState<Status>('idle');
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+  function resetAndClose() {
+    setOpen(false);
+    setStatus('idle');
+    setNote('');
+    setReason('spam');
+    setErrorMessage(null);
+  }
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    if (!isAuthenticated) {
+      setStatus('unauthorized');
+      return;
+    }
+    setStatus('submitting');
+    setErrorMessage(null);
+
+    try {
+      const res = await fetch('/api/reports', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          profileSlug,
+          reason,
+          note: note.trim() || null,
+        }),
+      });
+
+      if (res.status === 201) {
+        setStatus('success');
+      } else if (res.status === 401) {
+        setStatus('unauthorized');
+      } else if (res.status === 429) {
+        setStatus('rate-limited');
+      } else {
+        setStatus('error');
+        const body = await res.json().catch(() => null);
+        setErrorMessage(body?.detail ?? body?.error ?? 'Unknown error');
+      }
+    } catch {
+      setStatus('error');
+      setErrorMessage('Network error — please try again later.');
+    }
+  }
+
+  if (!open) {
+    return (
+      <button
+        type="button"
+        onClick={() => setOpen(true)}
+        className="text-xs text-stone-500 hover:text-stone-700 underline underline-offset-2 transition-colors"
+      >
+        Report this profile
+      </button>
+    );
+  }
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="report-dialog-title"
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4"
+      onClick={(e) => { if (e.target === e.currentTarget) resetAndClose(); }}
+    >
+      <div className="bg-white rounded-2xl shadow-lg max-w-md w-full p-6">
+        <h2 id="report-dialog-title" className="text-lg font-medium text-[var(--color-ink)] mb-1">
+          Report this profile
+        </h2>
+        <p className="text-sm text-[var(--color-muted)] mb-5">
+          A moderator will review your report. False reports may affect your account.
+        </p>
+
+        {status === 'success' ? (
+          <div>
+            <p className="text-sm text-[var(--color-ink)] mb-4">
+              Thanks — your report has been filed.
+            </p>
+            <button
+              type="button"
+              onClick={resetAndClose}
+              className="px-5 py-2.5 rounded-full bg-[var(--color-lyra-sage)] text-white text-sm font-medium hover:bg-[var(--color-lyra-sage-hover)] transition-colors"
+            >
+              Close
+            </button>
+          </div>
+        ) : (
+          <form onSubmit={handleSubmit} className="space-y-4">
+            <div>
+              <label htmlFor="report-reason" className="block text-sm text-[var(--color-ink)] mb-1">
+                Reason
+              </label>
+              <select
+                id="report-reason"
+                value={reason}
+                onChange={(e) => setReason(e.target.value as typeof reason)}
+                className="w-full p-2 text-sm rounded-lg border border-stone-300 bg-white"
+              >
+                {REASONS.map((r) => (
+                  <option key={r.value} value={r.value}>{r.label}</option>
+                ))}
+              </select>
+            </div>
+            <div>
+              <label htmlFor="report-note" className="block text-sm text-[var(--color-ink)] mb-1">
+                Note (optional)
+              </label>
+              <textarea
+                id="report-note"
+                value={note}
+                onChange={(e) => setNote(e.target.value.slice(0, 500))}
+                rows={3}
+                placeholder="Anything that would help the moderator?"
+                className="w-full p-2 text-sm rounded-lg border border-stone-300 bg-white resize-y"
+              />
+              <p className="text-xs text-stone-500 mt-1">{note.length} / 500</p>
+            </div>
+
+            {status === 'unauthorized' && (
+              <p className="text-sm text-amber-700 bg-amber-50 p-3 rounded-lg">
+                Please <Link href="/login" className="underline">sign in</Link> to file a report.
+              </p>
+            )}
+            {status === 'rate-limited' && (
+              <p className="text-sm text-amber-700 bg-amber-50 p-3 rounded-lg">
+                You&rsquo;ve already reported this profile in the last 24 hours.
+              </p>
+            )}
+            {status === 'error' && (
+              <p className="text-sm text-red-700 bg-red-50 p-3 rounded-lg">
+                {errorMessage ?? 'Something went wrong. Please try again.'}
+              </p>
+            )}
+
+            <div className="flex items-center justify-end gap-3 pt-2">
+              <button
+                type="button"
+                onClick={resetAndClose}
+                className="text-sm text-[var(--color-muted)] hover:text-[var(--color-ink)] transition-colors"
+              >
+                Cancel
+              </button>
+              <button
+                type="submit"
+                disabled={status === 'submitting'}
+                className="px-5 py-2.5 rounded-full bg-[var(--color-lyra-sage)] text-white text-sm font-medium hover:bg-[var(--color-lyra-sage-hover)] transition-colors disabled:opacity-60"
+              >
+                {status === 'submitting' ? 'Submitting…' : 'Submit report'}
+              </button>
+            </div>
+          </form>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/app/admin/audit/page.tsx
+++ b/src/app/admin/audit/page.tsx
@@ -1,0 +1,105 @@
+/**
+ * KAN-141: /admin/audit — read-only moderation log viewer.
+ *
+ * Append-only history of every admin action. Ordered most recent first.
+ * No actions on this page — just a transparent record of what happened
+ * and who did it.
+ */
+
+import Link from 'next/link';
+import { getAdminServiceClient } from '@/lib/admin';
+
+export const dynamic = 'force-dynamic';
+
+interface LogRow {
+  id: string;
+  action: string;
+  reason: string | null;
+  metadata: Record<string, unknown>;
+  created_at: string;
+  actor_user_id: string;
+  target_profile_id: string | null;
+  actor_profile: { display_name: string | null; slug: string } | null;
+  target_profile: { display_name: string | null; slug: string } | null;
+}
+
+async function loadLogs(): Promise<LogRow[]> {
+  const supabase = getAdminServiceClient();
+  const { data } = await supabase
+    .from('moderation_logs')
+    .select(`
+      id, action, reason, metadata, created_at,
+      actor_user_id, target_profile_id,
+      actor_profile:profiles!moderation_logs_actor_user_id_fkey(display_name, slug),
+      target_profile:profiles!moderation_logs_target_profile_id_fkey(display_name, slug)
+    `)
+    .order('created_at', { ascending: false })
+    .limit(100);
+  return ((data ?? []) as unknown) as LogRow[];
+}
+
+function actionLabel(action: string): string {
+  return action.replace(/_/g, ' ');
+}
+
+function actionColour(action: string): string {
+  if (action.includes('suspend') && !action.startsWith('un')) return 'bg-red-50 text-red-700';
+  if (action.startsWith('un') || action === 'restore_item') return 'bg-green-50 text-green-700';
+  if (action.includes('delete')) return 'bg-red-50 text-red-700';
+  if (action.includes('grant_admin') || action.includes('revoke_admin')) return 'bg-blue-50 text-blue-700';
+  return 'bg-stone-100 text-stone-700';
+}
+
+export default async function AuditLogPage() {
+  const logs = await loadLogs();
+
+  return (
+    <div className="max-w-6xl mx-auto px-6 py-8 space-y-6">
+      <header>
+        <h1 className="text-2xl font-medium text-[var(--color-ink)] font-[family-name:var(--font-serif)]">
+          Audit log
+        </h1>
+        <p className="text-sm text-[var(--color-muted)] mt-1">
+          Every admin action, append-only. Most recent first. Showing up to 100 entries.
+        </p>
+      </header>
+
+      <div className="rounded-xl border border-stone-200 bg-white divide-y divide-stone-100">
+        {logs.length === 0 ? (
+          <p className="p-5 text-sm text-[var(--color-muted)]">No moderation actions recorded yet.</p>
+        ) : logs.map((log) => (
+          <div key={log.id} className="p-4 space-y-1">
+            <div className="flex items-baseline justify-between gap-3">
+              <p className="text-sm text-[var(--color-ink)] truncate">
+                <span className={'text-xs px-2 py-0.5 rounded-full mr-2 ' + actionColour(log.action)}>
+                  {actionLabel(log.action)}
+                </span>
+                <span className="text-[var(--color-muted)]">by</span>{' '}
+                {log.actor_profile ? (
+                  <Link href={`/admin/users/${log.actor_profile.slug}`} className="underline">
+                    {log.actor_profile.display_name ?? '(unnamed)'}
+                  </Link>
+                ) : (
+                  <span className="italic">(account deleted)</span>
+                )}
+                {log.target_profile && (
+                  <>
+                    {' '}
+                    <span className="text-[var(--color-muted)]">on</span>{' '}
+                    <Link href={`/admin/users/${log.target_profile.slug}`} className="underline">
+                      {log.target_profile.display_name ?? '(unnamed)'}
+                    </Link>
+                  </>
+                )}
+              </p>
+              <span className="text-xs text-stone-500 shrink-0">
+                {new Date(log.created_at).toLocaleString('en-GB')}
+              </span>
+            </div>
+            {log.reason && <p className="text-xs text-[var(--color-muted)] italic">{log.reason}</p>}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/app/admin/layout.tsx
+++ b/src/app/admin/layout.tsx
@@ -1,0 +1,86 @@
+/**
+ * KAN-141: admin section root layout.
+ *
+ * Server-side admin gate — non-admins get `notFound()` (404). We
+ * deliberately don't show a "you don't have access" page: revealing
+ * that an admin section exists at all is information leakage. Anyone
+ * who hits /admin while not an admin gets the same 404 as anyone who
+ * hits /this-route-does-not-exist.
+ *
+ * The DB lookup happens here in the layout so every page under /admin
+ * shares the same gate without each page repeating itself. The cost is
+ * one extra row read per request — acceptable for an admin-only route
+ * that won't see heavy traffic.
+ */
+
+import { notFound } from 'next/navigation';
+import Link from 'next/link';
+import { getCurrentAdmin } from '@/lib/admin';
+
+export const metadata = {
+  title: 'Admin — Lyra',
+  robots: { index: false, follow: false },
+};
+
+export default async function AdminLayout({ children }: { children: React.ReactNode }) {
+  const admin = await getCurrentAdmin();
+  if (!admin) {
+    notFound();
+  }
+
+  return (
+    <div className="min-h-screen bg-stone-50">
+      <header className="border-b border-stone-200 bg-white">
+        <div className="max-w-6xl mx-auto px-6 py-4 flex items-center justify-between">
+          <div className="flex items-center gap-8">
+            <Link
+              href="/admin"
+              className="text-sm font-semibold text-[var(--color-ink)] tracking-wide"
+            >
+              Lyra Admin
+            </Link>
+            <nav aria-label="Admin sections" className="flex items-center gap-6">
+              <Link
+                href="/admin"
+                className="text-sm text-[var(--color-muted)] hover:text-[var(--color-ink)] transition-colors"
+              >
+                Overview
+              </Link>
+              <Link
+                href="/admin/reports"
+                className="text-sm text-[var(--color-muted)] hover:text-[var(--color-ink)] transition-colors"
+              >
+                Reports
+              </Link>
+              <Link
+                href="/admin/users"
+                className="text-sm text-[var(--color-muted)] hover:text-[var(--color-ink)] transition-colors"
+              >
+                Users
+              </Link>
+              <Link
+                href="/admin/audit"
+                className="text-sm text-[var(--color-muted)] hover:text-[var(--color-ink)] transition-colors"
+              >
+                Audit
+              </Link>
+            </nav>
+          </div>
+          <div className="flex items-center gap-3">
+            <span className="text-xs text-[var(--color-muted)]">
+              {admin.displayName ?? admin.email ?? 'admin'}
+            </span>
+            <Link
+              href="/dashboard"
+              className="text-xs text-[var(--color-muted)] hover:text-[var(--color-ink)] transition-colors"
+            >
+              ↗ My profile
+            </Link>
+          </div>
+        </div>
+      </header>
+
+      <main>{children}</main>
+    </div>
+  );
+}

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -1,0 +1,210 @@
+/**
+ * KAN-141: admin overview / dashboard.
+ *
+ * Server Component — reads everything fresh on each request. We deliberately
+ * skip caching: the whole point of this page is "what's happening right
+ * now". Reports queue, recent signups, suspension counts. Cached data
+ * would defeat the operator's mental model.
+ *
+ * Queries are all on the service-role client because admins can see
+ * everything; the RLS policies on these tables also accept admin reads
+ * via cookie session, but service-role is one consistent path for both
+ * "read everything" routes and "show counts" — avoids two query shapes.
+ */
+
+import Link from 'next/link';
+import { getCurrentAdmin, getAdminServiceClient } from '@/lib/admin';
+
+export const dynamic = 'force-dynamic';
+
+async function getCounts() {
+  const supabase = getAdminServiceClient();
+
+  // Run all four counts concurrently — they're independent and small.
+  const [totalProfiles, publishedProfiles, suspendedProfiles, pendingReports] = await Promise.all([
+    supabase.from('profiles').select('id', { count: 'exact', head: true }),
+    supabase.from('profiles').select('id', { count: 'exact', head: true }).eq('is_published', true),
+    supabase.from('profiles').select('id', { count: 'exact', head: true }).eq('is_suspended', true),
+    supabase.from('reports').select('id', { count: 'exact', head: true }).eq('status', 'pending'),
+  ]);
+
+  // 7-day signup count — uses a single point-in-time threshold computed
+  // here so we don't query the DB twice for the same window.
+  const sevenDaysAgo = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000).toISOString();
+  const recentSignups = await supabase
+    .from('profiles')
+    .select('id', { count: 'exact', head: true })
+    .gte('created_at', sevenDaysAgo);
+
+  return {
+    totalProfiles: totalProfiles.count ?? 0,
+    publishedProfiles: publishedProfiles.count ?? 0,
+    suspendedProfiles: suspendedProfiles.count ?? 0,
+    pendingReports: pendingReports.count ?? 0,
+    signups7d: recentSignups.count ?? 0,
+  };
+}
+
+async function getRecentSignups() {
+  const supabase = getAdminServiceClient();
+  const { data } = await supabase
+    .from('profiles')
+    .select('id, display_name, slug, created_at, is_published, is_suspended')
+    .order('created_at', { ascending: false })
+    .limit(10);
+  return data ?? [];
+}
+
+async function getRecentReports() {
+  const supabase = getAdminServiceClient();
+  const { data } = await supabase
+    .from('reports')
+    .select('id, reason, status, created_at, profile:profiles!reports_profile_id_fkey(slug, display_name)')
+    .order('created_at', { ascending: false })
+    .limit(10);
+  return data ?? [];
+}
+
+function StatCard({ label, value, href }: { label: string; value: number; href?: string }) {
+  const body = (
+    <div className="p-5 rounded-xl border border-stone-200 bg-white">
+      <p className="text-xs uppercase tracking-wider text-[var(--color-muted)] mb-2">{label}</p>
+      <p className="text-2xl font-semibold text-[var(--color-ink)]">{value.toLocaleString()}</p>
+    </div>
+  );
+  return href ? (
+    <Link href={href} className="block hover:shadow-sm transition-shadow">
+      {body}
+    </Link>
+  ) : body;
+}
+
+function formatRelative(iso: string): string {
+  const then = new Date(iso).getTime();
+  const now = Date.now();
+  const diff = Math.max(0, now - then);
+  const mins = Math.floor(diff / 60000);
+  if (mins < 1) return 'just now';
+  if (mins < 60) return `${mins}m ago`;
+  const hrs = Math.floor(mins / 60);
+  if (hrs < 24) return `${hrs}h ago`;
+  const days = Math.floor(hrs / 24);
+  return `${days}d ago`;
+}
+
+export default async function AdminOverviewPage() {
+  // Layout already ran the admin gate; this is just a typing reload so
+  // we have the admin record in scope if any UI needs it later. Cheap.
+  await getCurrentAdmin();
+
+  const [counts, recentSignups, recentReports] = await Promise.all([
+    getCounts(),
+    getRecentSignups(),
+    getRecentReports(),
+  ]);
+
+  return (
+    <div className="max-w-6xl mx-auto px-6 py-8 space-y-10">
+      <header>
+        <h1 className="text-2xl font-medium text-[var(--color-ink)] font-[family-name:var(--font-serif)]">
+          Overview
+        </h1>
+        <p className="text-sm text-[var(--color-muted)] mt-1">
+          Counts and recent activity. Drill into a section above for actions.
+        </p>
+      </header>
+
+      <section aria-label="Counts" className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-5 gap-4">
+        <StatCard label="Total profiles" value={counts.totalProfiles} />
+        <StatCard label="Published" value={counts.publishedProfiles} />
+        <StatCard label="Suspended" value={counts.suspendedProfiles} href="/admin/users?filter=suspended" />
+        <StatCard label="Pending reports" value={counts.pendingReports} href="/admin/reports?status=pending" />
+        <StatCard label="Signups · 7d" value={counts.signups7d} />
+      </section>
+
+      <section aria-labelledby="recent-signups-heading">
+        <h2 id="recent-signups-heading" className="text-base font-medium text-[var(--color-ink)] mb-3">
+          Recent signups
+        </h2>
+        <div className="rounded-xl border border-stone-200 bg-white divide-y divide-stone-100">
+          {recentSignups.length === 0 ? (
+            <p className="p-5 text-sm text-[var(--color-muted)]">No profiles yet.</p>
+          ) : recentSignups.map((p) => (
+            <div key={p.id as string} className="p-4 flex items-center justify-between gap-4">
+              <div className="min-w-0">
+                <p className="text-sm font-medium text-[var(--color-ink)] truncate">
+                  {(p.display_name as string) || '(no name)'}
+                </p>
+                <p className="text-xs text-[var(--color-muted)] truncate">
+                  /{p.slug as string} · {formatRelative(p.created_at as string)}
+                </p>
+              </div>
+              <div className="flex items-center gap-2 shrink-0">
+                {p.is_suspended ? (
+                  <span className="text-xs px-2 py-1 rounded-full bg-red-50 text-red-700">Suspended</span>
+                ) : p.is_published ? (
+                  <span className="text-xs px-2 py-1 rounded-full bg-green-50 text-green-700">Published</span>
+                ) : (
+                  <span className="text-xs px-2 py-1 rounded-full bg-stone-100 text-stone-600">Draft</span>
+                )}
+                <Link
+                  href={`/admin/users/${p.slug as string}`}
+                  className="text-xs text-[var(--color-muted)] hover:text-[var(--color-ink)] transition-colors"
+                >
+                  View →
+                </Link>
+              </div>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      <section aria-labelledby="recent-reports-heading">
+        <h2 id="recent-reports-heading" className="text-base font-medium text-[var(--color-ink)] mb-3">
+          Recent reports
+        </h2>
+        <div className="rounded-xl border border-stone-200 bg-white divide-y divide-stone-100">
+          {recentReports.length === 0 ? (
+            <p className="p-5 text-sm text-[var(--color-muted)]">No reports filed.</p>
+          ) : recentReports.map((r) => {
+            const prof = r.profile as { slug: string; display_name: string } | null;
+            return (
+              <div key={r.id as string} className="p-4 flex items-center justify-between gap-4">
+                <div className="min-w-0">
+                  <p className="text-sm text-[var(--color-ink)] truncate">
+                    <span className="font-medium">{r.reason as string}</span>
+                    {' against '}
+                    {prof ? `${prof.display_name} (/${prof.slug})` : 'unknown profile'}
+                  </p>
+                  <p className="text-xs text-[var(--color-muted)]">
+                    {formatRelative(r.created_at as string)}
+                  </p>
+                </div>
+                <div className="flex items-center gap-2 shrink-0">
+                  <span
+                    className={
+                      'text-xs px-2 py-1 rounded-full ' +
+                      (r.status === 'pending'
+                        ? 'bg-amber-50 text-amber-700'
+                        : r.status === 'actioned'
+                        ? 'bg-green-50 text-green-700'
+                        : 'bg-stone-100 text-stone-600')
+                    }
+                  >
+                    {r.status as string}
+                  </span>
+                  <Link
+                    href={`/admin/reports/${r.id as string}`}
+                    className="text-xs text-[var(--color-muted)] hover:text-[var(--color-ink)] transition-colors"
+                  >
+                    Open →
+                  </Link>
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -167,7 +167,13 @@ export default async function AdminOverviewPage() {
           {recentReports.length === 0 ? (
             <p className="p-5 text-sm text-[var(--color-muted)]">No reports filed.</p>
           ) : recentReports.map((r) => {
-            const prof = r.profile as { slug: string; display_name: string } | null;
+            // Supabase typegen sometimes infers the FK lookup as an array,
+            // sometimes as a single object — depends on the cardinality. We
+            // route through unknown so we don't depend on the inferred type.
+            const profCandidate = r.profile as unknown;
+            const prof = Array.isArray(profCandidate)
+              ? (profCandidate[0] as { slug: string; display_name: string } | undefined) ?? null
+              : (profCandidate as { slug: string; display_name: string } | null);
             return (
               <div key={r.id as string} className="p-4 flex items-center justify-between gap-4">
                 <div className="min-w-0">

--- a/src/app/admin/reports/[id]/page.tsx
+++ b/src/app/admin/reports/[id]/page.tsx
@@ -1,0 +1,287 @@
+/**
+ * KAN-141: per-report detail + moderation action page.
+ *
+ * Shows the full report (reporter, reason, note, status, target), the
+ * target profile state, and a form with three options: Resolve as
+ * Actioned, Dismiss, or Suspend the target profile. Every form
+ * submission goes through a server action that updates the report,
+ * mutates the target (if applicable), AND writes a moderation_logs
+ * row through `logModerationAction`.
+ */
+
+import { notFound, redirect } from 'next/navigation';
+import Link from 'next/link';
+import { getCurrentAdmin, getAdminServiceClient, logModerationAction } from '@/lib/admin';
+
+export const dynamic = 'force-dynamic';
+
+interface FullReport {
+  id: string;
+  profile_id: string;
+  profile_item_id: string | null;
+  reporter_user_id: string | null;
+  reason: string;
+  note: string | null;
+  status: string;
+  resolved_by: string | null;
+  resolved_at: string | null;
+  created_at: string;
+  profile: {
+    id: string;
+    slug: string;
+    display_name: string;
+    is_suspended: boolean;
+    is_published: boolean;
+  } | null;
+}
+
+async function loadReport(id: string): Promise<FullReport | null> {
+  const supabase = getAdminServiceClient();
+  const { data } = await supabase
+    .from('reports')
+    .select('id, profile_id, profile_item_id, reporter_user_id, reason, note, status, resolved_by, resolved_at, created_at, profile:profiles!reports_profile_id_fkey(id, slug, display_name, is_suspended, is_published)')
+    .eq('id', id)
+    .maybeSingle();
+  return (data ?? null) as unknown as FullReport | null;
+}
+
+// ── Server actions ────────────────────────────────────────────────
+
+async function actionDismissReport(formData: FormData) {
+  'use server';
+  const reportId = String(formData.get('reportId') ?? '');
+  const reason = String(formData.get('reason') ?? '');
+  await dismissOrResolveReport(reportId, 'dismissed', 'dismiss_report', reason);
+}
+
+async function actionResolveReport(formData: FormData) {
+  'use server';
+  const reportId = String(formData.get('reportId') ?? '');
+  const reason = String(formData.get('reason') ?? '');
+  await dismissOrResolveReport(reportId, 'actioned', 'resolve_report', reason);
+}
+
+async function actionSuspendProfile(formData: FormData) {
+  'use server';
+  const reportId = String(formData.get('reportId') ?? '');
+  const profileId = String(formData.get('profileId') ?? '');
+  const reason = String(formData.get('reason') ?? '');
+
+  const admin = await getCurrentAdmin();
+  if (!admin) redirect('/');
+
+  const supabase = getAdminServiceClient();
+
+  // 1. Audit-first: write the moderation log entry. If this fails we
+  // do NOT proceed with the mutation — see comment in logModerationAction.
+  await logModerationAction({
+    admin,
+    action: 'suspend',
+    targetProfileId: profileId,
+    reason: reason || 'Action taken following report',
+    metadata: { reportId },
+  });
+
+  // 2. Suspend the profile.
+  await supabase
+    .from('profiles')
+    .update({
+      is_suspended: true,
+      suspended_at: new Date().toISOString(),
+      suspension_reason: reason || 'Action taken following report',
+    })
+    .eq('id', profileId);
+
+  // 3. Mark the report as actioned.
+  await supabase
+    .from('reports')
+    .update({
+      status: 'actioned',
+      resolved_by: admin.userId,
+      resolved_at: new Date().toISOString(),
+    })
+    .eq('id', reportId);
+
+  redirect('/admin/reports');
+}
+
+async function dismissOrResolveReport(
+  reportId: string,
+  newStatus: 'actioned' | 'dismissed',
+  action: 'resolve_report' | 'dismiss_report',
+  reason: string,
+) {
+  const admin = await getCurrentAdmin();
+  if (!admin) redirect('/');
+
+  const supabase = getAdminServiceClient();
+  const { data: report } = await supabase
+    .from('reports')
+    .select('profile_id, profile_item_id')
+    .eq('id', reportId)
+    .maybeSingle();
+
+  await logModerationAction({
+    admin,
+    action,
+    targetProfileId: (report?.profile_id as string | undefined) ?? null,
+    targetItemId: (report?.profile_item_id as string | undefined) ?? null,
+    reason: reason || null,
+    metadata: { reportId },
+  });
+
+  await supabase
+    .from('reports')
+    .update({
+      status: newStatus,
+      resolved_by: admin.userId,
+      resolved_at: new Date().toISOString(),
+    })
+    .eq('id', reportId);
+
+  redirect('/admin/reports');
+}
+
+// ── UI ────────────────────────────────────────────────────────────
+
+export default async function ReportDetailPage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const { id } = await params;
+  const report = await loadReport(id);
+  if (!report) notFound();
+
+  return (
+    <div className="max-w-4xl mx-auto px-6 py-8 space-y-8">
+      <header>
+        <Link href="/admin/reports" className="text-sm text-[var(--color-muted)] hover:text-[var(--color-ink)]">
+          ← Back to reports
+        </Link>
+        <h1 className="text-2xl font-medium text-[var(--color-ink)] font-[family-name:var(--font-serif)] mt-2">
+          Report detail
+        </h1>
+      </header>
+
+      <section aria-label="Report" className="p-5 rounded-xl border border-stone-200 bg-white space-y-3">
+        <dl className="grid grid-cols-1 sm:grid-cols-2 gap-x-6 gap-y-3 text-sm">
+          <div>
+            <dt className="text-xs uppercase tracking-wider text-[var(--color-muted)]">Reason</dt>
+            <dd className="text-[var(--color-ink)]">{report.reason}</dd>
+          </div>
+          <div>
+            <dt className="text-xs uppercase tracking-wider text-[var(--color-muted)]">Status</dt>
+            <dd className="text-[var(--color-ink)]">{report.status}</dd>
+          </div>
+          <div>
+            <dt className="text-xs uppercase tracking-wider text-[var(--color-muted)]">Target profile</dt>
+            <dd className="text-[var(--color-ink)]">
+              {report.profile ? (
+                <Link
+                  href={`/admin/users/${report.profile.slug}`}
+                  className="underline hover:text-[var(--color-sage)]"
+                >
+                  {report.profile.display_name} (/{report.profile.slug})
+                </Link>
+              ) : (
+                <span className="text-[var(--color-muted)]">deleted profile</span>
+              )}
+            </dd>
+          </div>
+          <div>
+            <dt className="text-xs uppercase tracking-wider text-[var(--color-muted)]">Profile state</dt>
+            <dd>
+              {report.profile?.is_suspended ? (
+                <span className="text-red-700">Suspended</span>
+              ) : report.profile?.is_published ? (
+                <span className="text-green-700">Published</span>
+              ) : (
+                <span className="text-[var(--color-muted)]">Draft</span>
+              )}
+            </dd>
+          </div>
+        </dl>
+        {report.note && (
+          <div>
+            <dt className="text-xs uppercase tracking-wider text-[var(--color-muted)]">Reporter note</dt>
+            <dd className="text-sm text-[var(--color-ink)] mt-1 whitespace-pre-wrap">{report.note}</dd>
+          </div>
+        )}
+      </section>
+
+      {report.status === 'pending' ? (
+        <section aria-label="Actions" className="p-5 rounded-xl border border-stone-200 bg-white space-y-6">
+          <h2 className="text-base font-medium text-[var(--color-ink)]">Take action</h2>
+
+          <form action={actionResolveReport} className="space-y-3">
+            <input type="hidden" name="reportId" value={report.id} />
+            <label htmlFor="resolve-reason" className="block text-sm text-[var(--color-ink)]">
+              Resolution notes (optional)
+            </label>
+            <input
+              id="resolve-reason"
+              name="reason"
+              type="text"
+              maxLength={500}
+              className="w-full p-2 text-sm rounded-lg border border-stone-300 bg-white"
+              placeholder="e.g. profile content reviewed and edited"
+            />
+            <button
+              type="submit"
+              className="px-5 py-2 rounded-full bg-[var(--color-lyra-sage)] text-white text-sm font-medium hover:bg-[var(--color-lyra-sage-hover)] transition-colors"
+            >
+              Mark as actioned
+            </button>
+          </form>
+
+          <form action={actionDismissReport} className="space-y-3 pt-2 border-t border-stone-100">
+            <input type="hidden" name="reportId" value={report.id} />
+            <input
+              name="reason"
+              type="text"
+              maxLength={500}
+              className="w-full p-2 text-sm rounded-lg border border-stone-300 bg-white"
+              placeholder="Dismissal reason (optional)"
+            />
+            <button
+              type="submit"
+              className="px-5 py-2 rounded-full bg-stone-100 text-[var(--color-ink)] text-sm font-medium hover:bg-stone-200 transition-colors"
+            >
+              Dismiss report
+            </button>
+          </form>
+
+          {report.profile && !report.profile.is_suspended && (
+            <form action={actionSuspendProfile} className="space-y-3 pt-2 border-t border-stone-100">
+              <input type="hidden" name="reportId" value={report.id} />
+              <input type="hidden" name="profileId" value={report.profile.id} />
+              <label htmlFor="suspend-reason" className="block text-sm text-[var(--color-ink)]">
+                Suspension reason (will be recorded)
+              </label>
+              <input
+                id="suspend-reason"
+                name="reason"
+                type="text"
+                maxLength={500}
+                required
+                className="w-full p-2 text-sm rounded-lg border border-stone-300 bg-white"
+                placeholder="e.g. repeated harassment"
+              />
+              <button
+                type="submit"
+                className="px-5 py-2 rounded-full bg-red-600 text-white text-sm font-medium hover:bg-red-700 transition-colors"
+              >
+                Suspend profile + mark report actioned
+              </button>
+            </form>
+          )}
+        </section>
+      ) : (
+        <p className="text-sm text-[var(--color-muted)]">
+          This report has been resolved. No further actions available.
+        </p>
+      )}
+    </div>
+  );
+}

--- a/src/app/admin/reports/page.tsx
+++ b/src/app/admin/reports/page.tsx
@@ -1,0 +1,134 @@
+/**
+ * KAN-141: /admin/reports — list of filed reports.
+ *
+ * Filterable by status via ?status=… query param. The default view
+ * shows only `pending` because that's where the moderator's attention
+ * is needed. Clicking through to a row opens the per-report detail
+ * page where the actual moderation actions live.
+ */
+
+import Link from 'next/link';
+import { getAdminServiceClient } from '@/lib/admin';
+
+export const dynamic = 'force-dynamic';
+
+type StatusFilter = 'pending' | 'reviewed' | 'actioned' | 'dismissed' | 'all';
+
+interface ReportRow {
+  id: string;
+  reason: string;
+  status: string;
+  note: string | null;
+  created_at: string;
+  profile: { slug: string; display_name: string } | null;
+}
+
+async function listReports(status: StatusFilter): Promise<ReportRow[]> {
+  const supabase = getAdminServiceClient();
+  let q = supabase
+    .from('reports')
+    .select('id, reason, status, note, created_at, profile:profiles!reports_profile_id_fkey(slug, display_name)')
+    .order('created_at', { ascending: false })
+    .limit(100);
+
+  if (status !== 'all') {
+    q = q.eq('status', status);
+  }
+
+  const { data } = await q;
+  return (data ?? []) as unknown as ReportRow[];
+}
+
+function formatRelative(iso: string): string {
+  const diff = Date.now() - new Date(iso).getTime();
+  const mins = Math.floor(diff / 60000);
+  if (mins < 1) return 'just now';
+  if (mins < 60) return `${mins}m ago`;
+  const hrs = Math.floor(mins / 60);
+  if (hrs < 24) return `${hrs}h ago`;
+  return `${Math.floor(hrs / 24)}d ago`;
+}
+
+export default async function ReportsListPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ status?: string }>;
+}) {
+  const { status } = await searchParams;
+  const filter: StatusFilter = (['pending', 'reviewed', 'actioned', 'dismissed', 'all'] as const)
+    .includes(status as StatusFilter) ? (status as StatusFilter) : 'pending';
+
+  const reports = await listReports(filter);
+
+  return (
+    <div className="max-w-6xl mx-auto px-6 py-8 space-y-6">
+      <header>
+        <h1 className="text-2xl font-medium text-[var(--color-ink)] font-[family-name:var(--font-serif)]">
+          Reports
+        </h1>
+        <p className="text-sm text-[var(--color-muted)] mt-1">
+          User-filed reports. Resolve, dismiss, or action via the report detail page.
+        </p>
+      </header>
+
+      <nav aria-label="Filter by status" className="flex flex-wrap gap-2">
+        {(['pending', 'actioned', 'dismissed', 'reviewed', 'all'] as const).map((s) => (
+          <Link
+            key={s}
+            href={s === 'pending' ? '/admin/reports' : `/admin/reports?status=${s}`}
+            className={
+              'text-xs px-3 py-1.5 rounded-full transition-colors ' +
+              (filter === s
+                ? 'bg-[var(--color-ink)] text-white'
+                : 'bg-stone-100 text-[var(--color-muted)] hover:bg-stone-200')
+            }
+          >
+            {s}
+          </Link>
+        ))}
+      </nav>
+
+      <div className="rounded-xl border border-stone-200 bg-white divide-y divide-stone-100">
+        {reports.length === 0 ? (
+          <p className="p-5 text-sm text-[var(--color-muted)]">No reports match this filter.</p>
+        ) : reports.map((r) => (
+          <Link
+            key={r.id}
+            href={`/admin/reports/${r.id}`}
+            className="block p-4 hover:bg-stone-50 transition-colors"
+          >
+            <div className="flex items-baseline justify-between gap-4 mb-1">
+              <p className="text-sm text-[var(--color-ink)] truncate">
+                <span className="font-medium">{r.reason}</span>
+                {' · '}
+                {r.profile ? (
+                  <span>
+                    {r.profile.display_name}{' '}
+                    <span className="text-[var(--color-muted)]">(/{r.profile.slug})</span>
+                  </span>
+                ) : (
+                  <span className="text-[var(--color-muted)]">unknown profile</span>
+                )}
+              </p>
+              <span
+                className={
+                  'text-xs px-2 py-1 rounded-full shrink-0 ' +
+                  (r.status === 'pending' ? 'bg-amber-50 text-amber-700'
+                    : r.status === 'actioned' ? 'bg-green-50 text-green-700'
+                    : r.status === 'dismissed' ? 'bg-stone-100 text-stone-600'
+                    : 'bg-blue-50 text-blue-700')
+                }
+              >
+                {r.status}
+              </span>
+            </div>
+            {r.note && (
+              <p className="text-xs text-[var(--color-muted)] line-clamp-2 mb-1">{r.note}</p>
+            )}
+            <p className="text-xs text-stone-500">{formatRelative(r.created_at)}</p>
+          </Link>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/app/admin/users/[slug]/page.tsx
+++ b/src/app/admin/users/[slug]/page.tsx
@@ -1,0 +1,282 @@
+/**
+ * KAN-141: per-user admin view.
+ *
+ * Shows the profile state, recent items, link to public profile, and
+ * the suspend / unsuspend / delete-item actions. Self-moderation is
+ * blocked at the UI level (button hidden) and also at the action level
+ * (rejected if target_profile_id resolves to the admin's own profile).
+ */
+
+import { notFound, redirect } from 'next/navigation';
+import Link from 'next/link';
+import { getCurrentAdmin, getAdminServiceClient, logModerationAction } from '@/lib/admin';
+
+export const dynamic = 'force-dynamic';
+
+interface ProfileFull {
+  id: string;
+  user_id: string;
+  display_name: string | null;
+  slug: string;
+  headline: string | null;
+  bio_short: string | null;
+  is_published: boolean;
+  is_suspended: boolean;
+  is_admin: boolean;
+  suspended_at: string | null;
+  suspension_reason: string | null;
+  created_at: string;
+}
+
+interface ItemRow {
+  id: string;
+  category: string;
+  title: string;
+  description: string | null;
+  visibility: string;
+  created_at: string;
+}
+
+async function loadProfile(slug: string): Promise<ProfileFull | null> {
+  const supabase = getAdminServiceClient();
+  const { data } = await supabase
+    .from('profiles')
+    .select('id, user_id, display_name, slug, headline, bio_short, is_published, is_suspended, is_admin, suspended_at, suspension_reason, created_at')
+    .eq('slug', slug)
+    .maybeSingle();
+  return (data ?? null) as ProfileFull | null;
+}
+
+async function loadItems(profileId: string): Promise<ItemRow[]> {
+  const supabase = getAdminServiceClient();
+  const { data } = await supabase
+    .from('profile_items')
+    .select('id, category, title, description, visibility, created_at')
+    .eq('profile_id', profileId)
+    .order('created_at', { ascending: false })
+    .limit(50);
+  return (data ?? []) as ItemRow[];
+}
+
+// ── Server actions ────────────────────────────────────────────────
+
+async function actionSuspend(formData: FormData) {
+  'use server';
+  await setSuspendState(formData, true);
+}
+
+async function actionUnsuspend(formData: FormData) {
+  'use server';
+  await setSuspendState(formData, false);
+}
+
+async function setSuspendState(formData: FormData, suspend: boolean) {
+  const admin = await getCurrentAdmin();
+  if (!admin) redirect('/');
+
+  const profileId = String(formData.get('profileId') ?? '');
+  const slug = String(formData.get('slug') ?? '');
+  const reason = String(formData.get('reason') ?? '');
+
+  // Self-moderation guard. The admin's own profileId must never equal
+  // the target. Bail silently — UI doesn't render the button in this
+  // case but action handlers must be self-defending.
+  if (profileId === admin.profileId) {
+    redirect(`/admin/users/${slug}`);
+  }
+
+  await logModerationAction({
+    admin,
+    action: suspend ? 'suspend' : 'unsuspend',
+    targetProfileId: profileId,
+    reason: reason || null,
+  });
+
+  const supabase = getAdminServiceClient();
+  await supabase
+    .from('profiles')
+    .update(suspend
+      ? { is_suspended: true, suspended_at: new Date().toISOString(), suspension_reason: reason || null }
+      : { is_suspended: false, suspended_at: null, suspension_reason: null }
+    )
+    .eq('id', profileId);
+
+  redirect(`/admin/users/${slug}`);
+}
+
+async function actionDeleteItem(formData: FormData) {
+  'use server';
+  const admin = await getCurrentAdmin();
+  if (!admin) redirect('/');
+
+  const itemId = String(formData.get('itemId') ?? '');
+  const profileId = String(formData.get('profileId') ?? '');
+  const slug = String(formData.get('slug') ?? '');
+  const reason = String(formData.get('reason') ?? '');
+
+  await logModerationAction({
+    admin,
+    action: 'delete_item',
+    targetProfileId: profileId,
+    targetItemId: itemId,
+    reason: reason || null,
+  });
+
+  const supabase = getAdminServiceClient();
+  await supabase.from('profile_items').delete().eq('id', itemId);
+
+  redirect(`/admin/users/${slug}`);
+}
+
+// ── UI ────────────────────────────────────────────────────────────
+
+export default async function UserDetailPage({
+  params,
+}: {
+  params: Promise<{ slug: string }>;
+}) {
+  const { slug } = await params;
+  const admin = (await getCurrentAdmin())!; // layout already gated
+  const profile = await loadProfile(slug);
+  if (!profile) notFound();
+  const items = await loadItems(profile.id);
+  const isSelf = profile.id === admin.profileId;
+
+  return (
+    <div className="max-w-4xl mx-auto px-6 py-8 space-y-8">
+      <header>
+        <Link href="/admin/users" className="text-sm text-[var(--color-muted)] hover:text-[var(--color-ink)]">
+          ← Back to users
+        </Link>
+        <h1 className="text-2xl font-medium text-[var(--color-ink)] font-[family-name:var(--font-serif)] mt-2">
+          {profile.display_name ?? '(no name)'}
+        </h1>
+        <p className="text-sm text-[var(--color-muted)]">
+          <Link href={`/${profile.slug}`} className="underline">/{profile.slug}</Link>
+          {' · joined '}
+          {new Date(profile.created_at).toLocaleDateString('en-GB', { year: 'numeric', month: 'short', day: 'numeric' })}
+        </p>
+      </header>
+
+      <section className="p-5 rounded-xl border border-stone-200 bg-white">
+        <dl className="grid grid-cols-1 sm:grid-cols-3 gap-x-6 gap-y-3 text-sm">
+          <div>
+            <dt className="text-xs uppercase tracking-wider text-[var(--color-muted)]">Status</dt>
+            <dd className="mt-1">
+              {profile.is_suspended ? (
+                <span className="text-red-700">Suspended</span>
+              ) : profile.is_published ? (
+                <span className="text-green-700">Published</span>
+              ) : (
+                <span className="text-[var(--color-muted)]">Draft</span>
+              )}
+            </dd>
+          </div>
+          <div>
+            <dt className="text-xs uppercase tracking-wider text-[var(--color-muted)]">Admin</dt>
+            <dd className="mt-1">{profile.is_admin ? 'Yes' : 'No'}</dd>
+          </div>
+          <div>
+            <dt className="text-xs uppercase tracking-wider text-[var(--color-muted)]">Items</dt>
+            <dd className="mt-1">{items.length}</dd>
+          </div>
+          {profile.is_suspended && profile.suspension_reason && (
+            <div className="sm:col-span-3">
+              <dt className="text-xs uppercase tracking-wider text-[var(--color-muted)]">Suspension reason</dt>
+              <dd className="text-[var(--color-ink)] mt-1">{profile.suspension_reason}</dd>
+            </div>
+          )}
+        </dl>
+      </section>
+
+      {!isSelf && (
+        <section className="p-5 rounded-xl border border-stone-200 bg-white space-y-4">
+          <h2 className="text-base font-medium text-[var(--color-ink)]">Actions</h2>
+          {profile.is_suspended ? (
+            <form action={actionUnsuspend} className="flex flex-wrap gap-3 items-end">
+              <input type="hidden" name="profileId" value={profile.id} />
+              <input type="hidden" name="slug" value={profile.slug} />
+              <input
+                name="reason"
+                type="text"
+                maxLength={500}
+                className="flex-1 min-w-[200px] p-2 text-sm rounded-lg border border-stone-300 bg-white"
+                placeholder="Unsuspension note (optional)"
+              />
+              <button
+                type="submit"
+                className="px-4 py-2 rounded-full bg-[var(--color-lyra-sage)] text-white text-sm font-medium hover:bg-[var(--color-lyra-sage-hover)] transition-colors"
+              >
+                Unsuspend
+              </button>
+            </form>
+          ) : (
+            <form action={actionSuspend} className="flex flex-wrap gap-3 items-end">
+              <input type="hidden" name="profileId" value={profile.id} />
+              <input type="hidden" name="slug" value={profile.slug} />
+              <input
+                name="reason"
+                type="text"
+                maxLength={500}
+                required
+                className="flex-1 min-w-[200px] p-2 text-sm rounded-lg border border-stone-300 bg-white"
+                placeholder="Suspension reason (required)"
+              />
+              <button
+                type="submit"
+                className="px-4 py-2 rounded-full bg-red-600 text-white text-sm font-medium hover:bg-red-700 transition-colors"
+              >
+                Suspend
+              </button>
+            </form>
+          )}
+        </section>
+      )}
+
+      <section className="p-5 rounded-xl border border-stone-200 bg-white">
+        <h2 className="text-base font-medium text-[var(--color-ink)] mb-3">Items</h2>
+        {items.length === 0 ? (
+          <p className="text-sm text-[var(--color-muted)]">No items on this profile.</p>
+        ) : (
+          <ul className="divide-y divide-stone-100">
+            {items.map((it) => (
+              <li key={it.id} className="py-3 flex items-baseline justify-between gap-3">
+                <div className="min-w-0">
+                  <p className="text-sm text-[var(--color-ink)] truncate">
+                    <span className="text-xs uppercase tracking-wider text-[var(--color-muted)] mr-2">
+                      {it.category}
+                    </span>
+                    {it.title}
+                  </p>
+                  {it.description && (
+                    <p className="text-xs text-[var(--color-muted)] line-clamp-1">{it.description}</p>
+                  )}
+                </div>
+                {!isSelf && (
+                  <form action={actionDeleteItem} className="flex items-center gap-2 shrink-0">
+                    <input type="hidden" name="itemId" value={it.id} />
+                    <input type="hidden" name="profileId" value={profile.id} />
+                    <input type="hidden" name="slug" value={profile.slug} />
+                    <input
+                      name="reason"
+                      type="text"
+                      maxLength={500}
+                      className="p-1.5 text-xs rounded border border-stone-300 bg-white w-32"
+                      placeholder="Reason"
+                    />
+                    <button
+                      type="submit"
+                      className="text-xs px-3 py-1.5 rounded-full bg-stone-100 text-red-700 hover:bg-red-50 transition-colors"
+                    >
+                      Delete
+                    </button>
+                  </form>
+                )}
+              </li>
+            ))}
+          </ul>
+        )}
+      </section>
+    </div>
+  );
+}

--- a/src/app/admin/users/page.tsx
+++ b/src/app/admin/users/page.tsx
@@ -1,0 +1,184 @@
+/**
+ * KAN-141: /admin/users — list of profiles.
+ *
+ * Supports a `?filter=suspended` query to drill into the suspended set
+ * (linked from the overview card) and a `?q=` text query for fuzzy name
+ * / slug search. Pagination via `?page=` (10 per page) — the cursor is
+ * created_at-keyed but offset is fine at the scale we're at.
+ */
+
+import Link from 'next/link';
+import { getAdminServiceClient } from '@/lib/admin';
+
+export const dynamic = 'force-dynamic';
+
+const PAGE_SIZE = 20;
+
+interface UserRow {
+  id: string;
+  display_name: string | null;
+  slug: string;
+  is_published: boolean;
+  is_suspended: boolean;
+  is_admin: boolean;
+  created_at: string;
+}
+
+async function listUsers(opts: { q?: string; filter?: string; page?: number }): Promise<{ rows: UserRow[]; total: number }> {
+  const supabase = getAdminServiceClient();
+  let q = supabase
+    .from('profiles')
+    .select('id, display_name, slug, is_published, is_suspended, is_admin, created_at', { count: 'exact' });
+
+  if (opts.q && opts.q.trim().length > 0) {
+    const search = opts.q.trim().replace(/[%_]/g, '');
+    q = q.or(`display_name.ilike.%${search}%,slug.ilike.%${search}%`);
+  }
+  if (opts.filter === 'suspended') q = q.eq('is_suspended', true);
+  if (opts.filter === 'admin') q = q.eq('is_admin', true);
+
+  const page = Math.max(1, opts.page ?? 1);
+  q = q.order('created_at', { ascending: false })
+       .range((page - 1) * PAGE_SIZE, page * PAGE_SIZE - 1);
+
+  const { data, count } = await q;
+  return { rows: (data ?? []) as UserRow[], total: count ?? 0 };
+}
+
+export default async function UsersListPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ q?: string; filter?: string; page?: string }>;
+}) {
+  const sp = await searchParams;
+  const page = Math.max(1, Number(sp.page ?? '1') || 1);
+  const { rows, total } = await listUsers({ q: sp.q, filter: sp.filter, page });
+  const totalPages = Math.max(1, Math.ceil(total / PAGE_SIZE));
+
+  return (
+    <div className="max-w-6xl mx-auto px-6 py-8 space-y-6">
+      <header>
+        <h1 className="text-2xl font-medium text-[var(--color-ink)] font-[family-name:var(--font-serif)]">
+          Users
+        </h1>
+        <p className="text-sm text-[var(--color-muted)] mt-1">
+          {total} {total === 1 ? 'profile' : 'profiles'} {sp.filter ? `(${sp.filter})` : 'total'}.
+        </p>
+      </header>
+
+      <form className="flex flex-wrap gap-3 items-center" method="GET">
+        <input
+          name="q"
+          defaultValue={sp.q ?? ''}
+          placeholder="Search name or slug…"
+          className="flex-1 min-w-[200px] p-2 text-sm rounded-lg border border-stone-300 bg-white"
+        />
+        {sp.filter && <input type="hidden" name="filter" value={sp.filter} />}
+        <button
+          type="submit"
+          className="px-4 py-2 rounded-full bg-stone-100 text-[var(--color-ink)] text-sm font-medium hover:bg-stone-200 transition-colors"
+        >
+          Search
+        </button>
+        <Link
+          href="/admin/users"
+          className="text-xs text-[var(--color-muted)] hover:text-[var(--color-ink)]"
+        >
+          Clear
+        </Link>
+      </form>
+
+      <nav aria-label="Filter" className="flex gap-2">
+        <Link
+          href="/admin/users"
+          className={
+            'text-xs px-3 py-1.5 rounded-full transition-colors ' +
+            (!sp.filter
+              ? 'bg-[var(--color-ink)] text-white'
+              : 'bg-stone-100 text-[var(--color-muted)] hover:bg-stone-200')
+          }
+        >
+          All
+        </Link>
+        <Link
+          href="/admin/users?filter=suspended"
+          className={
+            'text-xs px-3 py-1.5 rounded-full transition-colors ' +
+            (sp.filter === 'suspended'
+              ? 'bg-[var(--color-ink)] text-white'
+              : 'bg-stone-100 text-[var(--color-muted)] hover:bg-stone-200')
+          }
+        >
+          Suspended
+        </Link>
+        <Link
+          href="/admin/users?filter=admin"
+          className={
+            'text-xs px-3 py-1.5 rounded-full transition-colors ' +
+            (sp.filter === 'admin'
+              ? 'bg-[var(--color-ink)] text-white'
+              : 'bg-stone-100 text-[var(--color-muted)] hover:bg-stone-200')
+          }
+        >
+          Admins
+        </Link>
+      </nav>
+
+      <div className="rounded-xl border border-stone-200 bg-white divide-y divide-stone-100">
+        {rows.length === 0 ? (
+          <p className="p-5 text-sm text-[var(--color-muted)]">No users match.</p>
+        ) : rows.map((u) => (
+          <Link
+            key={u.id}
+            href={`/admin/users/${u.slug}`}
+            className="block p-4 hover:bg-stone-50 transition-colors"
+          >
+            <div className="flex items-baseline justify-between gap-4 mb-1">
+              <p className="text-sm font-medium text-[var(--color-ink)] truncate">
+                {u.display_name ?? '(no name)'}{' '}
+                <span className="text-[var(--color-muted)]">/{u.slug}</span>
+              </p>
+              <div className="flex items-center gap-2 shrink-0">
+                {u.is_admin && (
+                  <span className="text-xs px-2 py-0.5 rounded-full bg-blue-50 text-blue-700">Admin</span>
+                )}
+                {u.is_suspended ? (
+                  <span className="text-xs px-2 py-0.5 rounded-full bg-red-50 text-red-700">Suspended</span>
+                ) : u.is_published ? (
+                  <span className="text-xs px-2 py-0.5 rounded-full bg-green-50 text-green-700">Published</span>
+                ) : (
+                  <span className="text-xs px-2 py-0.5 rounded-full bg-stone-100 text-stone-600">Draft</span>
+                )}
+              </div>
+            </div>
+            <p className="text-xs text-stone-500">
+              Joined {new Date(u.created_at).toLocaleDateString('en-GB', { year: 'numeric', month: 'short', day: 'numeric' })}
+            </p>
+          </Link>
+        ))}
+      </div>
+
+      {totalPages > 1 && (
+        <nav aria-label="Pagination" className="flex justify-between items-center text-sm">
+          {page > 1 ? (
+            <Link
+              href={{ pathname: '/admin/users', query: { ...sp, page: page - 1 } }}
+              className="text-[var(--color-muted)] hover:text-[var(--color-ink)]"
+            >
+              ← Previous
+            </Link>
+          ) : <span />}
+          <span className="text-[var(--color-muted)]">Page {page} of {totalPages}</span>
+          {page < totalPages ? (
+            <Link
+              href={{ pathname: '/admin/users', query: { ...sp, page: page + 1 } }}
+              className="text-[var(--color-muted)] hover:text-[var(--color-ink)]"
+            >
+              Next →
+            </Link>
+          ) : <span />}
+        </nav>
+      )}
+    </div>
+  );
+}

--- a/src/app/api/reports/route.ts
+++ b/src/app/api/reports/route.ts
@@ -1,0 +1,147 @@
+/**
+ * KAN-141: POST /api/reports
+ *
+ * User-side endpoint for filing a report against a profile or item.
+ * Auth-only (anonymous abuse is too easy otherwise). The reporter is
+ * always set to the authenticated user — we explicitly do NOT trust a
+ * `reporter_user_id` in the body. Rate-limited per-profile-per-day to
+ * stop a single user from mass-flagging the same target.
+ *
+ * Body shape:
+ *   {
+ *     "profileSlug": "luisa",                    // required — target profile
+ *     "profileItemId": "uuid"                    // optional — narrows to one item
+ *     "reason": "spam" | "harassment" | "impersonation" | "inappropriate" | "other",
+ *     "note": "free text"                        // optional, ≤500 chars
+ *   }
+ *
+ * Responses:
+ *   201 { "id": "uuid", "status": "pending" } — report filed
+ *   400 invalid body
+ *   401 not signed in
+ *   404 profile not found / not visible
+ *   429 already reported this profile in the last 24h
+ *   500 server error
+ */
+
+import { NextResponse } from 'next/server';
+import { createClient as createSupabaseServerClient } from '@/lib/supabase-server';
+import { getAdminServiceClient } from '@/lib/admin';
+
+const VALID_REASONS = ['spam', 'harassment', 'impersonation', 'inappropriate', 'other'] as const;
+type Reason = typeof VALID_REASONS[number];
+
+interface ReportBody {
+  profileSlug?: unknown;
+  profileItemId?: unknown;
+  reason?: unknown;
+  note?: unknown;
+}
+
+function parseBody(input: unknown): { ok: true; value: { profileSlug: string; profileItemId: string | null; reason: Reason; note: string | null } } | { ok: false; error: string } {
+  if (!input || typeof input !== 'object') return { ok: false, error: 'body must be an object' };
+  const body = input as ReportBody;
+
+  if (typeof body.profileSlug !== 'string' || body.profileSlug.length === 0) {
+    return { ok: false, error: 'profileSlug is required' };
+  }
+  if (typeof body.reason !== 'string' || !VALID_REASONS.includes(body.reason as Reason)) {
+    return { ok: false, error: `reason must be one of: ${VALID_REASONS.join(', ')}` };
+  }
+  const profileItemId =
+    body.profileItemId == null ? null
+    : typeof body.profileItemId === 'string' && /^[0-9a-f-]{36}$/i.test(body.profileItemId) ? body.profileItemId
+    : 'INVALID';
+  if (profileItemId === 'INVALID') {
+    return { ok: false, error: 'profileItemId must be a uuid' };
+  }
+  if (body.note != null && (typeof body.note !== 'string' || body.note.length > 500)) {
+    return { ok: false, error: 'note must be a string ≤500 chars' };
+  }
+
+  return {
+    ok: true,
+    value: {
+      profileSlug: body.profileSlug,
+      profileItemId,
+      reason: body.reason as Reason,
+      note: (body.note as string | null) ?? null,
+    },
+  };
+}
+
+export async function POST(request: Request) {
+  // 1. Auth check
+  const cookieClient = await createSupabaseServerClient();
+  const { data: { user } } = await cookieClient.auth.getUser();
+  if (!user) {
+    return NextResponse.json({ error: 'unauthorized' }, { status: 401 });
+  }
+
+  // 2. Parse + validate body
+  let rawBody: unknown;
+  try {
+    rawBody = await request.json();
+  } catch {
+    return NextResponse.json({ error: 'invalid_json' }, { status: 400 });
+  }
+  const parsed = parseBody(rawBody);
+  if (!parsed.ok) {
+    return NextResponse.json({ error: 'invalid_body', detail: parsed.error }, { status: 400 });
+  }
+  const { profileSlug, profileItemId, reason, note } = parsed.value;
+
+  // 3. Resolve target profile. Use service-role because we want to allow
+  // reporting suspended / unpublished profiles too (an admin viewing
+  // them might find a problem). If it's literally not there, 404.
+  const supabase = getAdminServiceClient();
+  const { data: profile } = await supabase
+    .from('profiles')
+    .select('id, user_id')
+    .eq('slug', profileSlug)
+    .maybeSingle();
+
+  if (!profile) {
+    return NextResponse.json({ error: 'profile_not_found' }, { status: 404 });
+  }
+
+  // Defensive: prevent self-reports. Users will work around this by
+  // creating sock-puppet accounts; we're not trying to be airtight, just
+  // to keep the queue sane.
+  if (profile.user_id === user.id) {
+    return NextResponse.json({ error: 'cannot_report_self' }, { status: 400 });
+  }
+
+  // 4. Rate-limit: one report per (reporter, target profile) per 24h.
+  const twentyFourHoursAgo = new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString();
+  const { count: recentCount } = await supabase
+    .from('reports')
+    .select('id', { count: 'exact', head: true })
+    .eq('reporter_user_id', user.id)
+    .eq('profile_id', profile.id)
+    .gte('created_at', twentyFourHoursAgo);
+
+  if ((recentCount ?? 0) > 0) {
+    return NextResponse.json({ error: 'already_reported' }, { status: 429 });
+  }
+
+  // 5. Insert
+  const { data: inserted, error: insertError } = await supabase
+    .from('reports')
+    .insert({
+      profile_id: profile.id,
+      profile_item_id: profileItemId,
+      reporter_user_id: user.id,
+      reason,
+      note,
+      status: 'pending',
+    })
+    .select('id, status')
+    .single();
+
+  if (insertError || !inserted) {
+    return NextResponse.json({ error: 'insert_failed', detail: insertError?.message }, { status: 500 });
+  }
+
+  return NextResponse.json({ id: inserted.id, status: inserted.status }, { status: 201 });
+}

--- a/src/lib/admin.ts
+++ b/src/lib/admin.ts
@@ -1,0 +1,135 @@
+/**
+ * KAN-141: admin auth + moderation helpers.
+ *
+ * Single source of truth for "is the current user an admin?" and the
+ * "do a moderation action + write an audit log row atomically" pattern.
+ *
+ * Two design rules baked in here:
+ *
+ *   1. The admin gate goes through the DB on every request. Caching the
+ *      admin flag in a JWT claim would be faster but would let an admin
+ *      who's been revoked keep their privileges until token refresh.
+ *      Reads are cheap (single-row, partial-indexed lookup), correctness
+ *      is non-negotiable.
+ *
+ *   2. Every moderation action MUST go through `logModerationAction` so
+ *      the audit table reflects reality. The helper writes the log row
+ *      first (using the service-role client) — if the subsequent
+ *      mutation fails, we still have the attempt logged for forensics.
+ *      A failed-but-logged action is a smaller hazard than a successful-
+ *      but-unlogged one.
+ */
+
+import { createClient as createSupabaseServerClient } from '@/lib/supabase-server';
+import { createClient as createServiceClient } from '@supabase/supabase-js';
+import { env } from '@/lib/env';
+
+/**
+ * The set of action strings we accept in moderation_logs. The DB column
+ * is `text` (not enum) so we can add new actions without a migration,
+ * but the application validates here so we don't accidentally log typos.
+ *
+ * - suspend / unsuspend       — profile-level
+ * - delete_item / restore_item — item-level (restore_item is theoretical;
+ *                                items are hard-deleted today)
+ * - warn                      — soft action (email only, no state change)
+ * - resolve_report / dismiss_report — report-state transitions
+ * - grant_admin / revoke_admin — change admin flag on another user
+ */
+export type ModerationAction =
+  | 'suspend'
+  | 'unsuspend'
+  | 'delete_item'
+  | 'restore_item'
+  | 'warn'
+  | 'resolve_report'
+  | 'dismiss_report'
+  | 'grant_admin'
+  | 'revoke_admin';
+
+export interface AdminUser {
+  userId: string;
+  profileId: string;
+  email: string | null;
+  displayName: string | null;
+}
+
+/**
+ * Returns the current admin user if-and-only-if the cookie-authenticated
+ * session is a real admin. Null otherwise. Never throws — the caller
+ * decides how to respond (rewrite to 404, redirect to login, return 403).
+ *
+ * The deliberate choice of `notFound()` over `403` in the route handlers
+ * is in `src/middleware.ts` — this helper just answers "is admin or no".
+ */
+export async function getCurrentAdmin(): Promise<AdminUser | null> {
+  const supabase = await createSupabaseServerClient();
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) return null;
+
+  const { data: profile, error } = await supabase
+    .from('profiles')
+    .select('id, display_name, is_admin')
+    .eq('user_id', user.id)
+    .maybeSingle();
+
+  if (error || !profile?.is_admin) return null;
+
+  return {
+    userId: user.id,
+    profileId: profile.id,
+    email: user.email ?? null,
+    displayName: profile.display_name as string | null,
+  };
+}
+
+/**
+ * Service-role client. Used by admin actions that need to bypass RLS
+ * (e.g. listing every report regardless of reporter). The function is
+ * exported so route handlers can compose it directly; callers should
+ * already have verified the requester is an admin before reaching here.
+ */
+export function getAdminServiceClient() {
+  return createServiceClient(env.supabaseUrl(), env.supabaseServiceRoleKey(), {
+    auth: { persistSession: false },
+  });
+}
+
+export interface LogModerationActionInput {
+  admin: AdminUser;
+  action: ModerationAction;
+  targetProfileId?: string | null;
+  targetItemId?: string | null;
+  reason?: string | null;
+  metadata?: Record<string, unknown>;
+}
+
+/**
+ * Inserts a single moderation log row. Returns the inserted row id so
+ * callers can correlate it with their downstream mutation.
+ *
+ * Throws if the insert fails — callers should let the error propagate
+ * to the route handler, which converts it to a 500. We DO NOT
+ * swallow log failures: a moderation action that we couldn't audit is
+ * a moderation action we shouldn't have committed.
+ */
+export async function logModerationAction(input: LogModerationActionInput): Promise<string> {
+  const client = getAdminServiceClient();
+  const { data, error } = await client
+    .from('moderation_logs')
+    .insert({
+      actor_user_id: input.admin.userId,
+      action: input.action,
+      target_profile_id: input.targetProfileId ?? null,
+      target_item_id: input.targetItemId ?? null,
+      reason: input.reason ?? null,
+      metadata: input.metadata ?? {},
+    })
+    .select('id')
+    .single();
+
+  if (error || !data) {
+    throw new Error(`Failed to write moderation_logs row: ${error?.message ?? 'unknown error'}`);
+  }
+  return data.id as string;
+}

--- a/supabase/migrations/20260516120000_admin_and_moderation.sql
+++ b/supabase/migrations/20260516120000_admin_and_moderation.sql
@@ -1,0 +1,263 @@
+-- KAN-141: admin dashboard + reports + moderation tooling.
+--
+-- This migration is the schema half of KAN-141; the route + UI work follows
+-- in subsequent PRs (KAN-141-B through KAN-141-H). After applying, bootstrap
+-- the first admin manually via:
+--
+--   update public.profiles set is_admin = true where slug = '<your-slug>';
+--
+-- Rollback (run in reverse order):
+--   drop policy if exists "Admins write moderation logs" on public.moderation_logs;
+--   drop policy if exists "Admins read moderation logs" on public.moderation_logs;
+--   drop policy if exists "Admins update reports" on public.reports;
+--   drop policy if exists "Admins read reports" on public.reports;
+--   drop policy if exists "Authenticated users can file reports" on public.reports;
+--   drop table if exists public.moderation_logs;
+--   drop table if exists public.reports;
+--   drop type if exists public.report_status;
+--   drop type if exists public.report_reason;
+--   alter table public.profiles
+--     drop column if exists is_admin,
+--     drop column if exists is_suspended,
+--     drop column if exists suspended_at,
+--     drop column if exists suspension_reason;
+--   drop policy if exists "Anyone can read published non-suspended profiles" on public.profiles;
+--   create policy "Anyone can read published profiles" on public.profiles for select using (is_published = true);
+
+-- ============================================================
+-- 1. Extend profiles: admin flag + suspension state
+-- ============================================================
+
+alter table public.profiles
+  add column if not exists is_admin boolean not null default false,
+  add column if not exists is_suspended boolean not null default false,
+  add column if not exists suspended_at timestamptz,
+  add column if not exists suspension_reason text;
+
+-- Partial index — vast majority of rows have is_admin = false, so a normal
+-- index would waste space. We only ever query "is this user an admin?",
+-- which is exactly what a `where is_admin = true` partial covers.
+create index if not exists profiles_is_admin_idx
+  on public.profiles(is_admin) where is_admin = true;
+
+create index if not exists profiles_is_suspended_idx
+  on public.profiles(is_suspended) where is_suspended = true;
+
+-- ============================================================
+-- 2. Enums for reports
+-- ============================================================
+
+do $$ begin
+  create type public.report_reason as enum (
+    'spam',
+    'harassment',
+    'impersonation',
+    'inappropriate',
+    'other'
+  );
+exception when duplicate_object then null;
+end $$;
+
+do $$ begin
+  create type public.report_status as enum (
+    'pending',
+    'reviewed',
+    'actioned',
+    'dismissed'
+  );
+exception when duplicate_object then null;
+end $$;
+
+-- ============================================================
+-- 3. Reports table — user-filed reports against profiles or items
+-- ============================================================
+
+create table if not exists public.reports (
+  id uuid primary key default gen_random_uuid(),
+  profile_id uuid not null references public.profiles(id) on delete cascade,
+  -- Optional: report a single item rather than the whole profile. Both
+  -- IDs are set when an item is reported (profile_id derived from the
+  -- item's parent so we can index by profile too).
+  profile_item_id uuid references public.profile_items(id) on delete cascade,
+  -- `set null` rather than cascade so historical reports survive a user
+  -- account deletion — moderation history is forever.
+  reporter_user_id uuid references auth.users(id) on delete set null,
+  reason public.report_reason not null,
+  note text,
+  status public.report_status not null default 'pending',
+  resolved_by uuid references auth.users(id) on delete set null,
+  resolved_at timestamptz,
+  created_at timestamptz not null default now()
+);
+
+create index if not exists reports_status_idx on public.reports(status);
+create index if not exists reports_profile_id_idx on public.reports(profile_id);
+create index if not exists reports_created_at_idx on public.reports(created_at desc);
+
+-- ============================================================
+-- 4. Moderation log — every admin action recorded, append-only
+-- ============================================================
+
+create table if not exists public.moderation_logs (
+  id uuid primary key default gen_random_uuid(),
+  -- The admin who took the action. Not nullable — every entry must have
+  -- a responsible party. If the user is later deleted, we keep the row
+  -- (`set null` would orphan the audit; `cascade` would delete the
+  -- audit trail). We don't expect admins to be deleted; if it ever
+  -- happens, the FK constraint will block the delete and force a manual
+  -- decision.
+  actor_user_id uuid not null references auth.users(id) on delete restrict,
+  target_profile_id uuid references public.profiles(id) on delete set null,
+  target_item_id uuid references public.profile_items(id) on delete set null,
+  -- Action strings (text rather than enum so adding new actions doesn't
+  -- need a migration): suspend, unsuspend, delete_item, warn,
+  -- resolve_report, dismiss_report, restore_item, grant_admin,
+  -- revoke_admin. Validated in application code; DB is permissive so
+  -- we can log unexpected actions for forensics rather than rejecting
+  -- them.
+  action text not null,
+  reason text,
+  metadata jsonb not null default '{}'::jsonb,
+  created_at timestamptz not null default now()
+);
+
+create index if not exists moderation_logs_actor_idx on public.moderation_logs(actor_user_id);
+create index if not exists moderation_logs_target_profile_idx on public.moderation_logs(target_profile_id);
+create index if not exists moderation_logs_created_idx on public.moderation_logs(created_at desc);
+
+-- ============================================================
+-- 5. RLS — reports
+-- ============================================================
+
+alter table public.reports enable row level security;
+
+-- Anyone authenticated can file a report. reporter_user_id MUST match
+-- the authenticated user — prevents impersonating other users as the
+-- source of a report.
+create policy "Authenticated users can file reports"
+  on public.reports for insert
+  to authenticated
+  with check (auth.uid() = reporter_user_id);
+
+-- Reporters can read their own reports (so a future "my reports" UI
+-- works) but cannot see other people's reports.
+create policy "Users read own reports"
+  on public.reports for select
+  to authenticated
+  using (reporter_user_id = auth.uid());
+
+-- Admins read all reports.
+create policy "Admins read all reports"
+  on public.reports for select
+  to authenticated
+  using (
+    exists (
+      select 1 from public.profiles
+      where user_id = auth.uid() and is_admin = true
+    )
+  );
+
+-- Admins update report status / resolution.
+create policy "Admins update reports"
+  on public.reports for update
+  to authenticated
+  using (
+    exists (
+      select 1 from public.profiles
+      where user_id = auth.uid() and is_admin = true
+    )
+  )
+  with check (
+    exists (
+      select 1 from public.profiles
+      where user_id = auth.uid() and is_admin = true
+    )
+  );
+
+-- ============================================================
+-- 6. RLS — moderation_logs (admin read + write, no update / delete)
+-- ============================================================
+
+alter table public.moderation_logs enable row level security;
+
+create policy "Admins read moderation logs"
+  on public.moderation_logs for select
+  to authenticated
+  using (
+    exists (
+      select 1 from public.profiles
+      where user_id = auth.uid() and is_admin = true
+    )
+  );
+
+create policy "Admins write moderation logs"
+  on public.moderation_logs for insert
+  to authenticated
+  with check (
+    exists (
+      select 1 from public.profiles
+      where user_id = auth.uid() and is_admin = true
+    )
+    and actor_user_id = auth.uid()
+  );
+
+-- Deliberately no UPDATE or DELETE policies — append-only audit trail.
+-- Service-role bypasses RLS and can clean up if absolutely needed, but
+-- regular admins cannot rewrite history.
+
+-- ============================================================
+-- 7. Profiles — suspended profiles are not public
+-- ============================================================
+-- Replace the "Anyone can read published profiles" policy with a tighter
+-- version that also excludes suspended profiles. Owners can still read
+-- their own (existing "Users can read own profile" policy) so they see
+-- their suspended-state in the dashboard.
+
+drop policy if exists "Anyone can read published profiles" on public.profiles;
+
+create policy "Anyone can read published non-suspended profiles"
+  on public.profiles for select
+  using (is_published = true and is_suspended = false);
+
+-- ============================================================
+-- 8. Items / links / schools — also hidden when parent profile suspended
+-- ============================================================
+-- These existing "Anyone can read X from published profiles" policies
+-- need the same is_suspended check so a suspended profile's content is
+-- fully invisible to the public.
+
+drop policy if exists "Anyone can read items from published profiles" on public.profile_items;
+create policy "Anyone can read items from published non-suspended profiles"
+  on public.profile_items for select
+  using (
+    exists (
+      select 1 from public.profiles
+      where id = profile_items.profile_id
+        and is_published = true
+        and is_suspended = false
+    )
+  );
+
+drop policy if exists "Anyone can read links from published profiles" on public.external_links;
+create policy "Anyone can read links from published non-suspended profiles"
+  on public.external_links for select
+  using (
+    exists (
+      select 1 from public.profiles
+      where id = external_links.profile_id
+        and is_published = true
+        and is_suspended = false
+    )
+  );
+
+drop policy if exists "Anyone can read schools from published profiles" on public.school_affiliations;
+create policy "Anyone can read schools from published non-suspended profiles"
+  on public.school_affiliations for select
+  using (
+    exists (
+      select 1 from public.profiles
+      where id = school_affiliations.profile_id
+        and is_published = true
+        and is_suspended = false
+    )
+  );

--- a/tests/unit/admin.test.ts
+++ b/tests/unit/admin.test.ts
@@ -1,0 +1,172 @@
+/**
+ * KAN-141: tests for the admin module shape.
+ *
+ * The admin module's behaviour is mostly hitting Supabase, which we
+ * mock. These tests pin:
+ *   - getCurrentAdmin returns null when there's no session
+ *   - getCurrentAdmin returns null when the profile is_admin=false
+ *   - getCurrentAdmin returns the admin record when is_admin=true
+ *   - logModerationAction inserts a correctly-shaped row
+ *   - logModerationAction throws when the insert fails (we don't swallow)
+ */
+
+// Mocks must be set up BEFORE any import of the module under test.
+// `jest` is the global injected by ts-jest / @swc/jest — don't import
+// it from @jest/globals or hoisting won't apply correctly.
+
+jest.mock('@/lib/env', () => ({
+  env: {
+    supabaseUrl: () => 'https://test.supabase.co',
+    supabaseServiceRoleKey: () => 'test-service-role-key',
+  },
+}));
+
+const authGetUser = jest.fn();
+const fromMock = jest.fn();
+jest.mock('@/lib/supabase-server', () => ({
+  createClient: jest.fn(async () => ({
+    auth: { getUser: authGetUser },
+    from: fromMock,
+  })),
+}));
+
+const serviceFromMock = jest.fn();
+jest.mock('@supabase/supabase-js', () => ({
+  createClient: jest.fn(() => ({ from: serviceFromMock })),
+}));
+
+import { getCurrentAdmin, logModerationAction } from '@/lib/admin';
+
+beforeEach(() => {
+  authGetUser.mockReset();
+  fromMock.mockReset();
+  serviceFromMock.mockReset();
+});
+
+describe('KAN-141 admin — getCurrentAdmin', () => {
+  test('returns null when no auth session', async () => {
+    authGetUser.mockResolvedValue({ data: { user: null } });
+    expect(await getCurrentAdmin()).toBeNull();
+  });
+
+  test('returns null when profile.is_admin = false', async () => {
+    authGetUser.mockResolvedValue({ data: { user: { id: 'u1', email: 'a@b.com' } } });
+    const mockEq = jest.fn().mockReturnThis();
+    const mockMaybeSingle = jest.fn().mockResolvedValue({
+      data: { id: 'p1', display_name: 'Alice', is_admin: false },
+      error: null,
+    });
+    fromMock.mockReturnValue({
+      select: jest.fn().mockReturnThis(),
+      eq: mockEq,
+      maybeSingle: mockMaybeSingle,
+    });
+    expect(await getCurrentAdmin()).toBeNull();
+  });
+
+  test('returns the admin record when is_admin = true', async () => {
+    authGetUser.mockResolvedValue({ data: { user: { id: 'u1', email: 'admin@b.com' } } });
+    fromMock.mockReturnValue({
+      select: jest.fn().mockReturnThis(),
+      eq: jest.fn().mockReturnThis(),
+      maybeSingle: jest.fn().mockResolvedValue({
+        data: { id: 'p1', display_name: 'Admin', is_admin: true },
+        error: null,
+      }),
+    });
+
+    const admin = await getCurrentAdmin();
+    expect(admin).toEqual({
+      userId: 'u1',
+      profileId: 'p1',
+      email: 'admin@b.com',
+      displayName: 'Admin',
+    });
+  });
+
+  test('returns null when the profile lookup errors', async () => {
+    authGetUser.mockResolvedValue({ data: { user: { id: 'u1', email: null } } });
+    fromMock.mockReturnValue({
+      select: jest.fn().mockReturnThis(),
+      eq: jest.fn().mockReturnThis(),
+      maybeSingle: jest.fn().mockResolvedValue({
+        data: null,
+        error: { message: 'rls denied' },
+      }),
+    });
+    expect(await getCurrentAdmin()).toBeNull();
+  });
+});
+
+describe('KAN-141 admin — logModerationAction', () => {
+  const admin = {
+    userId: 'admin-u',
+    profileId: 'admin-p',
+    email: 'admin@b.com',
+    displayName: 'Admin',
+  };
+
+  test('inserts a moderation_logs row with the expected shape', async () => {
+    const insertMock = jest.fn().mockReturnThis();
+    const selectMock = jest.fn().mockReturnThis();
+    const singleMock = jest.fn().mockResolvedValue({ data: { id: 'log-1' }, error: null });
+    serviceFromMock.mockReturnValue({
+      insert: insertMock,
+      select: selectMock,
+      single: singleMock,
+    });
+
+    const id = await logModerationAction({
+      admin,
+      action: 'suspend',
+      targetProfileId: 'target-p',
+      reason: 'spam',
+      metadata: { reportId: 'r-1' },
+    });
+
+    expect(id).toBe('log-1');
+    expect(serviceFromMock).toHaveBeenCalledWith('moderation_logs');
+    expect(insertMock).toHaveBeenCalledWith({
+      actor_user_id: 'admin-u',
+      action: 'suspend',
+      target_profile_id: 'target-p',
+      target_item_id: null,
+      reason: 'spam',
+      metadata: { reportId: 'r-1' },
+    });
+  });
+
+  test('throws when the insert fails (we never swallow audit failures)', async () => {
+    serviceFromMock.mockReturnValue({
+      insert: jest.fn().mockReturnThis(),
+      select: jest.fn().mockReturnThis(),
+      single: jest.fn().mockResolvedValue({ data: null, error: { message: 'rls denied' } }),
+    });
+
+    await expect(logModerationAction({
+      admin,
+      action: 'suspend',
+      targetProfileId: 'target-p',
+    })).rejects.toThrow(/moderation_logs/);
+  });
+
+  test('handles missing optional fields cleanly', async () => {
+    const insertMock = jest.fn().mockReturnThis();
+    serviceFromMock.mockReturnValue({
+      insert: insertMock,
+      select: jest.fn().mockReturnThis(),
+      single: jest.fn().mockResolvedValue({ data: { id: 'log-2' }, error: null }),
+    });
+
+    await logModerationAction({ admin, action: 'warn' });
+
+    expect(insertMock).toHaveBeenCalledWith({
+      actor_user_id: 'admin-u',
+      action: 'warn',
+      target_profile_id: null,
+      target_item_id: null,
+      reason: null,
+      metadata: {},
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Complete first-pass implementation of KAN-141. Schema + helpers + UI + tests in one PR. Ships behind the existing admin gate (`is_admin` boolean on `profiles`), with the bootstrap-first-admin step in the migration header.

### Schema (1 migration)
- `profiles.is_admin / is_suspended / suspended_at / suspension_reason` with partial indexes
- New `reports` table (reason enum + status enum)
- New `moderation_logs` table — append-only, FK `actor_user_id` with `on delete restrict` so admins can't disappear their audit trail
- RLS policies: authenticated users can file reports (forced to `reporter_user_id = auth.uid()`), reporters read-own, admins read-all + update; mod logs admin-only read + insert, never update/delete
- Tightens "anyone can read published profile/items/links/schools" policies to also require `is_suspended = false`
- ✅ Applied to dev Supabase project `ilprytcrnqyrsbsrfujj`

### Helpers (`src/lib/admin.ts`)
- `getCurrentAdmin()` — DB-backed check (no JWT-claim caching, so revokes are instant)
- `getAdminServiceClient()` — service-role client for admin reads/writes
- `logModerationAction()` — single funnel for every audit-logged action; throws on log failure rather than swallowing

### Routes
- `/admin` layout — `notFound()` for non-admins (no leak signal)
- `/admin` overview — counts + recent signups + recent reports
- `/admin/reports` — list, `?status=` filterable, default `pending`
- `/admin/reports/[id]` — detail + 3 server actions (resolve / dismiss / suspend-and-action), each logs first then mutates
- `/admin/users` — paginated list, `?q=` search, `?filter=suspended|admin`
- `/admin/users/[slug]` — single-profile admin view, suspend/unsuspend, per-item delete. Self-moderation blocked at UI + action level
- `/admin/audit` — read-only moderation_logs viewer
- `POST /api/reports` — auth-required, reporter forced to `auth.uid()`, 24h rate-limit, can't self-report
- `src/app/[slug]/report-button.tsx` — inline modal in the public profile footer (reason + optional note ≤500 chars). Hidden for profile owner.

### Tests
`tests/unit/admin.test.ts` — 7 cases pinning `getCurrentAdmin` (null on no session / non-admin / RLS error; admin record on is_admin=true) and `logModerationAction` (correct row shape, throws on failure, handles missing optionals).

## Test plan

- [x] Migration applied successfully to dev Supabase
- [x] 7 unit tests pass
- [x] Lint clean on every touched file
- [ ] PR Quality Gate passes
- [ ] Manual: with `is_admin=true` on Luisa's prod profile, `/admin` renders the overview; without it, `/admin` returns 404
- [ ] Manual: file a report on a test profile, see it appear in `/admin/reports`, resolve → see audit log entry
- [ ] Promote dev migration to staging/beta/prod when shipping

## What's deferred (call-outs for review)

1. **E2E coverage** of the report → resolve flow (Playwright). Skipped here to keep the PR focused; can be a follow-up.
2. **Email notification on suspension** — belongs in KAN-148 territory.
3. **Rate-limit hardening** — currently per (reporter, profile) per 24h. Per-IP + per-user across-the-board is a follow-up.
4. **Hard vs soft-delete** for items — currently hard-delete. Reversibility would need a `deleted_at` column.
5. **First admin bootstrap** — must run `update public.profiles set is_admin = true where slug = '<your-slug>'` manually once on prod after the migration ships.

🤖 Generated with [Claude Code](https://claude.com/claude-code)