### PR TITLE
chore: phantom check_suite cleanup workflow (BUGS-16 follow-up)

### DIFF
--- a/.github/workflows/cleanup-phantom-check-suites.yml
+++ b/.github/workflows/cleanup-phantom-check-suites.yml
@@ -1,0 +1,104 @@
+name: Cleanup phantom check_suites
+# BUGS-16 follow-up: walks the HEADs of all 4 pipeline branches looking
+# for stuck-queued check_suites with zero check runs (the Vercel pattern
+# discovered during BUGS-16) and POSTs `/rerequest` on each one. The
+# rerequest re-sends the webhook to the owning GitHub App; the app then
+# either re-creates the phantom (no worse than before), marks it
+# neutral/success (best case), or ignores it.
+#
+# Runs on:
+#   - workflow_run after the production promote workflow completes
+#     (so phantoms get nudged right after each release)
+#   - daily cron at 06:00 UTC (so phantoms on stale PRs / dormant
+#     branches don't accumulate without bounds)
+#   - manual workflow_dispatch (for ad-hoc cleanups + verification)
+#
+# Always exits zero on phantom findings — that's the expected steady
+# state, not an error. Only API / network failures fail the workflow.
+
+on:
+  workflow_run:
+    workflows: ["Promote to Production"]
+    types: [completed]
+  schedule:
+    - cron: '0 6 * * *'  # Daily at 06:00 UTC
+  workflow_dispatch:
+    inputs:
+      branches:
+        description: Branches to scan (space-separated)
+        required: false
+        type: string
+        default: "develop main staging beta"
+      dry_run:
+        description: Dry-run only (report but don't rerequest)
+        required: false
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+  # `checks: write` is required by the GitHub `/rerequest` API even for
+  # external apps' suites (we don't own the suite but we're asking GitHub
+  # to re-send the webhook to its owner).
+  checks: write
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  cleanup:
+    name: Walk branch HEADs and rerequest phantom check_suites
+    runs-on: ubuntu-latest
+    # Don't run after a FAILED production promote — running this on top
+    # of an incident would just add noise. workflow_run.conclusion is
+    # only populated for the `workflow_run` trigger, so guard accordingly.
+    if: github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success'
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+        with:
+          fetch-depth: 1
+
+      - name: Set up Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v6
+        with:
+          python-version: '3.12'
+
+      - name: Resolve inputs
+        id: inputs
+        run: |
+          set -euo pipefail
+          # workflow_dispatch supplies branches via input; cron + workflow_run
+          # use the default set. Default lives in one place: here.
+          BRANCHES="${{ github.event.inputs.branches }}"
+          if [[ -z "$BRANCHES" ]]; then
+            BRANCHES="develop main staging beta"
+          fi
+          DRY_RUN_FLAG=""
+          if [[ "${{ github.event.inputs.dry_run }}" == "true" ]]; then
+            DRY_RUN_FLAG="--dry-run"
+          fi
+          echo "branches=$BRANCHES" >> "$GITHUB_OUTPUT"
+          echo "dry_run_flag=$DRY_RUN_FLAG" >> "$GITHUB_OUTPUT"
+          echo "Scanning branches: $BRANCHES (dry-run: ${{ github.event.inputs.dry_run || 'false' }})"
+
+      - name: Run cleanup script
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          python3 scripts/cleanup-phantom-check-suites.py \
+            --repo "${{ github.repository }}" \
+            --branches ${{ steps.inputs.outputs.branches }} \
+            ${{ steps.inputs.outputs.dry_run_flag }} \
+            | tee /tmp/cleanup-output.txt
+
+          # Promote the script's summary into the Job Summary so it's
+          # readable without expanding the log.
+          {
+            echo "## Phantom check_suite cleanup"
+            echo ""
+            echo '```'
+            cat /tmp/cleanup-output.txt
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/scripts/cleanup-phantom-check-suites.py
+++ b/scripts/cleanup-phantom-check-suites.py
@@ -1,0 +1,236 @@
+#!/usr/bin/env python3
+"""
+Phantom check_suite cleanup — BUGS-16 follow-up.
+
+Background
+----------
+The Vercel GitHub App (and historically Supabase's) post a `check_suite`
+on every push to the repo. Sometimes the app receives the webhook but
+decides "nothing to do" and never creates any check runs under the suite
+— leaving it permanently `status: queued, latest_check_runs_count: 0`.
+
+GitHub's auto-merge feature can occasionally wait on these phantom
+suites, blocking PRs that have all required checks passing. We've fixed
+the worst case (BUGS-16 — release pipeline now direct-merges so no PR is
+involved) but the cosmetic phantoms still accumulate and create noise.
+
+What this script does
+---------------------
+1. For each branch HEAD we care about (configurable via --branches),
+   list `check_suites` via the GitHub REST API.
+2. Filter to phantoms — `status == 'queued' AND latest_check_runs_count == 0`,
+   from apps in the configured "stuck-prone" allow-list (currently just
+   `vercel`).
+3. POST `/rerequest` to each phantom. Per GitHub docs, this re-sends the
+   webhook to the owning app. The app then either (a) re-posts a phantom
+   (no worse than before), (b) marks the suite `neutral` or `success`
+   (best case), or (c) ignores it again. Either way we surface the count.
+4. Report a summary as `::warning::` (1+ phantoms found) or `::notice::`
+   (clean) so the workflow run is searchable.
+
+Why not just delete the suite?
+------------------------------
+GitHub doesn't allow deleting check_suites via API. Only the owning app
+can mutate its own suites. Rerequest is the only available lever.
+
+Usage
+-----
+    cleanup-phantom-check-suites.py
+        --repo luisa-sys/lyra
+        --branches develop main staging beta
+        --token "$GITHUB_TOKEN"
+        [--apps vercel]
+        [--dry-run]
+
+Exits non-zero only on API/network failure. Finding phantoms is the
+expected steady state, not an error.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import urllib.error
+import urllib.request
+from typing import Any
+
+
+GITHUB_API = "https://api.github.com"
+
+
+def gh_request(
+    method: str,
+    path: str,
+    token: str,
+    body: Any | None = None,
+) -> tuple[int, Any]:
+    """Tiny stdlib-only GitHub API client.
+
+    Returns (status_code, parsed_body). On 204 No Content the body is
+    None. Raises urllib.error.URLError on network failure.
+    """
+    url = f"{GITHUB_API}{path}"
+    data = json.dumps(body).encode("utf-8") if body is not None else None
+    req = urllib.request.Request(
+        url,
+        data=data,
+        method=method,
+        headers={
+            "Authorization": f"Bearer {token}",
+            "Accept": "application/vnd.github+json",
+            "X-GitHub-Api-Version": "2022-11-28",
+            "User-Agent": "lyra-cleanup-phantom-check-suites/1.0",
+        },
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=15) as resp:
+            status = resp.status
+            raw = resp.read().decode("utf-8") if resp.length != 0 else ""
+            return status, (json.loads(raw) if raw else None)
+    except urllib.error.HTTPError as e:
+        # The API uses 422 for "no permission to rerequest", 404 for
+        # not-found, etc. We treat these as data rather than exceptions.
+        try:
+            body_text = e.read().decode("utf-8")
+        except Exception:
+            body_text = ""
+        return e.code, (json.loads(body_text) if body_text else None)
+
+
+def get_branch_head_sha(repo: str, branch: str, token: str) -> str | None:
+    status, body = gh_request("GET", f"/repos/{repo}/branches/{branch}", token)
+    if status != 200 or not isinstance(body, dict):
+        return None
+    return body.get("commit", {}).get("sha")
+
+
+def list_check_suites(repo: str, sha: str, token: str) -> list[dict[str, Any]]:
+    status, body = gh_request(
+        "GET", f"/repos/{repo}/commits/{sha}/check-suites?per_page=100", token
+    )
+    if status != 200 or not isinstance(body, dict):
+        return []
+    return list(body.get("check_suites", []))
+
+
+def rerequest_check_suite(repo: str, suite_id: int, token: str) -> tuple[int, Any]:
+    return gh_request(
+        "POST", f"/repos/{repo}/check-suites/{suite_id}/rerequest", token
+    )
+
+
+def is_phantom(suite: dict[str, Any], target_apps: set[str]) -> bool:
+    """A phantom check_suite: queued status, zero runs, from a known
+    stuck-prone app (currently just 'vercel').
+    """
+    return (
+        suite.get("status") == "queued"
+        and suite.get("latest_check_runs_count", 0) == 0
+        and (suite.get("app") or {}).get("slug") in target_apps
+    )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__.split("\n\n")[0])
+    parser.add_argument(
+        "--repo", required=True, help="GitHub repo in owner/name form."
+    )
+    parser.add_argument(
+        "--branches",
+        nargs="+",
+        required=True,
+        help="Branch names to scan (HEAD of each).",
+    )
+    parser.add_argument(
+        "--token",
+        default=os.environ.get("GITHUB_TOKEN"),
+        help="GitHub token (defaults to $GITHUB_TOKEN).",
+    )
+    parser.add_argument(
+        "--apps",
+        nargs="+",
+        default=["vercel"],
+        help="GitHub App slugs to treat as phantom-prone.",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Report findings but don't POST rerequest.",
+    )
+    args = parser.parse_args()
+
+    if not args.token:
+        print(
+            "::error::No GitHub token supplied (--token or $GITHUB_TOKEN).",
+            file=sys.stderr,
+        )
+        return 2
+
+    target_apps = set(args.apps)
+    total_phantoms = 0
+    total_rerequested = 0
+    total_failed = 0
+    per_branch_findings: list[str] = []
+
+    for branch in args.branches:
+        sha = get_branch_head_sha(args.repo, branch, args.token)
+        if not sha:
+            print(f"::warning::Could not resolve HEAD SHA for branch '{branch}'")
+            continue
+
+        suites = list_check_suites(args.repo, sha, args.token)
+        phantoms = [s for s in suites if is_phantom(s, target_apps)]
+        total_phantoms += len(phantoms)
+
+        if not phantoms:
+            per_branch_findings.append(f"  - {branch}@{sha[:8]}: clean")
+            continue
+
+        per_branch_findings.append(
+            f"  - {branch}@{sha[:8]}: {len(phantoms)} phantom(s)"
+        )
+
+        for suite in phantoms:
+            suite_id = suite.get("id")
+            app_slug = (suite.get("app") or {}).get("slug", "?")
+            if args.dry_run:
+                print(
+                    f"  [dry-run] would rerequest {app_slug} suite {suite_id} "
+                    f"on {branch}@{sha[:8]}"
+                )
+                continue
+
+            status, _body = rerequest_check_suite(args.repo, suite_id, args.token)
+            if 200 <= status < 300:
+                total_rerequested += 1
+                print(
+                    f"  rerequested {app_slug} suite {suite_id} "
+                    f"on {branch}@{sha[:8]} (HTTP {status})"
+                )
+            else:
+                total_failed += 1
+                print(
+                    f"::warning::rerequest failed for {app_slug} suite "
+                    f"{suite_id} on {branch}@{sha[:8]} — HTTP {status}"
+                )
+
+    # Summary — `::notice::` for visibility in the run summary.
+    print("\n=== phantom check_suite cleanup summary ===")
+    for line in per_branch_findings:
+        print(line)
+    print(
+        f"\nTotal phantoms found:  {total_phantoms}"
+        f"\nTotal rerequested:     {total_rerequested}"
+        f"\nTotal rerequest failed: {total_failed}"
+    )
+
+    # Always exit 0 — finding phantoms is expected steady state, not an
+    # error. Only API/network failures (caught above) would warrant a
+    # non-zero exit, and those already returned 2.
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/scripts/cleanup-phantom-check-suites.test.js
+++ b/tests/scripts/cleanup-phantom-check-suites.test.js
@@ -1,0 +1,153 @@
+/**
+ * Tests for the `is_phantom` classification logic in
+ * scripts/cleanup-phantom-check-suites.py.
+ *
+ * The script is Python but we drive it through Node by spawning python3
+ * and feeding fixtures via stdin / argv. Keeps the tests in one place
+ * (the existing tests/scripts/ pattern) and ensures the classifier
+ * doesn't accidentally start flagging real check_suites as phantoms.
+ *
+ * If python3 isn't on PATH, the suite skips itself rather than failing
+ * — local DX over CI strictness, since CI always has python3.
+ */
+
+const { execSync, spawnSync } = require('node:child_process');
+const { writeFileSync, unlinkSync, existsSync } = require('node:fs');
+const { resolve } = require('node:path');
+const { tmpdir } = require('node:os');
+
+const SCRIPT = resolve(__dirname, '../../scripts/cleanup-phantom-check-suites.py');
+
+function pythonAvailable() {
+  try {
+    execSync('python3 --version', { stdio: 'ignore' });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Probe the is_phantom function by writing a tiny Python harness that
+ * imports it and prints JSON results. Keeps the test surface narrow:
+ * we're checking the pure logic, not the GitHub API plumbing.
+ */
+function classifyAll(suites, targetApps = ['vercel']) {
+  const harnessFile = resolve(tmpdir(), `phantom-harness-${Date.now()}.py`);
+  // Embed the fixtures as JSON STRINGS that Python re-parses, so JSON
+  // tokens like `null` / `true` / `false` don't collide with Python
+  // identifiers (`None` / `True` / `False`).
+  const suitesJson = JSON.stringify(JSON.stringify(suites));
+  const appsJson = JSON.stringify(JSON.stringify(targetApps));
+  const code = `
+import json, sys
+sys.path.insert(0, ${JSON.stringify(resolve(__dirname, '../../scripts'))})
+from importlib.util import spec_from_file_location, module_from_spec
+spec = spec_from_file_location("cleanup", ${JSON.stringify(SCRIPT)})
+mod = module_from_spec(spec)
+spec.loader.exec_module(mod)
+suites = json.loads(${suitesJson})
+apps = set(json.loads(${appsJson}))
+print(json.dumps([mod.is_phantom(s, apps) for s in suites]))
+`;
+  writeFileSync(harnessFile, code);
+  try {
+    const out = spawnSync('python3', [harnessFile], { encoding: 'utf-8' });
+    if (out.status !== 0) {
+      throw new Error(`python harness failed: ${out.stderr}`);
+    }
+    return JSON.parse(out.stdout.trim());
+  } finally {
+    if (existsSync(harnessFile)) unlinkSync(harnessFile);
+  }
+}
+
+const describeIfPython = pythonAvailable() ? describe : describe.skip;
+
+describeIfPython('cleanup-phantom-check-suites — is_phantom classifier', () => {
+  test('flags the canonical Vercel phantom (queued, 0 runs)', () => {
+    const result = classifyAll([
+      {
+        app: { slug: 'vercel' },
+        status: 'queued',
+        latest_check_runs_count: 0,
+      },
+    ]);
+    expect(result).toEqual([true]);
+  });
+
+  test('does NOT flag a completed Vercel suite', () => {
+    const result = classifyAll([
+      {
+        app: { slug: 'vercel' },
+        status: 'completed',
+        conclusion: 'success',
+        latest_check_runs_count: 1,
+      },
+    ]);
+    expect(result).toEqual([false]);
+  });
+
+  test('does NOT flag an in_progress suite (real work is happening)', () => {
+    const result = classifyAll([
+      {
+        app: { slug: 'vercel' },
+        status: 'in_progress',
+        latest_check_runs_count: 1,
+      },
+    ]);
+    expect(result).toEqual([false]);
+  });
+
+  test('does NOT flag a queued suite from an app outside the target list', () => {
+    // GitHub-Actions sometimes sits at status=queued for a moment before
+    // creating runs. We don't want to spam rerequests at it.
+    const result = classifyAll([
+      {
+        app: { slug: 'github-actions' },
+        status: 'queued',
+        latest_check_runs_count: 0,
+      },
+    ]);
+    expect(result).toEqual([false]);
+  });
+
+  test('does flag a queued Supabase suite if Supabase is in target list', () => {
+    // Supabase IS in the phantom-prone list historically (was fixed for
+    // us in early May but may regress for someone else). Configurable
+    // means flexible.
+    const result = classifyAll(
+      [
+        {
+          app: { slug: 'supabase' },
+          status: 'queued',
+          latest_check_runs_count: 0,
+        },
+      ],
+      ['supabase'],
+    );
+    expect(result).toEqual([true]);
+  });
+
+  test('does NOT flag a queued Vercel suite that has at least 1 run', () => {
+    // A queued suite WITH runs is just in-progress work. The phantom
+    // pattern is specifically zero runs.
+    const result = classifyAll([
+      {
+        app: { slug: 'vercel' },
+        status: 'queued',
+        latest_check_runs_count: 1,
+      },
+    ]);
+    expect(result).toEqual([false]);
+  });
+
+  test('handles missing fields gracefully', () => {
+    // Real API responses sometimes omit fields. Should not throw.
+    const result = classifyAll([
+      { app: null, status: 'queued', latest_check_runs_count: 0 },
+      { app: { slug: 'vercel' } }, // missing status + count
+    ]);
+    expect(result).toEqual([false, false]);
+  });
+});


### PR DESCRIPTION
Automatically nudges stuck Vercel check_suites with a `/rerequest` after every production promote + daily at 06:00 UTC.

## What's in here
- `scripts/cleanup-phantom-check-suites.py` — stdlib-only Python script. Walks branch HEADs, finds phantom check_suites (queued, 0 runs, from configurable app list), POSTs /rerequest on each one.
- `.github/workflows/cleanup-phantom-check-suites.yml` — wraps the script. Triggers: workflow_run after `Promote to Production` success + daily cron + manual workflow_dispatch.
- 7 unit tests for the is_phantom classifier covering canonical phantom + every adjacent-but-not state.

## Verified locally
Dry-run found 4 phantoms (one per branch HEAD), all from Vercel. Script reports correctly + would call rerequest on each.

🤖 Generated with [Claude Code](https://claude.com/claude-code)