### PR TITLE
feat(KAN-202): recommendation_events feedback schema

### DIFF
--- a/src/lib/recommender/events.ts
+++ b/src/lib/recommender/events.ts
@@ -1,0 +1,105 @@
+/**
+ * KAN-202: types + helpers for the recommendation_events feedback log.
+ *
+ * Keep enums aligned with the SQL check constraints in
+ * supabase/migrations/20260516230000_recommendation_events.sql.
+ *
+ * Producers (future):
+ *   - Web recommendation render — emits 'shown' (KAN-191)
+ *   - Affiliate Link Service — emits 'clicked' (KAN-188)
+ *   - Reconciliation cron — emits 'converted' (KAN-195)
+ *   - Web recommendation card — emits 'thumbs_up' / 'thumbs_down' / 'hidden'
+ *     (KAN-191)
+ *   - MCP `lyra_record_feedback` — emits 'thumbs_up' / 'thumbs_down' (KAN-201,
+ *     in the lyra-mcp-server repo)
+ *
+ * Consumers:
+ *   - Nightly aggregation cron — computes per-merchant EPC + CTR
+ *   - Admin dashboard — surfaces feedback signals (KAN-195)
+ *   - Future learned ranker (V2.1 evolution in KAN-199)
+ */
+
+export const RECOMMENDATION_EVENT_TYPES = [
+  'shown',
+  'clicked',
+  'converted',
+  'thumbs_up',
+  'thumbs_down',
+  'hidden',
+] as const;
+
+export type RecommendationEventType =
+  (typeof RECOMMENDATION_EVENT_TYPES)[number];
+
+const EVENT_TYPE_SET: ReadonlySet<string> = new Set(RECOMMENDATION_EVENT_TYPES);
+
+export function isRecommendationEventType(
+  value: unknown
+): value is RecommendationEventType {
+  return typeof value === 'string' && EVENT_TYPE_SET.has(value);
+}
+
+export type RecommendationEventSource = 'web' | 'mcp' | 'email';
+
+const SOURCE_SET: ReadonlySet<string> = new Set(['web', 'mcp', 'email']);
+
+export function isRecommendationEventSource(
+  value: unknown
+): value is RecommendationEventSource {
+  return typeof value === 'string' && SOURCE_SET.has(value);
+}
+
+export type RecommendationEventRow = {
+  event_id: string;
+  created_at: string;
+  recommendation_id: string;
+  session_id: string | null;
+  user_id: string | null;
+  recipient_id: string | null;
+  merchant_id: string | null;
+  event_type: RecommendationEventType;
+  source: RecommendationEventSource;
+  metadata: Record<string, unknown>;
+};
+
+/**
+ * Sanitise the free-form `metadata` JSONB before insert. The DB column is
+ * `jsonb not null default '{}'` so we always return a fresh plain object.
+ *
+ * Rules:
+ *   - Non-object / array / null input → empty object.
+ *   - Keys must be non-empty strings (defence against prototype-pollution
+ *     style keys like `__proto__`).
+ *   - Values may be: string (length-capped 200), finite number, boolean.
+ *     Anything else is dropped silently.
+ *
+ * NO PII: emails, phone numbers, full names should never appear in metadata.
+ * The caller is responsible for not putting them in; this function is the
+ * last-line defence shape-check, not a PII scrubber.
+ */
+export function sanitiseEventMetadata(raw: unknown): Record<string, unknown> {
+  if (raw === null || raw === undefined) return {};
+  if (typeof raw !== 'object') return {};
+  if (Array.isArray(raw)) return {};
+
+  const input = raw as Record<string, unknown>;
+  const out: Record<string, unknown> = {};
+
+  for (const [key, value] of Object.entries(input)) {
+    if (typeof key !== 'string' || key.length === 0 || key.length > 64) continue;
+    // Reject prototype-pollution attempts even though spreading into a fresh
+    // object would protect downstream consumers.
+    if (key === '__proto__' || key === 'constructor' || key === 'prototype') continue;
+
+    if (typeof value === 'string') {
+      out[key] = value.slice(0, 200);
+    } else if (typeof value === 'number' && Number.isFinite(value)) {
+      out[key] = value;
+    } else if (typeof value === 'boolean') {
+      out[key] = value;
+    }
+    // Skip everything else (objects, arrays, null, undefined, functions).
+  }
+
+  return out;
+}

--- a/supabase/migrations/20260516230000_recommendation_events.sql
+++ b/supabase/migrations/20260516230000_recommendation_events.sql
@@ -1,0 +1,101 @@
+-- KAN-202: recommendation_events — feedback + learning loop for the V2
+-- recommender.
+--
+-- The V2 ranker (KAN-199) needs signals to improve over time. This table
+-- captures every observable event on a recommendation:
+--   1. Explicit signals — thumbs up/down, hide, the user explicitly rated
+--      a recommendation either via the web UI (KAN-191) or via the MCP
+--      `lyra_record_feedback` tool (added in a separate lyra-mcp-server PR).
+--   2. Implicit signals — shown / clicked / converted. The recommender's
+--      render path emits 'shown', the link service (KAN-188) emits 'clicked'
+--      (mirrored into affiliate_clicks too, KAN-189), and the reconciliation
+--      cron (KAN-195) emits 'converted'.
+--
+-- A nightly aggregation cron (separate ticket) computes per-merchant EPC +
+-- CTR + per-concept satisfaction from this table and feeds them back into
+-- the ranker's weights via KV cache.
+--
+-- Join key: recommendation_id is a free-form text matching what the
+-- recommender emits and what `affiliate_clicks.recommendation_id` points
+-- at. We could FK it but the recommender's render event isn't persisted
+-- yet (V2 will introduce that in a later ticket) — keeping it free-form
+-- lets us start collecting signals immediately.
+--
+-- Rollback (one-time, do not include in migration body):
+--   drop table if exists public.recommendation_events;
+
+create table if not exists public.recommendation_events (
+  event_id uuid primary key default gen_random_uuid(),
+  created_at timestamptz not null default now(),
+
+  -- Joins to the affiliate_clicks row when the event_type is 'clicked' /
+  -- 'converted'; for 'shown' / 'thumbs_*' / 'hidden', the click hasn't
+  -- happened yet so the relationship is by recommendation_id alone.
+  recommendation_id text not null,
+
+  -- Attribution. session_id is always present (web + MCP both produce
+  -- one); user_id is null for anonymous web visitors; recipient_id is
+  -- null when feedback is on a sample/demo recommendation not tied to
+  -- a real profile.
+  session_id text,
+  user_id uuid references auth.users(id) on delete set null,
+  recipient_id uuid references public.profiles(id) on delete set null,
+
+  -- The merchant the surfaced recommendation pointed at. Useful for
+  -- per-merchant EPC computation without joining to affiliate_clicks.
+  merchant_id text,
+
+  event_type text not null check (event_type in (
+    'shown',           -- recommendation rendered to the user
+    'clicked',         -- user clicked the affiliate link
+    'converted',       -- provider reported a sale on this click
+    'thumbs_up',       -- explicit positive signal
+    'thumbs_down',     -- explicit negative signal
+    'hidden'           -- user hid the recommendation
+  )),
+
+  -- Source of the event — same enum as affiliate_clicks.source so the
+  -- two are aligned for reporting.
+  source text not null default 'web' check (source in ('web', 'mcp', 'email')),
+
+  -- Free-form bag for event-specific context. NO PII. Example uses:
+  --   { "position": 2, "concept": "books_reading" }  for 'shown'
+  --   { "reason": "too_expensive" }  for 'thumbs_down'
+  -- Schema-less by design — the ranker reads keys it knows about and
+  -- ignores the rest.
+  metadata jsonb not null default '{}'::jsonb
+);
+
+-- Indexes
+-- (recommendation_id) is the primary join key for analytics aggregation
+create index if not exists recommendation_events_recommendation_idx
+  on public.recommendation_events(recommendation_id);
+
+-- (merchant_id, event_type, created_at) supports per-merchant CTR / EPC
+-- computation in the nightly aggregation
+create index if not exists recommendation_events_merchant_idx
+  on public.recommendation_events(merchant_id, event_type, created_at desc)
+  where merchant_id is not null;
+
+-- (user_id, created_at) supports per-user feedback history (e.g. "what
+-- have I rated lately")
+create index if not exists recommendation_events_user_idx
+  on public.recommendation_events(user_id, created_at desc)
+  where user_id is not null;
+
+-- (recipient_id, event_type) supports per-profile feedback rollups for
+-- the future per-recipient learning (V2.2 in KAN-199)
+create index if not exists recommendation_events_recipient_idx
+  on public.recommendation_events(recipient_id, event_type)
+  where recipient_id is not null;
+
+-- RLS
+alter table public.recommendation_events enable row level security;
+
+-- Users can read their own events only. Service role bypasses RLS for writes
+-- (from the recommender / link service / cron) and aggregate reads (from the
+-- admin dashboard).
+drop policy if exists "Users can read own recommendation events" on public.recommendation_events;
+create policy "Users can read own recommendation events"
+  on public.recommendation_events for select to authenticated
+  using (user_id = auth.uid());

--- a/tests/unit/recommendation-events.test.ts
+++ b/tests/unit/recommendation-events.test.ts
@@ -1,0 +1,140 @@
+/**
+ * KAN-202: tests for the recommendation_events helpers.
+ *
+ * Locks the enum alignment with the SQL CHECK constraint and the metadata
+ * sanitiser which is the last-line defence between user-supplied feedback
+ * payloads and the `metadata jsonb` column.
+ */
+
+import {
+  RECOMMENDATION_EVENT_TYPES,
+  isRecommendationEventType,
+  isRecommendationEventSource,
+  sanitiseEventMetadata,
+} from '@/lib/recommender/events';
+
+describe('KAN-202 recommendation events — RECOMMENDATION_EVENT_TYPES', () => {
+  test('matches the SQL CHECK constraint exactly', () => {
+    // If you change the event-types here, also change the constraint in
+    // supabase/migrations/20260516230000_recommendation_events.sql.
+    expect([...RECOMMENDATION_EVENT_TYPES]).toEqual([
+      'shown',
+      'clicked',
+      'converted',
+      'thumbs_up',
+      'thumbs_down',
+      'hidden',
+    ]);
+  });
+});
+
+describe('KAN-202 recommendation events — isRecommendationEventType', () => {
+  test('accepts every canonical event type', () => {
+    for (const t of RECOMMENDATION_EVENT_TYPES) {
+      expect(isRecommendationEventType(t)).toBe(true);
+    }
+  });
+
+  test('rejects unknown / casing variants', () => {
+    expect(isRecommendationEventType('SHOWN')).toBe(false);
+    expect(isRecommendationEventType('liked')).toBe(false);
+    expect(isRecommendationEventType('')).toBe(false);
+    expect(isRecommendationEventType(null)).toBe(false);
+    expect(isRecommendationEventType(42)).toBe(false);
+  });
+});
+
+describe('KAN-202 recommendation events — isRecommendationEventSource', () => {
+  test('accepts web / mcp / email', () => {
+    expect(isRecommendationEventSource('web')).toBe(true);
+    expect(isRecommendationEventSource('mcp')).toBe(true);
+    expect(isRecommendationEventSource('email')).toBe(true);
+  });
+
+  test('rejects others', () => {
+    expect(isRecommendationEventSource('mobile')).toBe(false);
+    expect(isRecommendationEventSource('')).toBe(false);
+    expect(isRecommendationEventSource(null)).toBe(false);
+  });
+});
+
+describe('KAN-202 recommendation events — sanitiseEventMetadata', () => {
+  test('null / undefined / wrong shape → empty object', () => {
+    expect(sanitiseEventMetadata(null)).toEqual({});
+    expect(sanitiseEventMetadata(undefined)).toEqual({});
+    expect(sanitiseEventMetadata('hello')).toEqual({});
+    expect(sanitiseEventMetadata(42)).toEqual({});
+    expect(sanitiseEventMetadata([])).toEqual({});
+  });
+
+  test('passes through scalar values', () => {
+    const input = {
+      position: 2,
+      concept: 'books_reading',
+      first_render: true,
+      reason: 'too_expensive',
+    };
+    expect(sanitiseEventMetadata(input)).toEqual(input);
+  });
+
+  test('drops nested objects, arrays, null, undefined, functions', () => {
+    const input = {
+      ok: 'fine',
+      nested: { not: 'allowed' },
+      list: [1, 2, 3],
+      nullish: null,
+      missing: undefined,
+      func: () => 'no',
+    };
+    expect(sanitiseEventMetadata(input)).toEqual({ ok: 'fine' });
+  });
+
+  test('caps string values at 200 chars', () => {
+    const long = 'a'.repeat(500);
+    const out = sanitiseEventMetadata({ blob: long });
+    expect(out.blob).toBe('a'.repeat(200));
+  });
+
+  test('drops Infinity / NaN', () => {
+    expect(sanitiseEventMetadata({ inf: Infinity, nan: NaN, ok: 1 })).toEqual({
+      ok: 1,
+    });
+  });
+
+  test('rejects prototype-pollution-style keys', () => {
+    const input = {
+      __proto__: { polluted: true },
+      constructor: { also: 'bad' },
+      prototype: { worse: true },
+      ok: 'fine',
+    };
+    const out = sanitiseEventMetadata(input);
+    expect(out).toEqual({ ok: 'fine' });
+    // Confirm the prototype really isn't polluted.
+    expect((Object.prototype as Record<string, unknown>).polluted).toBeUndefined();
+  });
+
+  test('rejects empty / overlong keys', () => {
+    const longKey = 'k'.repeat(100);
+    const out = sanitiseEventMetadata({ '': 'empty', [longKey]: 'long', ok: 1 });
+    expect(out).toEqual({ ok: 1 });
+  });
+
+  test('produces a fresh object every call (no shared mutable state)', () => {
+    const a = sanitiseEventMetadata({});
+    const b = sanitiseEventMetadata({});
+    expect(a).not.toBe(b);
+    a.foo = 1;
+    expect(b.foo).toBeUndefined();
+  });
+
+  test('real-world examples from the design doc', () => {
+    expect(sanitiseEventMetadata({ position: 2, concept: 'books_reading' })).toEqual({
+      position: 2,
+      concept: 'books_reading',
+    });
+    expect(sanitiseEventMetadata({ reason: 'too_expensive' })).toEqual({
+      reason: 'too_expensive',
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- New `recommendation_events` table — captures explicit + implicit signals on every V2 recommendation so the ranker can learn over time
- Event types: `shown` / `clicked` / `converted` / `thumbs_up` / `thumbs_down` / `hidden`
- Aligned with `affiliate_clicks.source` and `affiliate_clicks.recommendation_id` so the two tables join cleanly
- 4 indexes for the expected aggregation patterns
- New helper module `src/lib/recommender/events.ts` with type guards + `sanitiseEventMetadata()` (rejects prototype-pollution keys, drops nested objects, caps strings)
- 14 new unit tests; all pass

## Migration ✓
Applied to dev (`ilprytcrnqyrsbsrfujj`) via `apply_migration`.

## Out of scope (deferred)
- Thumbs/hide UI on recommendation cards (needs KAN-191 web render)
- `lyra_record_feedback` MCP tool (`lyra-mcp-server` repo, separate PR)
- Nightly aggregation cron (separate ticket once data is flowing)

## Test plan
- [x] 14 new unit tests pass
- [x] `tsc --noEmit` clean

## Related
KAN-202, KAN-189, KAN-199, KAN-191, KAN-195, KAN-201

🤖 Generated with [Claude Code](https://claude.com/claude-code)