### PR TITLE
feat(KAN-190): V2 eligibility filter (replay of PR #219 onto clean develop)

### DIFF
--- a/src/lib/recommender/v2/eligibility-filter.ts
+++ b/src/lib/recommender/v2/eligibility-filter.ts
@@ -1,0 +1,158 @@
+/**
+ * KAN-190: V2 eligibility filter — drops product candidates whose merchant
+ * is not in `affiliate_merchant_eligibility` for the buyer's country (and
+ * separately, that can't ship to the recipient's country).
+ *
+ * Sits between candidate-sourcing (KAN-200) and the ranker (KAN-199) in the
+ * V2 pipeline. The candidate sourcer's Tier 1 already checks the
+ * `recommender_catalogue.buyer_countries[]` field; this filter adds a
+ * second pass against the canonical KAN-187 table so:
+ *
+ *   - Sovrn-sourced (Tier 2) and LLM-generated (Tier 3) candidates are
+ *     also filtered, not just Tier 1.
+ *   - Admins can toggle a merchant inactive globally (is_active=false in
+ *     KAN-187) without having to update every catalogue entry.
+ *
+ * Drop-ratio is logged at server-side INFO. If the filter would drop the
+ * candidate count below `minResults`, we return the un-filtered set with
+ * a warning rather than starve the recommendation — better to show
+ * possibly-ineligible products than nothing. Sovrn will reject the
+ * actual link generation downstream in those rare cases.
+ *
+ * Shipping-to-recipient (KAN-185 recipient_country) is a thinner shipping
+ * rule that's NOT yet in the eligibility table — for MVP we treat it as
+ * a per-merchant code helper (`canShipTo`) because each merchant's
+ * shipping rules are different and not all in Sovrn's data. Once we have
+ * structured shipping data, this collapses into the eligibility lookup.
+ */
+
+import type { SupabaseClient } from '@supabase/supabase-js';
+import { eligibleMerchantsForCountry } from '@/lib/affiliate/eligibility';
+import type { ProductCandidate } from './types';
+
+export type EligibilityFilterInput = {
+  candidates: ProductCandidate[];
+  buyerCountry: string;
+  recipientCountry: string;
+  /**
+   * If after filtering we have fewer than this many candidates, return the
+   * pre-filter list (with a warning) rather than starve the recommender.
+   * Default 3 — matches the KAN-190 ticket spec.
+   */
+  minResults?: number;
+};
+
+export type EligibilityFilterResult = {
+  candidates: ProductCandidate[];
+  /** How many candidates were dropped by the buyer-country eligibility check. */
+  droppedByEligibility: number;
+  /** How many candidates were dropped by the recipient-shipping check. */
+  droppedByShipping: number;
+  /** Set to true if the filter would have dropped below minResults and
+   *  was bypassed. */
+  fellBackToUnfiltered: boolean;
+};
+
+/**
+ * The main filter. Async because it consults Supabase.
+ */
+export async function filterCandidatesByEligibility(
+  supabase: SupabaseClient,
+  input: EligibilityFilterInput,
+): Promise<EligibilityFilterResult> {
+  const minResults = input.minResults ?? 3;
+  if (input.candidates.length === 0) {
+    return {
+      candidates: [],
+      droppedByEligibility: 0,
+      droppedByShipping: 0,
+      fellBackToUnfiltered: false,
+    };
+  }
+
+  // Single round-trip to fetch the eligible merchant set.
+  const merchantIds = Array.from(
+    new Set(input.candidates.map((c) => c.merchantId)),
+  );
+  const eligibleMerchants = await eligibleMerchantsForCountry(
+    supabase,
+    merchantIds,
+    input.buyerCountry,
+  );
+
+  // First pass: buyer-country eligibility.
+  let droppedByEligibility = 0;
+  const buyerEligible = input.candidates.filter((c) => {
+    const ok = eligibleMerchants.has(c.merchantId);
+    if (!ok) droppedByEligibility++;
+    return ok;
+  });
+
+  // Second pass: recipient shipping. Per-merchant helper for MVP.
+  let droppedByShipping = 0;
+  const finalSet = buyerEligible.filter((c) => {
+    const ok = canShipTo(c.merchantId, input.recipientCountry);
+    if (!ok) droppedByShipping++;
+    return ok;
+  });
+
+  // Drop-ratio guard.
+  if (finalSet.length < minResults) {
+    // Log the under-supply event for tuning. Sentry/console picks it up.
+    console.warn(
+      `[KAN-190 eligibility-filter] under-supply: ${finalSet.length} candidates after filter ` +
+        `(buyer=${input.buyerCountry}, recipient=${input.recipientCountry}, ` +
+        `dropped_eligibility=${droppedByEligibility}, dropped_shipping=${droppedByShipping}). ` +
+        `Returning pre-filter list of ${input.candidates.length} candidates.`,
+    );
+    return {
+      candidates: input.candidates,
+      droppedByEligibility,
+      droppedByShipping,
+      fellBackToUnfiltered: true,
+    };
+  }
+
+  return {
+    candidates: finalSet,
+    droppedByEligibility,
+    droppedByShipping,
+    fellBackToUnfiltered: false,
+  };
+}
+
+/**
+ * Per-merchant shipping rules for MVP. Encodes "this merchant ships to
+ * these countries" without the full eligibility-table lookup, because
+ * shipping rules aren't yet in Sovrn's data and we already have these
+ * from the merchant_detector allowlist.
+ *
+ * When a merchant is not in the rules table, we default to "true" (assume
+ * shipping is possible) — better to over-recommend than miss a sale.
+ * The Affiliate Link Service's Sovrn call will fail-soft anyway if the
+ * merchant can't actually deliver.
+ */
+const SHIPPING_RULES: Readonly<Record<string, ReadonlySet<string>>> = {
+  // Amazon — every storefront ships in-country. Cross-border via "Ships
+  // internationally" works for many SKUs but isn't guaranteed; treat as
+  // in-country only for the recommendation filter.
+  amazon: new Set([
+    'GB', 'US', 'DE', 'FR', 'IT', 'ES', 'NL', 'IE', 'CA', 'AU', 'JP',
+  ]),
+  etsy: new Set([
+    'GB', 'US', 'DE', 'FR', 'IT', 'ES', 'NL', 'IE', 'CA', 'AU', 'JP',
+  ]),
+  ebay: new Set([
+    'GB', 'US', 'DE', 'FR', 'IT', 'ES', 'IE', 'CA', 'AU',
+  ]),
+  johnlewis: new Set(['GB']),
+  notonthehighstreet: new Set(['GB', 'IE']),
+  bookshop_org: new Set(['GB', 'IE', 'US']),
+  otto: new Set(['DE']),
+};
+
+export function canShipTo(merchantId: string, recipientCountry: string): boolean {
+  const rules = SHIPPING_RULES[merchantId];
+  if (!rules) return true; // unknown merchant → don't block
+  return rules.has(recipientCountry.toUpperCase());
+}

--- a/tests/unit/eligibility-filter.test.ts
+++ b/tests/unit/eligibility-filter.test.ts
@@ -1,0 +1,216 @@
+/**
+ * KAN-190: tests for the V2 eligibility filter.
+ *
+ * Pure-function-shaped (the Supabase client is mocked). The filter's job
+ * is to drop candidates whose merchant isn't in `affiliate_merchant_eligibility`
+ * for the buyer's country and that can't ship to the recipient's country,
+ * with a safety-net fallback when the result count would drop too low.
+ */
+
+import {
+  filterCandidatesByEligibility,
+  canShipTo,
+} from '@/lib/recommender/v2/eligibility-filter';
+import type { ProductCandidate, ConceptInput } from '@/lib/recommender/v2/types';
+
+function concept(): ConceptInput {
+  return {
+    categoryKey: 'books_reading',
+    conceptTitle: 'A book',
+    conceptScore: 10,
+    reasons: [],
+    tags: [],
+  };
+}
+
+function candidate(merchantId: string): ProductCandidate {
+  return {
+    concept: concept(),
+    title: `${merchantId} item`,
+    description: null,
+    imageUrl: null,
+    rawUrl: `https://${merchantId}.example/x`,
+    merchantId,
+    priceMinMinor: 1000,
+    priceMaxMinor: 1000,
+    priceCurrency: 'GBP',
+    sourceTier: 'curated',
+    rationaleFragment: null,
+    sourceWeight: 0,
+  };
+}
+
+/** Build a Supabase stub whose .in('merchant_id', ...) on
+ *  affiliate_merchant_eligibility returns the given eligible set. */
+function mockSupabase(eligibleMerchants: string[]) {
+  const filters: Record<string, unknown> = {};
+  const rows = eligibleMerchants.map((m) => ({ merchant_id: m }));
+  const builder: Record<string, unknown> = {
+    from(_: string) {
+      return builder;
+    },
+    select(_: string) {
+      return builder;
+    },
+    eq(col: string, val: unknown) {
+      filters[col] = val;
+      return builder;
+    },
+    in(_col: string, _vals: unknown[]) {
+      return builder;
+    },
+    maybeSingle: async () => ({ data: null, error: null }),
+    then(resolve: (val: { data: unknown[]; error: null }) => void) {
+      resolve({ data: rows, error: null });
+    },
+  };
+  return builder as unknown as Parameters<typeof filterCandidatesByEligibility>[0];
+}
+
+// ── canShipTo ───────────────────────────────────────────────────────────
+
+describe('KAN-190 canShipTo', () => {
+  test('John Lewis ships to GB only', () => {
+    expect(canShipTo('johnlewis', 'GB')).toBe(true);
+    expect(canShipTo('johnlewis', 'DE')).toBe(false);
+  });
+
+  test('Notonthehighstreet ships to GB + IE', () => {
+    expect(canShipTo('notonthehighstreet', 'GB')).toBe(true);
+    expect(canShipTo('notonthehighstreet', 'IE')).toBe(true);
+    expect(canShipTo('notonthehighstreet', 'DE')).toBe(false);
+  });
+
+  test('Amazon ships to its supported storefronts', () => {
+    expect(canShipTo('amazon', 'GB')).toBe(true);
+    expect(canShipTo('amazon', 'US')).toBe(true);
+    expect(canShipTo('amazon', 'BR')).toBe(false);
+  });
+
+  test('case-insensitive on the country code', () => {
+    expect(canShipTo('johnlewis', 'gb')).toBe(true);
+    expect(canShipTo('amazon', 'de')).toBe(true);
+  });
+
+  test('unknown merchant defaults to true (better over-recommend than miss)', () => {
+    expect(canShipTo('made_up_merchant', 'GB')).toBe(true);
+  });
+});
+
+// ── filterCandidatesByEligibility — buyer-country path ───────────────────
+
+describe('KAN-190 filterCandidatesByEligibility — buyer eligibility', () => {
+  test('empty input → empty output, no DB hit', async () => {
+    const sb = mockSupabase([]);
+    const out = await filterCandidatesByEligibility(sb, {
+      candidates: [],
+      buyerCountry: 'GB',
+      recipientCountry: 'GB',
+    });
+    expect(out.candidates).toEqual([]);
+    expect(out.droppedByEligibility).toBe(0);
+    expect(out.droppedByShipping).toBe(0);
+    expect(out.fellBackToUnfiltered).toBe(false);
+  });
+
+  test('all candidates eligible → no drops', async () => {
+    const sb = mockSupabase(['amazon', 'etsy', 'johnlewis']);
+    const out = await filterCandidatesByEligibility(sb, {
+      candidates: [candidate('amazon'), candidate('etsy'), candidate('johnlewis')],
+      buyerCountry: 'GB',
+      recipientCountry: 'GB',
+    });
+    expect(out.candidates.length).toBe(3);
+    expect(out.droppedByEligibility).toBe(0);
+    expect(out.fellBackToUnfiltered).toBe(false);
+  });
+
+  test('drops ineligible candidates while keeping eligible ones', async () => {
+    // Stub says only amazon + etsy are eligible; johnlewis is not.
+    const sb = mockSupabase(['amazon', 'etsy']);
+    const out = await filterCandidatesByEligibility(sb, {
+      candidates: [
+        candidate('amazon'),
+        candidate('etsy'),
+        candidate('amazon'),
+        candidate('etsy'),
+        candidate('johnlewis'),
+      ],
+      buyerCountry: 'GB',
+      recipientCountry: 'GB',
+    });
+    expect(out.candidates.length).toBe(4);
+    expect(out.droppedByEligibility).toBe(1);
+    expect(out.candidates.every((c) => c.merchantId !== 'johnlewis')).toBe(true);
+    expect(out.fellBackToUnfiltered).toBe(false);
+  });
+});
+
+// ── filterCandidatesByEligibility — shipping path ────────────────────────
+
+describe('KAN-190 filterCandidatesByEligibility — shipping', () => {
+  test('drops candidates whose merchant cannot ship to recipient', async () => {
+    // All buyer-eligible. But recipient is in DE; John Lewis ships to GB only.
+    const sb = mockSupabase(['amazon', 'etsy', 'johnlewis']);
+    const out = await filterCandidatesByEligibility(sb, {
+      candidates: [
+        candidate('amazon'),
+        candidate('etsy'),
+        candidate('amazon'),
+        candidate('johnlewis'), // ships GB only — drop
+      ],
+      buyerCountry: 'GB',
+      recipientCountry: 'DE',
+    });
+    expect(out.candidates.length).toBe(3);
+    expect(out.droppedByShipping).toBe(1);
+    expect(out.candidates.every((c) => c.merchantId !== 'johnlewis')).toBe(true);
+  });
+});
+
+// ── filterCandidatesByEligibility — under-supply fallback ────────────────
+
+describe('KAN-190 filterCandidatesByEligibility — under-supply fallback', () => {
+  test('when filter would drop below minResults, returns pre-filter list', async () => {
+    // Only amazon eligible; the other candidates would be dropped.
+    // minResults=3, but only 1 candidate would survive — fallback kicks in.
+    const sb = mockSupabase(['amazon']);
+    const consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      const out = await filterCandidatesByEligibility(sb, {
+        candidates: [
+          candidate('amazon'),
+          candidate('johnlewis'),
+          candidate('etsy'),
+        ],
+        buyerCountry: 'XX',
+        recipientCountry: 'XX',
+        minResults: 3,
+      });
+      expect(out.fellBackToUnfiltered).toBe(true);
+      expect(out.candidates.length).toBe(3); // all 3 returned
+      expect(consoleWarnSpy).toHaveBeenCalled();
+    } finally {
+      consoleWarnSpy.mockRestore();
+    }
+  });
+
+  test('when fallback doesn\'t kick in, drop counters still report what would have been dropped', async () => {
+    const sb = mockSupabase(['amazon', 'etsy', 'johnlewis']);
+    const out = await filterCandidatesByEligibility(sb, {
+      candidates: [
+        candidate('amazon'),
+        candidate('etsy'),
+        candidate('amazon'),
+        candidate('etsy'),
+        candidate('johnlewis'),
+      ],
+      buyerCountry: 'GB',
+      recipientCountry: 'GB',
+      minResults: 3,
+    });
+    expect(out.fellBackToUnfiltered).toBe(false);
+    expect(out.droppedByEligibility).toBe(0);
+    expect(out.droppedByShipping).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary
Replay of [PR #219](https://github.com/luisa-sys/lyra/pull/219) onto a clean develop base. After dependency PRs squash-merged into develop, #219's stacked branch became un-rebaseable. Identical content; same 11 tests.

Closes #219.

## Test plan
- [x] 11 unit tests pass
- [x] `tsc --noEmit` clean

## Worktree-policy compliance
Developed in manual worktree `lyra-kan-219-replay`, pre-commit branch check ran clean.

## Related
KAN-190, KAN-187, KAN-200

🤖 Generated with [Claude Code](https://claude.com/claude-code)