### PR TITLE
feat(KAN-206): Convene P2 — Google Calendar adapter + real OAuth

### DIFF
--- a/src/app/api/convene/oauth/google/callback/route.ts
+++ b/src/app/api/convene/oauth/google/callback/route.ts
@@ -1,0 +1,139 @@
+/**
+ * KAN-206 — Convene OAuth callback route (Google).
+ *
+ * Handles the redirect from Google's consent screen. Validates state,
+ * exchanges the authorization code for tokens, fetches the user's Google
+ * profile to capture provider_account_id + display_name, and upserts the
+ * canonical oauth_connections row.
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { createClient as createSupabaseAdmin } from '@supabase/supabase-js';
+import { env } from '@/lib/env';
+import { isConveneEnabled } from '@/lib/convene/flags';
+import { exchangeCodeForTokens } from '@/lib/convene/google/oauth';
+import { upsertConnection } from '@/lib/convene/oauth-connections';
+
+interface GoogleUserInfo {
+  sub: string; // stable Google account id
+  email?: string;
+  name?: string;
+  picture?: string;
+}
+
+async function fetchGoogleUserInfo(accessToken: string): Promise<GoogleUserInfo> {
+  const res = await fetch('https://openidconnect.googleapis.com/v1/userinfo', {
+    headers: { authorization: `Bearer ${accessToken}` },
+  });
+  if (!res.ok) {
+    throw new Error(`Failed to fetch Google userinfo (${res.status})`);
+  }
+  return (await res.json()) as GoogleUserInfo;
+}
+
+export async function GET(req: NextRequest) {
+  if (!isConveneEnabled()) {
+    return NextResponse.json({ error: 'convene_disabled' }, { status: 404 });
+  }
+
+  const code = req.nextUrl.searchParams.get('code');
+  const state = req.nextUrl.searchParams.get('state');
+  const errorParam = req.nextUrl.searchParams.get('error');
+
+  if (errorParam) {
+    return NextResponse.redirect(
+      new URL(`/dashboard?convene_oauth=error&reason=${encodeURIComponent(errorParam)}`, req.url)
+    );
+  }
+  if (!code || !state) {
+    return NextResponse.json({ error: 'missing_code_or_state' }, { status: 400 });
+  }
+
+  const admin = createSupabaseAdmin(
+    env.supabaseUrl(),
+    env.supabaseServiceRoleKey(),
+    { auth: { persistSession: false } }
+  );
+
+  // Look up state — service-role read so we don't depend on the user's
+  // session cookie here (Google's redirect could land before Supabase auth
+  // refreshes).
+  // ownership-ok: state token is unguessable, single-use, user_id is the trusted source (KAN-206)
+  const { data: stateRow, error: stateErr } = await admin
+    .from('oauth_connect_state')
+    .select('user_id, provider, expires_at')
+    .eq('state', state)
+    .maybeSingle();
+
+  if (stateErr || !stateRow) {
+    return NextResponse.json({ error: 'bad_state' }, { status: 400 });
+  }
+  if (new Date(stateRow.expires_at) < new Date()) {
+    // Clean up the expired row.
+    await admin.from('oauth_connect_state').delete().eq('state', state);
+    return NextResponse.json({ error: 'state_expired' }, { status: 400 });
+  }
+  if (stateRow.provider !== 'google') {
+    return NextResponse.json({ error: 'state_provider_mismatch' }, { status: 400 });
+  }
+
+  // Single-use: delete immediately so a replay fails.
+  await admin.from('oauth_connect_state').delete().eq('state', state);
+
+  let tokens;
+  try {
+    tokens = await exchangeCodeForTokens(code);
+  } catch (e) {
+    return NextResponse.json(
+      { error: 'token_exchange_failed', detail: e instanceof Error ? e.message : 'unknown' },
+      { status: 502 }
+    );
+  }
+
+  if (!tokens.refresh_token) {
+    return NextResponse.json(
+      { error: 'no_refresh_token', hint: 'access_type=offline + prompt=consent required' },
+      { status: 400 }
+    );
+  }
+
+  let userInfo: GoogleUserInfo;
+  try {
+    userInfo = await fetchGoogleUserInfo(tokens.access_token);
+  } catch (e) {
+    return NextResponse.json(
+      { error: 'userinfo_failed', detail: e instanceof Error ? e.message : 'unknown' },
+      { status: 502 }
+    );
+  }
+
+  try {
+    await upsertConnection({
+      userId: stateRow.user_id,
+      provider: 'google',
+      providerAccountId: userInfo.sub,
+      displayName: userInfo.email ?? userInfo.name,
+      refreshToken: tokens.refresh_token,
+      scopeGranted: tokens.scope,
+    });
+  } catch (e) {
+    return NextResponse.json(
+      { error: 'persist_failed', detail: e instanceof Error ? e.message : 'unknown' },
+      { status: 500 }
+    );
+  }
+
+  // Log consent (append-only audit).
+  // ownership-ok: writing audit for the verified state user (KAN-206)
+  await admin.from('consent_log').insert({
+    user_id: stateRow.user_id,
+    event_type: 'oauth_granted',
+    subject_kind: 'provider',
+    subject_id: 'google',
+    metadata: { scope: tokens.scope, account: userInfo.email ?? userInfo.sub },
+  });
+
+  return NextResponse.redirect(
+    new URL('/dashboard?convene_oauth=connected&provider=google', req.url)
+  );
+}

--- a/src/app/api/convene/oauth/google/initiate/route.ts
+++ b/src/app/api/convene/oauth/google/initiate/route.ts
@@ -1,0 +1,57 @@
+/**
+ * KAN-206 — Convene OAuth initiate route (Google).
+ *
+ * Generates a state token, stores it in oauth_connect_state with TTL, and
+ * redirects the (signed-in) user to Google's consent screen. Also callable
+ * by the lyra_connect_calendar MCP tool which returns the same URL.
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { randomBytes } from 'crypto';
+import { createClient as createSupabaseServer } from '@/lib/supabase-server';
+import { createClient as createSupabaseAdmin } from '@supabase/supabase-js';
+import { env } from '@/lib/env';
+import { isConveneEnabled } from '@/lib/convene/flags';
+import { buildAuthorizeUrl } from '@/lib/convene/google/oauth';
+
+export async function GET(req: NextRequest) {
+  if (!isConveneEnabled()) {
+    return NextResponse.json({ error: 'convene_disabled' }, { status: 404 });
+  }
+
+  const sb = await createSupabaseServer();
+  const {
+    data: { user },
+  } = await sb.auth.getUser();
+  if (!user) {
+    return NextResponse.json({ error: 'unauthenticated' }, { status: 401 });
+  }
+
+  const state = randomBytes(32).toString('base64url');
+  const admin = createSupabaseAdmin(
+    env.supabaseUrl(),
+    env.supabaseServiceRoleKey(),
+    { auth: { persistSession: false } }
+  );
+  // ownership-ok: writing the user's own state row (KAN-206)
+  const { error } = await admin.from('oauth_connect_state').insert({
+    state,
+    user_id: user.id,
+    provider: 'google',
+  });
+  if (error) {
+    return NextResponse.json(
+      { error: 'state_persist_failed', detail: error.message },
+      { status: 500 }
+    );
+  }
+
+  // Support both browser redirect (default) and JSON response (for MCP).
+  const wantsJson = req.headers.get('accept')?.includes('application/json');
+  const authorizeUrl = buildAuthorizeUrl(state);
+
+  if (wantsJson) {
+    return NextResponse.json({ authorize_url: authorizeUrl, state });
+  }
+  return NextResponse.redirect(authorizeUrl);
+}

--- a/src/lib/convene/calendar/google.ts
+++ b/src/lib/convene/calendar/google.ts
@@ -1,0 +1,140 @@
+/**
+ * Google Calendar adapter (KAN-206).
+ *
+ * Implements the canonical CalendarAdapter interface against Google Calendar
+ * REST API v3. Uses the existing src/lib/convene/google/* helpers (from the
+ * P0 spike — promoted to first-class in P2).
+ *
+ * Tokens come from src/lib/convene/oauth-connections.ts (Vault round-trip +
+ * refresh-with-backoff). Event titles are sent to Google but NEVER persisted
+ * on our side — only IDs and start/end times come back.
+ *
+ * createEvent/updateEvent/deleteEvent ship in P2 to keep the adapter complete
+ * but aren't called from any user-facing flow until P4 (gathering lifecycle).
+ */
+
+import type {
+  CalendarAdapter,
+  GatheringEventData,
+  TimeWindow,
+  BusyBlock,
+} from './types';
+import { getFreshAccessToken } from '../oauth-connections';
+
+const BASE = 'https://www.googleapis.com/calendar/v3';
+
+async function googleFetch(
+  accessToken: string,
+  method: 'GET' | 'POST' | 'PATCH' | 'DELETE',
+  path: string,
+  body?: unknown
+): Promise<Response> {
+  const res = await fetch(`${BASE}${path}`, {
+    method,
+    headers: {
+      authorization: `Bearer ${accessToken}`,
+      ...(body ? { 'content-type': 'application/json' } : {}),
+    },
+    body: body ? JSON.stringify(body) : undefined,
+  });
+  return res;
+}
+
+async function readErrorOrThrow(res: Response, op: string): Promise<never> {
+  let detail = '';
+  try {
+    detail = await res.text();
+  } catch {
+    /* ignore */
+  }
+  const err = new Error(`Google ${op} failed (${res.status}): ${detail}`) as Error & {
+    status: number;
+    retryable: boolean;
+  };
+  err.status = res.status;
+  err.retryable = res.status >= 500 || res.status === 429;
+  throw err;
+}
+
+export const googleCalendarAdapter: CalendarAdapter = {
+  async getFreeBusy(connectionId: string, window: TimeWindow): Promise<BusyBlock[]> {
+    const { accessToken } = await getFreshAccessToken(connectionId);
+    const res = await googleFetch(accessToken, 'POST', '/freeBusy', {
+      timeMin: window.start.toISOString(),
+      timeMax: window.end.toISOString(),
+      items: [{ id: 'primary' }],
+    });
+    if (!res.ok) await readErrorOrThrow(res, 'freeBusy');
+    const json = (await res.json()) as {
+      calendars: Record<string, { busy: BusyBlock[] }>;
+    };
+    return json.calendars?.primary?.busy ?? [];
+  },
+
+  async createEvent(connectionId: string, data: GatheringEventData) {
+    const { accessToken } = await getFreshAccessToken(connectionId);
+    const res = await googleFetch(accessToken, 'POST', '/calendars/primary/events', {
+      summary: data.title,
+      description: data.description,
+      location: data.location,
+      start: { dateTime: data.startISO },
+      end: { dateTime: data.endISO },
+      attendees: data.attendees?.map((a) => ({
+        email: a.email,
+        displayName: a.displayName,
+        optional: a.optional ?? false,
+      })),
+    });
+    if (!res.ok) await readErrorOrThrow(res, 'createEvent');
+    const json = (await res.json()) as { id: string };
+    return { providerEventId: json.id };
+  },
+
+  async updateEvent(connectionId: string, providerEventId: string, data: GatheringEventData) {
+    const { accessToken } = await getFreshAccessToken(connectionId);
+    const res = await googleFetch(
+      accessToken,
+      'PATCH',
+      `/calendars/primary/events/${encodeURIComponent(providerEventId)}`,
+      {
+        summary: data.title,
+        description: data.description,
+        location: data.location,
+        start: { dateTime: data.startISO },
+        end: { dateTime: data.endISO },
+        attendees: data.attendees?.map((a) => ({
+          email: a.email,
+          displayName: a.displayName,
+          optional: a.optional ?? false,
+        })),
+      }
+    );
+    if (!res.ok) await readErrorOrThrow(res, 'updateEvent');
+  },
+
+  async deleteEvent(connectionId: string, providerEventId: string) {
+    const { accessToken } = await getFreshAccessToken(connectionId);
+    const res = await googleFetch(
+      accessToken,
+      'DELETE',
+      `/calendars/primary/events/${encodeURIComponent(providerEventId)}`
+    );
+    // 404/410 mean the event is already gone — idempotent success.
+    if (!res.ok && res.status !== 404 && res.status !== 410) {
+      await readErrorOrThrow(res, 'deleteEvent');
+    }
+  },
+
+  async revokeAtProvider(connectionId: string) {
+    const { accessToken } = await getFreshAccessToken(connectionId);
+    const res = await fetch(
+      `https://oauth2.googleapis.com/revoke?token=${encodeURIComponent(accessToken)}`,
+      { method: 'POST' }
+    );
+    // Best-effort: don't throw — we still want to forget locally even if Google
+    // says the token was already revoked.
+    if (!res.ok && res.status !== 400) {
+      console.warn(`[convene/google] revoke returned ${res.status}`);
+    }
+  },
+};

--- a/src/lib/convene/calendar/index.ts
+++ b/src/lib/convene/calendar/index.ts
@@ -1,0 +1,25 @@
+/**
+ * Calendar adapter registry (KAN-206).
+ *
+ * `adapterFor(provider)` returns the canonical CalendarAdapter for a given
+ * provider. P7 adds microsoft + caldav_generic.
+ */
+
+import type { CalendarAdapter } from './types';
+import { googleCalendarAdapter } from './google';
+
+const adapters: Partial<Record<string, CalendarAdapter>> = {
+  google: googleCalendarAdapter,
+};
+
+export function adapterFor(provider: string): CalendarAdapter {
+  const a = adapters[provider];
+  if (!a) {
+    throw new Error(
+      `No calendar adapter for provider "${provider}" (supported: ${Object.keys(adapters).join(', ')})`
+    );
+  }
+  return a;
+}
+
+export type { CalendarAdapter, TimeWindow, BusyBlock, GatheringEventData } from './types';

--- a/src/lib/convene/calendar/types.ts
+++ b/src/lib/convene/calendar/types.ts
@@ -1,0 +1,65 @@
+/**
+ * Canonical calendar adapter interface (KAN-206).
+ *
+ * Every calendar provider (Google, Microsoft Graph, Apple CalDAV, generic
+ * CalDAV) implements this. Higher-level Convene code consumes only this
+ * interface — provider-specific logic stays in the adapter file.
+ *
+ * P2 ships the Google implementation. Microsoft + CalDAV in P7.
+ */
+
+export interface TimeWindow {
+  start: Date;
+  end: Date;
+}
+
+export interface BusyBlock {
+  start: string; // ISO 8601 UTC
+  end: string; // ISO 8601 UTC
+}
+
+export interface CalendarAttendee {
+  email: string;
+  displayName?: string;
+  optional?: boolean;
+}
+
+export interface GatheringEventData {
+  title: string;
+  description?: string;
+  startISO: string; // ISO 8601 UTC
+  endISO: string; // ISO 8601 UTC
+  location?: string;
+  attendees?: CalendarAttendee[];
+}
+
+export interface CalendarAdapter {
+  /** Read busy/free blocks for the user's primary calendar in a window. */
+  getFreeBusy(connectionId: string, window: TimeWindow): Promise<BusyBlock[]>;
+
+  /** Create a calendar event on the user's primary calendar. */
+  createEvent(
+    connectionId: string,
+    data: GatheringEventData
+  ): Promise<{ providerEventId: string }>;
+
+  /** Update an existing event. providerEventId is the value returned by createEvent. */
+  updateEvent(
+    connectionId: string,
+    providerEventId: string,
+    data: GatheringEventData
+  ): Promise<void>;
+
+  /** Delete an event. Idempotent — silently ignores already-deleted events. */
+  deleteEvent(connectionId: string, providerEventId: string): Promise<void>;
+
+  /** Revoke OAuth refresh + access tokens at the provider. Best-effort. */
+  revokeAtProvider(connectionId: string): Promise<void>;
+}
+
+export interface AdapterError extends Error {
+  /** Network/transient — caller may retry with backoff. */
+  retryable?: boolean;
+  /** Provider HTTP status (if any). */
+  status?: number;
+}

--- a/src/lib/convene/oauth-connections.ts
+++ b/src/lib/convene/oauth-connections.ts
@@ -1,0 +1,219 @@
+/**
+ * Repository for public.oauth_connections (KAN-205/206).
+ *
+ * Encapsulates Vault token round-trip + access-token caching. Adapters call
+ * `getFreshAccessToken(connectionId)` to obtain a usable bearer token without
+ * caring about refresh mechanics.
+ */
+
+import { createClient } from '@supabase/supabase-js';
+import { env } from '@/lib/env';
+import { refreshAccessToken } from '@/lib/convene/google/oauth';
+import {
+  vaultReadRefreshToken,
+  vaultStoreRefreshToken,
+  vaultRevokeRefreshToken,
+} from '@/lib/convene/vault';
+
+function admin() {
+  return createClient(env.supabaseUrl(), env.supabaseServiceRoleKey(), {
+    auth: { persistSession: false },
+  });
+}
+
+export interface OAuthConnection {
+  id: string;
+  owner_user_id: string;
+  provider: 'google' | 'microsoft' | 'apple' | 'caldav_generic';
+  provider_account_id: string;
+  display_name: string | null;
+  refresh_token_secret_id: string;
+  access_token_secret_id: string | null;
+  access_token_expires_at: string | null;
+  scope_granted: string;
+  status: 'active' | 'revoked' | 'error';
+}
+
+export async function getConnection(
+  connectionId: string
+): Promise<OAuthConnection | null> {
+  const sb = admin();
+  // ownership-ok: connection id is the unique key; caller-side checks owner_user_id (KAN-206)
+  const { data, error } = await sb
+    .from('oauth_connections')
+    .select('*')
+    .eq('id', connectionId)
+    .is('deleted_at', null)
+    .maybeSingle();
+  if (error) throw new Error(`getConnection failed: ${error.message}`);
+  return (data as OAuthConnection | null) ?? null;
+}
+
+export async function getConnectionForUser(
+  userId: string,
+  provider: 'google' | 'microsoft' | 'apple' | 'caldav_generic',
+  providerAccountId?: string
+): Promise<OAuthConnection | null> {
+  const sb = admin();
+  let q = sb
+    .from('oauth_connections')
+    .select('*')
+    .eq('owner_user_id', userId)
+    .eq('provider', provider)
+    .is('deleted_at', null)
+    .order('created_at', { ascending: false })
+    .limit(1);
+  if (providerAccountId) {
+    q = q.eq('provider_account_id', providerAccountId);
+  }
+  const { data, error } = await q.maybeSingle();
+  if (error) throw new Error(`getConnectionForUser failed: ${error.message}`);
+  return (data as OAuthConnection | null) ?? null;
+}
+
+interface UpsertConnectionInput {
+  userId: string;
+  provider: 'google';
+  providerAccountId: string;
+  displayName?: string;
+  refreshToken: string;
+  scopeGranted: string;
+}
+
+/**
+ * Insert-or-update a connection. Rotates the refresh-token vault secret when
+ * the provider issued a new refresh token.
+ */
+export async function upsertConnection(
+  input: UpsertConnectionInput
+): Promise<OAuthConnection> {
+  const sb = admin();
+
+  const existing = await getConnectionForUser(
+    input.userId,
+    input.provider,
+    input.providerAccountId
+  );
+
+  if (existing) {
+    // Rotate the vault secret: store new, swap pointer, revoke old.
+    const newSecretId = await vaultStoreRefreshToken(
+      input.refreshToken,
+      `convene oauth (rotate) user=${input.userId} provider=${input.provider}`
+    );
+    const { data, error } = await sb
+      .from('oauth_connections')
+      .update({
+        refresh_token_secret_id: newSecretId,
+        scope_granted: input.scopeGranted,
+        display_name: input.displayName ?? existing.display_name,
+        status: 'active',
+      })
+      .eq('id', existing.id)
+      .select('*')
+      .single();
+    if (error) throw new Error(`upsertConnection update failed: ${error.message}`);
+
+    // Best-effort revoke of the old secret.
+    try {
+      await vaultRevokeRefreshToken(existing.refresh_token_secret_id);
+    } catch (e) {
+      // Non-fatal — log only.
+      console.warn(`[convene] vault revoke of old secret failed:`, e);
+    }
+
+    return data as OAuthConnection;
+  }
+
+  const secretId = await vaultStoreRefreshToken(
+    input.refreshToken,
+    `convene oauth user=${input.userId} provider=${input.provider}`
+  );
+  const { data, error } = await sb
+    .from('oauth_connections')
+    .insert({
+      owner_user_id: input.userId,
+      provider: input.provider,
+      provider_account_id: input.providerAccountId,
+      display_name: input.displayName ?? null,
+      refresh_token_secret_id: secretId,
+      scope_granted: input.scopeGranted,
+      status: 'active',
+    })
+    .select('*')
+    .single();
+  if (error) throw new Error(`upsertConnection insert failed: ${error.message}`);
+  return data as OAuthConnection;
+}
+
+/**
+ * Soft-delete the connection and revoke its vaulted refresh token.
+ * Caller is responsible for calling the adapter's revokeAtProvider beforehand
+ * (best-effort — if it fails, we still want to forget the token locally).
+ */
+export async function disconnectConnection(connectionId: string): Promise<void> {
+  const conn = await getConnection(connectionId);
+  if (!conn) return;
+  const sb = admin();
+  const { error } = await sb
+    .from('oauth_connections')
+    .update({ deleted_at: new Date().toISOString(), status: 'revoked' })
+    .eq('id', connectionId);
+  if (error) throw new Error(`disconnect update failed: ${error.message}`);
+  try {
+    await vaultRevokeRefreshToken(conn.refresh_token_secret_id);
+  } catch (e) {
+    console.warn(`[convene] vault revoke on disconnect failed:`, e);
+  }
+}
+
+/**
+ * Get a usable Google access token for a connection. Refreshes if needed.
+ * Caches the result on the connection row to avoid hammering the provider
+ * (best-effort; we still refresh if the cached token would expire within
+ * the next 60 seconds).
+ */
+export async function getFreshAccessToken(
+  connectionId: string
+): Promise<{ accessToken: string; expiresAt: Date }> {
+  const conn = await getConnection(connectionId);
+  if (!conn) throw new Error('Connection not found');
+  if (conn.status !== 'active') throw new Error(`Connection status: ${conn.status}`);
+
+  // Future: cache via access_token_secret_id with expires_at check.
+  // For now, always refresh — refresh tokens are cheap and we want simplicity.
+  const refreshToken = await vaultReadRefreshToken(conn.refresh_token_secret_id);
+
+  if (conn.provider !== 'google') {
+    throw new Error(`Provider ${conn.provider} not yet implemented (P7)`);
+  }
+
+  const tokens = await refreshWithBackoff(refreshToken);
+  const expiresAt = new Date(Date.now() + tokens.expires_in * 1000);
+
+  // Update last_used_at + expires (best-effort).
+  const sb = admin();
+  await sb
+    .from('oauth_connections')
+    .update({
+      last_used_at: new Date().toISOString(),
+      access_token_expires_at: expiresAt.toISOString(),
+    })
+    .eq('id', connectionId);
+
+  return { accessToken: tokens.access_token, expiresAt };
+}
+
+async function refreshWithBackoff(refreshToken: string, attempts = 3) {
+  let lastErr: unknown;
+  for (let i = 0; i < attempts; i++) {
+    try {
+      return await refreshAccessToken(refreshToken);
+    } catch (e) {
+      lastErr = e;
+      // Exponential backoff: 200ms, 800ms, 3.2s
+      await new Promise((r) => setTimeout(r, 200 * Math.pow(4, i)));
+    }
+  }
+  throw lastErr instanceof Error ? lastErr : new Error('refresh failed after retries');
+}

--- a/supabase/migrations/20260516250000_convene_oauth_connect_state.sql
+++ b/supabase/migrations/20260516250000_convene_oauth_connect_state.sql
@@ -1,0 +1,44 @@
+-- KAN-206 — Convene P2: ephemeral OAuth-initiation state.
+--
+-- When an MCP tool or a web UI button initiates a Convene OAuth flow, we need
+-- a CSRF state token that the provider's callback can verify. The state is
+-- short-lived (10-minute TTL) and self-cleaning.
+
+create table public.oauth_connect_state (
+  state text primary key,
+  user_id uuid not null references auth.users(id) on delete cascade,
+  provider text not null check (provider in ('google', 'microsoft', 'apple', 'caldav_generic')),
+  created_at timestamptz not null default now(),
+  expires_at timestamptz not null default (now() + interval '10 minutes')
+);
+
+create index oauth_connect_state_expires_idx on public.oauth_connect_state (expires_at);
+
+alter table public.oauth_connect_state enable row level security;
+
+-- The state token is opaque and unguessable; reads use the state value itself.
+-- We don't expose this table to anon/authenticated via policies — the
+-- callback route uses service-role to look up and delete. Auth users can see
+-- their own row to render a "connecting…" indicator if needed.
+create policy oauth_connect_state_owner_select on public.oauth_connect_state
+  for select using (auth.uid() = user_id);
+
+-- Cleanup helper — call periodically to remove stale rows.
+create or replace function public.oauth_connect_state_purge_expired()
+  returns int
+  language plpgsql
+  security definer
+  set search_path = public
+as $$
+declare
+  deleted int;
+begin
+  delete from public.oauth_connect_state where expires_at < now();
+  get diagnostics deleted = row_count;
+  return deleted;
+end;
+$$;
+
+revoke execute on function public.oauth_connect_state_purge_expired() from anon, authenticated;
+
+comment on table public.oauth_connect_state is 'KAN-206 — CSRF state for OAuth flows. 10-min TTL, service-role cleanup.';

--- a/tests/unit/convene/calendar-google-adapter.test.ts
+++ b/tests/unit/convene/calendar-google-adapter.test.ts
@@ -1,0 +1,142 @@
+/**
+ * KAN-206 — Google Calendar adapter unit tests.
+ *
+ * Uses jest module mocks to substitute the oauth-connections repository
+ * (which would otherwise hit Supabase). Verifies the adapter constructs the
+ * right HTTP calls and handles success + error paths.
+ */
+
+jest.mock('@/lib/convene/oauth-connections', () => ({
+  getFreshAccessToken: jest.fn(),
+}));
+
+import { googleCalendarAdapter } from '@/lib/convene/calendar/google';
+import { adapterFor } from '@/lib/convene/calendar';
+import { getFreshAccessToken } from '@/lib/convene/oauth-connections';
+
+const mockGetFresh = getFreshAccessToken as jest.MockedFunction<typeof getFreshAccessToken>;
+const ORIGINAL_FETCH = global.fetch;
+
+beforeEach(() => {
+  mockGetFresh.mockReset();
+  mockGetFresh.mockResolvedValue({ accessToken: 'AT-test', expiresAt: new Date(Date.now() + 3600_000) });
+});
+
+afterEach(() => {
+  global.fetch = ORIGINAL_FETCH;
+});
+
+function mockJson(body: unknown, status = 200) {
+  return jest.fn().mockResolvedValue({
+    ok: status >= 200 && status < 300,
+    status,
+    json: () => Promise.resolve(body),
+    text: () => Promise.resolve(JSON.stringify(body)),
+  }) as unknown as typeof fetch;
+}
+
+describe('adapterFor', () => {
+  it('returns googleCalendarAdapter for google', () => {
+    expect(adapterFor('google')).toBe(googleCalendarAdapter);
+  });
+
+  it('throws for unknown provider', () => {
+    expect(() => adapterFor('microsoft')).toThrow(/No calendar adapter/);
+  });
+});
+
+describe('googleCalendarAdapter.getFreeBusy', () => {
+  it('calls /freeBusy with bearer token and primary calendar', async () => {
+    global.fetch = mockJson({ calendars: { primary: { busy: [{ start: 'S', end: 'E' }] } } });
+
+    const out = await googleCalendarAdapter.getFreeBusy('conn-1', {
+      start: new Date('2026-06-01T00:00:00Z'),
+      end: new Date('2026-06-08T00:00:00Z'),
+    });
+
+    expect(mockGetFresh).toHaveBeenCalledWith('conn-1');
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+    const call = (global.fetch as jest.Mock).mock.calls[0];
+    expect(call[0]).toContain('/freeBusy');
+    expect(call[1].method).toBe('POST');
+    expect(call[1].headers.authorization).toBe('Bearer AT-test');
+    const body = JSON.parse(call[1].body as string);
+    expect(body.items).toEqual([{ id: 'primary' }]);
+    expect(body.timeMin).toBe('2026-06-01T00:00:00.000Z');
+
+    expect(out).toEqual([{ start: 'S', end: 'E' }]);
+  });
+
+  it('returns empty array when no busy blocks', async () => {
+    global.fetch = mockJson({ calendars: { primary: { busy: [] } } });
+    const out = await googleCalendarAdapter.getFreeBusy('conn-1', {
+      start: new Date(),
+      end: new Date(),
+    });
+    expect(out).toEqual([]);
+  });
+
+  it('throws with status code on Google error', async () => {
+    global.fetch = mockJson({ error: 'forbidden' }, 403);
+    await expect(
+      googleCalendarAdapter.getFreeBusy('conn-1', { start: new Date(), end: new Date() })
+    ).rejects.toThrow(/403/);
+  });
+});
+
+describe('googleCalendarAdapter.createEvent', () => {
+  it('POSTs to /calendars/primary/events with summary, times, attendees', async () => {
+    global.fetch = mockJson({ id: 'EVENT-123' }, 200);
+
+    const out = await googleCalendarAdapter.createEvent('conn-1', {
+      title: 'Dinner',
+      description: 'a meal',
+      startISO: '2026-06-01T19:00:00Z',
+      endISO: '2026-06-01T21:00:00Z',
+      location: 'Somewhere',
+      attendees: [{ email: 'a@b.com', displayName: 'A B', optional: false }],
+    });
+
+    expect(out).toEqual({ providerEventId: 'EVENT-123' });
+    const call = (global.fetch as jest.Mock).mock.calls[0];
+    expect(call[0]).toContain('/calendars/primary/events');
+    expect(call[1].method).toBe('POST');
+    const body = JSON.parse(call[1].body as string);
+    expect(body.summary).toBe('Dinner');
+    expect(body.location).toBe('Somewhere');
+    expect(body.start).toEqual({ dateTime: '2026-06-01T19:00:00Z' });
+    expect(body.attendees).toHaveLength(1);
+    expect(body.attendees[0].email).toBe('a@b.com');
+  });
+});
+
+describe('googleCalendarAdapter.deleteEvent', () => {
+  it('treats 404 / 410 as success (idempotent)', async () => {
+    global.fetch = jest.fn().mockResolvedValue({ ok: false, status: 404, text: () => Promise.resolve('') });
+    await expect(googleCalendarAdapter.deleteEvent('c', 'e')).resolves.toBeUndefined();
+    global.fetch = jest.fn().mockResolvedValue({ ok: false, status: 410, text: () => Promise.resolve('') });
+    await expect(googleCalendarAdapter.deleteEvent('c', 'e')).resolves.toBeUndefined();
+  });
+
+  it('throws on 500', async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: false,
+      status: 500,
+      text: () => Promise.resolve('server error'),
+    }) as unknown as typeof fetch;
+    await expect(googleCalendarAdapter.deleteEvent('c', 'e')).rejects.toThrow(/500/);
+  });
+
+  it('URL-encodes the providerEventId', async () => {
+    global.fetch = jest.fn().mockResolvedValue({ ok: true, status: 204 }) as unknown as typeof fetch;
+    await googleCalendarAdapter.deleteEvent('c', 'a/b c');
+    expect((global.fetch as jest.Mock).mock.calls[0][0]).toContain('a%2Fb%20c');
+  });
+});
+
+describe('googleCalendarAdapter.revokeAtProvider', () => {
+  it('best-effort: does not throw on 400 (already revoked)', async () => {
+    global.fetch = jest.fn().mockResolvedValue({ ok: false, status: 400 }) as unknown as typeof fetch;
+    await expect(googleCalendarAdapter.revokeAtProvider('c')).resolves.toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

Phase 2 of [KAN-203](https://checklyra.atlassian.net/browse/KAN-203) — replaces the P0 spike with production-quality Google Calendar integration:

- Canonical `CalendarAdapter` interface (Microsoft + CalDAV slot in here in P7).
- Google adapter implementation: `getFreeBusy`, `createEvent`, `updateEvent`, `deleteEvent`, `revokeAtProvider`.
- Repository pattern for `oauth_connections` with vault secret rotation + refresh-with-backoff.
- Real OAuth `/initiate` + `/callback` routes (replace the spike routes that were retired in P1).
- New `oauth_connect_state` table (CSRF state with 10-min TTL).

Paired MCP PR: [`luisa-sys/lyra-mcp-server#32`](https://github.com/luisa-sys/lyra-mcp-server/pull/32) adds `lyra_connect_calendar` + `lyra_disconnect_provider`.

## Architecture

```
src/lib/convene/calendar/
  types.ts     — CalendarAdapter interface (canonical)
  google.ts    — Google implementation (raw fetch, no googleapis dep)
  index.ts     — adapterFor(provider) registry

src/lib/convene/oauth-connections.ts
  Repository: getConnection, getConnectionForUser, upsertConnection,
  disconnectConnection, getFreshAccessToken (with backoff)

src/app/api/convene/oauth/google/
  initiate/route.ts   — generates 256-bit state, persists, redirects
  callback/route.ts   — validates state, exchanges code, upserts,
                        appends consent_log audit
```

## Privacy + integrity

- Event titles passed through to Google but **never persisted on our side** — only providerEventId + start/end live in our DB (when P4 ships event creation).
- OAuth refresh tokens stay in Supabase Vault. Secret rotation on every re-connect; old secret revoked best-effort.
- State table has 10-min TTL + service-role purge function (cron in a follow-up).
- `consent_log` append-only audit on every `oauth_granted` / `oauth_revoked`.

## Migration

`supabase/migrations/20260516250000_convene_oauth_connect_state.sql` — applied to dev. Staging + prod follow the existing cadence.

## Test plan

- [x] Typecheck clean
- [x] Lint clean on Convene paths
- [x] Full suite: **835 passing** (was 766 pre-P2)
- [x] 10 new adapter tests covering registry, getFreeBusy happy/error, createEvent body shape, deleteEvent idempotency on 404/410, URL encoding, revoke 400 best-effort
- [ ] Manual on dev (after merge + paired MCP PR merge): `lyra_connect_calendar` → URL → consent → callback creates row → `lyra_get_shared_availability` (next iteration) returns busy blocks

## What's NOT in this PR (deferred to next P2 iteration)

- `lyra_get_shared_availability` MCP tool (depends on real users having connected accounts; one more commit on this branch or a follow-up).
- `/dashboard/convene/connections` UI page.
- Edge Function for nightly token-health check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[KAN-203]: https://checklyra.atlassian.net/browse/KAN-203?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ