### PR TITLE
feat(KAN-189): affiliate_clicks schema + SubID convention + types

### DIFF
--- a/src/lib/affiliate/types.ts
+++ b/src/lib/affiliate/types.ts
@@ -1,0 +1,85 @@
+/**
+ * KAN-189: types + helpers for the `affiliate_clicks` table.
+ *
+ * The full Affiliate Link Service (KAN-188) is not yet implemented — this
+ * module defines the shapes and the SubID convention so future work
+ * (KAN-191 web rendering, KAN-201 MCP rendering, KAN-195 reconciliation)
+ * can import the canonical types.
+ *
+ * The SubID is what we send to the affiliate provider (Sovrn etc.) so they
+ * echo it back in their reports. It is the join key in monthly reconciliation
+ * (KAN-195). It must be opaque (no PII) and source-tagged so MCP traffic can
+ * be split from web traffic.
+ */
+
+export type AffiliateProvider = 'sovrn' | 'amazon_direct' | 'geniuslink' | 'raw';
+export type AffiliateClickSource = 'web' | 'mcp' | 'email';
+
+export type AffiliateClickRow = {
+  click_id: string;
+  created_at: string;
+  session_id: string | null;
+  user_id: string | null;
+  recipient_id: string | null;
+  recommendation_id: string | null;
+  merchant_id: string | null;
+  buyer_country: string | null;
+  recipient_country: string | null;
+  provider: AffiliateProvider;
+  provider_subid: string | null;
+  source: AffiliateClickSource;
+  raw_url: string;
+  monetised_url: string;
+  converted_at: string | null;
+  commission_amount: string | null;
+  commission_currency: string | null;
+  commission_gbp: string | null;
+};
+
+/**
+ * Build the SubID string we send to the affiliate provider. The format is
+ * `lyra-{click_id}` for web/email and `lyra-mcp-{click_id}` for MCP so the
+ * reconciliation cron can split traffic without an extra join.
+ *
+ * The provider echoes this back unchanged in its monthly report.
+ */
+export function buildSubId(clickId: string, source: AffiliateClickSource): string {
+  if (source === 'mcp') {
+    return `lyra-mcp-${clickId}`;
+  }
+  return `lyra-${clickId}`;
+}
+
+/**
+ * Extract the click_id from a SubID. Returns null if the input is not in our
+ * format — the reconciliation cron uses this to identify which rows in the
+ * provider's report originated from us vs. from any other publisher.
+ */
+export function parseSubId(subId: string | null | undefined): {
+  clickId: string;
+  source: AffiliateClickSource;
+} | null {
+  if (!subId || typeof subId !== 'string') return null;
+  // MCP-prefixed: lyra-mcp-{uuid}
+  const mcpMatch = subId.match(/^lyra-mcp-([0-9a-f-]{36})$/);
+  if (mcpMatch) {
+    return { clickId: mcpMatch[1], source: 'mcp' };
+  }
+  // Web/email: lyra-{uuid} (no further hyphen-prefix)
+  const webMatch = subId.match(/^lyra-([0-9a-f-]{36})$/);
+  if (webMatch) {
+    // Disambiguation: source is either 'web' or 'email'. We default to 'web'
+    // because the SubID alone cannot distinguish — the source is recorded
+    // in the affiliate_clicks row, which the reconciliation joins on click_id.
+    return { clickId: webMatch[1], source: 'web' };
+  }
+  return null;
+}
+
+/**
+ * Type guard for the ISO-3166 alpha-2 country format the schema enforces.
+ * Keep aligned with the check constraint in the migration.
+ */
+export function isCountryCode(value: unknown): value is string {
+  return typeof value === 'string' && /^[A-Z]{2}$/.test(value);
+}

--- a/supabase/migrations/20260516200000_affiliate_clicks.sql
+++ b/supabase/migrations/20260516200000_affiliate_clicks.sql
@@ -1,0 +1,100 @@
+-- KAN-189: affiliate_clicks — internal click log for affiliate-monetised links.
+--
+-- Every call to the Affiliate Link Service (KAN-188) writes a row here whether
+-- the click was monetised or not. The log is the source of truth for:
+--   1. Monthly reconciliation against Sovrn's report (KAN-195) — joined on
+--      provider_subid which is our generated UUID echoed back by Sovrn.
+--   2. Per-merchant EPC (KAN-195) which feeds back into the recommender's
+--      ranking weights (KAN-199).
+--   3. The feedback loop in KAN-202 — recommendation_id links clicks back to
+--      the recommendation render event.
+--
+-- The table is append-only on the hot path. The reconciliation cron updates
+-- the converted_at / commission_* fields once Sovrn confirms a sale.
+--
+-- SubID convention (set by KAN-188 link service, NOT by this migration):
+--   - web/email source: "lyra-{click_id}"   (lyra- prefix)
+--   - mcp source:       "lyra-mcp-{click_id}"
+-- We use the same opaque click_id as both PK and the seed of provider_subid so
+-- reconciliation is a straight equi-join after stripping the prefix.
+--
+-- RLS:
+--   - Users see their own clicks only.
+--   - Service-role bypasses RLS to write from the link service and read for
+--     the reconciliation cron.
+--
+-- Rollback (one-time, do not include in migration body):
+--   drop table if exists public.affiliate_clicks;
+
+create table if not exists public.affiliate_clicks (
+  click_id uuid primary key default gen_random_uuid(),
+  created_at timestamptz not null default now(),
+
+  -- Attribution context. Nullable because we want to allow anonymous browsing
+  -- (no auth) and landing-page clicks (no recipient anchor).
+  session_id text,
+  user_id uuid references auth.users(id) on delete set null,
+  recipient_id uuid references public.profiles(id) on delete set null,
+  recommendation_id text,  -- free-form until KAN-202 introduces the events table
+
+  -- Merchant + geo signals (per KAN-185 + KAN-187)
+  merchant_id text,                       -- e.g. "amazon", "etsy"; null if unknown to us
+  buyer_country text check (buyer_country ~ '^[A-Z]{2}$'),       -- ISO-3166 alpha-2
+  recipient_country text check (recipient_country ~ '^[A-Z]{2}$'),
+
+  -- Provider that monetised the click (or "raw" if none)
+  provider text not null check (provider in ('sovrn', 'amazon_direct', 'geniuslink', 'raw')),
+  provider_subid text,                    -- what we sent the provider; null for "raw"
+  source text not null default 'web' check (source in ('web', 'mcp', 'email')),
+
+  -- URLs (raw_url is the recommender's pre-monetised choice; monetised_url is
+  -- what the user clicked on)
+  raw_url text not null,
+  monetised_url text not null,
+
+  -- Reconciliation fields — populated by the cron in KAN-195
+  converted_at timestamptz,
+  commission_amount numeric(12, 4),
+  commission_currency text check (commission_currency ~ '^[A-Z]{3}$'),
+  commission_gbp numeric(12, 4)
+);
+
+-- Indexes
+-- (provider, provider_subid) is the reconciliation join key
+create index if not exists affiliate_clicks_provider_subid_idx
+  on public.affiliate_clicks(provider, provider_subid)
+  where provider_subid is not null;
+
+-- (session_id, created_at) supports session-attribution + time-window queries
+create index if not exists affiliate_clicks_session_idx
+  on public.affiliate_clicks(session_id, created_at desc)
+  where session_id is not null;
+
+-- (user_id, created_at) supports a user's own click history view
+create index if not exists affiliate_clicks_user_idx
+  on public.affiliate_clicks(user_id, created_at desc)
+  where user_id is not null;
+
+-- (recipient_id) supports analytics breakdown by recipient profile
+create index if not exists affiliate_clicks_recipient_idx
+  on public.affiliate_clicks(recipient_id)
+  where recipient_id is not null;
+
+-- (merchant_id, buyer_country, created_at) supports per-merchant per-country
+-- EPC computation in KAN-195
+create index if not exists affiliate_clicks_merchant_country_idx
+  on public.affiliate_clicks(merchant_id, buyer_country, created_at desc)
+  where merchant_id is not null;
+
+-- RLS
+alter table public.affiliate_clicks enable row level security;
+
+drop policy if exists "Users can read own clicks" on public.affiliate_clicks;
+create policy "Users can read own clicks"
+  on public.affiliate_clicks for select to authenticated
+  using (user_id = auth.uid());
+
+-- No insert / update / delete policies for authenticated role — writes happen
+-- only via the service role from the Affiliate Link Service (KAN-188) and the
+-- reconciliation cron (KAN-195). Service role bypasses RLS so no explicit
+-- policy is needed; clients cannot write through the regular Supabase client.

--- a/tests/unit/affiliate-clicks.test.ts
+++ b/tests/unit/affiliate-clicks.test.ts
@@ -1,0 +1,163 @@
+/**
+ * KAN-189: unit tests for the affiliate-click types + SubID helpers.
+ *
+ * Locks in the SubID format that the reconciliation cron in KAN-195 will
+ * depend on. If these tests break, monthly reconciliation breaks silently
+ * (rows in Sovrn's report won't match rows in our `affiliate_clicks` table).
+ */
+
+import {
+  buildSubId,
+  parseSubId,
+  isCountryCode,
+  type AffiliateClickRow,
+  type AffiliateProvider,
+  type AffiliateClickSource,
+} from '@/lib/affiliate/types';
+
+describe('KAN-189 affiliate clicks — buildSubId', () => {
+  const uuid = '550e8400-e29b-41d4-a716-446655440000';
+
+  test('web source produces lyra-{uuid}', () => {
+    expect(buildSubId(uuid, 'web')).toBe(`lyra-${uuid}`);
+  });
+
+  test('email source produces lyra-{uuid} (shares format with web)', () => {
+    // email and web share the same SubID prefix; source is differentiated
+    // in the affiliate_clicks row (not in the SubID).
+    expect(buildSubId(uuid, 'email')).toBe(`lyra-${uuid}`);
+  });
+
+  test('mcp source produces lyra-mcp-{uuid}', () => {
+    expect(buildSubId(uuid, 'mcp')).toBe(`lyra-mcp-${uuid}`);
+  });
+
+  test('SubID contains no PII — only the lyra prefix, optional mcp tag, and an opaque UUID', () => {
+    const subId = buildSubId(uuid, 'mcp');
+    expect(subId).not.toMatch(/@/);
+    expect(subId).not.toMatch(/email/i);
+    expect(subId).not.toMatch(/name/i);
+  });
+});
+
+describe('KAN-189 affiliate clicks — parseSubId', () => {
+  const uuid = '550e8400-e29b-41d4-a716-446655440000';
+
+  test('round-trips web SubID', () => {
+    const subId = buildSubId(uuid, 'web');
+    expect(parseSubId(subId)).toEqual({ clickId: uuid, source: 'web' });
+  });
+
+  test('round-trips mcp SubID', () => {
+    const subId = buildSubId(uuid, 'mcp');
+    expect(parseSubId(subId)).toEqual({ clickId: uuid, source: 'mcp' });
+  });
+
+  test('rejects unknown prefix', () => {
+    expect(parseSubId(`other-${uuid}`)).toBeNull();
+  });
+
+  test('rejects non-UUID body', () => {
+    expect(parseSubId('lyra-not-a-uuid')).toBeNull();
+    expect(parseSubId('lyra-mcp-also-bad')).toBeNull();
+  });
+
+  test('rejects null / empty / non-string', () => {
+    expect(parseSubId(null)).toBeNull();
+    expect(parseSubId(undefined)).toBeNull();
+    expect(parseSubId('')).toBeNull();
+    // @ts-expect-error — testing runtime guard
+    expect(parseSubId(123)).toBeNull();
+  });
+
+  test('rejects SubID where lyra- prefix is missing', () => {
+    expect(parseSubId(uuid)).toBeNull();
+  });
+
+  test('mcp prefix takes precedence over web prefix when both could match', () => {
+    // Real example from a future Sovrn report row
+    expect(parseSubId(`lyra-mcp-${uuid}`)).toEqual({ clickId: uuid, source: 'mcp' });
+  });
+});
+
+describe('KAN-189 affiliate clicks — isCountryCode', () => {
+  test('accepts ISO-3166 alpha-2 uppercase', () => {
+    expect(isCountryCode('GB')).toBe(true);
+    expect(isCountryCode('US')).toBe(true);
+    expect(isCountryCode('DE')).toBe(true);
+  });
+
+  test('rejects lowercase, 3-letter, full names, non-string', () => {
+    expect(isCountryCode('gb')).toBe(false);
+    expect(isCountryCode('USA')).toBe(false);
+    expect(isCountryCode('United Kingdom')).toBe(false);
+    expect(isCountryCode(null)).toBe(false);
+    expect(isCountryCode(undefined)).toBe(false);
+    expect(isCountryCode(42)).toBe(false);
+    expect(isCountryCode('G1')).toBe(false);
+  });
+});
+
+describe('KAN-189 affiliate clicks — type contract', () => {
+  test('AffiliateProvider enum stays aligned with the SQL check constraint', () => {
+    // If a new provider is added to the SQL check constraint in the migration
+    // (sovrn / amazon_direct / geniuslink / raw), this list must grow too.
+    const providers: AffiliateProvider[] = ['sovrn', 'amazon_direct', 'geniuslink', 'raw'];
+    expect(providers).toHaveLength(4);
+  });
+
+  test('AffiliateClickSource enum stays aligned with the SQL check constraint', () => {
+    // If a new source is added to the SQL check constraint in the migration
+    // (web / mcp / email), this list must grow too.
+    const sources: AffiliateClickSource[] = ['web', 'mcp', 'email'];
+    expect(sources).toHaveLength(3);
+  });
+
+  test('AffiliateClickRow shape compiles for a fully-populated row', () => {
+    const row: AffiliateClickRow = {
+      click_id: '550e8400-e29b-41d4-a716-446655440000',
+      created_at: '2026-05-16T20:00:00.000Z',
+      session_id: 'session-abc',
+      user_id: 'user-1',
+      recipient_id: 'profile-1',
+      recommendation_id: 'rec-1',
+      merchant_id: 'amazon',
+      buyer_country: 'GB',
+      recipient_country: 'DE',
+      provider: 'sovrn',
+      provider_subid: 'lyra-550e8400-e29b-41d4-a716-446655440000',
+      source: 'web',
+      raw_url: 'https://amazon.de/dp/B07XYZ',
+      monetised_url: 'https://redirect.sovrn.com/?u=https%3A%2F%2Famazon.de%2Fdp%2FB07XYZ',
+      converted_at: '2026-05-17T08:30:00.000Z',
+      commission_amount: '12.4500',
+      commission_currency: 'EUR',
+      commission_gbp: '10.7800',
+    };
+    expect(row.click_id).toBeTruthy();
+  });
+
+  test('AffiliateClickRow shape compiles for the minimum-nullable case (anon click that did not monetise)', () => {
+    const row: AffiliateClickRow = {
+      click_id: '550e8400-e29b-41d4-a716-446655440000',
+      created_at: '2026-05-16T20:00:00.000Z',
+      session_id: null,
+      user_id: null,
+      recipient_id: null,
+      recommendation_id: null,
+      merchant_id: null,
+      buyer_country: null,
+      recipient_country: null,
+      provider: 'raw',
+      provider_subid: null,
+      source: 'web',
+      raw_url: 'https://example.com/product',
+      monetised_url: 'https://example.com/product',
+      converted_at: null,
+      commission_amount: null,
+      commission_currency: null,
+      commission_gbp: null,
+    };
+    expect(row.provider).toBe('raw');
+  });
+});


### PR DESCRIPTION
## Summary
- New `affiliate_clicks` table — the internal click log for the Affiliate Link Service (KAN-188)
- SubID convention locked: `lyra-{uuid}` for web/email, `lyra-mcp-{uuid}` for MCP — lets monthly reconciliation (KAN-195) split MCP vs web traffic
- 5 indexes covering the reconciliation join, session/user/recipient lookups, and per-(merchant × country) EPC
- RLS: users read own clicks; writes via service role only
- 17 new unit tests for the SubID helpers + types + country-code validation
- All 607 existing unit tests still pass

## Migration ✓
Applied to dev (`ilprytcrnqyrsbsrfujj`) via `apply_migration`. Stage + prod will follow via the standard promotion pipeline.

## Test plan
- [x] 17 new unit tests pass
- [x] All 607 unit tests pass
- [x] `tsc --noEmit` clean
- [ ] Manual: query the new table on dev and confirm shape matches

## Related
KAN-189, KAN-188, KAN-195, KAN-202

🤖 Generated with [Claude Code](https://claude.com/claude-code)