### PR TITLE
docs(KAN-222): MCP-main lockstep policy

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -166,6 +166,54 @@ Large tasks must be broken into subtasks with one concern per ticket. When picki
 
 Full details: `docs/JIRA_TICKET_STANDARD.md`
 
+## MCP-main lockstep policy (KAN-222)
+
+**Every user-facing feature must ship MCP-tool coverage in the same epic, or carry an explicit deferral annotation.** The Lyra web app and the MCP server (`luisa-sys/lyra-mcp-server`) are two surfaces of the same product — anything an authenticated user can read or write on `checklyra.com` should be reachable by an agent through `mcp.checklyra.com`. Drift between the two erodes platform value and confuses users who assume parity.
+
+### What this means in practice
+
+For any KAN ticket that touches user-facing data:
+
+1. **Same epic, same cadence.** New MCP tool(s) ship in the same epic as the main-app feature. Cross-repo PRs are the norm, not the exception (one PR per repo, linked in description).
+2. **Read tools are non-negotiable.** Every new entity an agent could enumerate, search, or fetch must have a corresponding `lyra_list_*` / `lyra_get_*` / `lyra_search_*` read tool. These are public (no auth) per existing convention.
+3. **Write tools follow user-action parity.** Every form-action or API-mutation the main app exposes to the user should have a corresponding write tool. Auth via the current API-key (post-KAN-88: bearer-JWT) scheme.
+4. **Deferral path.** When MCP coverage is intentionally not in scope, the parent ticket description must include the literal line:
+   ```
+   MCP coverage: deferred — <reason> (follow-up: KAN-XYZ)
+   ```
+   The follow-up ticket must exist before merge.
+
+### When this kicks in
+
+- Any new MCP-relevant table (anything an agent would reasonably want to read).
+- Any new public API route under `src/app/api/` that mutates user data.
+- Any new server action under `src/app/.../actions.ts` that mutates user data.
+- Profile-data changes (new `profile_items` category, new visibility level, etc.).
+- Anything explicitly user-visible that an agent should mirror.
+
+### When it doesn't apply
+
+- Internal-only routes (admin, ops, monitoring).
+- Pure UI changes with no data-model impact.
+- Infrastructure / CI / docs work.
+- Maintenance worker code, scheduled jobs, audit pipelines.
+
+### Reviewer checklist
+
+Before approving any user-facing feature PR:
+
+1. Does the PR description list the MCP tools added/changed, OR carry the `MCP coverage: deferred — …` line?
+2. If MCP changes are claimed, is there a linked PR in `luisa-sys/lyra-mcp-server` ready for review?
+3. If deferred, is a follow-up KAN ticket linked and ready?
+
+Failure to do one of the above is a blocking review comment.
+
+### Why this exists
+
+Before KAN-222, MCP tools shipped opportunistically and the surfaces drifted. File uploads (KAN-142), conversation-starter prompts (KAN-181), problem-tracking (KAN-182) all landed in the main app first; MCP coverage was opened as separate follow-ups that sat in the backlog for weeks. By the time the Convene epic (KAN-203) arrives — with its 14+ planned MCP tools — drift would have been intractable. Make the lockstep explicit before the gap reopens.
+
+Mirror in `lyra-mcp-server/CLAUDE.md` — that file points back here as the source of truth.
+
 ## Deployment Pipeline
 
 The pipeline is: **develop → staging → beta → main** (promotion-based, four envs since KAN-175).

--- a/docs/JIRA_TICKET_STANDARD.md
+++ b/docs/JIRA_TICKET_STANDARD.md
@@ -15,6 +15,7 @@
 - Files to create/modify
 - Code snippets where helpful
 - NEEDS DESKTOP flag if local machine access is required
+- **MCP coverage line (KAN-222)** — for any user-facing feature, list the MCP tools added/changed in the same epic, or include the literal line `MCP coverage: deferred — <reason> (follow-up: KAN-XYZ)`. The follow-up ticket must exist before merge. See `CLAUDE.md` → "MCP-main lockstep policy".
 
 ### 3. Tests Required
 **This section is mandatory. No ticket ships without tests.**
@@ -41,6 +42,7 @@
 - New API endpoints or routes
 - Database schema changes (migration SQL required)
 - Impact on existing tests (will any break?)
+- **MCP surface delta** — explicitly list new/changed MCP tools (or note `none` with rationale). Cross-link to PR(s) in `lyra-mcp-server` if applicable. KAN-222 enforces this for user-facing features.
 
 ### 6. Acceptance Criteria
 - Specific, testable conditions that must be true when done

--- a/docs/RUNBOOK.md
+++ b/docs/RUNBOOK.md
@@ -323,3 +323,20 @@ ServiceDashboardSupportVercel[vercel.com/luisa-sys-projects/lyra](http://vercel.
 curl https://mcp.checklyra.com/health      # Production
 curl https://mcp-dev.checklyra.com/health   # Dev
 ```
+
+### MCP-main lockstep cadence (KAN-222)
+
+The MCP server and the main web app are two surfaces of the same product. Drift between them is a long-running platform risk — agents over-promise to users when the MCP exposes less than the web does. Policy:
+
+- **Lockstep epics.** Every user-facing feature that touches data exposable by MCP ships MCP tool coverage in the same epic. Cross-repo PRs (`luisa-sys/lyra` + `luisa-sys/lyra-mcp-server`) are the norm. Linked in PR descriptions.
+- **Deferral annotation.** When coverage is intentionally not in scope, the parent KAN ticket must carry `MCP coverage: deferred — <reason> (follow-up: KAN-XYZ)`, and the follow-up ticket must exist before merge.
+- **Reviewer checklist** at the bottom of `CLAUDE.md` → "MCP-main lockstep policy".
+
+When deploying a feature with MCP changes:
+
+1. Merge the MCP server PR first (Railway auto-deploys from `main`).
+2. Wait for `mcp-dev.checklyra.com/health` to report the new build.
+3. Then merge the main-app PR to `develop` (Vercel auto-deploys to `dev.checklyra.com`).
+4. End-to-end test exercises the MCP tool from a real agent on `dev.checklyra.com`.
+
+Reverse the order on rollback (web first, then MCP).


### PR DESCRIPTION
## Summary

Adds an explicit policy that user-facing features must ship MCP tool coverage in the same epic, or carry a deferral annotation. Triggered by the Convene build ([KAN-203](https://checklyra.atlassian.net/browse/KAN-203)).

## What's in this PR

- **`CLAUDE.md`** — new section *"MCP-main lockstep policy (KAN-222)"* between Jira Ticket Standard and Deployment Pipeline. Defines: same-epic coverage, deferral annotation format, when it kicks in vs. doesn't apply, reviewer checklist, rationale.
- **`docs/JIRA_TICKET_STANDARD.md`** — adds MCP coverage line to *Implementation* section + MCP surface delta to *Architecture Impact* section. Net +2 bullets in the standard template.
- **`docs/RUNBOOK.md`** — *"MCP-main lockstep cadence (KAN-222)"* subsection under MCP Server Operations. Documents deploy order (MCP first, then web) and rollback order (reverse).

## Deferral annotation format

For tickets that intentionally defer MCP coverage:
```
MCP coverage: deferred — <reason> (follow-up: KAN-XYZ)
```
The follow-up ticket must exist before merge. Reviewer checklist enforces this.

## Related

- Mirror PR in `lyra-mcp-server` ships separately (will link here once opened).
- Convene phase tickets [KAN-204](https://checklyra.atlassian.net/browse/KAN-204)…[KAN-214](https://checklyra.atlassian.net/browse/KAN-214) are already MCP-compliant per the existing per-phase tool lists.

## Test plan

- [x] Documentation-only change; no code paths affected.
- [x] PR Quality Gate green expected.

MCP coverage: not applicable (process change, no data surface).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[KAN-203]: https://checklyra.atlassian.net/browse/KAN-203?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[KAN-204]: https://checklyra.atlassian.net/browse/KAN-204?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ