### PR TITLE
feat(KAN-191,KAN-192): render V2 monetisable recommendations on the public profile

### DIFF
--- a/src/app/[slug]/page.tsx
+++ b/src/app/[slug]/page.tsx
@@ -316,7 +316,12 @@ export default async function PublicProfilePage({ params }: Props) {
     sessionId: null,
     userId: viewer?.id ?? null,
     recipientId: typedProfile.id,
-    recommendationId: `web-${typedProfile.id}-${Date.now()}`,
+    // recommendationId is intentionally stable per profile, not
+    // per-request: react-compiler rejects Date.now() during render
+    // ("impure function"). The link service's click_id gives us
+    // per-click uniqueness; recommendationId just groups clicks under
+    // the same render context.
+    recommendationId: `web-${typedProfile.id}`,
     limit: 5,
   });
 

--- a/src/app/[slug]/page.tsx
+++ b/src/app/[slug]/page.tsx
@@ -12,7 +12,12 @@ import {
 } from '@/app/dashboard/profile/manual-of-me-fields';
 import { getRecommendations } from '@/lib/recommend';
 import RecommendationsSection from './recommendations-section';
+import V2RecommendationsSection from './v2-recommendations-section';
 import ReportButton from './report-button';
+import { headers } from 'next/headers';
+import { isIsoAlpha2, normaliseDeliveryCountry } from '@/lib/affiliate/country-codes';
+import { buildV2Recommendations } from '@/lib/recommender/v2/pipeline';
+import type { ConceptInput } from '@/lib/recommender/v2/types';
 
 /**
  * BUGS-14: profile pages render dynamically per-request.
@@ -269,6 +274,51 @@ export default async function PublicProfilePage({ params }: Props) {
     },
     { limit: 8 },
   );
+
+  // KAN-191 / KAN-200: V2 pipeline — turn V1's concepts into real
+  // monetisable product recommendations. Buyer country is detected from
+  // Cloudflare's CF-IPCountry header (KAN-185 geo design); recipient
+  // delivery country comes off the profile (KAN-186). The Affiliate Link
+  // Service (KAN-188) caches per-URL so repeat profile views don't hammer
+  // Sovrn. When Sovrn isn't configured (current state), buildV2
+  // recommendations returns curated-catalogue entries with un-monetised
+  // raw URLs and the Affiliate badge reflects that honestly.
+  //
+  // We compute V2 unconditionally and let the rendering decide which
+  // section to show — if V2 returns 0 items (sparse profile + nothing in
+  // the curated catalogue) the page falls back to the V1 section so
+  // sparse profiles aren't left empty.
+  const requestHeaders = await headers();
+  const buyerCountryHeader = requestHeaders.get('cf-ipcountry') ?? '';
+  const buyerCountry = isIsoAlpha2(buyerCountryHeader.toUpperCase())
+    ? buyerCountryHeader.toUpperCase()
+    : 'GB';
+  // delivery_country_code is added by KAN-186 (PR #203); the column is
+  // accessed defensively because that PR may not be in develop yet when
+  // this lands.
+  const recipientCountryRaw =
+    (typedProfile as { delivery_country_code?: string | null }).delivery_country_code ?? null;
+  const recipientCountry = normaliseDeliveryCountry(recipientCountryRaw) ?? buyerCountry;
+
+  const v2Concepts: ConceptInput[] = recommendations.map((r) => ({
+    categoryKey: r.categoryKey,
+    conceptTitle: r.title,
+    conceptScore: r.score,
+    reasons: r.reasons,
+    tags: r.tags,
+  }));
+
+  const v2Recommendations = await buildV2Recommendations({
+    concepts: v2Concepts,
+    buyerCountry,
+    recipientCountry,
+    source: 'web',
+    sessionId: null,
+    userId: viewer?.id ?? null,
+    recipientId: typedProfile.id,
+    recommendationId: `web-${typedProfile.id}-${Date.now()}`,
+    limit: 5,
+  });
 
   const categoryLabels: Record<string, string> = {
     likes: 'Likes',
@@ -636,12 +686,22 @@ export default async function PublicProfilePage({ params }: Props) {
         </div>
       )}
 
-      {/* KAN-139: gift recommendations based on profile data */}
+      {/* KAN-191 / KAN-200: V2 gift recommendations — monetisable when
+          Sovrn is live (KAN-184), un-monetised but click-logged today.
+          Falls back to V1 concept-only section (KAN-139) when V2 has
+          nothing in the curated catalogue for this profile. */}
       <div className="max-w-2xl mx-auto px-6">
-        <RecommendationsSection
-          displayName={typedProfile.display_name}
-          recommendations={recommendations}
-        />
+        {v2Recommendations.length > 0 ? (
+          <V2RecommendationsSection
+            displayName={typedProfile.display_name}
+            recommendations={v2Recommendations}
+          />
+        ) : (
+          <RecommendationsSection
+            displayName={typedProfile.display_name}
+            recommendations={recommendations}
+          />
+        )}
       </div>
 
       {/* Footer */}

--- a/src/app/[slug]/v2-recommendations-helpers.ts
+++ b/src/app/[slug]/v2-recommendations-helpers.ts
@@ -1,0 +1,59 @@
+/**
+ * KAN-191: pure helpers extracted from v2-recommendations-section.tsx so
+ * they can be unit-tested without a DOM environment (the rest of the
+ * Lyra test suite runs against Jest's `node` test environment).
+ */
+
+import type { V2Recommendation } from '@/lib/recommender/v2/types';
+
+/**
+ * Price range in human form. Returns null when no price info is available.
+ *
+ * Examples:
+ *   { min: 1000, max: 2500, GBP } → "£10–£25"
+ *   { min: 1000, max: 1000, GBP } → "from £10"
+ *   { min: null, max: 5000, GBP } → "up to £50"
+ *   { min: null, max: null }       → null
+ */
+export function formatPriceRange(
+  product: Pick<V2Recommendation['product'], 'priceMinMinor' | 'priceMaxMinor' | 'priceCurrency'>,
+): string | null {
+  const { priceMinMinor, priceMaxMinor, priceCurrency } = product;
+  if (priceMinMinor == null && priceMaxMinor == null) return null;
+  const symbol =
+    priceCurrency === 'GBP'
+      ? '£'
+      : priceCurrency === 'USD'
+        ? '$'
+        : priceCurrency === 'EUR'
+          ? '€'
+          : '';
+  const fmt = (minor: number) => `${symbol}${(minor / 100).toFixed(0)}`;
+  if (priceMinMinor != null && priceMaxMinor != null && priceMinMinor !== priceMaxMinor) {
+    return `${fmt(priceMinMinor)}–${fmt(priceMaxMinor)}`;
+  }
+  if (priceMinMinor != null) return `from ${fmt(priceMinMinor)}`;
+  if (priceMaxMinor != null) return `up to ${fmt(priceMaxMinor)}`;
+  return null;
+}
+
+/**
+ * Merchant id → human display label. Keeps the recommender's canonical
+ * ids machine-readable while presenting something readable to the user.
+ *
+ * Unknown ids return the id itself (so the page never blanks out — better
+ * to show "weirdmerchant_xyz" than nothing).
+ */
+export function merchantLabel(id: string): string {
+  return (
+    {
+      amazon: 'Amazon',
+      etsy: 'Etsy',
+      ebay: 'eBay',
+      johnlewis: 'John Lewis',
+      notonthehighstreet: 'Notonthehighstreet',
+      bookshop_org: 'Bookshop.org',
+      otto: 'Otto',
+    }[id] ?? id
+  );
+}

--- a/src/app/[slug]/v2-recommendations-section.tsx
+++ b/src/app/[slug]/v2-recommendations-section.tsx
@@ -17,6 +17,7 @@
  * to the V1 concept-only section gracefully.
  */
 
+import Link from 'next/link';
 import type { V2Recommendation } from '@/lib/recommender/v2/types';
 import AffiliateBadge from '@/components/AffiliateBadge';
 import { formatPriceRange, merchantLabel } from './v2-recommendations-helpers';
@@ -51,9 +52,9 @@ export default function V2RecommendationsSection({
         <p className="text-sm text-[var(--color-muted)] mt-2">
           Selected based on {first}&rsquo;s profile. Lyra may earn a commission on
           some links &mdash;{' '}
-          <a href="/partners" className="text-[var(--color-lyra-sage,#5a7a5e)] hover:underline">
+          <Link href="/partners" className="text-[var(--color-lyra-sage,#5a7a5e)] hover:underline">
             see how this works
-          </a>
+          </Link>
           .
         </p>
       </header>
@@ -97,9 +98,9 @@ export default function V2RecommendationsSection({
 
       <p className="text-xs text-stone-500 mt-6">
         Suggestions are auto-generated &mdash; not endorsements. Read the{' '}
-        <a href="/partners" className="text-[var(--color-lyra-sage,#5a7a5e)] hover:underline">
+        <Link href="/partners" className="text-[var(--color-lyra-sage,#5a7a5e)] hover:underline">
           partners disclosure
-        </a>{' '}
+        </Link>{' '}
         for details on how Lyra works with affiliate networks.
       </p>
     </section>

--- a/src/app/[slug]/v2-recommendations-section.tsx
+++ b/src/app/[slug]/v2-recommendations-section.tsx
@@ -1,0 +1,107 @@
+/**
+ * KAN-191 (rendering) + KAN-192 (FTC affiliate badge): V2 "Gift ideas"
+ * section on the public profile page.
+ *
+ * Server component — receives pre-computed V2Recommendation[] from the
+ * parent profile page so the V2 pipeline call (which can do remote IO
+ * against Sovrn once live) happens once per request.
+ *
+ * Each card shows: product title, merchant + price range, rationale,
+ * affiliate disclosure badge, and a CTA anchor with the affiliate URL.
+ *
+ * The anchor uses `rel="sponsored noopener nofollow"` per FTC guidance
+ * + Google search-engine best practice for paid links.
+ *
+ * Returns null for empty input (sparse profile + nothing in the curated
+ * catalogue + Sovrn not yet live) so the parent component can fall back
+ * to the V1 concept-only section gracefully.
+ */
+
+import type { V2Recommendation } from '@/lib/recommender/v2/types';
+import AffiliateBadge from '@/components/AffiliateBadge';
+import { formatPriceRange, merchantLabel } from './v2-recommendations-helpers';
+
+interface V2RecommendationsSectionProps {
+  /** Display name of the recipient — used in the section heading. */
+  displayName: string;
+  /** Output of the V2 pipeline. */
+  recommendations: V2Recommendation[];
+}
+
+export default function V2RecommendationsSection({
+  displayName,
+  recommendations,
+}: V2RecommendationsSectionProps) {
+  if (recommendations.length === 0) return null;
+
+  const first = displayName.split(/\s+/)[0] ?? displayName;
+
+  return (
+    <section
+      aria-labelledby="v2-recommendations-heading"
+      className="mt-16 pt-12 border-t border-stone-200"
+    >
+      <header className="mb-8">
+        <h2
+          id="v2-recommendations-heading"
+          className="text-2xl font-medium text-[var(--color-ink)] font-[family-name:var(--font-serif)]"
+        >
+          Gift ideas for {first}
+        </h2>
+        <p className="text-sm text-[var(--color-muted)] mt-2">
+          Selected based on {first}&rsquo;s profile. Lyra may earn a commission on
+          some links &mdash;{' '}
+          <a href="/partners" className="text-[var(--color-lyra-sage,#5a7a5e)] hover:underline">
+            see how this works
+          </a>
+          .
+        </p>
+      </header>
+
+      <ul className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+        {recommendations.map((rec) => {
+          const price = formatPriceRange(rec.product);
+          const merchant = merchantLabel(rec.product.merchantId);
+          return (
+            <li
+              key={rec.affiliate.clickId}
+              className="p-5 rounded-xl border border-stone-200 bg-white flex flex-col"
+            >
+              <div className="flex items-baseline justify-between gap-3 mb-1">
+                <h3 className="text-base font-medium text-[var(--color-ink)] leading-snug">
+                  {rec.product.title}
+                </h3>
+                <AffiliateBadge monetised={rec.affiliate.monetised} />
+              </div>
+              <p className="text-xs text-stone-500 mb-2">
+                {merchant}
+                {price ? <span className="text-stone-400"> &middot; {price}</span> : null}
+              </p>
+              <p className="text-sm text-[var(--color-muted)] leading-relaxed flex-1">
+                {rec.rationale}
+              </p>
+              <div className="mt-4">
+                <a
+                  href={rec.affiliate.url}
+                  rel="sponsored noopener nofollow"
+                  target="_blank"
+                  className="inline-flex items-center text-sm font-medium text-[var(--color-lyra-sage,#5a7a5e)] hover:underline"
+                >
+                  View at {merchant} &rarr;
+                </a>
+              </div>
+            </li>
+          );
+        })}
+      </ul>
+
+      <p className="text-xs text-stone-500 mt-6">
+        Suggestions are auto-generated &mdash; not endorsements. Read the{' '}
+        <a href="/partners" className="text-[var(--color-lyra-sage,#5a7a5e)] hover:underline">
+          partners disclosure
+        </a>{' '}
+        for details on how Lyra works with affiliate networks.
+      </p>
+    </section>
+  );
+}

--- a/src/components/AffiliateBadge.tsx
+++ b/src/components/AffiliateBadge.tsx
@@ -1,0 +1,77 @@
+/**
+ * KAN-192: per-card "Affiliate" disclosure badge.
+ *
+ * FTC 2026 enforcement guidance requires disclosure of affiliate
+ * relationships to be unavoidable and adjacent to the recommendation. This
+ * is the smallest UI surface that meets that bar: a pill labelled
+ * "Affiliate" with a tooltip explaining what it means, plus a link to the
+ * full disclosure on /partners.
+ *
+ * Used by:
+ *   - V2 recommendation cards on the public profile (this PR)
+ *   - Future email gift-suggestion templates (KAN-192 follow-up)
+ *   - MCP-driven AI assistant responses surface the same disclosure as a
+ *     string in the response payload, not via this React component
+ *     (KAN-201 in lyra-mcp-server)
+ *
+ * Accessibility:
+ *   - The badge has an aria-label that screen readers announce as a full
+ *     sentence rather than just "Affiliate".
+ *   - The tooltip text is also in the DOM as a hidden span so non-hover
+ *     readers (screen readers, keyboard nav users) get the same content.
+ */
+
+import Link from 'next/link';
+
+export type AffiliateBadgeProps = {
+  /**
+   * When false, render a "not monetised" muted variant. Lyra logs the click
+   * either way (KAN-189 schema) but the user-facing disclosure should be
+   * honest: if no commission is earned on the click, the pill says so.
+   */
+  monetised?: boolean;
+  /** Visual size. The default 'sm' fits the V2 recommendation card. */
+  size?: 'sm' | 'md';
+  /** Optional className for extra layout. */
+  className?: string;
+};
+
+export default function AffiliateBadge({
+  monetised = true,
+  size = 'sm',
+  className = '',
+}: AffiliateBadgeProps) {
+  const label = monetised ? 'Affiliate' : 'Tracked';
+  const sentence = monetised
+    ? 'Affiliate link — Lyra may earn a commission if you buy via this link, at no extra cost to you.'
+    : 'Link tracked for analytics — no commission earned.';
+
+  const sizeClasses =
+    size === 'sm'
+      ? 'text-[10px] px-1.5 py-0.5'
+      : 'text-xs px-2 py-0.5';
+
+  const colourClasses = monetised
+    ? 'bg-[var(--color-lyra-sage-50,#eef2ec)] text-[var(--color-lyra-sage,#5a7a5e)] border-[var(--color-lyra-sage,#5a7a5e)]/30'
+    : 'bg-stone-100 text-stone-600 border-stone-300';
+
+  return (
+    <span
+      className={`inline-flex items-center gap-1 rounded-full border font-medium uppercase tracking-wider ${sizeClasses} ${colourClasses} ${className}`}
+      role="img"
+      aria-label={sentence}
+      title={sentence}
+    >
+      {label}
+      <Link
+        href="/partners"
+        rel="noopener"
+        className="text-[var(--color-lyra-sage,#5a7a5e)] hover:underline focus:underline outline-none focus:ring-1 focus:ring-[var(--color-lyra-sage,#5a7a5e)] rounded"
+        aria-label="What this means — affiliate partners page"
+      >
+        ?
+      </Link>
+      <span className="sr-only">{sentence}</span>
+    </span>
+  );
+}

--- a/tests/unit/affiliate-badge.test.js
+++ b/tests/unit/affiliate-badge.test.js
@@ -1,0 +1,68 @@
+/**
+ * KAN-192: file-content tests for the AffiliateBadge disclosure component.
+ *
+ * The project runs Jest in the `node` env (no DOM), so component-render
+ * assertions aren't available without adding jsdom — which would expand
+ * the test infrastructure for one widget. Instead we lock the
+ * FTC-relevant invariants by inspecting the source file.
+ *
+ * The invariants:
+ *   - Disclosure sentence contains the word "commission" (FTC required).
+ *   - "no extra cost" appears so users know there's no surcharge.
+ *   - Badge links to /partners for the long-form disclosure.
+ *   - Anchor uses noopener (security + good Anchor hygiene).
+ *   - role="img" so screen readers announce it as a single unit.
+ *   - sr-only span exists for screen-reader-only disclosure.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const filePath = path.join(__dirname, '../../src/components/AffiliateBadge.tsx');
+
+describe('KAN-192 AffiliateBadge — file content invariants', () => {
+  let content;
+
+  beforeAll(() => {
+    content = fs.readFileSync(filePath, 'utf8');
+  });
+
+  test('file exists', () => {
+    expect(fs.existsSync(filePath)).toBe(true);
+  });
+
+  test('disclosure includes the word "commission"', () => {
+    expect(content).toContain('commission');
+  });
+
+  test('disclosure includes "no extra cost"', () => {
+    expect(content).toMatch(/no extra cost/i);
+  });
+
+  test('links to /partners for the long-form disclosure', () => {
+    expect(content).toMatch(/href=\{?["']\/partners["']\}?/);
+  });
+
+  test('uses rel="noopener" on the partners link', () => {
+    expect(content).toContain('noopener');
+  });
+
+  test('uses role="img" so screen readers announce it as a unit', () => {
+    expect(content).toContain('role="img"');
+  });
+
+  test('has an sr-only span for screen-reader-only disclosure', () => {
+    expect(content).toContain('sr-only');
+  });
+
+  test('un-monetised variant says "Tracked" not "Affiliate"', () => {
+    // The badge is honest: if the click does NOT earn a commission, we
+    // don't call it "Affiliate" — that'd be misleading.
+    expect(content).toContain("'Tracked'");
+    expect(content).toContain("'Affiliate'");
+  });
+
+  test('un-monetised aria-label says "no commission"', () => {
+    expect(content).toMatch(/no commission/i);
+  });
+});

--- a/tests/unit/v2-recommendations-helpers.test.ts
+++ b/tests/unit/v2-recommendations-helpers.test.ts
@@ -1,0 +1,66 @@
+/**
+ * KAN-191: tests for the V2 recommendations rendering helpers.
+ *
+ * Pure functions extracted from v2-recommendations-section.tsx so they
+ * can be tested in the existing Node-env Jest setup (no DOM dependency).
+ */
+
+import {
+  formatPriceRange,
+  merchantLabel,
+} from '@/app/[slug]/v2-recommendations-helpers';
+
+describe('KAN-191 formatPriceRange — GBP', () => {
+  test('range with distinct min and max → "£X–£Y"', () => {
+    expect(formatPriceRange({ priceMinMinor: 1000, priceMaxMinor: 2500, priceCurrency: 'GBP' })).toBe('£10–£25');
+  });
+
+  test('range with equal min and max → "from £X"', () => {
+    expect(formatPriceRange({ priceMinMinor: 1500, priceMaxMinor: 1500, priceCurrency: 'GBP' })).toBe('from £15');
+  });
+
+  test('only min → "from £X"', () => {
+    expect(formatPriceRange({ priceMinMinor: 1000, priceMaxMinor: null, priceCurrency: 'GBP' })).toBe('from £10');
+  });
+
+  test('only max → "up to £X"', () => {
+    expect(formatPriceRange({ priceMinMinor: null, priceMaxMinor: 5000, priceCurrency: 'GBP' })).toBe('up to £50');
+  });
+
+  test('no price → null', () => {
+    expect(formatPriceRange({ priceMinMinor: null, priceMaxMinor: null, priceCurrency: null })).toBeNull();
+  });
+});
+
+describe('KAN-191 formatPriceRange — non-GBP currencies', () => {
+  test('USD → $', () => {
+    expect(formatPriceRange({ priceMinMinor: 2500, priceMaxMinor: 5000, priceCurrency: 'USD' })).toBe('$25–$50');
+  });
+
+  test('EUR → €', () => {
+    expect(formatPriceRange({ priceMinMinor: 1000, priceMaxMinor: 1000, priceCurrency: 'EUR' })).toBe('from €10');
+  });
+
+  test('unknown currency → no symbol (just numbers)', () => {
+    // Defensive: a Sovrn-returned product with a currency we don't have a
+    // glyph for should still produce something readable, not break the
+    // render.
+    expect(formatPriceRange({ priceMinMinor: 1000, priceMaxMinor: 2000, priceCurrency: 'CAD' })).toBe('10–20');
+  });
+});
+
+describe('KAN-191 merchantLabel', () => {
+  test('canonical ids return human labels', () => {
+    expect(merchantLabel('amazon')).toBe('Amazon');
+    expect(merchantLabel('etsy')).toBe('Etsy');
+    expect(merchantLabel('ebay')).toBe('eBay');
+    expect(merchantLabel('johnlewis')).toBe('John Lewis');
+    expect(merchantLabel('notonthehighstreet')).toBe('Notonthehighstreet');
+    expect(merchantLabel('bookshop_org')).toBe('Bookshop.org');
+    expect(merchantLabel('otto')).toBe('Otto');
+  });
+
+  test('unknown id falls back to the id itself (never breaks render)', () => {
+    expect(merchantLabel('unknown_merchant_xyz')).toBe('unknown_merchant_xyz');
+  });
+});


### PR DESCRIPTION
## Summary
The V2 recommender pipeline already exists at `/api/recommendations/v2/[slug]` (KAN-200, [PR #211](https://github.com/luisa-sys/lyra/pull/211)) but isn't yet visible to users. This PR puts it on the public profile page at `/[slug]` so anyone visiting a profile sees real, click-tracked, FTC-disclosed gift recommendations.

- New `AffiliateBadge` component (KAN-192) — small disclosure pill, "Affiliate" when monetised, **"Tracked"** when not. FTC-compliant aria-label + sr-only disclosure, links to `/partners`
- New `V2RecommendationsSection` server component — renders the V2 grid with title / merchant / price range / rationale / badge / `rel="sponsored noopener nofollow"` CTA
- Public profile page reads buyer country from Cloudflare `CF-IPCountry` per the KAN-185 geo design and recipient country from `profile.delivery_country_code` (KAN-186 field, accessed defensively)
- **V1 stays as fallback** — if V2 returns nothing (sparse profile + empty catalogue match) the existing `RecommendationsSection` still renders. Zero regression.

## State of monetisation
- **Today**: every card shows the honest "Tracked" badge — `SOVRN_API_KEY` isn't set yet so the link service returns raw URLs with `monetised:false`. Clicks are still logged in `affiliate_clicks`.
- **When `SOVRN_API_KEY` lands** (after Sovrn approves KAN-184, see [PR #209](https://github.com/luisa-sys/lyra/pull/209)): the link service's Sovrn provider auto-activates and the badge flips to "Affiliate" with monetised URLs. **No code change required.**

## Test plan
- [x] 19 new unit tests pass (helpers + FTC badge invariants)
- [x] `tsc --noEmit` clean
- [x] `next build` clean — `/[slug]` route compiles
- [ ] Manual after merge: view a published profile on `dev.checklyra.com`, see ≥1 V2 card with "Tracked" badge and click-tracked URL
- [ ] After Sovrn key lands: same view shows "Affiliate" badge with monetised URLs

## Dependencies (must merge first; zero file overlap)
- [#202](https://github.com/luisa-sys/lyra/pull/202) (KAN-189): `affiliate_clicks` schema + types
- [#203](https://github.com/luisa-sys/lyra/pull/203) (KAN-186): delivery country field + country-codes helper
- [#206](https://github.com/luisa-sys/lyra/pull/206) (KAN-191 svc): Affiliate Link Service skeleton
- [#211](https://github.com/luisa-sys/lyra/pull/211) (KAN-200): V2 pipeline + curated catalogue

## Related
KAN-191, KAN-192, KAN-200, KAN-184, KAN-188

🤖 Generated with [Claude Code](https://claude.com/claude-code)