### PR TITLE
feat(KAN-186): recipient delivery country field

### DIFF
--- a/src/app/dashboard/profile/delivery-country-actions.ts
+++ b/src/app/dashboard/profile/delivery-country-actions.ts
@@ -1,0 +1,60 @@
+'use server';
+
+/**
+ * KAN-186: server action for the recipient's "Delivery country" field.
+ *
+ * Why a dedicated action (not just an entry in ALLOWED_PROFILE_FIELDS):
+ *   - `updateProfileFields` runs `sanitiseText` on every string value, which
+ *     does not uppercase / restrict to ISO-2. Putting delivery_country_code
+ *     through the generic path would surface DB check-constraint errors to
+ *     the user for any non-canonical input (lowercase, full names, etc).
+ *   - This action normalises input via `normaliseDeliveryCountry`, accepts
+ *     empty / null to clear the field, and returns a clear UX-friendly error
+ *     if the chosen country is not in our supported list.
+ *
+ * Auth model:
+ *   - Authenticated user only.
+ *   - The owning profile is resolved server-side from `auth.uid()` — caller
+ *     cannot supply a `profile_id`. Same pattern as updateManualOfMe (KAN-154).
+ *
+ * Pairs with src/lib/affiliate/country-codes.ts (the supported-country
+ * allowlist, also used by KAN-187 seed and KAN-194 smoke monitor).
+ */
+
+import { createClient } from '@/lib/supabase-server';
+import { revalidatePath } from 'next/cache';
+import { type ActionResult } from '@/lib/sanitise';
+import { normaliseDeliveryCountry } from '@/lib/affiliate/country-codes';
+
+export async function updateDeliveryCountry(
+  input: string | null
+): Promise<ActionResult> {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) return { success: false, error: 'Not authenticated' };
+
+  // Normalise: trim, uppercase, restrict to supported allowlist.
+  // null / empty after normalisation means "clear the field" — the recommender
+  // will then fall back to the buyer's country at query time (KAN-185).
+  let normalised: string | null = null;
+  if (input !== null && input !== undefined && input !== '') {
+    normalised = normaliseDeliveryCountry(input);
+    if (normalised === null) {
+      return {
+        success: false,
+        error: `Unsupported delivery country: ${input}. See SUPPORTED_DELIVERY_COUNTRIES.`,
+      };
+    }
+  }
+
+  const { error } = await supabase
+    .from('profiles')
+    .update({ delivery_country_code: normalised })
+    .eq('user_id', user.id);
+
+  if (error) return { success: false, error: error.message };
+  revalidatePath('/dashboard/profile');
+  return { success: true };
+}

--- a/src/app/dashboard/profile/steps/identity-step.tsx
+++ b/src/app/dashboard/profile/steps/identity-step.tsx
@@ -1,7 +1,9 @@
 'use client';
 
-import { useState, useRef } from 'react';
+import { useState, useRef, useTransition } from 'react';
 import { Field, SaveButton, type WizardProfile } from './types';
+import { SUPPORTED_DELIVERY_COUNTRIES } from '@/lib/affiliate/country-codes';
+import { updateDeliveryCountry } from '../delivery-country-actions';
 
 export function IdentityStep({ profile, onSave, onUploadAvatar, isPending }: {
   profile: WizardProfile;
@@ -13,6 +15,13 @@ export function IdentityStep({ profile, onSave, onUploadAvatar, isPending }: {
   const [headline, setHeadline] = useState(profile.headline || '');
   const [city, setCity] = useState(profile.city || '');
   const [country, setCountry] = useState(profile.country || 'GB');
+  // KAN-186: separate from `country` (freeform display) — this is the
+  // strict ISO-2 used by the recommender's eligibility filter.
+  const [deliveryCountry, setDeliveryCountry] = useState<string>(
+    profile.delivery_country_code || '',
+  );
+  const [deliveryCountryError, setDeliveryCountryError] = useState<string | null>(null);
+  const [savingDeliveryCountry, startSavingDeliveryCountry] = useTransition();
   const [preview, setPreview] = useState<string | null>(profile.avatar_url || null);
   const [uploadError, setUploadError] = useState<string | null>(null);
   const fileRef = useRef<HTMLInputElement>(null);
@@ -95,6 +104,45 @@ export function IdentityStep({ profile, onSave, onUploadAvatar, isPending }: {
         <Field label="Headline" value={headline} onChange={setHeadline} placeholder="Mum, teacher, coffee lover" />
         <Field label="City" value={city} onChange={setCity} placeholder="London" />
         <Field label="Country" value={country} onChange={setCountry} placeholder="GB" />
+
+        {/* KAN-186: delivery country — separate from the freeform `country`
+            field above; this one is the strict ISO-2 the recommender uses to
+            filter products that can ship to you. */}
+        <div>
+          <label htmlFor="delivery-country" className="block text-sm font-medium text-[var(--color-ink)]">
+            Delivery country
+          </label>
+          <p className="text-xs text-[var(--color-muted)] mt-0.5">
+            Where gift recommendations should be able to ship to. Leave blank to use the buyer&apos;s country.
+          </p>
+          <select
+            id="delivery-country"
+            value={deliveryCountry}
+            onChange={(e) => {
+              const next = e.target.value;
+              setDeliveryCountry(next);
+              setDeliveryCountryError(null);
+              startSavingDeliveryCountry(async () => {
+                const result = await updateDeliveryCountry(next || null);
+                if (!result.success) {
+                  setDeliveryCountryError(result.error ?? 'Could not save');
+                }
+              });
+            }}
+            disabled={savingDeliveryCountry}
+            className="mt-1 block w-full rounded-md border border-[var(--color-border)] bg-white px-3 py-2 text-sm text-[var(--color-ink)] focus:outline-none focus:ring-2 focus:ring-[var(--color-sage)]"
+          >
+            <option value="">— Use buyer&apos;s country —</option>
+            {SUPPORTED_DELIVERY_COUNTRIES.map(({ code, name: countryName }) => (
+              <option key={code} value={code}>
+                {countryName} ({code})
+              </option>
+            ))}
+          </select>
+          {deliveryCountryError && (
+            <p className="text-xs text-red-500 mt-0.5">{deliveryCountryError}</p>
+          )}
+        </div>
       </div>
       <SaveButton
         onClick={() => onSave({ display_name: name, headline, city, country })}

--- a/src/app/dashboard/profile/steps/types.tsx
+++ b/src/app/dashboard/profile/steps/types.tsx
@@ -8,6 +8,10 @@ export interface WizardProfile {
   region: string | null;
   postcode_prefix: string | null;
   country: string | null;
+  // KAN-186: ISO-3166 alpha-2 country where gifts for this profile should
+  // ship. Separate from `country` (which is freeform display text). NULL
+  // means "unknown — fall back to buyer country at recommendation time".
+  delivery_country_code: string | null;
   is_published: boolean;
   avatar_url: string | null;
 }

--- a/src/lib/affiliate/country-codes.ts
+++ b/src/lib/affiliate/country-codes.ts
@@ -1,0 +1,61 @@
+/**
+ * KAN-186: supported delivery countries for the recommendation engine.
+ *
+ * This list backs the "Delivery country" selector on the profile edit page
+ * and is the canonical set of countries that:
+ *   1. We accept on the `profiles.delivery_country_code` column (schema-level
+ *      check constraint allows any ISO-2; the UI restricts to this allowlist).
+ *   2. The eligibility matrix (KAN-187) is seeded for.
+ *   3. The affiliate-link smoke monitor (KAN-194) exercises.
+ *
+ * Order matches the rollout priority for Phase 1: UK first (primary market),
+ * then the Earn Globally umbrella, then North America, then a small APAC tail.
+ * The order is also the display order in the UI <select>.
+ *
+ * Adding a country here ALONE does not make recommendations work there — the
+ * eligibility matrix (KAN-187) must also have entries for it. Keep the two
+ * lists in sync; the seed script for KAN-187 reads this allowlist.
+ */
+export const SUPPORTED_DELIVERY_COUNTRIES = [
+  { code: 'GB', name: 'United Kingdom' },
+  { code: 'IE', name: 'Ireland' },
+  { code: 'DE', name: 'Germany' },
+  { code: 'FR', name: 'France' },
+  { code: 'IT', name: 'Italy' },
+  { code: 'ES', name: 'Spain' },
+  { code: 'NL', name: 'Netherlands' },
+  { code: 'US', name: 'United States' },
+  { code: 'CA', name: 'Canada' },
+  { code: 'AU', name: 'Australia' },
+  { code: 'JP', name: 'Japan' },
+] as const;
+
+export type SupportedDeliveryCountry =
+  (typeof SUPPORTED_DELIVERY_COUNTRIES)[number]['code'];
+
+const SUPPORTED_CODES: ReadonlySet<string> = new Set(
+  SUPPORTED_DELIVERY_COUNTRIES.map((c) => c.code)
+);
+
+/**
+ * Normalise input to upper-case ISO-2 and verify it's in the supported list.
+ * Returns the normalised code or null. Empty/whitespace input returns null
+ * (the caller should treat null as "clear the field").
+ */
+export function normaliseDeliveryCountry(input: string | null | undefined): string | null {
+  if (input === null || input === undefined) return null;
+  if (typeof input !== 'string') return null;
+  const trimmed = input.trim();
+  if (trimmed === '') return null;
+  const upper = trimmed.toUpperCase();
+  return SUPPORTED_CODES.has(upper) ? upper : null;
+}
+
+/**
+ * Type guard for the strict ISO-2 format that the DB check constraint enforces.
+ * This is the wider guard (any ISO-2) vs. `normaliseDeliveryCountry` which
+ * tightens to the supported set.
+ */
+export function isIsoAlpha2(value: unknown): value is string {
+  return typeof value === 'string' && /^[A-Z]{2}$/.test(value);
+}

--- a/supabase/migrations/20260516210000_delivery_country_code.sql
+++ b/supabase/migrations/20260516210000_delivery_country_code.sql
@@ -1,0 +1,28 @@
+-- KAN-186: add delivery_country_code to profiles.
+--
+-- Per the KAN-185 geo-signal design, the recipient's delivery country is a
+-- separate signal from the buyer's country: the buyer's country drives which
+-- affiliate program receives the commission, while the recipient's delivery
+-- country filters which products are eligible to recommend (e.g. don't surface
+-- US-only items if the gift ships to Germany).
+--
+-- Why a new column rather than re-using existing `country`:
+--   - `country` is freeform text (values seen in dev include 'GB', 'Crawley UK',
+--     'United Kingdom') and is used for display, not filtering. Stricter typing
+--     here would break existing rows.
+--   - `delivery_country_code` is a strict ISO-3166 alpha-2 with a check
+--     constraint at the DB level so the recommender + link service can safely
+--     index on it.
+--
+-- NULL semantics: NULL means "unknown — fall back to buyer's country at query
+-- time" per KAN-185. We do NOT backfill; existing recipients stay NULL.
+--
+-- Rollback (one-time, do not include in migration body):
+--   alter table public.profiles drop column if exists delivery_country_code;
+
+alter table public.profiles
+  add column if not exists delivery_country_code text
+    check (delivery_country_code is null or delivery_country_code ~ '^[A-Z]{2}$');
+
+comment on column public.profiles.delivery_country_code is
+  'ISO-3166 alpha-2 country where gifts for this profile should ship. NULL = unknown, fall back to buyer country at recommendation time (KAN-185 / KAN-186).';

--- a/tests/unit/delivery-country.test.ts
+++ b/tests/unit/delivery-country.test.ts
@@ -1,0 +1,134 @@
+/**
+ * KAN-186: unit tests for the delivery-country helpers.
+ *
+ * These pure functions back the `delivery_country_code` column on the
+ * `profiles` table — they're the last line of defence between user input
+ * (UI <select>, MCP tool, future API) and the DB check constraint
+ * (`^[A-Z]{2}$` + the supported-country allowlist).
+ *
+ * If these tests break, the recommender's eligibility filter (KAN-190) may
+ * surface ineligible recommendations.
+ */
+
+import {
+  SUPPORTED_DELIVERY_COUNTRIES,
+  normaliseDeliveryCountry,
+  isIsoAlpha2,
+  type SupportedDeliveryCountry,
+} from '@/lib/affiliate/country-codes';
+
+describe('KAN-186 delivery country — SUPPORTED_DELIVERY_COUNTRIES', () => {
+  test('includes GB as the primary market', () => {
+    const codes = SUPPORTED_DELIVERY_COUNTRIES.map((c) => c.code);
+    expect(codes).toContain('GB');
+    expect(codes[0]).toBe('GB'); // first by rollout priority
+  });
+
+  test('covers the Earn Globally umbrella (UK + DE + FR + IT + ES)', () => {
+    // Amazon UK Associates auto-extends to DE/FR/IT/ES via Earn Globally,
+    // so all five need to be present together for Phase 2 to work.
+    const codes: string[] = SUPPORTED_DELIVERY_COUNTRIES.map((c) => c.code);
+    for (const c of ['GB', 'DE', 'FR', 'IT', 'ES']) {
+      expect(codes).toContain(c);
+    }
+  });
+
+  test('every entry has a 2-letter uppercase code + a non-empty name', () => {
+    for (const entry of SUPPORTED_DELIVERY_COUNTRIES) {
+      expect(entry.code).toMatch(/^[A-Z]{2}$/);
+      expect(entry.name.length).toBeGreaterThan(0);
+    }
+  });
+
+  test('no duplicate codes', () => {
+    const codes = SUPPORTED_DELIVERY_COUNTRIES.map((c) => c.code);
+    expect(new Set(codes).size).toBe(codes.length);
+  });
+});
+
+describe('KAN-186 delivery country — normaliseDeliveryCountry', () => {
+  test('round-trips supported codes', () => {
+    expect(normaliseDeliveryCountry('GB')).toBe('GB');
+    expect(normaliseDeliveryCountry('US')).toBe('US');
+    expect(normaliseDeliveryCountry('DE')).toBe('DE');
+  });
+
+  test('uppercases lowercase input', () => {
+    expect(normaliseDeliveryCountry('gb')).toBe('GB');
+    expect(normaliseDeliveryCountry('us')).toBe('US');
+    expect(normaliseDeliveryCountry('De')).toBe('DE');
+  });
+
+  test('trims surrounding whitespace', () => {
+    expect(normaliseDeliveryCountry('  GB  ')).toBe('GB');
+    expect(normaliseDeliveryCountry('\tUS\n')).toBe('US');
+  });
+
+  test('returns null for empty / whitespace / null / undefined', () => {
+    expect(normaliseDeliveryCountry('')).toBeNull();
+    expect(normaliseDeliveryCountry('   ')).toBeNull();
+    expect(normaliseDeliveryCountry(null)).toBeNull();
+    expect(normaliseDeliveryCountry(undefined)).toBeNull();
+  });
+
+  test('returns null for codes not in the supported list', () => {
+    // Brazil is a valid ISO-2 but not in our supported list (yet).
+    expect(normaliseDeliveryCountry('BR')).toBeNull();
+    // Three-letter code (ISO-3) — never accepted.
+    expect(normaliseDeliveryCountry('USA')).toBeNull();
+    // Full name — never accepted.
+    expect(normaliseDeliveryCountry('United Kingdom')).toBeNull();
+    // Random string.
+    expect(normaliseDeliveryCountry('XX')).toBeNull();
+  });
+
+  test('rejects non-string runtime input safely', () => {
+    // @ts-expect-error — testing runtime guard
+    expect(normaliseDeliveryCountry(42)).toBeNull();
+    // @ts-expect-error — testing runtime guard
+    expect(normaliseDeliveryCountry({})).toBeNull();
+  });
+
+  test('handles the union with the type for callers that need it', () => {
+    const result = normaliseDeliveryCountry('GB');
+    if (result !== null) {
+      // Compile-time check: the result widens to string, callers that need
+      // SupportedDeliveryCountry must verify via membership.
+      const code: string = result;
+      expect(code).toBe('GB');
+    }
+  });
+});
+
+describe('KAN-186 delivery country — isIsoAlpha2', () => {
+  // Wider than the supported list — used for narrowing against the DB check
+  // constraint shape, not against our merchant coverage.
+
+  test('accepts any uppercase 2-letter string', () => {
+    expect(isIsoAlpha2('GB')).toBe(true);
+    expect(isIsoAlpha2('US')).toBe(true);
+    expect(isIsoAlpha2('XX')).toBe(true); // matches the DB constraint, even if not in our allowlist
+  });
+
+  test('rejects lowercase, 3-letter, full names, non-string', () => {
+    expect(isIsoAlpha2('gb')).toBe(false);
+    expect(isIsoAlpha2('USA')).toBe(false);
+    expect(isIsoAlpha2('United Kingdom')).toBe(false);
+    expect(isIsoAlpha2(null)).toBe(false);
+    expect(isIsoAlpha2(undefined)).toBe(false);
+    expect(isIsoAlpha2(42)).toBe(false);
+    expect(isIsoAlpha2('G1')).toBe(false);
+  });
+});
+
+describe('KAN-186 delivery country — type contract', () => {
+  test('SupportedDeliveryCountry derives from the as-const tuple', () => {
+    // Compile-time check that the type narrows correctly. If you add a new
+    // country to SUPPORTED_DELIVERY_COUNTRIES, this still compiles because
+    // the type is derived; if you accidentally widen the literal type, this
+    // test still compiles but downstream callers benefit from the narrower
+    // type. Runtime check that GB is a valid member:
+    const gb: SupportedDeliveryCountry = 'GB';
+    expect(gb).toBe('GB');
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `delivery_country_code` to `profiles` — the strict ISO-3166 alpha-2 used by the recommendation engine's eligibility filter
- Separate from the existing freeform `country` field (which keeps its display purpose)
- New `SUPPORTED_DELIVERY_COUNTRIES` allowlist covering GB / IE / DE / FR / IT / ES / NL / US / CA / AU / JP — the Earn Globally umbrella plus North America and a small APAC tail
- New `<select>` on the profile wizard identity step, wired to a dedicated server action
- NULL semantics: "fall back to buyer country at recommendation time" per the KAN-185 geo-signal design

## Migration ✓
Applied to dev (`ilprytcrnqyrsbsrfujj`) via `apply_migration`. Stage + prod will follow via the standard promotion pipeline.

## Out of scope
The MCP server's `lyra_update_profile` tool also needs to learn this field — that's a separate PR in `luisa-sys/lyra-mcp-server`.

## Test plan
- [x] 14 new unit tests pass
- [x] All existing unit tests pass
- [x] `tsc --noEmit` clean
- [x] `next build` clean
- [ ] Manual: open the profile wizard, pick a delivery country, refresh, confirm it's persisted
- [ ] Manual: try an unsupported country via curl → expect a 4xx with the supported-countries error

## Related
KAN-186, KAN-185, KAN-187, KAN-190, KAN-198, KAN-199

🤖 Generated with [Claude Code](https://claude.com/claude-code)