### PR TITLE
feat(KAN-198): recommender data input audit + structured fields

### DIFF
--- a/docs/RECOMMENDER_INPUTS.md
+++ b/docs/RECOMMENDER_INPUTS.md
@@ -1,0 +1,126 @@
+# Recommender inputs — canonical field list (KAN-198)
+
+> The recommendation engine's quality is bounded by the data it gets about the recipient, the buyer, and the occasion. This document is the canonical inventory of every field the V2 recommender (KAN-139, design in KAN-199) reads — what we have today, what's in flight, what's added in this ticket, and what stays unstored (per-request inputs).
+
+If you add a new field to a recipient profile, or a new parameter to the recommendation request, list it here. The recommender, eligibility filter, ranker, and MCP tool all reference this doc.
+
+## Three buckets
+
+### 1. Recipient profile (persistent, on `profiles` or sibling tables)
+
+| Field | Type | Source | Used by |
+|---|---|---|---|
+| `profiles.display_name` | text | onboarding wizard | rationale string ("Anna mentioned…") |
+| `profiles.headline` | text | onboarding wizard | optional context for V1 + LLM |
+| `profiles.bio_short` | text | onboarding wizard | V1 + LLM context |
+| `profiles.city` / `region` / `country` | text (freeform) | onboarding wizard | display / loose geo cue |
+| `profiles.delivery_country_code` | text (ISO-2) | KAN-186 | **hard filter** — recipient shipping eligibility |
+| `profiles.age_range` | text (bucket enum) | **KAN-198 — this ticket** | V1 + LLM context; future demographic-aware ranking |
+| `profiles.recipient_attributes` | JSONB | **KAN-198 — this ticket** | bag for dietary / allergies / sizes / dislikes / future structured signals |
+| `profile_items` rows (category `likes`) | rows | onboarding wizard | V1 main input + LLM context |
+| `profile_items` rows (category `gifts_to_avoid`) | rows | onboarding wizard | V1 anti-category + LLM "don't suggest" list |
+| `profile_items` rows (other categories) | rows | onboarding wizard | V1 input |
+| `profile_manual_of_me` (KAN-154) | freeform text | KAN-154 | LLM context for richer profiles |
+| `profile_conversation_starters` answers (KAN-181) | text | KAN-181 | LLM context |
+| `profile_files` (KAN-142) | rows | KAN-142 | NOT used by recommender (display only) |
+| `profile_items` rows (category `current_problems` — KAN-182) | rows | KAN-182 | LLM context for problem-solving gift ideas |
+
+### 2. Buyer context (per-recommendation request, not stored)
+
+These are passed into the recommender on every call — either from a small form on the web (KAN-191) or as parameters to the MCP tool (KAN-201). They are NOT stored on the recipient profile because they're buyer-specific.
+
+| Parameter | Type | Required | Default | Notes |
+|---|---|---|---|---|
+| `buyer_country` | ISO-2 | yes | from KAN-185 detection chain | drives commission attribution |
+| `occasion` | enum: birthday / christmas / anniversary / valentines / just_because / other | no | `just_because` | a tag string for the ranker + rationale |
+| `budget_min` | numeric | no | 0 | buyer's preferred minimum |
+| `budget_max` | numeric | no | unset (no upper bound) | hard ceiling — products above this are dropped |
+| `budget_currency` | ISO-4217 | no | inferred from buyer_country | display + budget comparison |
+| `delivery_by_date` | ISO date | no | unset | urgency signal, reserved for V2.1 |
+| `relationship_to_recipient` | enum: partner / parent / child / sibling / friend / colleague / other | no | `other` | LLM context; never persisted |
+
+### 3. Signals — derived at recommendation time
+
+These are computed, not user-supplied.
+
+| Signal | Source | Used by |
+|---|---|---|
+| `merchant_eligibility[country]` | KAN-187 matrix | hard filter (KAN-190) |
+| `merchant_EPC[merchant, country]` | KAN-195 reporting feedback | ranker weight 20% (KAN-199) |
+| `merchantSeenCount` (within current result list) | computed | diversity penalty in ranker |
+| `recipient_dietary_inferred` | V1 free-text inference from likes/avoids | falls back to `recipient_attributes.dietary` if structured |
+| `profile_completeness_score` | existing `profiles.completion_score` | weighted "show this prompt" UX for sparse profiles |
+
+## What's new in this ticket
+
+### `age_range` — bucket enum on `profiles`
+
+A bucketed value, NOT a date of birth. Buckets:
+- `0_5` — infant to early-years
+- `6_12` — primary school
+- `13_17` — secondary school (AADC applies — see KAN-155 / KAN-164)
+- `18_29`
+- `30_44`
+- `45_64`
+- `65_plus`
+
+Why buckets, not DOB:
+- AADC (Age Appropriate Design Code) for under-13 profiles requires that we minimise data collection. Buckets are sufficient for recommendation quality and avoid storing precise DOB.
+- The V2 ranker uses age for rough product-class matching (e.g. don't recommend a £200 gadget to a recipient in `0_5`). Bucket granularity is plenty.
+
+NULL allowed — sparse profiles work fine without it, falling back to V1's existing behaviour.
+
+### `recipient_attributes` — JSONB on `profiles`
+
+A small JSONB bag for structured recipient attributes that the recommender can read but that don't merit their own column. Shape (all keys optional):
+
+```json
+{
+  "dietary": ["vegan", "gluten_free"],
+  "allergies": ["nuts", "shellfish"],
+  "sizes": { "clothing": "M", "shoes_uk": "8" },
+  "dislikes_text": "Strong perfumes, anything pink"
+}
+```
+
+Why JSONB instead of columns-per-attribute:
+- Schema iteration without a migration. We expect the V2.1 + V2.2 evolution (per KAN-199) to introduce new fields (gift-history, preferences) — JSONB lets us add without churning the schema.
+- Most attributes feed an LLM prompt as text, so structured queries on them aren't required for MVP.
+- A migration to lift any attribute into its own column is cheap when the access pattern justifies it.
+
+NULL allowed and default `'{}'::jsonb`.
+
+NOT stored in JSONB:
+- Anything PII-grade (full address, real DOB) — those go in columns with RLS we can reason about.
+- Anything regulated (financial, health) — Lyra is not a healthcare app and we keep that boundary deliberately.
+
+### Helper module: `src/lib/recommender/inputs.ts`
+
+Type guards and constants for the new fields (the canonical age-range buckets, the dietary enum, the allergies enum) — used by the (future) recommender, the (future) MCP tool, and the (future) profile UI. Adding the helpers in this ticket so downstream tickets can import canonical types instead of duplicating literals.
+
+## Tests required (this ticket)
+
+- Unit: `AGE_RANGE_BUCKETS` matches the migration's check constraint.
+- Unit: `isAgeRangeBucket` / `isDietaryRestriction` / `isAllergy` type guards reject unknown values.
+- Unit: `coerceRecipientAttributes` normalises a raw JSONB blob into the typed shape (drops unknown keys, validates enums, length-caps free text).
+
+## Not in this ticket (deferred)
+
+- **UI surfaces** for these fields — small form on the profile wizard (deferred until V2 needs it, expected next session).
+- **MCP `lyra_recommend_gifts` parameter extension** — handled in KAN-201 because it's the same surface as wiring monetised links.
+- **Buyer-context capture UX** (occasion / budget form on the web) — handled in KAN-191 because it lives next to the recommendation render path.
+
+## Cross-reference
+
+| Ticket | Relationship to this audit |
+|---|---|
+| KAN-139 | Umbrella V2 recommender ticket |
+| KAN-154 | Adds Manual of Me + conversation-starters + current-problems profile data — counted above |
+| KAN-181 | Conversation-starters table — counted above |
+| KAN-186 | Delivery country — counted above |
+| KAN-187 | Eligibility matrix — secondary derived signal |
+| KAN-191 | Web recommendation render — consumer of these inputs |
+| KAN-195 | Reporting — produces `merchant_EPC` signal |
+| KAN-199 | V2 architecture — references this inventory |
+| KAN-201 | MCP `lyra_recommend_gifts` — consumer of these inputs |
+| KAN-202 | Feedback loop — adds new event-type signal not covered here |

--- a/src/lib/recommender/inputs.ts
+++ b/src/lib/recommender/inputs.ts
@@ -1,0 +1,204 @@
+/**
+ * KAN-198: canonical types + helpers for the recommender-input fields on
+ * `profiles`. See docs/RECOMMENDER_INPUTS.md for the full inventory.
+ *
+ * Used by:
+ *   - The (future) V2 recommender that reads recipient_attributes.
+ *   - The (future) MCP tool that accepts buyer-context parameters.
+ *   - The (future) profile UI that lets a buyer edit these fields.
+ *
+ * Keep the enum literals here aligned with:
+ *   - The SQL check constraint in
+ *     supabase/migrations/20260516220000_recipient_recommender_fields.sql
+ *   - The JSONB shape in docs/RECOMMENDER_INPUTS.md
+ *
+ * No `'use server'` — this module exports types + constants + pure
+ * functions, callable from any context.
+ */
+
+// -----------------------------------------------------------------------------
+// Age range buckets (column `profiles.age_range`)
+// -----------------------------------------------------------------------------
+
+export const AGE_RANGE_BUCKETS = [
+  '0_5',
+  '6_12',
+  '13_17',
+  '18_29',
+  '30_44',
+  '45_64',
+  '65_plus',
+] as const;
+
+export type AgeRangeBucket = (typeof AGE_RANGE_BUCKETS)[number];
+
+const AGE_RANGE_SET: ReadonlySet<string> = new Set(AGE_RANGE_BUCKETS);
+
+export function isAgeRangeBucket(value: unknown): value is AgeRangeBucket {
+  return typeof value === 'string' && AGE_RANGE_SET.has(value);
+}
+
+// -----------------------------------------------------------------------------
+// Dietary restrictions (recipient_attributes.dietary[])
+// -----------------------------------------------------------------------------
+
+export const DIETARY_RESTRICTIONS = [
+  'vegan',
+  'vegetarian',
+  'pescatarian',
+  'gluten_free',
+  'dairy_free',
+  'nut_free',
+  'shellfish_free',
+  'halal',
+  'kosher',
+  'no_pork',
+  'no_alcohol',
+] as const;
+
+export type DietaryRestriction = (typeof DIETARY_RESTRICTIONS)[number];
+
+const DIETARY_SET: ReadonlySet<string> = new Set(DIETARY_RESTRICTIONS);
+
+export function isDietaryRestriction(value: unknown): value is DietaryRestriction {
+  return typeof value === 'string' && DIETARY_SET.has(value);
+}
+
+// -----------------------------------------------------------------------------
+// Allergies (recipient_attributes.allergies[])
+// -----------------------------------------------------------------------------
+
+export const ALLERGIES = [
+  'nuts',
+  'peanuts',
+  'shellfish',
+  'fish',
+  'eggs',
+  'dairy',
+  'gluten',
+  'soy',
+  'sesame',
+  'wheat',
+  'latex',
+] as const;
+
+export type Allergy = (typeof ALLERGIES)[number];
+
+const ALLERGY_SET: ReadonlySet<string> = new Set(ALLERGIES);
+
+export function isAllergy(value: unknown): value is Allergy {
+  return typeof value === 'string' && ALLERGY_SET.has(value);
+}
+
+// -----------------------------------------------------------------------------
+// recipient_attributes JSONB shape
+// -----------------------------------------------------------------------------
+
+export type RecipientAttributes = {
+  dietary?: DietaryRestriction[];
+  allergies?: Allergy[];
+  sizes?: {
+    clothing?: string;
+    shoes_uk?: string;
+    shoes_us?: string;
+    shoes_eu?: string;
+  };
+  dislikes_text?: string;
+};
+
+/**
+ * Coerce a raw JSONB blob (from the DB or an untyped API client) into the
+ * typed RecipientAttributes shape. Unknown keys are dropped, enums are
+ * validated and filtered to known values, sizes are coerced to short strings,
+ * dislikes_text is length-capped.
+ *
+ * Returns an empty object on null / undefined / wrong shape.
+ *
+ * Used everywhere we read recipient_attributes — the SQL column is `jsonb`
+ * so the DB driver hands us `unknown`, and we never trust the shape blind.
+ */
+export function coerceRecipientAttributes(
+  raw: unknown
+): RecipientAttributes {
+  if (raw === null || raw === undefined) return {};
+  if (typeof raw !== 'object') return {};
+  if (Array.isArray(raw)) return {};
+
+  const obj = raw as Record<string, unknown>;
+  const out: RecipientAttributes = {};
+
+  if (Array.isArray(obj.dietary)) {
+    const filtered = obj.dietary.filter(isDietaryRestriction);
+    if (filtered.length > 0) out.dietary = filtered;
+  }
+
+  if (Array.isArray(obj.allergies)) {
+    const filtered = obj.allergies.filter(isAllergy);
+    if (filtered.length > 0) out.allergies = filtered;
+  }
+
+  if (obj.sizes && typeof obj.sizes === 'object' && !Array.isArray(obj.sizes)) {
+    const sizesIn = obj.sizes as Record<string, unknown>;
+    const sizes: NonNullable<RecipientAttributes['sizes']> = {};
+    // Each size value is coerced to a short trimmed string. Reject anything
+    // longer than 20 chars — sizes are codes like "M", "L", "EU42", not prose.
+    for (const key of ['clothing', 'shoes_uk', 'shoes_us', 'shoes_eu'] as const) {
+      const v = sizesIn[key];
+      if (typeof v === 'string') {
+        const trimmed = v.trim();
+        if (trimmed.length > 0 && trimmed.length <= 20) {
+          sizes[key] = trimmed;
+        }
+      }
+    }
+    if (Object.keys(sizes).length > 0) out.sizes = sizes;
+  }
+
+  if (typeof obj.dislikes_text === 'string') {
+    const trimmed = obj.dislikes_text.trim();
+    if (trimmed.length > 0) {
+      out.dislikes_text = trimmed.slice(0, 500);
+    }
+  }
+
+  return out;
+}
+
+// -----------------------------------------------------------------------------
+// Buyer-context per-request inputs (NOT stored on the profile)
+// -----------------------------------------------------------------------------
+
+export const OCCASIONS = [
+  'birthday',
+  'christmas',
+  'anniversary',
+  'valentines',
+  'just_because',
+  'other',
+] as const;
+
+export type Occasion = (typeof OCCASIONS)[number];
+
+const OCCASION_SET: ReadonlySet<string> = new Set(OCCASIONS);
+
+export function isOccasion(value: unknown): value is Occasion {
+  return typeof value === 'string' && OCCASION_SET.has(value);
+}
+
+export const RELATIONSHIPS = [
+  'partner',
+  'parent',
+  'child',
+  'sibling',
+  'friend',
+  'colleague',
+  'other',
+] as const;
+
+export type Relationship = (typeof RELATIONSHIPS)[number];
+
+const RELATIONSHIP_SET: ReadonlySet<string> = new Set(RELATIONSHIPS);
+
+export function isRelationship(value: unknown): value is Relationship {
+  return typeof value === 'string' && RELATIONSHIP_SET.has(value);
+}

--- a/supabase/migrations/20260516220000_recipient_recommender_fields.sql
+++ b/supabase/migrations/20260516220000_recipient_recommender_fields.sql
@@ -1,0 +1,34 @@
+-- KAN-198: structured recommender-input fields on profiles.
+--
+-- Per docs/RECOMMENDER_INPUTS.md, the V2 recommender (KAN-139 / KAN-199)
+-- needs two new persistent fields on a recipient profile beyond what already
+-- exists today: a bucketed age range (NOT a DOB) and a flexible JSONB bag
+-- for dietary / allergies / sizes / dislikes etc.
+--
+-- Both are nullable. Sparse profiles continue to work — the recommender
+-- falls back to V1's existing free-text inference when these are unset.
+--
+-- AADC note: age_range is intentionally a bucket, NOT a date of birth.
+-- For under-13 profiles (KAN-155 / KAN-164) the bucket is the only age
+-- information stored, keeping us aligned with the Age Appropriate Design
+-- Code minimum-data principle.
+--
+-- Rollback (one-time, do not include in migration body):
+--   alter table public.profiles drop column if exists age_range;
+--   alter table public.profiles drop column if exists recipient_attributes;
+
+alter table public.profiles
+  add column if not exists age_range text
+    check (
+      age_range is null or
+      age_range in ('0_5', '6_12', '13_17', '18_29', '30_44', '45_64', '65_plus')
+    );
+
+alter table public.profiles
+  add column if not exists recipient_attributes jsonb not null default '{}'::jsonb;
+
+comment on column public.profiles.age_range is
+  'Bucketed age band for the recipient. Buckets aligned with KAN-198 / docs/RECOMMENDER_INPUTS.md. NULL = unknown. NOT a DOB — AADC minimum-data principle.';
+
+comment on column public.profiles.recipient_attributes is
+  'JSONB bag for structured recipient attributes used by the V2 recommender — dietary, allergies, sizes, dislikes_text, etc. Schema in docs/RECOMMENDER_INPUTS.md. No PII or regulated data.';

--- a/tests/unit/recommender-inputs.test.ts
+++ b/tests/unit/recommender-inputs.test.ts
@@ -1,0 +1,209 @@
+/**
+ * KAN-198: tests for the structured recommender-input helpers.
+ *
+ * Locks in:
+ *   1. The age-range buckets match the SQL CHECK constraint exactly.
+ *   2. Enum type guards reject unknown values (defence against future schema
+ *      drift between TS literals and DB constraints).
+ *   3. coerceRecipientAttributes returns a safe typed shape from any raw
+ *      JSONB input — the DB column is `jsonb` so we never trust the input
+ *      shape blind.
+ */
+
+import {
+  AGE_RANGE_BUCKETS,
+  DIETARY_RESTRICTIONS,
+  ALLERGIES,
+  OCCASIONS,
+  RELATIONSHIPS,
+  isAgeRangeBucket,
+  isDietaryRestriction,
+  isAllergy,
+  isOccasion,
+  isRelationship,
+  coerceRecipientAttributes,
+} from '@/lib/recommender/inputs';
+
+describe('KAN-198 recommender inputs — AGE_RANGE_BUCKETS', () => {
+  test('matches the SQL CHECK constraint exactly', () => {
+    // If you change the buckets here, also change the constraint in
+    // supabase/migrations/20260516220000_recipient_recommender_fields.sql
+    // and the docs in docs/RECOMMENDER_INPUTS.md.
+    expect([...AGE_RANGE_BUCKETS]).toEqual([
+      '0_5',
+      '6_12',
+      '13_17',
+      '18_29',
+      '30_44',
+      '45_64',
+      '65_plus',
+    ]);
+  });
+
+  test('includes the AADC-relevant under-13 bucket', () => {
+    // The under-13 bucket exists separately from 13-17 because UK GDPR Art 8
+    // / AADC apply differently to under-13s. The recommender uses the bucket
+    // to skip age-inappropriate gift categories.
+    expect([...AGE_RANGE_BUCKETS]).toContain('0_5');
+    expect([...AGE_RANGE_BUCKETS]).toContain('6_12');
+  });
+});
+
+describe('KAN-198 recommender inputs — isAgeRangeBucket', () => {
+  test('accepts every canonical bucket', () => {
+    for (const b of AGE_RANGE_BUCKETS) {
+      expect(isAgeRangeBucket(b)).toBe(true);
+    }
+  });
+
+  test('rejects unknown / malformed', () => {
+    expect(isAgeRangeBucket('0-5')).toBe(false); // hyphen instead of underscore
+    expect(isAgeRangeBucket('18_30')).toBe(false); // boundary mismatch
+    expect(isAgeRangeBucket('teen')).toBe(false);
+    expect(isAgeRangeBucket('')).toBe(false);
+    expect(isAgeRangeBucket(null)).toBe(false);
+    expect(isAgeRangeBucket(42)).toBe(false);
+  });
+});
+
+describe('KAN-198 recommender inputs — isDietaryRestriction', () => {
+  test('accepts the common diets', () => {
+    expect(isDietaryRestriction('vegan')).toBe(true);
+    expect(isDietaryRestriction('vegetarian')).toBe(true);
+    expect(isDietaryRestriction('gluten_free')).toBe(true);
+    expect(isDietaryRestriction('halal')).toBe(true);
+    expect(isDietaryRestriction('kosher')).toBe(true);
+  });
+
+  test('rejects unknown / casing', () => {
+    expect(isDietaryRestriction('Vegan')).toBe(false); // case sensitive
+    expect(isDietaryRestriction('gluten free')).toBe(false); // space, not underscore
+    expect(isDietaryRestriction('paleo')).toBe(false);
+    expect(isDietaryRestriction(null)).toBe(false);
+  });
+});
+
+describe('KAN-198 recommender inputs — isAllergy', () => {
+  test('accepts the common allergens', () => {
+    expect(isAllergy('nuts')).toBe(true);
+    expect(isAllergy('shellfish')).toBe(true);
+    expect(isAllergy('eggs')).toBe(true);
+    expect(isAllergy('latex')).toBe(true);
+  });
+
+  test('rejects unknown', () => {
+    expect(isAllergy('strawberries')).toBe(false);
+    expect(isAllergy('cats')).toBe(false);
+    expect(isAllergy(null)).toBe(false);
+  });
+});
+
+describe('KAN-198 recommender inputs — isOccasion / isRelationship', () => {
+  test('isOccasion accepts every canonical occasion', () => {
+    for (const o of OCCASIONS) {
+      expect(isOccasion(o)).toBe(true);
+    }
+    expect(isOccasion('wedding')).toBe(false);
+  });
+
+  test('isRelationship accepts every canonical relationship', () => {
+    for (const r of RELATIONSHIPS) {
+      expect(isRelationship(r)).toBe(true);
+    }
+    expect(isRelationship('cousin')).toBe(false);
+  });
+});
+
+describe('KAN-198 recommender inputs — coerceRecipientAttributes', () => {
+  test('null / undefined / wrong shape → empty object', () => {
+    expect(coerceRecipientAttributes(null)).toEqual({});
+    expect(coerceRecipientAttributes(undefined)).toEqual({});
+    expect(coerceRecipientAttributes('string')).toEqual({});
+    expect(coerceRecipientAttributes(42)).toEqual({});
+    expect(coerceRecipientAttributes([])).toEqual({});
+  });
+
+  test('passes through a well-formed payload', () => {
+    const raw = {
+      dietary: ['vegan', 'gluten_free'],
+      allergies: ['nuts'],
+      sizes: { clothing: 'M', shoes_uk: '8' },
+      dislikes_text: 'Strong perfumes',
+    };
+    expect(coerceRecipientAttributes(raw)).toEqual({
+      dietary: ['vegan', 'gluten_free'],
+      allergies: ['nuts'],
+      sizes: { clothing: 'M', shoes_uk: '8' },
+      dislikes_text: 'Strong perfumes',
+    });
+  });
+
+  test('filters unknown enum values out of arrays', () => {
+    const raw = {
+      dietary: ['vegan', 'paleo', 'gluten_free'], // paleo not in our list
+      allergies: ['nuts', 'kryptonite'], // kryptonite not in our list
+    };
+    expect(coerceRecipientAttributes(raw)).toEqual({
+      dietary: ['vegan', 'gluten_free'],
+      allergies: ['nuts'],
+    });
+  });
+
+  test('drops a dietary array that filters to empty', () => {
+    expect(coerceRecipientAttributes({ dietary: ['paleo'] })).toEqual({});
+  });
+
+  test('drops unknown top-level keys', () => {
+    const raw = {
+      dietary: ['vegan'],
+      religion: 'something', // not in schema
+      favourite_colour: 'blue', // not in schema
+    };
+    expect(coerceRecipientAttributes(raw)).toEqual({ dietary: ['vegan'] });
+  });
+
+  test('caps dislikes_text at 500 chars', () => {
+    const long = 'a'.repeat(1000);
+    const out = coerceRecipientAttributes({ dislikes_text: long });
+    expect(out.dislikes_text).toHaveLength(500);
+  });
+
+  test('trims dislikes_text', () => {
+    expect(coerceRecipientAttributes({ dislikes_text: '   pink   ' })).toEqual({
+      dislikes_text: 'pink',
+    });
+  });
+
+  test('rejects size values longer than 20 chars (defence against prose)', () => {
+    expect(
+      coerceRecipientAttributes({
+        sizes: {
+          clothing: 'this is a very long string trying to inject prose into the sizes field',
+          shoes_uk: '8',
+        },
+      })
+    ).toEqual({ sizes: { shoes_uk: '8' } });
+  });
+
+  test('non-string size values dropped', () => {
+    expect(
+      coerceRecipientAttributes({
+        sizes: { clothing: 42, shoes_uk: '8' },
+      })
+    ).toEqual({ sizes: { shoes_uk: '8' } });
+  });
+
+  test('non-array dietary dropped silently', () => {
+    expect(
+      coerceRecipientAttributes({ dietary: 'vegan' as unknown as string[] })
+    ).toEqual({});
+  });
+
+  test('count of enum values stays in sync between TS and SQL', () => {
+    // If you add a new enum value to DIETARY_RESTRICTIONS or ALLERGIES,
+    // this is a reminder to double-check that nothing downstream pins on
+    // the count. Just a sanity check, not a hard floor.
+    expect(DIETARY_RESTRICTIONS.length).toBeGreaterThanOrEqual(8);
+    expect(ALLERGIES.length).toBeGreaterThanOrEqual(8);
+  });
+});


### PR DESCRIPTION
## Summary
- **Audit doc** `docs/RECOMMENDER_INPUTS.md` — the canonical inventory of every field the V2 recommender reads (profile / buyer context / derived signals)
- **Schema migration** adds two persistent fields on `profiles`:
  - `age_range` — bucketed (`0_5` / `6_12` / `13_17` / `18_29` / `30_44` / `45_64` / `65_plus`), AADC-aligned (NOT a DOB)
  - `recipient_attributes` JSONB — bag for dietary / allergies / sizes / dislikes_text so we can iterate without further migrations
- **Helper module** `src/lib/recommender/inputs.ts` — type guards + `coerceRecipientAttributes()` for safe consumption of the JSONB
- **21 new unit tests** covering the bucket/enum guards and JSONB coercion edge cases (unknown keys, prose-in-sizes attacks, length caps)

## Migration ✓
Applied to dev (`ilprytcrnqyrsbsrfujj`) via `apply_migration`. Stage + prod will follow via the standard promotion pipeline.

## Out of scope (deferred)
- UI surfaces for these fields on the profile wizard (KAN-191-ish follow-up)
- MCP `lyra_recommend_gifts` parameter extension (KAN-201)
- Buyer-context capture UX on web (KAN-191)

## Test plan
- [x] 21 new unit tests pass
- [x] All 611 unit tests pass
- [x] `tsc --noEmit` clean

## Related
KAN-198, KAN-139, KAN-199, KAN-191, KAN-201

🤖 Generated with [Claude Code](https://claude.com/claude-code)