### PR TITLE
docs(KAN-216): parallel-Claude worktree policy in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,6 +41,67 @@ Before starting any task, Claude must:
 3. **Check for existing work** — search the codebase and recent PRs to avoid duplicating effort.
 4. **Run tests before and after** — every change must leave tests green.
 5. **Check the surface** — confirm this is Claude Code, not chat. See "Editing the environment: Claude Code only" above.
+6. **Confirm working-tree isolation** — if Luisa might be running other Claude Code instances against this repo, this session MUST be in its own git worktree (see "Parallel Claude sessions" below). Verify with `git branch --show-current` at the start of work AND right before every `git add` / `git commit`. If HEAD switched unexpectedly, stop and recover per BUGS-17.
+
+## Parallel Claude sessions — use git worktrees
+
+**Luisa runs multiple Claude Code instances in parallel** to work on independent features in this repo. The shared main checkout is a single working tree, so two Claude sessions that both `git checkout` or `git commit` on the same tree will trample each other — one session's commits silently end up on top of the other's, mixing two unrelated features into one branch. This is BUGS-17. It was caught in May 2026 because a `gh pr create` errored; if it hadn't, a mixed-feature PR would have shipped contaminated code to production.
+
+### The rule
+
+**Any Claude Code session that is not the only one running against this repo MUST operate in a git worktree, not the shared checkout.** Worktrees are first-class Git: each worktree has its own working directory + index + HEAD, but shares the underlying object database with the main checkout. Two sessions in two worktrees cannot trample each other's HEAD.
+
+### How to isolate
+
+In rough order of preference:
+
+1. **Spawning a sub-agent for a discrete task** → pass `isolation: "worktree"` on the Agent tool call. The agent runs in a clean throwaway worktree and the result merges back to your tree if it made changes. Cleanest option for short-lived tasks.
+
+2. **Continuing your current session in isolation** → use `EnterWorktree` (Claude Code built-in). The current shell moves into a fresh worktree and stays there until `ExitWorktree`. Use this whenever you suspect another session might be active.
+
+3. **Launching a fresh Claude Code instance for parallel work** → before running `claude`, create the worktree manually:
+
+   ```bash
+   git worktree add ../lyra-<branch-name> origin/develop
+   cd ../lyra-<branch-name>
+   claude
+   ```
+
+   Treat that directory as the session's home. When done: `git worktree remove ../lyra-<branch-name>`.
+
+### Mandatory pre-commit safety check
+
+Even with worktrees, run this single-line check immediately before every `git add` / `git commit`:
+
+```bash
+git branch --show-current
+```
+
+The output must equal the branch you believe you are on. If it doesn't, stop, do not commit. The other parallel session has switched your HEAD. Recover via:
+
+```bash
+# 1. Snapshot your work-in-progress so the parallel process can't clobber it
+git stash push --include-untracked -m "wip-rescue-$(date +%s)"
+
+# 2. Checkout the intended branch
+git checkout <intended-branch>
+
+# 3. Restore your work
+git stash pop
+```
+
+If your commit already landed on the wrong branch, see BUGS-17's recovery section — `git reset --hard origin/<intended-base>` then `git cherry-pick <your-commit-sha>`.
+
+### Never use `git add -A` or `git add .` in a shared tree
+
+In a shared checkout, parallel processes may have staged unrelated files in the index. `git add -A` will include them in your commit. Always stage files **explicitly by path**:
+
+```bash
+git add CLAUDE.md docs/RUNBOOK.md   # named files only
+git add tests/unit/my-feature.test.ts   # likewise
+```
+
+This is doubly mandatory if you didn't use a worktree.
 
 ## Jira Ticket Standard
 


### PR DESCRIPTION
## Summary

Closes the canonical half of KAN-216 (the lyra-mcp-server mirror is in lyra-mcp-server PR #26).

Adds a "Parallel Claude sessions — use git worktrees" section to `CLAUDE.md`. The user runs multiple Claude Code instances in parallel for independent features; without per-instance isolation the shared main checkout causes BUGS-17-style contamination. The new section makes the rule explicit, gives three isolation mechanisms (preferred → fallback), and adds a mandatory pre-commit safety check with a recovery snippet.

## What changed in CLAUDE.md

- **Pre-Work Checklist** gains a step 6: confirm working-tree isolation at start + before every `git add` / `git commit`. References BUGS-17.
- **New section "Parallel Claude sessions — use git worktrees"** with:
  - The rule (must use worktree if not the only session)
  - 3 isolation mechanisms ranked by preference: `isolation: \"worktree\"` on Agent, `EnterWorktree` for current session, manual `git worktree add` for fresh `claude`
  - Mandatory `git branch --show-current` check before every `git add`/`git commit`
  - Recovery snippet for when HEAD has already moved (stash + checkout + pop)
  - Explicit ban on `git add -A` / `git add .` in shared trees

## Why this matters

BUGS-17 was caught in May 2026 because a `gh pr create` errored. Without that signal, a mixed-feature PR would have shipped contaminated code. BUGS-17 recurred during KAN-215's doc-drift session even though I was careful — the parallel process moved my HEAD between `git push` and `gh pr create`. The PR was rescued only because origin had the right commit; if origin had been stale, the recovery would have been more expensive. The rule fixes the underlying race rather than relying on Claude vigilance.

## Verification

```bash
$ grep -nE "worktree|git branch --show-current|BUGS-17" CLAUDE.md
44:6. **Confirm working-tree isolation** — ...
46:## Parallel Claude sessions — use git worktrees
48: ... BUGS-17
52: ... worktree, not the shared checkout
58: ... isolation: \"worktree\"
60: ... EnterWorktree
62: ... fresh Claude Code instance for parallel work
65:   git worktree add ../lyra-<branch-name> origin/develop
70: ... git worktree remove
74-77: ... git branch --show-current
93: BUGS-17 recovery
104: ... didn't use a worktree
```

15+ matches across the new section.

## Security review

Tightening; no new threats.

## Architecture impact

Docs only. No code, no test, no CI changes. Test floor (330 tests) unaffected.

## Test plan

- [x] Pre-merge grep returns matches (above)
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)