### PR TITLE
docs(KAN-217): worktree cleanup rules in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -103,6 +103,52 @@ git add tests/unit/my-feature.test.ts   # likewise
 
 This is doubly mandatory if you didn't use a worktree.
 
+### Cleanup — remove your own worktrees, don't leave orphans
+
+Worktrees accumulate quickly across sessions. A worktree whose work is merged is dead weight: it still appears in `git worktree list`, it still locks its branch from deletion, and it confuses future audits ("is this an active in-flight session or an abandoned one?"). Claude is responsible for cleaning up the worktrees it created.
+
+**Mandatory: at the end of every session, audit your worktrees and clean up the ones that are done.**
+
+The audit:
+
+```bash
+git worktree list   # what's on disk
+git fetch --prune   # bring branch state up to date with remote
+```
+
+For each worktree Claude created in this session, decide one of:
+
+- **Merged + Claude is done** → `remove`. Work is in the upstream chain (develop/main); the worktree is dead weight.
+- **In progress, will resume next session** → `keep`. Note in the session summary why it's worth keeping.
+- **Abandoned (no commits, no merge target)** → `remove` with `--force` if needed. Don't leave failed experiments on disk indefinitely.
+
+Removal commands:
+
+```bash
+# Preferred — from inside the main checkout (or any other worktree of the same repo)
+git worktree remove ../<worktree-name>          # work merged + done
+git worktree remove --force ../<worktree-name>  # abandoned, has unmerged commits
+
+# If EnterWorktree created the worktree
+# (call from inside Claude)
+ExitWorktree action="remove"                    # work merged + done
+ExitWorktree action="remove" discard_changes=true  # abandoned
+
+# Stale-reference cleanup — always safe to run periodically
+git worktree prune
+```
+
+**Cleanup decision tree (apply in order):**
+
+1. `git worktree list` — what worktrees did THIS session create?
+2. For each, `gh pr view --json state` (or `git log origin/develop ^<branch>` to check merge state) — has its work landed?
+3. Landed → `git worktree remove`; not landed and still being worked on → keep + note; not landed and abandoned → `git worktree remove --force`.
+4. `git worktree prune` to clear any stale registry entries.
+
+**The summary at end of session must explicitly list which worktrees were removed, which were kept, and why.** This makes the next session's first action (audit) trivial.
+
+**Don't `rm -rf` a worktree directory.** That leaves a stale entry in `.git/worktrees/` and a phantom branch reference. Use `git worktree remove` so git tears down both the tree and its metadata atomically.
+
 ## Jira Ticket Standard
 
 All work must be tracked in Jira. KAN project for design/deployment, BUGS project for bug tracking.


### PR DESCRIPTION
## Summary

Adds the cleanup half of the parallel-Claude worktree policy from KAN-216. Luisa asked for explicit rules so Claude removes its own worktrees at end of session rather than leaving orphans on disk.

## What changed

New subsection "Cleanup — remove your own worktrees, don't leave orphans" inside the existing "Parallel Claude sessions — use git worktrees" section:

- End-of-session audit is mandatory: `git worktree list` + `git fetch --prune`
- Per-worktree decision tree: merged (remove) / WIP (keep + note) / abandoned (remove --force)
- Removal commands for the three cases (`git worktree remove`, `--force`, and `ExitWorktree action="remove"`)
- `git worktree prune` to clear stale registry entries
- Explicit warning against `rm -rf` (leaves zombie metadata in `.git/worktrees/`)
- Session summary must list what was removed, what was kept, and why

## Verification

```bash
$ grep -nE "git worktree remove|git worktree prune|Cleanup" CLAUDE.md
70:   Treat that directory as the session's home. When done: `git worktree remove ../lyra-<branch-name>`.
106:### Cleanup — remove your own worktrees, don't leave orphans
129:git worktree remove ../<worktree-name>          # work merged + done
130:git worktree remove --force ../<worktree-name>  # abandoned, has unmerged commits
138:git worktree prune
141:**Cleanup decision tree (apply in order):**
145:3. Landed → `git worktree remove`; ...
146:4. `git worktree prune` ...
150:**Don't `rm -rf` a worktree directory.** ...
```

8 hits across the new subsection.

## Dogfooding note

This commit was authored from inside an isolated git worktree (`../lyra-claude-isolated` off `origin/develop`) on a feature branch. Pre-commit safety check (`git branch --show-current`) passed before staging. Eating my own KAN-216 dogfood.

## Security review

None — pure docs.

## Architecture impact

Docs only. No code, test, or CI changes. Test floor (330 tests) unaffected.

## Test plan

- [x] Pre-merge grep returns matches (above)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)