### PR TITLE
feat(KAN-181): conversation-starter prompts (closes KAN-154 quintet)

### DIFF
--- a/docs/GEO_SIGNAL_DESIGN.md
+++ b/docs/GEO_SIGNAL_DESIGN.md
@@ -1,0 +1,98 @@
+# Geo-signal design — buyer location + recipient delivery country (KAN-185)
+
+> The recommendation engine and the affiliate link service both need to know two different geographies for every recommendation: **where the buyer is** (drives which affiliate program receives the commission) and **where the recipient is** (drives which products are eligible to recommend, because shipping rules differ per merchant per country). This document locks the data flow and precedence rules ahead of implementation in KAN-186, KAN-188, KAN-190, KAN-198, KAN-201.
+
+## The two signals
+
+| Signal | Source | Purpose | Used by |
+|---|---|---|---|
+| **Buyer country** (ISO-3166 alpha-2) | (1) Cloudflare `CF-IPCountry` header on the request, (2) cached for the session, (3) user account-level override in Settings | Decides which affiliate program (Amazon UK vs Amazon US, Sovrn region) the commission attributes to | Affiliate Link Service (KAN-188), eligibility filter (KAN-190), MCP tool inputs (KAN-201) |
+| **Recipient delivery country** (ISO-3166 alpha-2) | New nullable field `recipients.delivery_country_code` on the recipient profile (KAN-186) | Decides which products are eligible to recommend, by filtering out merchants that don't ship to the recipient's country | Recommender input audit (KAN-198), eligibility filter (KAN-190) |
+
+These are **separate fields with different lifetimes**: buyer country can change per session (a UK buyer travelling in the US still gets attributed to UK Amazon, by default); recipient country only changes when the user explicitly edits the recipient profile.
+
+## Detection precedence — buyer country
+
+1. **Explicit user setting**, if present on the authenticated user's account (`users.country_code_override`). Stable across sessions. Highest priority because a user might be travelling and want commission to still route via their home country.
+2. **Cloudflare `CF-IPCountry` request header** (set by Cloudflare on every request to `*.checklyra.com`). 99%+ accurate for non-VPN traffic. Captured at the edge, attached to the session.
+3. **Session-cached value** from a previous request in the same session — avoids re-checking on every navigation.
+4. **Fallback: `GB`** (Lyra's primary market). Logged as a low-confidence detection.
+
+The detected value is cached on the session for 24h and is overwritten only when the user signs out or explicitly changes their country in Settings.
+
+### Why not the IP geolocation lookup directly?
+We deliberately do not retain raw IP addresses or use a paid geolocation service. Cloudflare's `CF-IPCountry` is already supplied for free on every request, derived at the edge from MaxMind data. We trust it as our only IP-derived signal and never see the underlying IP outside the request lifecycle.
+
+## Recipient delivery country
+
+- Stored as `recipients.delivery_country_code` (KAN-186 migration).
+- Nullable. NULL means **"unknown — fall back to buyer country"** at query time.
+- Editable in the recipient/profile edit UI. Defaults to the buyer's detected country when first creating a recipient profile, so the buyer can leave it untouched in the common case (buyer and recipient in the same country).
+- Exposed via the existing MCP tool `lyra_update_profile` (additive parameter).
+- Used as a hard filter against the country × merchant eligibility matrix (KAN-187): if the recipient is in DE, we will not surface a merchant whose only eligible storefront is the UK.
+
+## Precedence rules (which signal applies where)
+
+| Decision | Signal used | Reason |
+|---|---|---|
+| Which affiliate program receives the click | **Buyer country** | Commission must be attributed to the program that matches the buyer's domicile; cross-country attribution breaks the affiliate ToS. |
+| Which products are surfaced as candidates | **Recipient delivery country** (falls back to buyer country when NULL) | Shipping eligibility is a recipient-side concern. |
+| Which Amazon storefront the link points at (Phase 2) | **Recipient delivery country** at the link level, **buyer country** at the program level (Earn Globally) | Once Amazon direct is live, Earn Globally lets a UK Associates tag earn on DE / FR / IT / ES orders — so the storefront follows the recipient while the program follows the buyer. |
+| Currency shown in the UI | **Buyer country** (default) with explicit override on the recommendation request | Buyers think in their own currency by default. |
+
+## Edge cases
+
+| Case | Handling |
+|---|---|
+| **Buyer in US, recipient in UK** | Affiliate link routes via Sovrn's US-eligible program for the buyer; recommender filters to merchants that ship to UK; UI shows GBP price (recipient currency? buyer currency?). _Decision: show buyer's currency in the UI; show the destination currency in the rationale string._ |
+| **Recipient delivery country NULL** | Treat as "same as buyer". Recommender uses buyer country for the eligibility filter. Logged so we can prompt the user to fill it in. |
+| **Buyer in unsupported country** (e.g. Brazil pre-Phase 2) | Recommender returns concepts (V1) but no monetised products. UI shows recommendations with no affiliate links, explanatory copy "Affiliate links not yet available in your region". |
+| **Buyer using a VPN** | We use whatever country `CF-IPCountry` reports. If the user wants to override, they can in Settings. We do not attempt to detect VPN/proxy use. |
+| **Embedded WebView (mobile app, KAN-69) without Cloudflare** | If the request reaches us via a path that bypasses Cloudflare, the header is missing. We treat missing as `GB` (logged) and rely on the user's account-level override. |
+| **MCP server invocation** | The MCP server today exposes `lyra_recommend_gifts` as a **public** read tool (no auth, per `docs/ARCHITECTURE.md`). The buyer's identity is therefore unknown at MCP-call time, and `CF-IPCountry` reflects the AI assistant's egress IP, not the end-user's. **Resolution**: KAN-201 makes `lyra_recommend_gifts` an authenticated tool (via the existing MCP OAuth flow, KAN-88) so the server can identify the buyer and look up their stored country preference. Until KAN-88 + KAN-201 ship, MCP recommendations default to GB and a top-level note in the response asks the assistant to confirm the buyer's country. |
+
+## Privacy & GDPR / UK GDPR / PECR
+
+- **No PII is created by this design.** `CF-IPCountry` is derived from the IP at the edge and is not user-identifying.
+- Raw IP addresses are never persisted by application code. They appear in Cloudflare logs (retained per Cloudflare's policy) but not in our Supabase tables.
+- The buyer country override stored on the user account (`users.country_code_override`) is a single ISO-2 code, set explicitly by the user. Low-sensitivity.
+- The recipient delivery country (`recipients.delivery_country_code`) is set by the buyer for the recipient. Treated with the same RLS as other recipient fields (owner + viewers-with-link).
+- **Lawful basis** under UK GDPR Art. 6(1)(f) legitimate interest: detecting buyer country to route commission to the correct affiliate program is necessary to operate the monetisation product the buyer is using. Documented in the affiliate-partners section of the privacy policy (KAN-193).
+- **No cookie required** for buyer-country detection — `CF-IPCountry` is a request header, not a stored cookie. Means no PECR consent burden for this specific signal.
+- Privacy policy (KAN-193) is updated to disclose that we use the Cloudflare-supplied country code to route affiliate commission and filter recommendations.
+
+## Affiliate-tooling implications
+
+- **Eligibility matrix** (KAN-187) is keyed on `(merchant_id, country_code)` with the country always being the **buyer's** country at the program level. Recipient country is used as a secondary filter on shipping.
+- **Affiliate Link Service** (KAN-188) takes both signals as inputs and is responsible for resolving them into a final, monetised URL.
+- **Click log** (KAN-189) records both `buyer_country` and `recipient_country` per click so reporting (KAN-195) can break commission down by either axis.
+- **Smoke monitor** (KAN-194) iterates over `(merchant_id × buyer_country)` and spoofs `Accept-Language` + `CF-IPCountry` headers to verify localisation. Recipient country is also exercised in a smaller cross-country matrix.
+
+## Implementation summary (no code in this ticket)
+
+| Ticket | Reads buyer country | Reads recipient country |
+|---|---|---|
+| KAN-186 — recipient profile field | — | adds the field |
+| KAN-187 — eligibility matrix seed | (key) | (used by KAN-190 for shipping filter) |
+| KAN-188 — link service design | input parameter | input parameter |
+| KAN-189 — click log schema | column `buyer_country` | column `recipient_country` |
+| KAN-190 — recommender eligibility filter | hard filter | hard filter |
+| KAN-191 — link rendering | request param | request param |
+| KAN-194 — smoke monitor | iterates | iterates secondary axis |
+| KAN-195 — reporting | break-down dimension | break-down dimension |
+| KAN-201 — MCP `lyra_recommend_gifts` | from authenticated user | from authenticated user's named recipient |
+
+## Open questions (resolve when ticket activates)
+
+1. **User-account-level override UX**: where to put the "country" Setting? Current account page does not have a country field. Suggested under Account → Region. Tracked when implementation starts.
+2. **Currency display in UI** when buyer and recipient diverge: confirm the rule above ("buyer currency in card; destination currency in rationale") with Luisa before KAN-191 lands.
+3. **Mobile app (KAN-69) handling**: confirm the mobile app routes API calls through `checklyra.com` (so `CF-IPCountry` is present) and not directly to Supabase.
+
+## Acceptance for KAN-185
+
+- [x] Two signals defined with sources, lifetimes, and use sites.
+- [x] Buyer-country detection precedence locked.
+- [x] Edge cases enumerated.
+- [x] GDPR / PECR position stated.
+- [x] Downstream-ticket inputs spelled out.
+- [ ] Reviewed and approved by Luisa (in PR review).

--- a/src/app/[slug]/page.tsx
+++ b/src/app/[slug]/page.tsx
@@ -221,6 +221,32 @@ export default async function PublicProfilePage({ params }: Props) {
       : f.visibility === 'public',
   );
 
+  // KAN-181: conversation-starter answers (joined with the prompt text
+  // so the public profile can render the prompt as a heading). No
+  // visibility filter — all answers on a published profile are public.
+  const { data: starterRowsRaw } = await getSupabase()
+    .from('profile_conversation_starters')
+    .select('id, answer, prompt:conversation_starter_prompts!profile_conversation_starters_prompt_id_fkey(prompt, sort_order)')
+    .eq('profile_id', typedProfile.id)
+    .order('created_at', { ascending: true });
+  const typedStarters = (starterRowsRaw ?? []).map((r) => {
+    // Supabase typegen sometimes flattens the joined row to object,
+    // sometimes array — see same pattern in dashboard/profile/page.tsx.
+    const promptCandidate = r.prompt as unknown;
+    const joined = Array.isArray(promptCandidate)
+      ? (promptCandidate[0] as { prompt: string; sort_order: number } | undefined)
+      : (promptCandidate as { prompt: string; sort_order: number } | null);
+    return {
+      id: r.id as string,
+      answer: r.answer as string,
+      prompt: joined?.prompt ?? '',
+      sort_order: joined?.sort_order ?? 0,
+    };
+  })
+  // Curated prompts are sorted by sort_order in the seed data; preserve
+  // that on the public render so the most "warm-up" prompts come first.
+  .sort((a, b) => a.sort_order - b.sort_order);
+
   // KAN-143: visibility-filtered items (see filterItemsByVisibility above).
   const typedItems = visibleItems;
   const typedSchools = (schools || []) as SchoolAffiliation[];
@@ -529,6 +555,30 @@ export default async function PublicProfilePage({ params }: Props) {
                   <span className="text-[var(--color-ink)] group-hover:text-[var(--color-sage)]">{l.title}</span>
                   <span className="text-xs text-[var(--color-muted)]">↗</span>
                 </a>
+              ))}
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* KAN-181: conversation-starter prompts. Each prompt with a
+          user-supplied answer renders as a small Q&A card. Encourages
+          deeper conversations than the items lists alone. Section is
+          hidden if no prompts answered. */}
+      {typedStarters.length > 0 && (
+        <div className="max-w-2xl mx-auto px-6 pb-6">
+          <div className="bg-white rounded-xl border border-stone-200 p-5">
+            <h2 className="text-xs font-medium text-[var(--color-muted)] uppercase tracking-wide mb-4">💬 Things to ask me about</h2>
+            <div className="space-y-4">
+              {typedStarters.map((s) => (
+                <div key={s.id}>
+                  <p className="text-xs font-medium text-[var(--color-muted)] uppercase tracking-wide mb-1">
+                    {s.prompt}
+                  </p>
+                  <p className="text-sm text-[var(--color-ink)] leading-relaxed whitespace-pre-wrap">
+                    {s.answer}
+                  </p>
+                </div>
               ))}
             </div>
           </div>

--- a/src/app/dashboard/profile/conversation-starters-actions.ts
+++ b/src/app/dashboard/profile/conversation-starters-actions.ts
@@ -1,0 +1,132 @@
+'use server';
+
+import { createClient } from '@/lib/supabase-server';
+import { revalidatePath } from 'next/cache';
+import { sanitiseText, type ActionResult } from '@/lib/sanitise';
+
+/**
+ * KAN-181: server actions for `profile_conversation_starters`.
+ *
+ * Three rules baked into every action:
+ *
+ *  1. **Auth required.** No anonymous mutations.
+ *  2. **Own profile only.** Each action joins `profiles` on
+ *     `user_id = auth.uid()`. RLS enforces the same at the DB layer
+ *     but the application checks too so error messages are useful.
+ *  3. **Answer sanitised + length-capped.** `sanitiseText` strips HTML;
+ *     length cap mirrors the DB CHECK (≤500 chars). Empty / whitespace-
+ *     only answers rejected client- and server-side.
+ *
+ * The 5-answer cap is enforced by the DB trigger `pcs_cap`; we surface
+ * it as a user-facing error instead of a raw Postgres exception.
+ */
+
+const ANSWER_MAX = 500;
+
+interface AuthedRequest {
+  supabase: Awaited<ReturnType<typeof createClient>>;
+  profileId: string;
+}
+
+async function getAuthedRequest(): Promise<AuthedRequest | { error: string }> {
+  const supabase = await createClient();
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) return { error: 'Not authenticated' };
+  const { data: profile } = await supabase
+    .from('profiles')
+    .select('id')
+    .eq('user_id', user.id)
+    .single();
+  if (!profile) return { error: 'No profile for current user' };
+  return { supabase, profileId: profile.id as string };
+}
+
+export async function addConversationStarter(input: {
+  promptId: string;
+  answer: string;
+}): Promise<ActionResult> {
+  const authed = await getAuthedRequest();
+  if ('error' in authed) return { success: false, error: authed.error };
+  const { supabase, profileId } = authed;
+
+  // UUID-ish sanity check on the prompt_id — DB will FK-validate either
+  // way, but a clear application-level error is friendlier than a 22P02.
+  if (typeof input.promptId !== 'string' || !/^[0-9a-f-]{36}$/i.test(input.promptId)) {
+    return { success: false, error: 'Invalid prompt' };
+  }
+
+  const cleaned = sanitiseText(input.answer ?? '').slice(0, ANSWER_MAX);
+  if (cleaned.trim().length === 0) {
+    return { success: false, error: 'Answer cannot be empty' };
+  }
+
+  const { error } = await supabase
+    .from('profile_conversation_starters')
+    .insert({
+      profile_id: profileId,
+      prompt_id: input.promptId,
+      answer: cleaned,
+    });
+
+  if (error) {
+    // The DB trigger raises a custom message for the 5-cap; surface it
+    // verbatim so the UI can show a clean toast.
+    if (error.message.includes('limit (5)')) {
+      return { success: false, error: 'You can answer up to 5 prompts. Remove one to add another.' };
+    }
+    // 23505 = unique_violation on (profile_id, prompt_id)
+    if (error.code === '23505') {
+      return { success: false, error: 'You already answered this prompt — edit your existing answer instead.' };
+    }
+    return { success: false, error: error.message };
+  }
+
+  revalidatePath('/dashboard/profile');
+  return { success: true };
+}
+
+export async function updateConversationStarter(
+  id: string,
+  answer: string,
+): Promise<ActionResult> {
+  const authed = await getAuthedRequest();
+  if ('error' in authed) return { success: false, error: authed.error };
+  const { supabase, profileId } = authed;
+
+  const cleaned = sanitiseText(answer ?? '').slice(0, ANSWER_MAX);
+  if (cleaned.trim().length === 0) {
+    return { success: false, error: 'Answer cannot be empty' };
+  }
+
+  const { error } = await supabase
+    .from('profile_conversation_starters')
+    .update({ answer: cleaned })
+    .eq('id', id)
+    .eq('profile_id', profileId);
+
+  if (error) {
+    return { success: false, error: error.message };
+  }
+
+  revalidatePath('/dashboard/profile');
+  return { success: true };
+}
+
+export async function removeConversationStarter(id: string): Promise<ActionResult> {
+  const authed = await getAuthedRequest();
+  if ('error' in authed) return { success: false, error: authed.error };
+  const { supabase, profileId } = authed;
+
+  const { error } = await supabase
+    .from('profile_conversation_starters')
+    .delete()
+    .eq('id', id)
+    .eq('profile_id', profileId);
+
+  if (error) {
+    return { success: false, error: error.message };
+  }
+
+  revalidatePath('/dashboard/profile');
+  return { success: true };
+}

--- a/src/app/dashboard/profile/page.tsx
+++ b/src/app/dashboard/profile/page.tsx
@@ -60,6 +60,34 @@ export default async function ProfilePage() {
     .order('sort_order', { ascending: true })
     .order('created_at', { ascending: true });
 
+  // KAN-181: conversation starters — the curated prompt library plus the
+  // user's own answers (joined with the prompt text for display).
+  const { data: conversationPrompts } = await supabase
+    .from('conversation_starter_prompts')
+    .select('id, prompt, sort_order')
+    .eq('is_active', true)
+    .order('sort_order', { ascending: true });
+  const { data: starterRows } = await supabase
+    .from('profile_conversation_starters')
+    .select('id, prompt_id, answer, prompt:conversation_starter_prompts!profile_conversation_starters_prompt_id_fkey(prompt)')
+    .eq('profile_id', profile.id)
+    .order('created_at', { ascending: true });
+  const conversationAnswers = (starterRows ?? []).map((r) => {
+    // The Supabase typegen sometimes flattens the joined row to an
+    // object, sometimes to an array. Route through `unknown` to keep
+    // this code resilient to either shape.
+    const promptCandidate = r.prompt as unknown;
+    const joinedPrompt = Array.isArray(promptCandidate)
+      ? ((promptCandidate[0] as { prompt: string } | undefined)?.prompt ?? '')
+      : ((promptCandidate as { prompt: string } | null)?.prompt ?? '');
+    return {
+      id: r.id as string,
+      prompt_id: r.prompt_id as string,
+      answer: r.answer as string,
+      prompt: joinedPrompt,
+    };
+  });
+
   return (
     <ProfileWizard
       profile={profile}
@@ -68,6 +96,8 @@ export default async function ProfilePage() {
       links={links || []}
       manualOfMe={(manualOfMeRow as ManualOfMe | null) ?? EMPTY_MANUAL_OF_ME}
       files={files || []}
+      conversationPrompts={conversationPrompts || []}
+      conversationAnswers={conversationAnswers}
     />
   );
 }

--- a/src/app/dashboard/profile/steps/conversation-starters-step.tsx
+++ b/src/app/dashboard/profile/steps/conversation-starters-step.tsx
@@ -1,0 +1,221 @@
+'use client';
+
+import { useState } from 'react';
+import { SaveButton, type ConversationPrompt, type ConversationAnswer } from './types';
+
+/**
+ * KAN-181: conversation-starter prompts wizard step.
+ *
+ * Two sections, each rendered conditionally:
+ *
+ *   1. **Answered** — prompts the user has already answered, with inline
+ *      edit + remove. Edit is in-place (no separate route) to keep the
+ *      flow tight in a multi-step wizard.
+ *   2. **Unanswered** — prompts not yet answered, each clickable to
+ *      expand into an answer form. Hidden when the 5-answer cap is hit
+ *      so the user isn't tempted by something they can't add.
+ *
+ * 5-answer cap is enforced at the DB layer (BEFORE INSERT trigger); the
+ * UI mirrors it for a friendly nudge and to hide the "add" affordances
+ * when at limit.
+ */
+
+const ANSWER_MAX = 500;
+const ANSWER_CAP = 5;
+
+export function ConversationStartersStep({
+  prompts,
+  answers,
+  onAdd,
+  onUpdate,
+  onRemove,
+  onNext,
+  isPending,
+}: {
+  prompts: ConversationPrompt[];
+  answers: ConversationAnswer[];
+  onAdd: (input: { promptId: string; answer: string }) => void;
+  onUpdate: (id: string, answer: string) => void;
+  onRemove: (id: string) => void;
+  onNext: () => void;
+  isPending: boolean;
+}) {
+  const [openPromptId, setOpenPromptId] = useState<string | null>(null);
+  const [newAnswer, setNewAnswer] = useState('');
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [editingAnswer, setEditingAnswer] = useState('');
+
+  const answeredPromptIds = new Set(answers.map((a) => a.prompt_id));
+  const unanswered = prompts.filter((p) => !answeredPromptIds.has(p.id));
+  const atCap = answers.length >= ANSWER_CAP;
+
+  function handleStartAnswer(promptId: string) {
+    setOpenPromptId(promptId);
+    setNewAnswer('');
+  }
+
+  function handleSubmitNew() {
+    if (!openPromptId || !newAnswer.trim()) return;
+    onAdd({ promptId: openPromptId, answer: newAnswer.trim() });
+    setOpenPromptId(null);
+    setNewAnswer('');
+  }
+
+  function handleStartEdit(answer: ConversationAnswer) {
+    setEditingId(answer.id);
+    setEditingAnswer(answer.answer);
+  }
+
+  function handleSaveEdit() {
+    if (!editingId || !editingAnswer.trim()) return;
+    onUpdate(editingId, editingAnswer.trim());
+    setEditingId(null);
+    setEditingAnswer('');
+  }
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h2 className="text-xl font-medium text-[var(--color-ink)]">Things to ask me about</h2>
+        <p className="text-sm text-[var(--color-muted)] mt-1">
+          Pick a prompt and write a short answer. These give people something to ask you about
+          beyond &ldquo;how are you?&rdquo;.
+        </p>
+      </div>
+
+      {answers.length > 0 && (
+        <div className="space-y-2">
+          {answers.map((a) => (
+            <div
+              key={a.id}
+              className="bg-white rounded-lg border border-stone-200 px-4 py-3"
+            >
+              <p className="text-xs font-medium text-[var(--color-muted)] uppercase tracking-wide mb-1">
+                {a.prompt}
+              </p>
+              {editingId === a.id ? (
+                <div className="space-y-2">
+                  <textarea
+                    value={editingAnswer}
+                    onChange={(e) => setEditingAnswer(e.target.value.slice(0, ANSWER_MAX))}
+                    rows={3}
+                    className="w-full p-2 text-sm rounded border border-stone-300 bg-white"
+                  />
+                  <div className="flex items-center justify-between text-xs">
+                    <span className="text-stone-500">{editingAnswer.length} / {ANSWER_MAX}</span>
+                    <div className="flex gap-2">
+                      <button
+                        type="button"
+                        onClick={() => { setEditingId(null); setEditingAnswer(''); }}
+                        disabled={isPending}
+                        className="text-[var(--color-muted)] hover:text-[var(--color-ink)]"
+                      >
+                        Cancel
+                      </button>
+                      <button
+                        type="button"
+                        onClick={handleSaveEdit}
+                        disabled={isPending || !editingAnswer.trim()}
+                        className="px-3 py-1 rounded-full bg-[var(--color-sage)] text-white disabled:opacity-50"
+                      >
+                        Save
+                      </button>
+                    </div>
+                  </div>
+                </div>
+              ) : (
+                <>
+                  <p className="text-sm text-[var(--color-ink)] leading-relaxed">{a.answer}</p>
+                  <div className="mt-2 flex items-center gap-3 text-xs">
+                    <button
+                      type="button"
+                      onClick={() => handleStartEdit(a)}
+                      disabled={isPending}
+                      className="text-[var(--color-muted)] hover:text-[var(--color-ink)]"
+                    >
+                      Edit
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => onRemove(a.id)}
+                      disabled={isPending}
+                      className="text-red-400 hover:text-red-600"
+                    >
+                      Remove
+                    </button>
+                  </div>
+                </>
+              )}
+            </div>
+          ))}
+        </div>
+      )}
+
+      {atCap ? (
+        <p className="text-sm text-[var(--color-muted)] italic">
+          You&rsquo;ve answered {ANSWER_CAP} prompts — the max. Remove one to add another.
+        </p>
+      ) : unanswered.length === 0 ? (
+        <p className="text-sm text-[var(--color-muted)] italic">
+          You&rsquo;ve answered all available prompts. Nice.
+        </p>
+      ) : (
+        <div className="space-y-2">
+          <p className="text-xs font-medium text-[var(--color-muted)] uppercase tracking-wide">
+            Prompts to try ({ANSWER_CAP - answers.length} answer{ANSWER_CAP - answers.length === 1 ? '' : 's'} left)
+          </p>
+          {unanswered.map((p) => (
+            <div
+              key={p.id}
+              className="bg-white rounded-lg border border-stone-200"
+            >
+              <button
+                type="button"
+                onClick={() => handleStartAnswer(p.id)}
+                disabled={isPending}
+                className="w-full text-left px-4 py-3 text-sm text-[var(--color-ink)] hover:bg-stone-50 disabled:opacity-60"
+              >
+                {openPromptId === p.id ? '▼' : '▸'} {p.prompt}
+              </button>
+              {openPromptId === p.id && (
+                <div className="p-4 pt-0 space-y-2">
+                  <textarea
+                    autoFocus
+                    value={newAnswer}
+                    onChange={(e) => setNewAnswer(e.target.value.slice(0, ANSWER_MAX))}
+                    rows={3}
+                    placeholder="Write a short, honest answer — a few sentences."
+                    className="w-full p-2 text-sm rounded border border-stone-300 bg-white"
+                  />
+                  <div className="flex items-center justify-between text-xs">
+                    <span className="text-stone-500">{newAnswer.length} / {ANSWER_MAX}</span>
+                    <div className="flex gap-2">
+                      <button
+                        type="button"
+                        onClick={() => { setOpenPromptId(null); setNewAnswer(''); }}
+                        disabled={isPending}
+                        className="text-[var(--color-muted)] hover:text-[var(--color-ink)]"
+                      >
+                        Cancel
+                      </button>
+                      <button
+                        type="button"
+                        onClick={handleSubmitNew}
+                        disabled={isPending || !newAnswer.trim()}
+                        className="px-3 py-1 rounded-full bg-[var(--color-sage)] text-white disabled:opacity-50"
+                      >
+                        Save answer
+                      </button>
+                    </div>
+                  </div>
+                </div>
+              )}
+            </div>
+          ))}
+        </div>
+      )}
+
+      <SaveButton onClick={onNext} isPending={false} label="Continue →" />
+    </div>
+  );
+}

--- a/src/app/dashboard/profile/steps/index.ts
+++ b/src/app/dashboard/profile/steps/index.ts
@@ -5,5 +5,14 @@ export { ItemsStep } from './items-step';
 export { LinksStep } from './links-step';
 export { ManualOfMeStep } from './manual-of-me-step';
 export { FilesStep } from './files-step';
+export { ConversationStartersStep } from './conversation-starters-step';
 export { PreviewStep } from './preview-step';
-export type { WizardProfile, WizardItem, WizardSchool, WizardLink, WizardFile } from './types';
+export type {
+  WizardProfile,
+  WizardItem,
+  WizardSchool,
+  WizardLink,
+  WizardFile,
+  ConversationPrompt,
+  ConversationAnswer,
+} from './types';

--- a/src/app/dashboard/profile/steps/types.tsx
+++ b/src/app/dashboard/profile/steps/types.tsx
@@ -46,6 +46,21 @@ export interface WizardFile {
   visibility: string;
 }
 
+// KAN-181: conversation starters — both the curated prompt library
+// and the user's answers (joined to the prompt for display).
+export interface ConversationPrompt {
+  id: string;
+  prompt: string;
+  sort_order: number;
+}
+
+export interface ConversationAnswer {
+  id: string;
+  prompt_id: string;
+  answer: string;
+  prompt: string; // joined for display
+}
+
 export function Field({ label, value, onChange, placeholder }: {
   label: string; value: string; onChange: (v: string) => void; placeholder?: string;
 }) {

--- a/src/app/dashboard/profile/wizard.tsx
+++ b/src/app/dashboard/profile/wizard.tsx
@@ -19,10 +19,16 @@ import {
 import { updateManualOfMe } from './manual-of-me-actions';
 import type { ManualOfMe } from './manual-of-me-fields';
 import {
-  IdentityStep, BioStep, SchoolStep, ItemsStep, LinksStep, ManualOfMeStep, FilesStep, PreviewStep,
+  IdentityStep, BioStep, SchoolStep, ItemsStep, LinksStep, ManualOfMeStep, FilesStep, ConversationStartersStep, PreviewStep,
   type WizardProfile, type WizardItem, type WizardSchool, type WizardLink, type WizardFile,
+  type ConversationPrompt, type ConversationAnswer,
 } from './steps';
 import { uploadProfileFile, removeProfileFile, updateProfileFileVisibility } from './files-actions';
+import {
+  addConversationStarter,
+  updateConversationStarter,
+  removeConversationStarter,
+} from './conversation-starters-actions';
 
 const STEPS = [
   { id: 'identity', label: 'Identity', icon: '👤' },
@@ -39,6 +45,9 @@ const STEPS = [
   // KAN-142: files & media — inserted between links and preview so the
   // user has filled out everything else by the time they upload files.
   { id: 'files', label: 'Files & media', icon: '📎' },
+  // KAN-181: conversation starters — sits late in the flow because it
+  // benefits from the user having warmed up on the easier sections first.
+  { id: 'starters', label: 'Things to ask me', icon: '💬' },
   { id: 'preview', label: 'Preview', icon: '👁️' },
 ];
 
@@ -49,6 +58,8 @@ export function ProfileWizard({
   links,
   manualOfMe,
   files,
+  conversationPrompts,
+  conversationAnswers,
 }: {
   profile: WizardProfile;
   items: WizardItem[];
@@ -56,6 +67,8 @@ export function ProfileWizard({
   links: WizardLink[];
   manualOfMe: ManualOfMe;
   files: WizardFile[];
+  conversationPrompts: ConversationPrompt[];
+  conversationAnswers: ConversationAnswer[];
 }) {
   const [step, setStep] = useState(0);
   const [isPending, startTransition] = useTransition();
@@ -213,6 +226,16 @@ export function ProfileWizard({
           />
         )}
         {step === 12 && (
+          <ConversationStartersStep
+            prompts={conversationPrompts}
+            answers={conversationAnswers}
+            onAdd={(input) => { startTransition(async () => { await addConversationStarter(input); router.refresh(); }); }}
+            onUpdate={(id, answer) => { startTransition(async () => { await updateConversationStarter(id, answer); router.refresh(); }); }}
+            onRemove={(id) => { startTransition(async () => { await removeConversationStarter(id); router.refresh(); }); }}
+            onNext={next} isPending={isPending}
+          />
+        )}
+        {step === 13 && (
           <PreviewStep profile={profile} items={items} schools={schools} links={links}
             onPublish={() => { startTransition(async () => { await publishProfile(); router.refresh(); router.push('/dashboard'); }); }}
             isPending={isPending} />

--- a/supabase/migrations/20260516200000_conversation_starters.sql
+++ b/supabase/migrations/20260516200000_conversation_starters.sql
@@ -1,0 +1,107 @@
+-- KAN-181: conversation-starter prompts (KAN-154 sub-feature D).
+--
+-- Two-table model:
+--   * conversation_starter_prompts — admin-seeded reference list, ~8 rows.
+--     Curated content the user picks from. Read-only to authenticated users;
+--     write access is service-role only (no INSERT policy for 'authenticated')
+--     so users cannot inject their own prompts.
+--   * profile_conversation_starters — user's answers. FK to both `profiles`
+--     and `conversation_starter_prompts`. Cap of 5 answered prompts per
+--     profile (UI nudges + DB trigger enforces). Answer is sanitised
+--     free text, 1-500 chars.
+--
+-- Why not reuse profile_items with a new category?
+--   Because the curation matters. If users free-type their own "questions",
+--   we lose the lightly-curated prompt library that makes this feature
+--   distinct from the existing `questions` item_category ("Questions I
+--   wish people asked"). FK to the reference table is the cleanest way
+--   to keep the prompt list reviewable in one place.
+--
+-- Applied to all 3 envs on 2026-05-16:
+--   dev    (ilprytcrnqyrsbsrfujj): ✓ via apply_migration
+--   stage  (uobmlkzrjkptwhttzmmi): ✓ via apply_migration
+--   prod   (llzkgprqewuwkiwclowi): ✓ via apply_migration
+
+create table if not exists public.conversation_starter_prompts (
+  id uuid primary key default gen_random_uuid(),
+  prompt text not null,
+  category text,        -- optional grouping (work/personal/fun) — not used in v1
+  sort_order integer default 0,
+  is_active boolean default true,
+  created_at timestamptz default now()
+);
+
+-- Seed 8 prompts. Adding more later doesn't need a migration — just an
+-- INSERT via SQL editor or a future admin UI.
+insert into public.conversation_starter_prompts (prompt, sort_order) values
+  ('A book that changed how I think', 10),
+  ('The best advice I''ve ever received', 20),
+  ('A skill I''m practising right now', 30),
+  ('Something I''ve changed my mind about recently', 40),
+  ('A small thing that makes my day', 50),
+  ('A question I''m sitting with', 60),
+  ('What I wish more people asked me', 70),
+  ('A weird hobby of mine', 80)
+on conflict do nothing;
+
+create table if not exists public.profile_conversation_starters (
+  id uuid primary key default gen_random_uuid(),
+  profile_id uuid references public.profiles(id) on delete cascade not null,
+  prompt_id uuid references public.conversation_starter_prompts(id) not null,
+  answer text not null check (length(answer) <= 500 and length(trim(answer)) > 0),
+  sort_order integer default 0,
+  created_at timestamptz default now(),
+  updated_at timestamptz default now(),
+  -- One answer per (profile, prompt). Stops accidental double-answers
+  -- without needing application-level uniqueness checks.
+  unique (profile_id, prompt_id)
+);
+create index if not exists pcs_profile_id_idx on public.profile_conversation_starters(profile_id);
+
+-- updated_at autoupdater (reuses handle_updated_at from the base schema)
+drop trigger if exists on_pcs_updated on public.profile_conversation_starters;
+create trigger on_pcs_updated before update on public.profile_conversation_starters
+  for each row execute function public.handle_updated_at();
+
+-- 5-answer cap enforced at DB layer so UI can't be the only gate.
+create or replace function public.enforce_pcs_cap()
+returns trigger as $$
+begin
+  if (select count(*) from public.profile_conversation_starters where profile_id = new.profile_id) >= 5 then
+    raise exception 'Conversation-starter answer limit (5) reached';
+  end if;
+  return new;
+end$$ language plpgsql;
+
+drop trigger if exists pcs_cap on public.profile_conversation_starters;
+create trigger pcs_cap before insert on public.profile_conversation_starters
+  for each row execute function public.enforce_pcs_cap();
+
+-- RLS
+alter table public.conversation_starter_prompts enable row level security;
+
+drop policy if exists "Anyone can read active prompts" on public.conversation_starter_prompts;
+create policy "Anyone can read active prompts"
+  on public.conversation_starter_prompts for select
+  using (is_active = true);
+-- No INSERT/UPDATE/DELETE policies — service-role only.
+
+alter table public.profile_conversation_starters enable row level security;
+
+drop policy if exists "Users manage own starters" on public.profile_conversation_starters;
+create policy "Users manage own starters"
+  on public.profile_conversation_starters for all
+  using (profile_id in (select id from public.profiles where user_id = auth.uid()))
+  with check (profile_id in (select id from public.profiles where user_id = auth.uid()));
+
+drop policy if exists "Anyone reads starters from published profiles" on public.profile_conversation_starters;
+create policy "Anyone reads starters from published profiles"
+  on public.profile_conversation_starters for select
+  using (
+    exists (
+      select 1 from public.profiles
+      where id = profile_conversation_starters.profile_id
+        and is_published = true
+        and is_suspended = false
+    )
+  );

--- a/tests/unit/conversation-starters.test.ts
+++ b/tests/unit/conversation-starters.test.ts
@@ -1,0 +1,120 @@
+/**
+ * KAN-181: regression guards for the conversation-starter prompt
+ * surface area.
+ *
+ * Static-grep tests in the style of `current-problems-category.test.ts`
+ * — cheap and catch the regressing case of an accidental drop of the
+ * wizard step, the public render, or one of the actions. Combined with
+ * the migration, the wizard step, the public render, and the actions
+ * file all referencing each other by name, these tests give wide
+ * coverage with very little maintenance burden.
+ *
+ * The harder behavioural tests (DB cap, RLS denial for non-owner) are
+ * left to the integration-test pass; static guards keep the unit suite
+ * quick and CI green-cycles fast.
+ */
+
+import { readFileSync, existsSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const ROOT = resolve(__dirname, '../..');
+
+describe('KAN-181 conversation starters — surface-area regression guards', () => {
+  test('migration file exists and creates both tables', () => {
+    const src = readFileSync(
+      resolve(ROOT, 'supabase/migrations/20260516200000_conversation_starters.sql'),
+      'utf-8',
+    );
+    expect(src).toMatch(/create table.*conversation_starter_prompts/i);
+    expect(src).toMatch(/create table.*profile_conversation_starters/i);
+  });
+
+  test('migration seeds at least 8 prompts', () => {
+    const src = readFileSync(
+      resolve(ROOT, 'supabase/migrations/20260516200000_conversation_starters.sql'),
+      'utf-8',
+    );
+    const matches = src.match(/^\s*\(['"]/gm);
+    // Each seed row starts with an open paren + quote — count them as
+    // a proxy for the seed-row count.
+    expect(matches).not.toBeNull();
+    expect((matches ?? []).length).toBeGreaterThanOrEqual(8);
+  });
+
+  test('migration enforces the 5-answer cap via a BEFORE INSERT trigger', () => {
+    const src = readFileSync(
+      resolve(ROOT, 'supabase/migrations/20260516200000_conversation_starters.sql'),
+      'utf-8',
+    );
+    expect(src).toMatch(/limit \(5\) reached/i);
+    expect(src).toMatch(/before insert on public\.profile_conversation_starters/i);
+  });
+
+  test('migration enforces 500-char answer limit via CHECK', () => {
+    const src = readFileSync(
+      resolve(ROOT, 'supabase/migrations/20260516200000_conversation_starters.sql'),
+      'utf-8',
+    );
+    expect(src).toMatch(/check \(length\(answer\) <= 500/i);
+  });
+
+  test('migration enforces unique (profile_id, prompt_id)', () => {
+    const src = readFileSync(
+      resolve(ROOT, 'supabase/migrations/20260516200000_conversation_starters.sql'),
+      'utf-8',
+    );
+    expect(src).toMatch(/unique\s*\(\s*profile_id\s*,\s*prompt_id\s*\)/i);
+  });
+
+  test('server-actions file exports the three CRUD functions', () => {
+    const src = readFileSync(
+      resolve(ROOT, 'src/app/dashboard/profile/conversation-starters-actions.ts'),
+      'utf-8',
+    );
+    expect(src).toMatch(/export\s+async\s+function\s+addConversationStarter/);
+    expect(src).toMatch(/export\s+async\s+function\s+updateConversationStarter/);
+    expect(src).toMatch(/export\s+async\s+function\s+removeConversationStarter/);
+  });
+
+  test('server-actions file uses sanitiseText and a 500-char cap', () => {
+    const src = readFileSync(
+      resolve(ROOT, 'src/app/dashboard/profile/conversation-starters-actions.ts'),
+      'utf-8',
+    );
+    expect(src).toMatch(/sanitiseText/);
+    expect(src).toMatch(/500/);
+  });
+
+  test('server-actions file surfaces the 5-answer cap as a clean error', () => {
+    const src = readFileSync(
+      resolve(ROOT, 'src/app/dashboard/profile/conversation-starters-actions.ts'),
+      'utf-8',
+    );
+    expect(src).toMatch(/limit \(5\)/);
+    expect(src).toMatch(/up to 5/);
+  });
+
+  test('wizard step component exists', () => {
+    expect(existsSync(
+      resolve(ROOT, 'src/app/dashboard/profile/steps/conversation-starters-step.tsx'),
+    )).toBe(true);
+  });
+
+  test('public profile page references the conversation starters table', () => {
+    const src = readFileSync(
+      resolve(ROOT, 'src/app/[slug]/page.tsx'),
+      'utf-8',
+    );
+    expect(src).toMatch(/profile_conversation_starters/);
+    expect(src).toMatch(/Things to ask me about/);
+  });
+
+  test('dashboard profile page fetches conversation starter data', () => {
+    const src = readFileSync(
+      resolve(ROOT, 'src/app/dashboard/profile/page.tsx'),
+      'utf-8',
+    );
+    expect(src).toMatch(/conversation_starter_prompts/);
+    expect(src).toMatch(/profile_conversation_starters/);
+  });
+});

--- a/tests/unit/profile-sections.test.js
+++ b/tests/unit/profile-sections.test.js
@@ -25,20 +25,26 @@ describe('KAN-137: Wizard supports new section categories', () => {
     expect(fs.existsSync(wizardPath)).toBe(true);
   });
 
-  test('wizard has 13 steps (was 12; KAN-142 added Files & media)', () => {
+  test('wizard has 14 steps (was 13; KAN-181 added Things to ask me)', () => {
     // KAN-154 took this from 11 → 12 (Manual of Me).
-    // KAN-142 took it from 12 → 13 (Files & media). Both are deliberate
-    // user-facing additions, not regressions — update the assertion to
-    // match. If a future refactor drops a step accidentally, this test
-    // catches it.
+    // KAN-142 took it from 12 → 13 (Files & media).
+    // KAN-181 took it from 13 → 14 (Things to ask me / conversation
+    // starters). Each is a deliberate user-facing addition, not a
+    // regression — update the assertion to match. If a future refactor
+    // drops a step accidentally, this test catches it.
     const stepMatches = wizardContent.match(/\{ id: '/g);
     expect(stepMatches).not.toBeNull();
-    expect(stepMatches.length).toBe(13);
+    expect(stepMatches.length).toBe(14);
   });
 
   test('wizard includes Files & media step (KAN-142)', () => {
     expect(wizardContent).toContain("'files'");
     expect(wizardContent).toContain('Files & media');
+  });
+
+  test('wizard includes Things to ask me step (KAN-181)', () => {
+    expect(wizardContent).toContain("'starters'");
+    expect(wizardContent).toContain('Things to ask me');
   });
 
   test('wizard includes Books & Media step', () => {


### PR DESCRIPTION
Last sub-feature of the KAN-154 enrichment set. Two-table model: 8 curated prompts + per-user answers, 5-per-profile cap, 500-char limit, unique(profile, prompt). Wizard step + public-profile render + 11 regression tests + step-count bump 13→14.

## Migration ✓
Applied to dev / staging / prod via `apply_migration`.

## Test plan
- [x] 11 regression-guard unit tests pass
- [x] profile-sections tests pass (with bumped 14-step assertion)
- [x] `next build` clean
- [x] Lint clean (1 pre-existing avatar img warning, unrelated)
- [ ] PR Quality Gate
- [ ] Manual: pick a prompt, write an answer, save, see it on the public profile

🤖 Generated with [Claude Code](https://claude.com/claude-code)