### PR TITLE
feat(KAN-219): URL field on profile items + lift Python prompts onto wizard descriptions

### DIFF
--- a/src/app/[slug]/page.tsx
+++ b/src/app/[slug]/page.tsx
@@ -67,6 +67,10 @@ interface ProfileItem {
   category: string;
   title: string;
   description: string | null;
+  // KAN-219 — optional URL on items (Python `lyra-app` parity). Already
+  // selected by the `*` query; surfaced in the chip + Q&A rendering as a
+  // clickable link when present.
+  url: string | null;
   visibility: string;
 }
 
@@ -530,7 +534,23 @@ export default async function PublicProfilePage({ params }: Props) {
                 <div className="space-y-3">
                   {catItems.map((item) => (
                     <div key={item.id} className="border-l-3 border-[var(--color-sage)] bg-stone-50 rounded-r-lg pl-4 pr-4 py-3">
-                      <p className="text-sm font-medium text-[var(--color-ink)]">{item.title}</p>
+                      {/* KAN-219: when an item has a URL, the title becomes a
+                          clickable link. Server-side sanitiseUrl restricts
+                          to http(s); React escapes attribute values; we add
+                          rel="noopener noreferrer" to prevent tab-nabbing. */}
+                      {item.url ? (
+                        <a
+                          href={item.url}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="text-sm font-medium text-[var(--color-sage)] hover:underline"
+                        >
+                          {item.title}
+                          <span aria-hidden className="ml-1 text-xs opacity-70">↗</span>
+                        </a>
+                      ) : (
+                        <p className="text-sm font-medium text-[var(--color-ink)]">{item.title}</p>
+                      )}
                       {item.description && (
                         <p className="text-sm text-[var(--color-muted)] mt-1 leading-relaxed">{item.description}</p>
                       )}
@@ -541,9 +561,23 @@ export default async function PublicProfilePage({ params }: Props) {
                 <div className="flex flex-wrap gap-2">
                   {catItems.map((item) => (
                     <div key={item.id} className="group relative">
-                      <span className="inline-block px-3 py-1.5 bg-stone-50 border border-stone-200 rounded-full text-sm text-[var(--color-ink)]">
-                        {item.title}
-                      </span>
+                      {/* KAN-219: linked chip when URL present; plain
+                          chip otherwise. Hover preserves the same styling. */}
+                      {item.url ? (
+                        <a
+                          href={item.url}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="inline-block px-3 py-1.5 bg-stone-50 border border-stone-200 rounded-full text-sm text-[var(--color-ink)] hover:border-[var(--color-sage)] hover:text-[var(--color-sage)] transition-colors"
+                        >
+                          {item.title}
+                          <span aria-hidden className="ml-1 text-xs opacity-70">↗</span>
+                        </a>
+                      ) : (
+                        <span className="inline-block px-3 py-1.5 bg-stone-50 border border-stone-200 rounded-full text-sm text-[var(--color-ink)]">
+                          {item.title}
+                        </span>
+                      )}
                       {item.description && (
                         <div className="hidden group-hover:block absolute bottom-full left-0 mb-1 px-3 py-2 bg-[var(--color-ink)] text-white text-xs rounded-lg max-w-xs z-10">
                           {item.description}

--- a/src/app/dashboard/profile/actions.ts
+++ b/src/app/dashboard/profile/actions.ts
@@ -80,6 +80,7 @@ export async function addProfileItem(data: {
   category: string;
   title: string;
   description?: string;
+  url?: string;
   visibility?: string;
 }): Promise<ActionResult> {
   const { user, supabase, error: authError } = await getAuthenticatedUser();
@@ -88,6 +89,19 @@ export async function addProfileItem(data: {
   const profile = await getUserProfile(supabase, user!.id);
   if (!profile) return { success: false, error: 'Profile not found' };
 
+  // KAN-219 — optional URL on items (Python `lyra-app` parity). If absent or
+  // empty, insert NULL. If provided, `sanitiseUrl` returns '' on anything
+  // that's not http(s) — surface that as an error rather than silently
+  // dropping the field so the user knows their input was rejected.
+  let sanitisedUrl: string | null = null;
+  if (data.url && data.url.trim() !== '') {
+    const cleaned = sanitiseUrl(data.url);
+    if (!cleaned) {
+      return { success: false, error: 'Invalid URL — must start with http:// or https://' };
+    }
+    sanitisedUrl = cleaned;
+  }
+
   const { error } = await supabase
     .from('profile_items')
     .insert({
@@ -95,6 +109,7 @@ export async function addProfileItem(data: {
       category: sanitiseText(data.category, 50),
       title: sanitiseText(data.title, 200),
       description: data.description ? sanitiseText(data.description, 1000) : null,
+      url: sanitisedUrl,
       // Coerce to one of the allowed visibility levels — anything else falls
       // back to 'public'. KAN-143.
       visibility: coerceVisibility(data.visibility),

--- a/src/app/dashboard/profile/steps/items-step.tsx
+++ b/src/app/dashboard/profile/steps/items-step.tsx
@@ -21,7 +21,11 @@ const visibilityShort: Record<string, string> = {
 
 export function ItemsStep({ title, description, categories, items, onAdd, onRemove, onUpdateVisibility, onNext, isPending }: {
   title: string; description: string; categories: string[]; items: WizardItem[];
-  onAdd: (data: { category: string; title: string; description?: string; visibility?: string }) => void;
+  // KAN-219 — items now carry an optional URL (Python `lyra-app` parity).
+  // Server-side `addProfileItem` runs the value through `sanitiseUrl`, which
+  // rejects anything not http(s). UI emits the trimmed string; empty is
+  // treated as "no URL".
+  onAdd: (data: { category: string; title: string; description?: string; url?: string; visibility?: string }) => void;
   onRemove: (id: string) => void;
   onUpdateVisibility: (id: string, visibility: string) => void;
   onNext: () => void; isPending: boolean;
@@ -29,6 +33,7 @@ export function ItemsStep({ title, description, categories, items, onAdd, onRemo
   const [category, setCategory] = useState(categories[0]);
   const [itemTitle, setItemTitle] = useState('');
   const [itemDesc, setItemDesc] = useState('');
+  const [itemUrl, setItemUrl] = useState('');
   const [itemVisibility, setItemVisibility] = useState<string>('public');
 
   const categoryLabels: Record<string, string> = {
@@ -46,14 +51,17 @@ export function ItemsStep({ title, description, categories, items, onAdd, onRemo
 
   const handleAdd = () => {
     if (!itemTitle.trim()) return;
+    const trimmedUrl = itemUrl.trim();
     onAdd({
       category,
       title: itemTitle,
       ...(itemDesc ? { description: itemDesc } : {}),
+      ...(trimmedUrl ? { url: trimmedUrl } : {}),
       visibility: itemVisibility,
     });
     setItemTitle('');
     setItemDesc('');
+    setItemUrl('');
     setItemVisibility('public');
   };
 
@@ -70,6 +78,19 @@ export function ItemsStep({ title, description, categories, items, onAdd, onRemo
               <div className="flex-1 min-w-0">
                 <p className="text-sm font-medium text-[var(--color-ink)]">
                   <span className="opacity-60">{categoryLabels[item.category] || item.category}</span> — {item.title}
+                  {/* KAN-219: ↗ chip when an item has a URL. Open in new tab
+                      with noopener+noreferrer to prevent tab-nabbing. */}
+                  {item.url && (
+                    <a
+                      href={item.url}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="ml-1.5 text-xs text-[var(--color-sage)] hover:underline"
+                      aria-label={`Open link for ${item.title}`}
+                    >
+                      ↗
+                    </a>
+                  )}
                 </p>
                 {item.description && <p className="text-xs text-[var(--color-muted)] mt-0.5">{item.description}</p>}
               </div>
@@ -111,6 +132,22 @@ export function ItemsStep({ title, description, categories, items, onAdd, onRemo
           <input value={itemDesc} onChange={(e) => setItemDesc(e.target.value)}
             className="w-full px-3 py-2 rounded-lg border border-stone-300 bg-white text-sm focus:outline-none focus:ring-2 focus:ring-[var(--color-sage)]"
             placeholder="Any extra detail" />
+        </div>
+        {/* KAN-219: optional URL on items (Python lyra-app parity).
+            Server-side sanitiseUrl rejects anything that's not http(s);
+            the user gets a clear error rather than silent drop. */}
+        <div>
+          <label className="block text-sm font-medium text-[var(--color-ink)] mb-1" htmlFor="new-item-url">
+            Link (optional)
+          </label>
+          <input
+            id="new-item-url"
+            type="url"
+            value={itemUrl}
+            onChange={(e) => setItemUrl(e.target.value)}
+            className="w-full px-3 py-2 rounded-lg border border-stone-300 bg-white text-sm focus:outline-none focus:ring-2 focus:ring-[var(--color-sage)]"
+            placeholder="https://example.com/this-book"
+          />
         </div>
         <div>
           <label className="block text-sm font-medium text-[var(--color-ink)] mb-1" htmlFor="new-item-visibility">

--- a/src/app/dashboard/profile/wizard.tsx
+++ b/src/app/dashboard/profile/wizard.tsx
@@ -38,6 +38,10 @@ const STEPS = [
   { id: 'likes', label: 'Likes & Dislikes', icon: '💚' },
   { id: 'gifts', label: 'Gift ideas', icon: '🎁' },
   { id: 'boundaries', label: 'Boundaries', icon: '🛑' },
+  // KAN-219: chip labels + section titles unchanged; the richer Python
+  // `lyra-app` copy is lifted onto each ItemsStep's `description` prop
+  // below, where the user actually reads it. Phase 2's single-page
+  // form will revisit the headings as part of the layout rewrite.
   { id: 'interests', label: 'Books & Media', icon: '📚' },
   { id: 'values', label: 'Causes & Quotes', icon: '💛' },
   { id: 'more', label: 'More about you', icon: '✨' },
@@ -157,7 +161,8 @@ export function ProfileWizard({
           }} isPending={isPending} />
         )}
         {step === 4 && (
-          <ItemsStep title="Likes & Dislikes" description="What do you love? What can't you stand?"
+          // KAN-219: lift richer Python `lyra-app` prompt.
+          <ItemsStep title="Likes & Dislikes" description="Tastes, interests, and favourites — plus the things you'd rather steer clear of."
             categories={['likes', 'dislikes']}
             items={items.filter((i) => ['likes', 'dislikes'].includes(i.category))}
             onAdd={(data) => { startTransition(async () => { await addProfileItem(data); router.refresh(); }); }}
@@ -166,7 +171,8 @@ export function ProfileWizard({
             onNext={next} isPending={isPending} />
         )}
         {step === 5 && (
-          <ItemsStep title="Gift ideas" description="Help people find the perfect gift for you."
+          // KAN-219: lift richer Python `lyra-app` prompt.
+          <ItemsStep title="Gift ideas" description="Things you'd love to receive, luxuries you don't give yourself, things you can't have enough of — and gifts that aren't for you."
             categories={['gift_ideas', 'gifts_to_avoid']}
             items={items.filter((i) => ['gift_ideas', 'gifts_to_avoid'].includes(i.category))}
             onAdd={(data) => { startTransition(async () => { await addProfileItem(data); router.refresh(); }); }}
@@ -175,7 +181,9 @@ export function ProfileWizard({
             onNext={next} isPending={isPending} />
         )}
         {step === 6 && (
-          <ItemsStep title="Boundaries" description="Things people should know to respect your space."
+          // KAN-219: lift richer Python `lyra-app` prompt onto description;
+          // title kept as-is to keep nav/section heading consistent.
+          <ItemsStep title="Boundaries" description="Practical preferences, boundaries, and things that help people respect your space."
             categories={['boundaries', 'helpful_to_know']}
             items={items.filter((i) => ['boundaries', 'helpful_to_know'].includes(i.category))}
             onAdd={(data) => { startTransition(async () => { await addProfileItem(data); router.refresh(); }); }}
@@ -184,7 +192,9 @@ export function ProfileWizard({
             onNext={next} isPending={isPending} />
         )}
         {step === 7 && (
-          <ItemsStep title="Books & Media" description="Favourite books, movies, and series — the things that shaped you."
+          // KAN-219: lift richer Python `lyra-app` prompt onto description;
+          // title kept as-is to keep nav/section heading consistent.
+          <ItemsStep title="Books & Media" description="Books you love and the screen favourites that shaped you."
             categories={['favourite_books', 'favourite_media']}
             items={items.filter((i) => ['favourite_books', 'favourite_media'].includes(i.category))}
             onAdd={(data) => { startTransition(async () => { await addProfileItem(data); router.refresh(); }); }}
@@ -193,7 +203,9 @@ export function ProfileWizard({
             onNext={next} isPending={isPending} />
         )}
         {step === 8 && (
-          <ItemsStep title="Causes & Quotes" description="What matters to you — charities, causes, and words that resonate."
+          // KAN-219: lift richer Python `lyra-app` prompt onto description;
+          // title kept as-is to keep nav/section heading consistent.
+          <ItemsStep title="Causes & Quotes" description="Causes and charities you care about, and the words that resonate with you."
             categories={['causes', 'quotes']}
             items={items.filter((i) => ['causes', 'quotes'].includes(i.category))}
             onAdd={(data) => { startTransition(async () => { await addProfileItem(data); router.refresh(); }); }}
@@ -202,7 +214,11 @@ export function ProfileWizard({
             onNext={next} isPending={isPending} />
         )}
         {step === 9 && (
-          <ItemsStep title="More about you" description="What makes you proud, life hacks, questions you wish people asked, problems you're currently working on."
+          // KAN-219: lift richer Python `lyra-app` prompts. Combines the five
+          // Python sections (proud_of, life_hacks, questions, billboard,
+          // current_problems) under one wizard step; Phase 2 will split them
+          // out as collapsible blocks in the single-page form.
+          <ItemsStep title="More about you" description="What you're most proud of, life hacks worth sharing, places you'd recommend, questions you wish people asked, problems you're working on, and your billboard message."
             categories={['proud_of', 'life_hacks', 'questions', 'billboard', 'current_problems']}
             items={items.filter((i) => ['proud_of', 'life_hacks', 'questions', 'billboard', 'current_problems'].includes(i.category))}
             onAdd={(data) => { startTransition(async () => { await addProfileItem(data); router.refresh(); }); }}

--- a/tests/unit/profile-item-url.test.ts
+++ b/tests/unit/profile-item-url.test.ts
@@ -1,0 +1,281 @@
+/**
+ * KAN-219: URL field on profile items.
+ *
+ * Two layers of coverage:
+ *
+ * 1. Behavioural tests for `addProfileItem` — verify the URL is sanitised
+ *    via `sanitiseUrl` (the same helper external_links uses) and that
+ *    invalid URLs are REJECTED with an error rather than silently dropped.
+ *    This is the security guarantee — `javascript:` / `data:` / malformed
+ *    inputs cannot reach the DB column.
+ *
+ * 2. Static-grep regression guards — cheap checks that the UI components
+ *    and public-profile renderer reference the URL plumbing, so a future
+ *    refactor can't accidentally remove the field without a test failing.
+ *    Same pattern as KAN-181 (conversation-starters.test.ts) and KAN-182
+ *    (current-problems-category.test.ts).
+ *
+ * Why URL on items? Python `lyra-app/templates/edit_profile.html` shipped
+ * a Link input alongside Title + Description for every item — the user
+ * could attach a buy-it-here URL to a gift idea, an Amazon link to a
+ * favourite book, etc. The Next.js wizard inherited the `url` DB column
+ * but never wrote to it; this restores the missing surface.
+ */
+
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+// ───────────── Mocks ─────────────
+
+const mockInsertCapture = jest.fn();
+const mockRevalidatePath = jest.fn();
+
+jest.mock('next/cache', () => ({
+  revalidatePath: (...args: unknown[]) => mockRevalidatePath(...args),
+}));
+
+// addProfileItem invokes the chain
+//   .from('profiles').select('id').eq('user_id', x).single() → look up profile_id
+//   .from('profile_items').insert({...})                     → write the item
+// Dispatch on the table name so each chain returns the right shape.
+jest.mock('@/lib/supabase-server', () => ({
+  createClient: jest.fn().mockResolvedValue({
+    auth: {
+      getUser: jest.fn().mockResolvedValue({
+        data: { user: { id: 'test-user-id' } },
+      }),
+    },
+    from: jest.fn().mockImplementation((tableName: string) => {
+      if (tableName === 'profiles') {
+        return {
+          select: () => ({
+            eq: () => ({
+              single: () => Promise.resolve({ data: { id: 'test-profile-id' } }),
+            }),
+          }),
+        };
+      }
+      if (tableName === 'profile_items') {
+        return {
+          insert: (data: unknown) => {
+            mockInsertCapture(data);
+            return Promise.resolve({ error: null });
+          },
+        };
+      }
+      throw new Error(`Unexpected table in mock: ${tableName}`);
+    }),
+  }),
+}));
+
+import { addProfileItem } from '@/app/dashboard/profile/actions';
+
+beforeEach(() => {
+  mockInsertCapture.mockClear();
+  mockRevalidatePath.mockClear();
+});
+
+// ───────────── Behavioural tests ─────────────
+
+describe('KAN-219: addProfileItem — URL handling', () => {
+  test('persists a valid https URL', async () => {
+    const result = await addProfileItem({
+      category: 'favourite_books',
+      title: 'The Hobbit',
+      url: 'https://example.com/hobbit',
+    });
+    expect(result).toEqual({ success: true });
+    expect(mockInsertCapture).toHaveBeenCalledWith(
+      expect.objectContaining({
+        url: 'https://example.com/hobbit',
+        title: 'The Hobbit',
+        category: 'favourite_books',
+      }),
+    );
+    expect(mockRevalidatePath).toHaveBeenCalledWith('/dashboard/profile');
+  });
+
+  test('persists a valid http URL (not just https)', async () => {
+    await addProfileItem({
+      category: 'life_hacks',
+      title: 'Old recipe site',
+      url: 'http://example.com/recipe',
+    });
+    expect(mockInsertCapture).toHaveBeenCalledWith(
+      expect.objectContaining({ url: 'http://example.com/recipe' }),
+    );
+  });
+
+  test('REJECTS a javascript: URL with a clear error', async () => {
+    const result = await addProfileItem({
+      category: 'likes',
+      title: 'Sneaky',
+      url: 'javascript:alert(1)',
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error).toMatch(/invalid url/i);
+    }
+    // Critical: no DB write happened — the bad URL never reaches the column
+    expect(mockInsertCapture).not.toHaveBeenCalled();
+    expect(mockRevalidatePath).not.toHaveBeenCalled();
+  });
+
+  test('REJECTS a data: URL', async () => {
+    const result = await addProfileItem({
+      category: 'likes',
+      title: 'Embedded',
+      url: 'data:text/html,<script>alert(1)</script>',
+    });
+    expect(result.success).toBe(false);
+    expect(mockInsertCapture).not.toHaveBeenCalled();
+  });
+
+  test('REJECTS a malformed URL', async () => {
+    const result = await addProfileItem({
+      category: 'likes',
+      title: 'Broken',
+      url: 'not-a-url',
+    });
+    expect(result.success).toBe(false);
+    expect(mockInsertCapture).not.toHaveBeenCalled();
+  });
+
+  test('REJECTS a file:// URL', async () => {
+    const result = await addProfileItem({
+      category: 'likes',
+      title: 'Local file',
+      url: 'file:///etc/passwd',
+    });
+    expect(result.success).toBe(false);
+    expect(mockInsertCapture).not.toHaveBeenCalled();
+  });
+
+  test('stores NULL when url is omitted (backward compat with pre-KAN-219 callers)', async () => {
+    await addProfileItem({
+      category: 'likes',
+      title: 'No link here',
+    });
+    expect(mockInsertCapture).toHaveBeenCalledWith(
+      expect.objectContaining({ url: null, title: 'No link here' }),
+    );
+  });
+
+  test('stores NULL when url is an empty string', async () => {
+    await addProfileItem({
+      category: 'likes',
+      title: 'Also no link',
+      url: '',
+    });
+    expect(mockInsertCapture).toHaveBeenCalledWith(
+      expect.objectContaining({ url: null }),
+    );
+  });
+
+  test('stores NULL when url is whitespace only', async () => {
+    await addProfileItem({
+      category: 'likes',
+      title: 'Spaces only',
+      url: '   ',
+    });
+    expect(mockInsertCapture).toHaveBeenCalledWith(
+      expect.objectContaining({ url: null }),
+    );
+  });
+
+  test('still sanitises title + description alongside the URL', async () => {
+    // sanitiseText strips HTML tags but preserves text between them (React
+    // also auto-escapes on render). We're checking that the title/description
+    // path is unchanged by the addition of the url param — not testing
+    // sanitiseText itself.
+    await addProfileItem({
+      category: 'gift_ideas',
+      title: 'Camera <b>fancy</b>',
+      description: '<p>Nice shot</p>',
+      url: 'https://example.com/camera',
+    });
+    expect(mockInsertCapture).toHaveBeenCalledWith(
+      expect.objectContaining({
+        title: 'Camera fancy',
+        description: 'Nice shot',
+        url: 'https://example.com/camera',
+      }),
+    );
+  });
+});
+
+// ───────────── Static-grep regression guards ─────────────
+
+describe('KAN-219: surface-area regression guards', () => {
+  const ROOT = resolve(__dirname, '../..');
+
+  test('items-step.tsx renders a Link input with type="url"', () => {
+    const src = readFileSync(
+      resolve(ROOT, 'src/app/dashboard/profile/steps/items-step.tsx'),
+      'utf-8',
+    );
+    expect(src).toMatch(/Link \(optional\)/);
+    expect(src).toMatch(/type="url"/);
+    expect(src).toMatch(/itemUrl/);
+  });
+
+  test('items-step.tsx handleAdd passes the trimmed URL in onAdd payload', () => {
+    const src = readFileSync(
+      resolve(ROOT, 'src/app/dashboard/profile/steps/items-step.tsx'),
+      'utf-8',
+    );
+    expect(src).toMatch(/trimmedUrl/);
+    expect(src).toMatch(/url: trimmedUrl/);
+  });
+
+  test('items-step.tsx renders ↗ link on saved items when url is present', () => {
+    const src = readFileSync(
+      resolve(ROOT, 'src/app/dashboard/profile/steps/items-step.tsx'),
+      'utf-8',
+    );
+    expect(src).toMatch(/item\.url/);
+    expect(src).toMatch(/rel="noopener noreferrer"/);
+  });
+
+  test('actions.ts addProfileItem accepts url param and uses sanitiseUrl', () => {
+    const src = readFileSync(
+      resolve(ROOT, 'src/app/dashboard/profile/actions.ts'),
+      'utf-8',
+    );
+    // url is an optional param on the addProfileItem data type
+    expect(src).toMatch(/url\?:\s*string/);
+    // url is sanitised via sanitiseUrl (same helper external_links uses)
+    expect(src).toMatch(/sanitiseUrl\(data\.url\)/);
+    // The rejection path returns a clear error rather than silently dropping
+    expect(src).toMatch(/Invalid URL/);
+  });
+
+  test('public profile [slug]/page.tsx renders item URLs as clickable links', () => {
+    const src = readFileSync(
+      resolve(ROOT, 'src/app/[slug]/page.tsx'),
+      'utf-8',
+    );
+    // The ProfileItem interface declares the url column
+    expect(src).toMatch(/url:\s*string\s*\|\s*null/);
+    // The chip and Q&A renderers branch on item.url
+    expect(src).toMatch(/item\.url \?/);
+    // Outbound links use rel="noopener noreferrer" to prevent tab-nabbing
+    expect(src).toMatch(/rel="noopener noreferrer"/);
+  });
+
+  test('wizard.tsx uses the richer Python lyra-app prompts', () => {
+    const src = readFileSync(
+      resolve(ROOT, 'src/app/dashboard/profile/wizard.tsx'),
+      'utf-8',
+    );
+    // Replaces the terse one-liners with the Python predecessor's longer
+    // prompts. We check for distinctive phrases that wouldn't appear by
+    // accident, not the entire string, so minor copy edits won't break.
+    expect(src).toMatch(/Tastes, interests, and favourites/);
+    expect(src).toMatch(/luxuries you don't give yourself/);
+    expect(src).toMatch(/things that help people respect/);
+    expect(src).toMatch(/screen favourites that shaped you/);
+    expect(src).toMatch(/Causes and charities you care about/);
+    expect(src).toMatch(/billboard message/);
+  });
+});


### PR DESCRIPTION
## Summary

Phase 1 of [KAN-218](https://checklyra.atlassian.net/browse/KAN-218) (port the Python `lyra-app` edit-profile UX to Next.js). UI/copy-only — no Supabase migration. Restores the **Title + Description + Link** triple that the Python predecessor shipped: the `profile_items.url` column already existed at the DB level and was declared on `WizardItem`, but the wizard form has never collected it.

Also lifts the richer Python `lyra-app/db.py` prompts onto the six items-step descriptions (e.g. _"Things you'd love to receive, luxuries you don't give yourself…"_ replaces _"Help people find the perfect gift for you."_). Chip labels and section titles are unchanged in this PR — Phase 2's single-page rewrite will revisit headings.

## What's in this PR

- **`actions.ts`** — `addProfileItem` accepts optional `url`; validates via existing `sanitiseUrl` (same helper external_links uses). `javascript:`, `data:`, `file://`, malformed → rejected with a clear error. Empty/omitted/whitespace → NULL.
- **`items-step.tsx`** — new Link (optional) input below Description. Saved items get a `↗` chip when URL present (`rel="noopener noreferrer"`).
- **`wizard.tsx`** — richer descriptions on the 6 items-step instances. Chip labels + titles untouched.
- **`[slug]/page.tsx`** — `ProfileItem` interface gets `url: string | null`. Chips + Q&A cards render as clickable links when URL present, plain text otherwise. `target="_blank" rel="noopener noreferrer"` on both.
- **`tests/unit/profile-item-url.test.ts`** (new, 16 tests) — behavioural for the action + static-grep regression guards across all four touched files.

## Test plan

- [x] `npx jest` — **846 ✅** (was 830 pre-PR; +16 new)
- [x] `npm run lint` — 0 errors (17 pre-existing warnings, none in my files)
- [x] `npm run build` — green
- [x] CLAUDE.md pre-merge grep checks (silent-skip, xtest, empty bodies, workflow patterns) — no new matches
- [ ] dev.checklyra.com — manually verify after merge: add an item with a URL, confirm it persists across reload and renders as a link on the public profile

## Where this fits

This is the first of three phases under [KAN-218](https://checklyra.atlassian.net/browse/KAN-218):

| Phase | Ticket | Status |
|---|---|---|
| **1** — URL field + rich prompts | [KAN-219](https://checklyra.atlassian.net/browse/KAN-219) | **this PR** |
| 2 — Single-page editor + collapsible + autosave + Schools/Orgs/Communities split | [KAN-220](https://checklyra.atlassian.net/browse/KAN-220) | gates on Phase 1 |
| 3 — Hybrid section + item visibility | [KAN-221](https://checklyra.atlassian.net/browse/KAN-221) | gates on Phase 2 |

Supersedes the **layout aspect** of [KAN-154](https://checklyra.atlassian.net/browse/KAN-154) (content/data already shipped there).

## Notes

- `WizardItem.url` was already declared in `types.tsx`; `dashboard/profile/page.tsx` already does `.select('*')` so the column flows through without a query change. No migration needed.
- `profile-sections.test.js` (the wizard-section regression guard) still passes — chip labels and section titles deliberately unchanged to preserve those assertions per Test Integrity Policy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[KAN-218]: https://checklyra.atlassian.net/browse/KAN-218?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[KAN-218]: https://checklyra.atlassian.net/browse/KAN-218?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ