### PR TITLE
feat(KAN-220): single-page profile editor + autosave + Schools/Orgs/Communities split

### DIFF
--- a/src/app/[slug]/page.tsx
+++ b/src/app/[slug]/page.tsx
@@ -67,6 +67,10 @@ interface ProfileItem {
   category: string;
   title: string;
   description: string | null;
+  // KAN-219 — optional URL on items (Python `lyra-app` parity). Already
+  // selected by the `*` query; surfaced in the chip + Q&A rendering as a
+  // clickable link when present.
+  url: string | null;
   visibility: string;
 }
 
@@ -530,7 +534,23 @@ export default async function PublicProfilePage({ params }: Props) {
                 <div className="space-y-3">
                   {catItems.map((item) => (
                     <div key={item.id} className="border-l-3 border-[var(--color-sage)] bg-stone-50 rounded-r-lg pl-4 pr-4 py-3">
-                      <p className="text-sm font-medium text-[var(--color-ink)]">{item.title}</p>
+                      {/* KAN-219: when an item has a URL, the title becomes a
+                          clickable link. Server-side sanitiseUrl restricts
+                          to http(s); React escapes attribute values; we add
+                          rel="noopener noreferrer" to prevent tab-nabbing. */}
+                      {item.url ? (
+                        <a
+                          href={item.url}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="text-sm font-medium text-[var(--color-sage)] hover:underline"
+                        >
+                          {item.title}
+                          <span aria-hidden className="ml-1 text-xs opacity-70">↗</span>
+                        </a>
+                      ) : (
+                        <p className="text-sm font-medium text-[var(--color-ink)]">{item.title}</p>
+                      )}
                       {item.description && (
                         <p className="text-sm text-[var(--color-muted)] mt-1 leading-relaxed">{item.description}</p>
                       )}
@@ -541,9 +561,23 @@ export default async function PublicProfilePage({ params }: Props) {
                 <div className="flex flex-wrap gap-2">
                   {catItems.map((item) => (
                     <div key={item.id} className="group relative">
-                      <span className="inline-block px-3 py-1.5 bg-stone-50 border border-stone-200 rounded-full text-sm text-[var(--color-ink)]">
-                        {item.title}
-                      </span>
+                      {/* KAN-219: linked chip when URL present; plain
+                          chip otherwise. Hover preserves the same styling. */}
+                      {item.url ? (
+                        <a
+                          href={item.url}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="inline-block px-3 py-1.5 bg-stone-50 border border-stone-200 rounded-full text-sm text-[var(--color-ink)] hover:border-[var(--color-sage)] hover:text-[var(--color-sage)] transition-colors"
+                        >
+                          {item.title}
+                          <span aria-hidden className="ml-1 text-xs opacity-70">↗</span>
+                        </a>
+                      ) : (
+                        <span className="inline-block px-3 py-1.5 bg-stone-50 border border-stone-200 rounded-full text-sm text-[var(--color-ink)]">
+                          {item.title}
+                        </span>
+                      )}
                       {item.description && (
                         <div className="hidden group-hover:block absolute bottom-full left-0 mb-1 px-3 py-2 bg-[var(--color-ink)] text-white text-xs rounded-lg max-w-xs z-10">
                           {item.description}

--- a/src/app/[slug]/page.tsx
+++ b/src/app/[slug]/page.tsx
@@ -79,6 +79,10 @@ interface SchoolAffiliation {
   school_name: string;
   school_location: string | null;
   relationship: string;
+  // KAN-220: one of school|organisation|community (column added by
+  // migration 20260517010000_affiliation_type.sql). Older rows from
+  // before the migration default to 'school' at the DB level.
+  affiliation_type: string;
 }
 
 interface ExternalLink {
@@ -503,22 +507,52 @@ export default async function PublicProfilePage({ params }: Props) {
         </div>
       )}
 
-      {/* Schools */}
-      {typedSchools.length > 0 && (
-        <div className="max-w-2xl mx-auto px-6 pb-6">
-          <div className="bg-white rounded-xl border border-stone-200 p-5">
-            <h2 className="text-xs font-medium text-[var(--color-muted)] uppercase tracking-wide mb-3">🏫 Schools</h2>
-            <div className="space-y-2">
-              {typedSchools.map((s) => (
-                <div key={s.id} className="flex items-baseline justify-between">
-                  <span className="text-[var(--color-ink)] font-medium">{s.school_name}</span>
-                  <span className="text-sm text-[var(--color-muted)]">{s.relationship}</span>
+      {/* KAN-220: Schools / Organisations / Communities — three groups
+          rendered from one table (`school_affiliations`). Older rows
+          default to 'school' at the DB level, so a profile that pre-dates
+          the migration still renders correctly under the Schools heading. */}
+      {typedSchools.length > 0 && (() => {
+        const groups: Array<{ key: string; label: string; icon: string }> = [
+          { key: 'school', label: 'Schools', icon: '🏫' },
+          { key: 'organisation', label: 'Organisations', icon: '🏢' },
+          { key: 'community', label: 'Communities', icon: '👥' },
+        ];
+        const byType = groups.map((g) => ({
+          ...g,
+          items: typedSchools.filter((s) => (s.affiliation_type || 'school') === g.key),
+        })).filter((g) => g.items.length > 0);
+        if (byType.length === 0) return null;
+        return (
+          <div className="max-w-2xl mx-auto px-6 pb-6">
+            <div className="bg-white rounded-xl border border-stone-200 p-5 space-y-4">
+              {byType.map((g) => (
+                <div key={g.key}>
+                  <h2 className="text-xs font-medium text-[var(--color-muted)] uppercase tracking-wide mb-2">
+                    {g.icon} {g.label}
+                  </h2>
+                  <div className="space-y-2">
+                    {g.items.map((s) => (
+                      <div key={s.id} className="flex items-baseline justify-between">
+                        <span className="text-[var(--color-ink)] font-medium">
+                          {s.school_name}
+                          {s.school_location && (
+                            <span className="ml-2 text-xs text-[var(--color-muted)] font-normal">
+                              · {s.school_location}
+                            </span>
+                          )}
+                        </span>
+                        {s.relationship && (
+                          <span className="text-sm text-[var(--color-muted)]">{s.relationship}</span>
+                        )}
+                      </div>
+                    ))}
+                  </div>
                 </div>
               ))}
             </div>
           </div>
-        </div>
-      )}
+        );
+      })()}
 
       {/* Profile items by category */}
       {categoryOrder.map((cat) => {

--- a/src/app/dashboard/profile/actions.ts
+++ b/src/app/dashboard/profile/actions.ts
@@ -80,6 +80,7 @@ export async function addProfileItem(data: {
   category: string;
   title: string;
   description?: string;
+  url?: string;
   visibility?: string;
 }): Promise<ActionResult> {
   const { user, supabase, error: authError } = await getAuthenticatedUser();
@@ -88,6 +89,19 @@ export async function addProfileItem(data: {
   const profile = await getUserProfile(supabase, user!.id);
   if (!profile) return { success: false, error: 'Profile not found' };
 
+  // KAN-219 — optional URL on items (Python `lyra-app` parity). If absent or
+  // empty, insert NULL. If provided, `sanitiseUrl` returns '' on anything
+  // that's not http(s) — surface that as an error rather than silently
+  // dropping the field so the user knows their input was rejected.
+  let sanitisedUrl: string | null = null;
+  if (data.url && data.url.trim() !== '') {
+    const cleaned = sanitiseUrl(data.url);
+    if (!cleaned) {
+      return { success: false, error: 'Invalid URL — must start with http:// or https://' };
+    }
+    sanitisedUrl = cleaned;
+  }
+
   const { error } = await supabase
     .from('profile_items')
     .insert({
@@ -95,6 +109,7 @@ export async function addProfileItem(data: {
       category: sanitiseText(data.category, 50),
       title: sanitiseText(data.title, 200),
       description: data.description ? sanitiseText(data.description, 1000) : null,
+      url: sanitisedUrl,
       // Coerce to one of the allowed visibility levels — anything else falls
       // back to 'public'. KAN-143.
       visibility: coerceVisibility(data.visibility),

--- a/src/app/dashboard/profile/actions.ts
+++ b/src/app/dashboard/profile/actions.ts
@@ -5,6 +5,7 @@ import { revalidatePath } from 'next/cache';
 import { sanitiseText, sanitiseUrl, type ActionResult } from '@/lib/sanitise';
 import { isAllowedProfileField } from './profile-fields';
 import { coerceVisibility } from './visibility';
+import { coerceAffiliationType } from './affiliation-fields';
 
 async function getAuthenticatedUser() {
   const supabase = await createClient();
@@ -157,6 +158,11 @@ export async function addSchoolAffiliation(data: {
   school_name: string;
   school_location?: string;
   relationship?: string;
+  // KAN-220: one of school|organisation|community. Defaults to 'school'
+  // for backward compat with pre-KAN-220 callers; coerced on write so
+  // anything outside the allowlist becomes 'school' rather than reaching
+  // the DB and triggering the CHECK constraint.
+  affiliation_type?: string;
 }): Promise<ActionResult> {
   const { user, supabase, error: authError } = await getAuthenticatedUser();
   if (authError) return { success: false, error: authError };
@@ -171,6 +177,7 @@ export async function addSchoolAffiliation(data: {
       school_name: sanitiseText(data.school_name, 200),
       school_location: data.school_location ? sanitiseText(data.school_location, 200) : null,
       relationship: data.relationship || 'parent',
+      affiliation_type: coerceAffiliationType(data.affiliation_type),
     });
 
   if (error) return { success: false, error: error.message };

--- a/src/app/dashboard/profile/affiliation-fields.ts
+++ b/src/app/dashboard/profile/affiliation-fields.ts
@@ -1,0 +1,45 @@
+/**
+ * KAN-220: helpers for the `affiliation_type` column added to
+ * `school_affiliations` by migration 20260517010000_affiliation_type.sql.
+ *
+ * Lives in this sibling module (NOT `actions.ts`) because Next.js 16+
+ * rejects non-async-function exports from `'use server'` files at
+ * action-invocation time — see BUGS-12. Constants, types, and synchronous
+ * coercion helpers must live outside the action file.
+ *
+ * The allowlist mirrors the DB-side CHECK constraint:
+ *   check (affiliation_type in ('school', 'organisation', 'community'))
+ *
+ * Anything not in this list is coerced to 'school' on write rather than
+ * reaching the DB and triggering a constraint violation.
+ */
+
+export const ALLOWED_AFFILIATION_TYPES = ['school', 'organisation', 'community'] as const;
+
+export type AffiliationType = typeof ALLOWED_AFFILIATION_TYPES[number];
+
+export function isAffiliationType(v: string): v is AffiliationType {
+  return (ALLOWED_AFFILIATION_TYPES as readonly string[]).includes(v);
+}
+
+export function coerceAffiliationType(v: string | undefined): AffiliationType {
+  if (v && isAffiliationType(v)) {
+    return v;
+  }
+  return 'school';
+}
+
+// Human-readable labels for each type. Used as section headings in the
+// affiliations editor and to label items on the public profile.
+export const AFFILIATION_LABELS: Record<AffiliationType, string> = {
+  school: 'Schools',
+  organisation: 'Organisations',
+  community: 'Communities',
+};
+
+// Singular forms for "+ Add a …" buttons and per-row placeholders.
+export const AFFILIATION_SINGULAR: Record<AffiliationType, string> = {
+  school: 'school',
+  organisation: 'organisation',
+  community: 'community',
+};

--- a/src/app/dashboard/profile/edit-profile-form.tsx
+++ b/src/app/dashboard/profile/edit-profile-form.tsx
@@ -132,7 +132,7 @@ export function EditProfileForm({
   useEffect(() => {
     if (typeof window === 'undefined') return;
     if (window.matchMedia('(max-width: 767px)').matches) {
-      // eslint-disable-next-line react-hooks/set-state-in-effect -- one-time mount-only matchMedia detection. Empty deps array prevents cascading renders; this is the standard pattern for hydration-time viewport-dependent state. Alternative (useSyncExternalStore) would also subscribe to viewport changes, which we deliberately don't want here.
+      // eslint-disable-next-line react-hooks/set-state-in-effect -- KAN-220: one-time mount-only matchMedia detection. Empty deps array prevents cascading renders; this is the standard pattern for hydration-time viewport-dependent state. Alternative (useSyncExternalStore) would also subscribe to viewport changes, which we deliberately don't want here.
       setOpenSections(new Set([SECTIONS[0].id]));
     }
   }, []);

--- a/src/app/dashboard/profile/edit-profile-form.tsx
+++ b/src/app/dashboard/profile/edit-profile-form.tsx
@@ -1,0 +1,402 @@
+'use client';
+
+/**
+ * KAN-220 — single-page profile editor. Replaces the 14-step wizard
+ * with one long form, ports the Python `lyra-app/templates/edit_profile.html`
+ * layout. The wizard file (`wizard.tsx`) is kept for the legacy route
+ * at `/dashboard/profile/legacy` and for the existing `profile-sections.test.js`
+ * regression guards (test-integrity policy — guards stay green by
+ * leaving the file unchanged).
+ *
+ * Layout:
+ *   - Sticky header with Lyra logo + "View public profile" link
+ *   - Desktop: left sidebar Table of Contents (sticky), main column with
+ *     all sections expanded by default. Mobile: no sidebar, all sections
+ *     collapsed except Basic Info.
+ *   - Each section is a controlled `<section>` with a button header that
+ *     toggles open/closed.
+ *   - Sticky bottom bar: Publish (or "Unpublish & save draft") button.
+ *
+ * Save UX:
+ *   - Free-text sections (BasicInfo, Bio, ManualOfMe) autosave on blur
+ *     after 800ms debounce. Status indicator in section.
+ *   - List sections (items, links, files, schools, conversation starters)
+ *     save instantly on Add / Remove via existing server actions.
+ *   - The sticky Publish button only handles the publish/unpublish flip
+ *     — it doesn't need to "save the form" because everything's already
+ *     persisted.
+ *
+ * Mobile collapse state: SSR renders with all sections expanded (no
+ * flash on desktop). On mount, a `useEffect` checks `matchMedia` and
+ * collapses non-first sections on mobile. Brief flash on mobile is an
+ * accepted trade-off — moving to per-section CSS state to eliminate
+ * the flash entirely is a follow-up if it bothers anyone.
+ */
+
+import { useEffect, useState, useTransition } from 'react';
+import { useRouter } from 'next/navigation';
+import Link from 'next/link';
+import Image from 'next/image';
+import {
+  addProfileItem,
+  removeProfileItem,
+  updateProfileItemVisibility,
+  addExternalLink,
+  removeExternalLink,
+  publishProfile,
+} from './actions';
+import {
+  ItemsStep,
+  LinksStep,
+  FilesStep,
+  ConversationStartersStep,
+  type WizardProfile,
+  type WizardItem,
+  type WizardSchool,
+  type WizardLink,
+  type WizardFile,
+  type ConversationPrompt,
+  type ConversationAnswer,
+} from './steps';
+import {
+  uploadProfileFile,
+  removeProfileFile,
+  updateProfileFileVisibility,
+} from './files-actions';
+import {
+  addConversationStarter,
+  updateConversationStarter,
+  removeConversationStarter,
+} from './conversation-starters-actions';
+import {
+  BasicInfoSection,
+  BioSection,
+  ManualOfMeSection,
+  AffiliationsSection,
+} from './sections';
+import type { ManualOfMe } from './manual-of-me-fields';
+
+interface SectionDef {
+  id: string;
+  label: string;
+  icon: string;
+}
+
+// Section order mirrors the Python `lyra-app` editor (`edit_profile.html`).
+// Free-text sections that benefit from autosave come first; lists come next;
+// files + starters at the end (lowest-engagement sections per KAN-181 reasoning).
+const SECTIONS: SectionDef[] = [
+  { id: 'basic-info', label: 'Basic Information', icon: '👤' },
+  { id: 'affiliations', label: 'Schools / Orgs / Communities', icon: '🏫' },
+  { id: 'bio', label: 'About you', icon: '✏️' },
+  { id: 'manual-of-me', label: 'Manual of Me', icon: '📖' },
+  { id: 'likes', label: 'Likes & Dislikes', icon: '💚' },
+  { id: 'gifts', label: 'Gift ideas', icon: '🎁' },
+  { id: 'boundaries', label: 'Boundaries & Preferences', icon: '🛑' },
+  { id: 'books-media', label: 'Books & Media', icon: '📚' },
+  { id: 'causes-quotes', label: 'Things that matter to me', icon: '💛' },
+  { id: 'more', label: 'More about you', icon: '✨' },
+  { id: 'links', label: 'Links', icon: '🔗' },
+  { id: 'files', label: 'Files & media', icon: '📎' },
+  { id: 'starters', label: 'Things to ask me about', icon: '💬' },
+];
+
+export function EditProfileForm({
+  profile,
+  items,
+  schools,
+  links,
+  manualOfMe,
+  files,
+  conversationPrompts,
+  conversationAnswers,
+}: {
+  profile: WizardProfile;
+  items: WizardItem[];
+  schools: WizardSchool[];
+  links: WizardLink[];
+  manualOfMe: ManualOfMe;
+  files: WizardFile[];
+  conversationPrompts: ConversationPrompt[];
+  conversationAnswers: ConversationAnswer[];
+}) {
+  const router = useRouter();
+  const [isPending, startTransition] = useTransition();
+
+  // SSR-safe: all expanded by default (no flash on desktop). On mount,
+  // matchMedia narrows to mobile and we collapse all but the first.
+  const [openSections, setOpenSections] = useState<Set<string>>(
+    () => new Set(SECTIONS.map((s) => s.id)),
+  );
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    if (window.matchMedia('(max-width: 767px)').matches) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect -- one-time mount-only matchMedia detection. Empty deps array prevents cascading renders; this is the standard pattern for hydration-time viewport-dependent state. Alternative (useSyncExternalStore) would also subscribe to viewport changes, which we deliberately don't want here.
+      setOpenSections(new Set([SECTIONS[0].id]));
+    }
+  }, []);
+
+  const toggleSection = (id: string) => {
+    setOpenSections((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  };
+
+  const renderItemsSection = (
+    sectionId: string,
+    title: string,
+    description: string,
+    categories: string[],
+  ) => (
+    <ItemsStep
+      title={title}
+      description={description}
+      categories={categories}
+      items={items.filter((i) => categories.includes(i.category))}
+      onAdd={(data) => {
+        startTransition(async () => {
+          await addProfileItem(data);
+          router.refresh();
+        });
+      }}
+      onRemove={(id) => {
+        startTransition(async () => {
+          await removeProfileItem(id);
+          router.refresh();
+        });
+      }}
+      onUpdateVisibility={(id, visibility) => {
+        startTransition(async () => {
+          await updateProfileItemVisibility(id, visibility);
+          router.refresh();
+        });
+      }}
+      // Single-page form has no "next step" — Continue collapses
+      // the section so the user knows they're done with it.
+      onNext={() => toggleSection(sectionId)}
+      isPending={isPending}
+    />
+  );
+
+  return (
+    <main className="min-h-screen bg-stone-50 pb-24">
+      {/* Header */}
+      <header className="border-b border-stone-200 bg-white">
+        <div className="max-w-5xl mx-auto px-4 py-4 flex items-center justify-between">
+          <Link href="/dashboard" className="flex items-center">
+            <Image src="/lyra-logo.png" alt="Lyra" width={32} height={32} className="h-8 w-auto" />
+          </Link>
+          <div className="flex items-center gap-4">
+            {profile.is_published && (
+              <Link
+                href={`/${profile.slug}`}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-sm text-[var(--color-sage)] hover:underline"
+              >
+                View public profile ↗
+              </Link>
+            )}
+            <Link
+              href="/dashboard/profile/legacy"
+              className="text-xs text-[var(--color-muted)] hover:underline"
+              title="Open the old step-by-step wizard"
+            >
+              Use legacy wizard
+            </Link>
+          </div>
+        </div>
+      </header>
+
+      <div className="max-w-5xl mx-auto px-4 py-6 md:grid md:grid-cols-[200px_1fr] md:gap-8">
+        {/* Sidebar ToC — desktop only */}
+        <nav aria-label="Section navigation" className="hidden md:block">
+          <div className="sticky top-4 space-y-1">
+            <p className="text-xs font-medium uppercase tracking-wide text-[var(--color-muted)] mb-2">
+              Sections
+            </p>
+            {SECTIONS.map((s) => (
+              <a
+                key={s.id}
+                href={`#${s.id}`}
+                className="block text-sm text-[var(--color-ink)] hover:text-[var(--color-sage)] py-1 px-2 -mx-2 rounded hover:bg-stone-100"
+              >
+                <span className="mr-1.5">{s.icon}</span> {s.label}
+              </a>
+            ))}
+          </div>
+        </nav>
+
+        {/* Main column */}
+        <div className="space-y-3">
+          {SECTIONS.map((s) => {
+            const isOpen = openSections.has(s.id);
+            return (
+              <section
+                key={s.id}
+                id={s.id}
+                className="bg-white rounded-lg border border-stone-200 overflow-hidden scroll-mt-4"
+              >
+                <button
+                  type="button"
+                  aria-expanded={isOpen}
+                  aria-controls={`${s.id}-body`}
+                  onClick={() => toggleSection(s.id)}
+                  className="w-full flex items-center justify-between px-4 py-3 text-left hover:bg-stone-50 transition-colors"
+                >
+                  <span className="text-base font-medium text-[var(--color-ink)]">
+                    <span className="mr-2">{s.icon}</span> {s.label}
+                  </span>
+                  <span aria-hidden className="text-[var(--color-muted)] text-sm">
+                    {isOpen ? '▾' : '▸'}
+                  </span>
+                </button>
+                {isOpen && (
+                  <div id={`${s.id}-body`} className="px-4 pb-5 pt-1 border-t border-stone-200">
+                    {s.id === 'basic-info' && <BasicInfoSection profile={profile} />}
+                    {s.id === 'affiliations' && <AffiliationsSection schools={schools} />}
+                    {s.id === 'bio' && <BioSection profile={profile} />}
+                    {s.id === 'manual-of-me' && <ManualOfMeSection manualOfMe={manualOfMe} />}
+                    {s.id === 'likes' && renderItemsSection(
+                      s.id,
+                      'Likes & Dislikes',
+                      "Tastes, interests, and favourites — plus the things you'd rather steer clear of.",
+                      ['likes', 'dislikes'],
+                    )}
+                    {s.id === 'gifts' && renderItemsSection(
+                      s.id,
+                      'Gift ideas',
+                      "Things you'd love to receive, luxuries you don't give yourself, things you can't have enough of — and gifts that aren't for you.",
+                      ['gift_ideas', 'gifts_to_avoid'],
+                    )}
+                    {s.id === 'boundaries' && renderItemsSection(
+                      s.id,
+                      'Boundaries & Preferences',
+                      'Practical preferences, boundaries, and things that help people respect your space.',
+                      ['boundaries', 'helpful_to_know'],
+                    )}
+                    {s.id === 'books-media' && renderItemsSection(
+                      s.id,
+                      'Books & Media',
+                      'Books you love and the screen favourites that shaped you.',
+                      ['favourite_books', 'favourite_media'],
+                    )}
+                    {s.id === 'causes-quotes' && renderItemsSection(
+                      s.id,
+                      'Things that matter to me',
+                      'Causes and charities you care about, and the words that resonate with you.',
+                      ['causes', 'quotes'],
+                    )}
+                    {s.id === 'more' && renderItemsSection(
+                      s.id,
+                      'More about you',
+                      "What you're most proud of, life hacks worth sharing, places you'd recommend, questions you wish people asked, problems you're working on, and your billboard message.",
+                      ['proud_of', 'life_hacks', 'questions', 'billboard', 'current_problems'],
+                    )}
+                    {s.id === 'links' && (
+                      <LinksStep
+                        links={links}
+                        onAdd={(data) => {
+                          startTransition(async () => {
+                            await addExternalLink(data);
+                            router.refresh();
+                          });
+                        }}
+                        onRemove={(id) => {
+                          startTransition(async () => {
+                            await removeExternalLink(id);
+                            router.refresh();
+                          });
+                        }}
+                        onNext={() => toggleSection(s.id)}
+                        isPending={isPending}
+                      />
+                    )}
+                    {s.id === 'files' && (
+                      <FilesStep
+                        files={files}
+                        onUpload={(formData) => {
+                          startTransition(async () => {
+                            await uploadProfileFile(formData);
+                            router.refresh();
+                          });
+                        }}
+                        onRemove={(id) => {
+                          startTransition(async () => {
+                            await removeProfileFile(id);
+                            router.refresh();
+                          });
+                        }}
+                        onUpdateVisibility={(id, visibility) => {
+                          startTransition(async () => {
+                            await updateProfileFileVisibility(id, visibility);
+                            router.refresh();
+                          });
+                        }}
+                        onNext={() => toggleSection(s.id)}
+                        isPending={isPending}
+                      />
+                    )}
+                    {s.id === 'starters' && (
+                      <ConversationStartersStep
+                        prompts={conversationPrompts}
+                        answers={conversationAnswers}
+                        onAdd={(input) => {
+                          startTransition(async () => {
+                            await addConversationStarter(input);
+                            router.refresh();
+                          });
+                        }}
+                        onUpdate={(id, answer) => {
+                          startTransition(async () => {
+                            await updateConversationStarter(id, answer);
+                            router.refresh();
+                          });
+                        }}
+                        onRemove={(id) => {
+                          startTransition(async () => {
+                            await removeConversationStarter(id);
+                            router.refresh();
+                          });
+                        }}
+                        onNext={() => toggleSection(s.id)}
+                        isPending={isPending}
+                      />
+                    )}
+                  </div>
+                )}
+              </section>
+            );
+          })}
+        </div>
+      </div>
+
+      {/* Sticky save bar */}
+      <div className="fixed bottom-0 inset-x-0 bg-white border-t border-stone-200 px-4 py-3 z-10">
+        <div className="max-w-5xl mx-auto flex items-center justify-between gap-4">
+          <p className="text-xs text-[var(--color-muted)] hidden sm:block">
+            Changes save automatically as you type.
+          </p>
+          <button
+            type="button"
+            onClick={() => {
+              startTransition(async () => {
+                await publishProfile();
+                router.refresh();
+                router.push('/dashboard');
+              });
+            }}
+            disabled={isPending}
+            className="px-5 py-2 rounded-lg bg-[var(--color-sage)] text-white text-sm font-medium hover:opacity-90 disabled:opacity-50 transition-opacity"
+          >
+            {profile.is_published ? 'Save & re-publish' : 'Save & publish'}
+          </button>
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/src/app/dashboard/profile/legacy/page.tsx
+++ b/src/app/dashboard/profile/legacy/page.tsx
@@ -1,11 +1,12 @@
 import { createClient } from '@/lib/supabase-server';
 import { redirect } from 'next/navigation';
-import { EditProfileForm } from './edit-profile-form';
-import type { ManualOfMe } from './manual-of-me-fields';
+import { ProfileWizard } from '../wizard';
+import type { ManualOfMe } from '../manual-of-me-fields';
 
 export const metadata = {
-  title: 'Edit your profile — Lyra',
-  description: 'Set up your Lyra profile so people in your life can get to know you better.',
+  title: 'Edit your profile (legacy) — Lyra',
+  description: 'Step-by-step profile editor — kept for one release as a rollback path. The new single-page editor at /dashboard/profile is the default.',
+  robots: { index: false, follow: false },
 };
 
 const EMPTY_MANUAL_OF_ME: ManualOfMe = {
@@ -16,14 +17,15 @@ const EMPTY_MANUAL_OF_ME: ManualOfMe = {
 };
 
 /**
- * KAN-220 — single-page profile editor. Replaces the 14-step wizard,
- * which is preserved one route over at `/dashboard/profile/legacy` for
- * one release as a rollback path. Data fetching duplicated across both
- * routes by design (small price for keeping each route independent —
- * also matches `conversation_starter_prompts` / `profile_conversation_starters`
- * regression guard in `tests/unit/conversation-starters.test.ts`).
+ * KAN-220 — preserved legacy wizard route. The new single-page editor
+ * at `/dashboard/profile` is the default; this route exists for one
+ * release as a rollback path in case the new layout reveals a regression.
+ *
+ * Data fetching duplicated from `page.tsx` by design — see comment there.
+ *
+ * Will be removed in a follow-up after one stable release on prod.
  */
-export default async function ProfilePage() {
+export default async function LegacyProfilePage() {
   const supabase = await createClient();
   const { data: { user } } = await supabase.auth.getUser();
   if (!user) redirect('/login');
@@ -76,8 +78,6 @@ export default async function ProfilePage() {
     .eq('profile_id', profile.id)
     .order('created_at', { ascending: true });
   const conversationAnswers = (starterRows ?? []).map((r) => {
-    // Supabase typegen sometimes flattens the joined row to an object,
-    // sometimes to an array — handle both shapes.
     const promptCandidate = r.prompt as unknown;
     const joinedPrompt = Array.isArray(promptCandidate)
       ? ((promptCandidate[0] as { prompt: string } | undefined)?.prompt ?? '')
@@ -91,7 +91,7 @@ export default async function ProfilePage() {
   });
 
   return (
-    <EditProfileForm
+    <ProfileWizard
       profile={profile}
       items={items || []}
       schools={schools || []}

--- a/src/app/dashboard/profile/sections/affiliations-section.tsx
+++ b/src/app/dashboard/profile/sections/affiliations-section.tsx
@@ -1,0 +1,150 @@
+'use client';
+
+/**
+ * KAN-220 — Schools / Organisations / Communities section for the
+ * single-page profile editor. Splits the legacy single-type SchoolStep
+ * into three multi-input groups, matching the Python `lyra-app` UX
+ * (`templates/edit_profile.html` — "Schools / Organisations / Communities
+ * I'm part of"). All three use the same `school_affiliations` table
+ * with the new `affiliation_type` column (migration 20260517010000).
+ *
+ * No autosave — each row is added/removed explicitly via the existing
+ * `addSchoolAffiliation` / `removeSchoolAffiliation` server actions,
+ * which fire on click (same instant-save pattern as the items step).
+ */
+
+import { useState, useTransition } from 'react';
+import { Field, type WizardSchool } from '../steps/types';
+import {
+  AFFILIATION_LABELS,
+  AFFILIATION_SINGULAR,
+  type AffiliationType,
+} from '../affiliation-fields';
+import { addSchoolAffiliation, removeSchoolAffiliation } from '../actions';
+import { useRouter } from 'next/navigation';
+
+const AFFILIATION_ORDER: AffiliationType[] = ['school', 'organisation', 'community'];
+
+export function AffiliationsSection({ schools }: { schools: WizardSchool[] }) {
+  const router = useRouter();
+  const [isPending, startTransition] = useTransition();
+
+  const grouped = AFFILIATION_ORDER.reduce<Record<AffiliationType, WizardSchool[]>>(
+    (acc, type) => {
+      // Older rows pre-migration default to 'school' via the DB default,
+      // but defend against missing/unknown values just in case.
+      acc[type] = schools.filter((s) => (s.affiliation_type || 'school') === type);
+      return acc;
+    },
+    { school: [], organisation: [], community: [] },
+  );
+
+  return (
+    <div className="space-y-6">
+      <p className="text-sm text-[var(--color-muted)]">
+        Schools, organisations, and communities you&apos;re part of. Helps people who know you
+        from any of these find your profile.
+      </p>
+      {AFFILIATION_ORDER.map((type) => (
+        <AffiliationGroup
+          key={type}
+          type={type}
+          items={grouped[type]}
+          onAdd={(name, location) => {
+            startTransition(async () => {
+              const result = await addSchoolAffiliation({
+                school_name: name,
+                school_location: location || undefined,
+                affiliation_type: type,
+              });
+              if (result.success) router.refresh();
+            });
+          }}
+          onRemove={(id) => {
+            startTransition(async () => {
+              const result = await removeSchoolAffiliation(id);
+              if (result.success) router.refresh();
+            });
+          }}
+          isPending={isPending}
+        />
+      ))}
+    </div>
+  );
+}
+
+function AffiliationGroup({
+  type, items, onAdd, onRemove, isPending,
+}: {
+  type: AffiliationType;
+  items: WizardSchool[];
+  onAdd: (name: string, location: string) => void;
+  onRemove: (id: string) => void;
+  isPending: boolean;
+}) {
+  const [name, setName] = useState('');
+  const [location, setLocation] = useState('');
+
+  const handleAdd = () => {
+    if (!name.trim()) return;
+    onAdd(name.trim(), location.trim());
+    setName('');
+    setLocation('');
+  };
+
+  return (
+    <div className="space-y-3">
+      <h3 className="text-sm font-medium text-[var(--color-ink)]">
+        {AFFILIATION_LABELS[type]}
+      </h3>
+
+      {items.length > 0 && (
+        <div className="space-y-2">
+          {items.map((s) => (
+            <div key={s.id} className="flex items-center justify-between bg-white rounded-lg border border-stone-200 px-4 py-3">
+              <div>
+                <p className="text-sm font-medium text-[var(--color-ink)]">{s.school_name}</p>
+                {s.school_location && (
+                  <p className="text-xs text-[var(--color-muted)]">{s.school_location}</p>
+                )}
+              </div>
+              <button
+                onClick={() => onRemove(s.id)}
+                disabled={isPending}
+                className="text-xs text-red-400 hover:text-red-600 disabled:opacity-40"
+              >
+                Remove
+              </button>
+            </div>
+          ))}
+        </div>
+      )}
+
+      <div className="space-y-3 bg-white rounded-lg border border-stone-200 p-4">
+        <Field
+          label={`${AFFILIATION_LABELS[type].slice(0, -1)} name`}
+          value={name}
+          onChange={setName}
+          placeholder={
+            type === 'school' ? 'Greenfield Primary' :
+            type === 'organisation' ? 'Acme Ltd' :
+            'Local running club'
+          }
+        />
+        <Field
+          label="Location (optional)"
+          value={location}
+          onChange={setLocation}
+          placeholder="London"
+        />
+        <button
+          onClick={handleAdd}
+          disabled={isPending || !name.trim()}
+          className="px-4 py-2 rounded-lg bg-stone-100 text-sm font-medium text-[var(--color-ink)] hover:bg-stone-200 disabled:opacity-40 transition-colors"
+        >
+          + Add {AFFILIATION_SINGULAR[type]}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/app/dashboard/profile/sections/basic-info-section.tsx
+++ b/src/app/dashboard/profile/sections/basic-info-section.tsx
@@ -110,7 +110,7 @@ export function BasicInfoSection({ profile }: { profile: WizardProfile }) {
           className="relative w-20 h-20 rounded-full overflow-hidden bg-[var(--color-sage)] flex items-center justify-center cursor-pointer hover:opacity-90 transition-opacity shrink-0 disabled:opacity-50"
         >
           {preview ? (
-            // eslint-disable-next-line @next/next/no-img-element -- preview is a FileReader data: URL or Supabase Storage public URL; not an asset that benefits from the Next/Image optimizer.
+            // eslint-disable-next-line @next/next/no-img-element -- KAN-220: preview is a FileReader data: URL or Supabase Storage public URL; not an asset that benefits from the Next/Image optimizer.
             <img src={preview} alt="Profile photo" className="w-full h-full object-cover" />
           ) : (
             <span className="text-2xl text-white font-[family-name:var(--font-serif)]">

--- a/src/app/dashboard/profile/sections/basic-info-section.tsx
+++ b/src/app/dashboard/profile/sections/basic-info-section.tsx
@@ -1,0 +1,208 @@
+'use client';
+
+/**
+ * KAN-220 — Basic Info section for the single-page profile editor.
+ *
+ * Autosave version of `IdentityStep`. The legacy IdentityStep stays in
+ * `steps/` for the legacy wizard at `/dashboard/profile/legacy` and the
+ * existing tests; this new component is what the single-page form uses.
+ *
+ * Differences from IdentityStep:
+ *   - Field changes auto-save after a debounce (800ms). No Save button.
+ *   - Status indicator in the section header shows Saving… / Saved /
+ *     Save failed.
+ *   - Avatar upload still fires on file pick (no autosave needed —
+ *     uploads are immediate).
+ *   - Delivery country still autosaves on change (already independent
+ *     server action; see KAN-186).
+ *
+ * State shape: a single `draft` object so the autosave hook debounces
+ * across ALL fields together — if the user types in display_name then
+ * immediately switches to headline, ONE save fires 800ms after the
+ * last keystroke (not two).
+ */
+
+import { useRef, useState, useTransition } from 'react';
+import { Field, type WizardProfile } from '../steps/types';
+import { SUPPORTED_DELIVERY_COUNTRIES } from '@/lib/affiliate/country-codes';
+import { updateDeliveryCountry } from '../delivery-country-actions';
+import { updateProfileFields, uploadAvatar } from '../actions';
+import { AutoSaveStatusLabel, useAutoSave } from './use-auto-save';
+
+interface BasicInfoDraft {
+  display_name: string;
+  headline: string;
+  city: string;
+  country: string;
+}
+
+export function BasicInfoSection({ profile }: { profile: WizardProfile }) {
+  const [draft, setDraft] = useState<BasicInfoDraft>({
+    display_name: profile.display_name || '',
+    headline: profile.headline || '',
+    city: profile.city || '',
+    country: profile.country || 'GB',
+  });
+
+  const [deliveryCountry, setDeliveryCountry] = useState<string>(
+    profile.delivery_country_code || '',
+  );
+  const [deliveryCountryError, setDeliveryCountryError] = useState<string | null>(null);
+  const [savingDeliveryCountry, startSavingDeliveryCountry] = useTransition();
+
+  const [preview, setPreview] = useState<string | null>(profile.avatar_url || null);
+  const [uploadError, setUploadError] = useState<string | null>(null);
+  const [uploadingAvatar, startUploadAvatar] = useTransition();
+  const fileRef = useRef<HTMLInputElement>(null);
+
+  const status = useAutoSave(draft, async (v) => {
+    return updateProfileFields({
+      display_name: v.display_name,
+      headline: v.headline,
+      city: v.city,
+      country: v.country,
+    });
+  });
+
+  const set = <K extends keyof BasicInfoDraft>(key: K, value: BasicInfoDraft[K]) =>
+    setDraft((d) => ({ ...d, [key]: value }));
+
+  const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+
+    setUploadError(null);
+
+    const allowed = ['image/jpeg', 'image/png', 'image/webp', 'image/gif'];
+    if (!allowed.includes(file.type)) {
+      setUploadError('Please choose a JPEG, PNG, WebP, or GIF image.');
+      return;
+    }
+    if (file.size > 5 * 1024 * 1024) {
+      setUploadError('Image must be under 5MB.');
+      return;
+    }
+
+    const reader = new FileReader();
+    reader.onload = (ev) => setPreview(ev.target?.result as string);
+    reader.readAsDataURL(file);
+
+    const fd = new FormData();
+    fd.append('avatar', file);
+    startUploadAvatar(async () => {
+      await uploadAvatar(fd);
+    });
+  };
+
+  return (
+    <div className="space-y-6">
+      {/* Status indicator — rendered inline so the user can see autosave fire */}
+      <div className="flex justify-end">
+        <AutoSaveStatusLabel status={status} />
+      </div>
+
+      {/* Avatar */}
+      <div className="flex items-center gap-4">
+        <button
+          type="button"
+          onClick={() => fileRef.current?.click()}
+          disabled={uploadingAvatar}
+          className="relative w-20 h-20 rounded-full overflow-hidden bg-[var(--color-sage)] flex items-center justify-center cursor-pointer hover:opacity-90 transition-opacity shrink-0 disabled:opacity-50"
+        >
+          {preview ? (
+            // eslint-disable-next-line @next/next/no-img-element -- preview is a FileReader data: URL or Supabase Storage public URL; not an asset that benefits from the Next/Image optimizer.
+            <img src={preview} alt="Profile photo" className="w-full h-full object-cover" />
+          ) : (
+            <span className="text-2xl text-white font-[family-name:var(--font-serif)]">
+              {draft.display_name ? draft.display_name.charAt(0).toUpperCase() : '?'}
+            </span>
+          )}
+        </button>
+        <div>
+          <button
+            type="button"
+            onClick={() => fileRef.current?.click()}
+            disabled={uploadingAvatar}
+            className="text-sm text-[var(--color-sage)] hover:underline cursor-pointer disabled:opacity-50"
+          >
+            {preview ? 'Change photo' : 'Add a photo'}
+          </button>
+          <p className="text-xs text-[var(--color-muted)] mt-0.5">JPEG, PNG, WebP or GIF. Max 5MB.</p>
+          {uploadError && <p className="text-xs text-red-500 mt-0.5">{uploadError}</p>}
+        </div>
+        <input
+          ref={fileRef}
+          type="file"
+          accept="image/jpeg,image/png,image/webp,image/gif"
+          onChange={handleFileChange}
+          className="hidden"
+        />
+      </div>
+
+      <div className="space-y-4">
+        <Field
+          label="Display name"
+          value={draft.display_name}
+          onChange={(v) => set('display_name', v)}
+          placeholder="Sarah Ashworth"
+        />
+        <Field
+          label="Headline"
+          value={draft.headline}
+          onChange={(v) => set('headline', v)}
+          placeholder="Mum, teacher, coffee lover"
+        />
+        <Field
+          label="City"
+          value={draft.city}
+          onChange={(v) => set('city', v)}
+          placeholder="London"
+        />
+        <Field
+          label="Country"
+          value={draft.country}
+          onChange={(v) => set('country', v)}
+          placeholder="GB"
+        />
+
+        {/* KAN-186: delivery country (separate server action, kept inline-save
+            since it's a single-field dropdown, not an autosave-friendly text). */}
+        <div>
+          <label htmlFor="delivery-country" className="block text-sm font-medium text-[var(--color-ink)]">
+            Delivery country
+          </label>
+          <p className="text-xs text-[var(--color-muted)] mt-0.5">
+            Where gift recommendations should be able to ship to. Leave blank to use the buyer&apos;s country.
+          </p>
+          <select
+            id="delivery-country"
+            value={deliveryCountry}
+            onChange={(e) => {
+              const next = e.target.value;
+              setDeliveryCountry(next);
+              setDeliveryCountryError(null);
+              startSavingDeliveryCountry(async () => {
+                const result = await updateDeliveryCountry(next || null);
+                if (!result.success) {
+                  setDeliveryCountryError(result.error ?? 'Could not save');
+                }
+              });
+            }}
+            disabled={savingDeliveryCountry}
+            className="mt-1 block w-full rounded-md border border-[var(--color-border)] bg-white px-3 py-2 text-sm text-[var(--color-ink)] focus:outline-none focus:ring-2 focus:ring-[var(--color-sage)]"
+          >
+            <option value="">— Use buyer&apos;s country —</option>
+            {SUPPORTED_DELIVERY_COUNTRIES.map(({ code, name: countryName }) => (
+              <option key={code} value={code}>
+                {countryName} ({code})
+              </option>
+            ))}
+          </select>
+          {deliveryCountryError && (
+            <p className="text-xs text-red-500 mt-0.5">{deliveryCountryError}</p>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/dashboard/profile/sections/bio-section.tsx
+++ b/src/app/dashboard/profile/sections/bio-section.tsx
@@ -1,0 +1,42 @@
+'use client';
+
+/**
+ * KAN-220 — Bio section for the single-page profile editor.
+ *
+ * Autosave version of `BioStep`. Single textarea (bio_short, max 300 chars)
+ * with debounced auto-save. Status indicator at the top.
+ */
+
+import { useState } from 'react';
+import type { WizardProfile } from '../steps/types';
+import { updateProfileFields } from '../actions';
+import { AutoSaveStatusLabel, useAutoSave } from './use-auto-save';
+
+export function BioSection({ profile }: { profile: WizardProfile }) {
+  const [bio, setBio] = useState(profile.bio_short || '');
+
+  const status = useAutoSave(bio, async (v) => updateProfileFields({ bio_short: v }));
+
+  return (
+    <div className="space-y-3">
+      <div className="flex justify-end">
+        <AutoSaveStatusLabel status={status} />
+      </div>
+      <div>
+        <label htmlFor="bio_short" className="block text-sm font-medium text-[var(--color-ink)] mb-1">
+          Short bio
+        </label>
+        <textarea
+          id="bio_short"
+          value={bio}
+          onChange={(e) => setBio(e.target.value)}
+          rows={4}
+          maxLength={300}
+          className="w-full px-3 py-2 rounded-lg border border-stone-300 bg-white text-[var(--color-ink)] text-sm focus:outline-none focus:ring-2 focus:ring-[var(--color-sage)] focus:border-transparent resize-none"
+          placeholder="I'm a primary school teacher who loves hiking, terrible puns, and finding the best flat white in town."
+        />
+        <p className="text-xs text-[var(--color-muted)] mt-1">{bio.length}/300</p>
+      </div>
+    </div>
+  );
+}

--- a/src/app/dashboard/profile/sections/index.ts
+++ b/src/app/dashboard/profile/sections/index.ts
@@ -1,0 +1,13 @@
+/**
+ * KAN-220 — barrel export for the single-page profile editor's section
+ * components. Sections live in this directory; the legacy `steps/`
+ * directory keeps the wizard step components (still used by the legacy
+ * wizard at `/dashboard/profile/legacy` and the existing tests).
+ */
+
+export { BasicInfoSection } from './basic-info-section';
+export { BioSection } from './bio-section';
+export { ManualOfMeSection } from './manual-of-me-section';
+export { AffiliationsSection } from './affiliations-section';
+export { useAutoSave, AutoSaveStatusLabel } from './use-auto-save';
+export type { AutoSaveStatus, AutoSaveResult } from './use-auto-save';

--- a/src/app/dashboard/profile/sections/manual-of-me-section.tsx
+++ b/src/app/dashboard/profile/sections/manual-of-me-section.tsx
@@ -1,0 +1,120 @@
+'use client';
+
+/**
+ * KAN-220 — Manual of Me section for the single-page profile editor.
+ *
+ * Autosave version of `ManualOfMeStep`. Four optional textareas debounced
+ * together so a single save fires 800ms after the last keystroke across
+ * any field. Status indicator at the top of the section.
+ */
+
+import { useState } from 'react';
+import type { ManualOfMe } from '../manual-of-me-fields';
+import { MANUAL_OF_ME_MAX_LENGTHS } from '../manual-of-me-fields';
+import { updateManualOfMe } from '../manual-of-me-actions';
+import { AutoSaveStatusLabel, useAutoSave } from './use-auto-save';
+
+interface ManualOfMeDraft {
+  communication_style: string;
+  working_preferences: string;
+  energises_me: string;
+  drains_me: string;
+}
+
+export function ManualOfMeSection({ manualOfMe }: { manualOfMe: ManualOfMe }) {
+  const [draft, setDraft] = useState<ManualOfMeDraft>({
+    communication_style: manualOfMe.communication_style || '',
+    working_preferences: manualOfMe.working_preferences || '',
+    energises_me: manualOfMe.energises_me || '',
+    drains_me: manualOfMe.drains_me || '',
+  });
+
+  // `updateManualOfMe` takes Record<string, string | null>; ManualOfMeDraft's
+  // typed keys narrow it to a literal-keyed object, so we widen explicitly.
+  const status = useAutoSave(draft, async (v) =>
+    updateManualOfMe(v as unknown as Record<string, string | null>),
+  );
+
+  const set = <K extends keyof ManualOfMeDraft>(key: K, value: ManualOfMeDraft[K]) =>
+    setDraft((d) => ({ ...d, [key]: value }));
+
+  return (
+    <div className="space-y-5">
+      <div className="flex justify-end">
+        <AutoSaveStatusLabel status={status} />
+      </div>
+
+      <p className="text-sm text-[var(--color-muted)]">
+        A short user-guide for working with you. All fields are optional — fill in what feels useful.
+      </p>
+
+      <MoMField
+        label="Communication style"
+        helper="How do you prefer people communicate with you?"
+        placeholder="Async messages over meetings. Be direct — I'd rather hear it than guess."
+        value={draft.communication_style}
+        onChange={(v) => set('communication_style', v)}
+        rows={3}
+        maxLength={MANUAL_OF_ME_MAX_LENGTHS.communication_style}
+      />
+
+      <MoMField
+        label="Best ways to work with me"
+        helper="What working preferences should people know?"
+        placeholder="Mornings are my deep-work time. I think out loud, so don't take rough drafts as final."
+        value={draft.working_preferences}
+        onChange={(v) => set('working_preferences', v)}
+        rows={5}
+        maxLength={MANUAL_OF_ME_MAX_LENGTHS.working_preferences}
+      />
+
+      <MoMField
+        label="What energises me"
+        helper="What gives you energy?"
+        placeholder="Solving hard problems, making people laugh, walking meetings."
+        value={draft.energises_me}
+        onChange={(v) => set('energises_me', v)}
+        rows={3}
+        maxLength={MANUAL_OF_ME_MAX_LENGTHS.energises_me}
+      />
+
+      <MoMField
+        label="What drains me"
+        helper="What pulls your energy down?"
+        placeholder="Back-to-back meetings with no breaks. Surprise context switches."
+        value={draft.drains_me}
+        onChange={(v) => set('drains_me', v)}
+        rows={3}
+        maxLength={MANUAL_OF_ME_MAX_LENGTHS.drains_me}
+      />
+    </div>
+  );
+}
+
+function MoMField({
+  label, helper, placeholder, value, onChange, rows, maxLength,
+}: {
+  label: string;
+  helper: string;
+  placeholder: string;
+  value: string;
+  onChange: (v: string) => void;
+  rows: number;
+  maxLength: number;
+}) {
+  return (
+    <div>
+      <label className="block text-sm font-medium text-[var(--color-ink)] mb-1">{label}</label>
+      <p className="text-xs text-[var(--color-muted)] mb-1.5">{helper}</p>
+      <textarea
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        rows={rows}
+        maxLength={maxLength}
+        placeholder={placeholder}
+        className="w-full px-3 py-2 rounded-lg border border-stone-300 bg-white text-[var(--color-ink)] text-sm focus:outline-none focus:ring-2 focus:ring-[var(--color-sage)] focus:border-transparent resize-none"
+      />
+      <p className="text-xs text-[var(--color-muted)] mt-1">{value.length}/{maxLength}</p>
+    </div>
+  );
+}

--- a/src/app/dashboard/profile/sections/use-auto-save.tsx
+++ b/src/app/dashboard/profile/sections/use-auto-save.tsx
@@ -64,7 +64,7 @@ export function useAutoSave<T>(
       }
     }, debounceMs);
     return () => clearTimeout(timer);
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- saveRef intentionally not a dep; see file comment.
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- KAN-220: saveRef intentionally not a dep; re-creating the save function on every parent render would otherwise re-trigger the effect. See file comment.
   }, [value, debounceMs]);
 
   return status;

--- a/src/app/dashboard/profile/sections/use-auto-save.tsx
+++ b/src/app/dashboard/profile/sections/use-auto-save.tsx
@@ -1,0 +1,91 @@
+'use client';
+
+/**
+ * KAN-220 — debounced auto-save hook used by the single-page profile
+ * editor's free-text sections (BasicInfo, Bio, ManualOfMe).
+ *
+ * Behaviour:
+ *   - First render is treated as the data load, not user input — does NOT
+ *     trigger a save.
+ *   - Every subsequent change to `value` resets a debounce timer.
+ *   - When the timer fires, the save function is called once with the
+ *     latest value.
+ *   - The save function is held in a ref so that re-creating it on every
+ *     parent render does NOT continually re-trigger the effect.
+ *   - Returns a status the section can render in its header
+ *     ("Saving…" / "Saved" / "Save failed").
+ *
+ * The 800ms default is a balance between "feels instant" and "respects
+ * the user's pause". Server Actions deduplicate concurrent writes
+ * through Postgres transactions; if the user types again during a
+ * save, the next debounce window catches it and the last write wins —
+ * matching what users expect from auto-save.
+ */
+
+import { useEffect, useRef, useState } from 'react';
+
+export type AutoSaveStatus = 'idle' | 'saving' | 'saved' | 'error';
+
+export type AutoSaveResult =
+  | { success: true }
+  | { success: false; error: string }
+  | void;
+
+export function useAutoSave<T>(
+  value: T,
+  save: (v: T) => Promise<AutoSaveResult>,
+  debounceMs: number = 800,
+): AutoSaveStatus {
+  // Hold save in a ref so that re-creating the function on each parent
+  // render doesn't continually re-trigger the effect.
+  const saveRef = useRef(save);
+  saveRef.current = save;
+
+  const [status, setStatus] = useState<AutoSaveStatus>('idle');
+  const isFirstRender = useRef(true);
+
+  useEffect(() => {
+    if (isFirstRender.current) {
+      isFirstRender.current = false;
+      return;
+    }
+    setStatus('idle');
+    const timer = setTimeout(async () => {
+      setStatus('saving');
+      try {
+        const result = await saveRef.current(value);
+        if (result && 'success' in result && result.success === false) {
+          setStatus('error');
+        } else {
+          setStatus('saved');
+        }
+      } catch {
+        setStatus('error');
+      }
+    }, debounceMs);
+    return () => clearTimeout(timer);
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- saveRef intentionally not a dep; see file comment.
+  }, [value, debounceMs]);
+
+  return status;
+}
+
+/** Small render-helper for the autosave status indicator. Sections that
+ * use `useAutoSave` typically render this in their header.
+ *
+ * Returns null when status is idle so the UI doesn't flash on mount or
+ * between changes. */
+export function AutoSaveStatusLabel({ status }: { status: AutoSaveStatus }) {
+  if (status === 'idle') return null;
+  const text =
+    status === 'saving' ? 'Saving…'
+    : status === 'saved' ? 'Saved'
+    : 'Save failed — retry on next change';
+  const colour =
+    status === 'error' ? 'text-red-500' : 'text-[var(--color-muted)]';
+  return (
+    <span className={`text-xs ${colour}`} role="status" aria-live="polite">
+      {text}
+    </span>
+  );
+}

--- a/src/app/dashboard/profile/steps/items-step.tsx
+++ b/src/app/dashboard/profile/steps/items-step.tsx
@@ -21,7 +21,11 @@ const visibilityShort: Record<string, string> = {
 
 export function ItemsStep({ title, description, categories, items, onAdd, onRemove, onUpdateVisibility, onNext, isPending }: {
   title: string; description: string; categories: string[]; items: WizardItem[];
-  onAdd: (data: { category: string; title: string; description?: string; visibility?: string }) => void;
+  // KAN-219 — items now carry an optional URL (Python `lyra-app` parity).
+  // Server-side `addProfileItem` runs the value through `sanitiseUrl`, which
+  // rejects anything not http(s). UI emits the trimmed string; empty is
+  // treated as "no URL".
+  onAdd: (data: { category: string; title: string; description?: string; url?: string; visibility?: string }) => void;
   onRemove: (id: string) => void;
   onUpdateVisibility: (id: string, visibility: string) => void;
   onNext: () => void; isPending: boolean;
@@ -29,6 +33,7 @@ export function ItemsStep({ title, description, categories, items, onAdd, onRemo
   const [category, setCategory] = useState(categories[0]);
   const [itemTitle, setItemTitle] = useState('');
   const [itemDesc, setItemDesc] = useState('');
+  const [itemUrl, setItemUrl] = useState('');
   const [itemVisibility, setItemVisibility] = useState<string>('public');
 
   const categoryLabels: Record<string, string> = {
@@ -46,14 +51,17 @@ export function ItemsStep({ title, description, categories, items, onAdd, onRemo
 
   const handleAdd = () => {
     if (!itemTitle.trim()) return;
+    const trimmedUrl = itemUrl.trim();
     onAdd({
       category,
       title: itemTitle,
       ...(itemDesc ? { description: itemDesc } : {}),
+      ...(trimmedUrl ? { url: trimmedUrl } : {}),
       visibility: itemVisibility,
     });
     setItemTitle('');
     setItemDesc('');
+    setItemUrl('');
     setItemVisibility('public');
   };
 
@@ -70,6 +78,19 @@ export function ItemsStep({ title, description, categories, items, onAdd, onRemo
               <div className="flex-1 min-w-0">
                 <p className="text-sm font-medium text-[var(--color-ink)]">
                   <span className="opacity-60">{categoryLabels[item.category] || item.category}</span> — {item.title}
+                  {/* KAN-219: ↗ chip when an item has a URL. Open in new tab
+                      with noopener+noreferrer to prevent tab-nabbing. */}
+                  {item.url && (
+                    <a
+                      href={item.url}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="ml-1.5 text-xs text-[var(--color-sage)] hover:underline"
+                      aria-label={`Open link for ${item.title}`}
+                    >
+                      ↗
+                    </a>
+                  )}
                 </p>
                 {item.description && <p className="text-xs text-[var(--color-muted)] mt-0.5">{item.description}</p>}
               </div>
@@ -111,6 +132,22 @@ export function ItemsStep({ title, description, categories, items, onAdd, onRemo
           <input value={itemDesc} onChange={(e) => setItemDesc(e.target.value)}
             className="w-full px-3 py-2 rounded-lg border border-stone-300 bg-white text-sm focus:outline-none focus:ring-2 focus:ring-[var(--color-sage)]"
             placeholder="Any extra detail" />
+        </div>
+        {/* KAN-219: optional URL on items (Python lyra-app parity).
+            Server-side sanitiseUrl rejects anything that's not http(s);
+            the user gets a clear error rather than silent drop. */}
+        <div>
+          <label className="block text-sm font-medium text-[var(--color-ink)] mb-1" htmlFor="new-item-url">
+            Link (optional)
+          </label>
+          <input
+            id="new-item-url"
+            type="url"
+            value={itemUrl}
+            onChange={(e) => setItemUrl(e.target.value)}
+            className="w-full px-3 py-2 rounded-lg border border-stone-300 bg-white text-sm focus:outline-none focus:ring-2 focus:ring-[var(--color-sage)]"
+            placeholder="https://example.com/this-book"
+          />
         </div>
         <div>
           <label className="block text-sm font-medium text-[var(--color-ink)] mb-1" htmlFor="new-item-visibility">

--- a/src/app/dashboard/profile/steps/types.tsx
+++ b/src/app/dashboard/profile/steps/types.tsx
@@ -30,6 +30,10 @@ export interface WizardSchool {
   school_name: string;
   school_location: string | null;
   relationship: string;
+  // KAN-220: one of school|organisation|community. Backward-compatible
+  // default — older rows from before migration 20260517010000 have this
+  // column with the default value 'school'.
+  affiliation_type: string;
 }
 
 export interface WizardLink {

--- a/src/app/dashboard/profile/wizard.tsx
+++ b/src/app/dashboard/profile/wizard.tsx
@@ -38,6 +38,10 @@ const STEPS = [
   { id: 'likes', label: 'Likes & Dislikes', icon: '💚' },
   { id: 'gifts', label: 'Gift ideas', icon: '🎁' },
   { id: 'boundaries', label: 'Boundaries', icon: '🛑' },
+  // KAN-219: chip labels + section titles unchanged; the richer Python
+  // `lyra-app` copy is lifted onto each ItemsStep's `description` prop
+  // below, where the user actually reads it. Phase 2's single-page
+  // form will revisit the headings as part of the layout rewrite.
   { id: 'interests', label: 'Books & Media', icon: '📚' },
   { id: 'values', label: 'Causes & Quotes', icon: '💛' },
   { id: 'more', label: 'More about you', icon: '✨' },
@@ -157,7 +161,8 @@ export function ProfileWizard({
           }} isPending={isPending} />
         )}
         {step === 4 && (
-          <ItemsStep title="Likes & Dislikes" description="What do you love? What can't you stand?"
+          // KAN-219: lift richer Python `lyra-app` prompt.
+          <ItemsStep title="Likes & Dislikes" description="Tastes, interests, and favourites — plus the things you'd rather steer clear of."
             categories={['likes', 'dislikes']}
             items={items.filter((i) => ['likes', 'dislikes'].includes(i.category))}
             onAdd={(data) => { startTransition(async () => { await addProfileItem(data); router.refresh(); }); }}
@@ -166,7 +171,8 @@ export function ProfileWizard({
             onNext={next} isPending={isPending} />
         )}
         {step === 5 && (
-          <ItemsStep title="Gift ideas" description="Help people find the perfect gift for you."
+          // KAN-219: lift richer Python `lyra-app` prompt.
+          <ItemsStep title="Gift ideas" description="Things you'd love to receive, luxuries you don't give yourself, things you can't have enough of — and gifts that aren't for you."
             categories={['gift_ideas', 'gifts_to_avoid']}
             items={items.filter((i) => ['gift_ideas', 'gifts_to_avoid'].includes(i.category))}
             onAdd={(data) => { startTransition(async () => { await addProfileItem(data); router.refresh(); }); }}
@@ -175,7 +181,9 @@ export function ProfileWizard({
             onNext={next} isPending={isPending} />
         )}
         {step === 6 && (
-          <ItemsStep title="Boundaries" description="Things people should know to respect your space."
+          // KAN-219: lift richer Python `lyra-app` prompt onto description;
+          // title kept as-is to keep nav/section heading consistent.
+          <ItemsStep title="Boundaries" description="Practical preferences, boundaries, and things that help people respect your space."
             categories={['boundaries', 'helpful_to_know']}
             items={items.filter((i) => ['boundaries', 'helpful_to_know'].includes(i.category))}
             onAdd={(data) => { startTransition(async () => { await addProfileItem(data); router.refresh(); }); }}
@@ -184,7 +192,9 @@ export function ProfileWizard({
             onNext={next} isPending={isPending} />
         )}
         {step === 7 && (
-          <ItemsStep title="Books & Media" description="Favourite books, movies, and series — the things that shaped you."
+          // KAN-219: lift richer Python `lyra-app` prompt onto description;
+          // title kept as-is to keep nav/section heading consistent.
+          <ItemsStep title="Books & Media" description="Books you love and the screen favourites that shaped you."
             categories={['favourite_books', 'favourite_media']}
             items={items.filter((i) => ['favourite_books', 'favourite_media'].includes(i.category))}
             onAdd={(data) => { startTransition(async () => { await addProfileItem(data); router.refresh(); }); }}
@@ -193,7 +203,9 @@ export function ProfileWizard({
             onNext={next} isPending={isPending} />
         )}
         {step === 8 && (
-          <ItemsStep title="Causes & Quotes" description="What matters to you — charities, causes, and words that resonate."
+          // KAN-219: lift richer Python `lyra-app` prompt onto description;
+          // title kept as-is to keep nav/section heading consistent.
+          <ItemsStep title="Causes & Quotes" description="Causes and charities you care about, and the words that resonate with you."
             categories={['causes', 'quotes']}
             items={items.filter((i) => ['causes', 'quotes'].includes(i.category))}
             onAdd={(data) => { startTransition(async () => { await addProfileItem(data); router.refresh(); }); }}
@@ -202,7 +214,11 @@ export function ProfileWizard({
             onNext={next} isPending={isPending} />
         )}
         {step === 9 && (
-          <ItemsStep title="More about you" description="What makes you proud, life hacks, questions you wish people asked, problems you're currently working on."
+          // KAN-219: lift richer Python `lyra-app` prompts. Combines the five
+          // Python sections (proud_of, life_hacks, questions, billboard,
+          // current_problems) under one wizard step; Phase 2 will split them
+          // out as collapsible blocks in the single-page form.
+          <ItemsStep title="More about you" description="What you're most proud of, life hacks worth sharing, places you'd recommend, questions you wish people asked, problems you're working on, and your billboard message."
             categories={['proud_of', 'life_hacks', 'questions', 'billboard', 'current_problems']}
             items={items.filter((i) => ['proud_of', 'life_hacks', 'questions', 'billboard', 'current_problems'].includes(i.category))}
             onAdd={(data) => { startTransition(async () => { await addProfileItem(data); router.refresh(); }); }}

--- a/supabase/migrations/20260517010000_affiliation_type.sql
+++ b/supabase/migrations/20260517010000_affiliation_type.sql
@@ -1,0 +1,29 @@
+-- KAN-220 Phase 2 — Schools / Organisations / Communities split
+--
+-- Adds `affiliation_type` to `school_affiliations` so the table can hold
+-- all three kinds of community affiliations, matching the Python
+-- `lyra-app` editor UX. Existing rows default to 'school' (the only
+-- thing the table held before), which is backward-compatible — no
+-- backfill needed.
+--
+-- The check constraint is a plain TEXT column with a CHECK rather than
+-- a Postgres enum so future additions ("club", "team", "religious community"?)
+-- only require a constraint swap rather than the heavier `alter type … add value`.
+-- Keep the values short, lowercase, ASCII so they're SQL-safe and
+-- pleasant to use in queries.
+--
+-- Rollback:
+--   drop index if exists public.school_affiliations_profile_type_idx;
+--   alter table public.school_affiliations drop column if exists affiliation_type;
+
+alter table public.school_affiliations
+  add column affiliation_type text not null default 'school'
+    check (affiliation_type in ('school', 'organisation', 'community'));
+
+comment on column public.school_affiliations.affiliation_type is
+  'KAN-220: one of school|organisation|community. UI splits these into three multi-input groups on the profile editor (Python lyra-app parity).';
+
+-- Composite index so the dashboard + public-profile queries that filter
+-- to one type stay fast even with the column added.
+create index if not exists school_affiliations_profile_type_idx
+  on public.school_affiliations (profile_id, affiliation_type);

--- a/tests/unit/affiliations-and-autosave.test.ts
+++ b/tests/unit/affiliations-and-autosave.test.ts
@@ -1,0 +1,357 @@
+/**
+ * KAN-220 Phase 2 — coverage for the single-page profile editor.
+ *
+ * Three layers:
+ *
+ * 1. **Static-grep regression guards** — migration file, affiliation-fields
+ *    module, new section components, legacy route, and edit-profile-form
+ *    orchestrator all exist and reference each other by name. Same cheap-
+ *    coverage pattern as `current-problems-category.test.ts` (KAN-182)
+ *    and `conversation-starters.test.ts` (KAN-181).
+ *
+ * 2. **Behavioural tests for the `affiliation-fields` helpers** — `coerceAffiliationType`
+ *    must default to 'school' on unknown values (including the SQL
+ *    injection-style strings someone could put on the wire), and
+ *    `ALLOWED_AFFILIATION_TYPES` must match the DB CHECK constraint
+ *    exactly so the two stay in sync.
+ *
+ * 3. **Behavioural tests for `addSchoolAffiliation`** — accepts each of
+ *    the three legitimate types, coerces unknown to 'school' (defence
+ *    in depth alongside the DB CHECK), backward-compat when
+ *    `affiliation_type` is omitted.
+ *
+ * The `useAutoSave` hook isn't unit-tested here — exercising it
+ * meaningfully needs a React testing environment (which the Jest config
+ * doesn't currently provide); it's covered indirectly by the E2E pass
+ * that loads the edit page and types into a field, and the static guard
+ * test that confirms the hook exists and is imported by the sections
+ * that use it.
+ */
+
+import { readFileSync, existsSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const ROOT = resolve(__dirname, '../..');
+
+// ─────────── Mocks for behavioural tests ───────────
+
+const mockInsertCapture = jest.fn();
+const mockRevalidatePath = jest.fn();
+
+jest.mock('next/cache', () => ({
+  revalidatePath: (...args: unknown[]) => mockRevalidatePath(...args),
+}));
+
+jest.mock('@/lib/supabase-server', () => ({
+  createClient: jest.fn().mockResolvedValue({
+    auth: {
+      getUser: jest.fn().mockResolvedValue({
+        data: { user: { id: 'test-user-id' } },
+      }),
+    },
+    from: jest.fn().mockImplementation((tableName: string) => {
+      if (tableName === 'profiles') {
+        return {
+          select: () => ({
+            eq: () => ({
+              single: () => Promise.resolve({ data: { id: 'test-profile-id' } }),
+            }),
+          }),
+        };
+      }
+      if (tableName === 'school_affiliations') {
+        return {
+          insert: (data: unknown) => {
+            mockInsertCapture(data);
+            return Promise.resolve({ error: null });
+          },
+        };
+      }
+      throw new Error(`Unexpected table in mock: ${tableName}`);
+    }),
+  }),
+}));
+
+import { addSchoolAffiliation } from '@/app/dashboard/profile/actions';
+import {
+  ALLOWED_AFFILIATION_TYPES,
+  AFFILIATION_LABELS,
+  AFFILIATION_SINGULAR,
+  coerceAffiliationType,
+  isAffiliationType,
+} from '@/app/dashboard/profile/affiliation-fields';
+
+beforeEach(() => {
+  mockInsertCapture.mockClear();
+  mockRevalidatePath.mockClear();
+});
+
+// ─────────── 2. affiliation-fields helpers ───────────
+
+describe('KAN-220: affiliation-fields helpers', () => {
+  test('ALLOWED_AFFILIATION_TYPES matches the DB CHECK constraint exactly', () => {
+    expect(ALLOWED_AFFILIATION_TYPES).toEqual(['school', 'organisation', 'community']);
+  });
+
+  test('AFFILIATION_LABELS has a label for each type', () => {
+    for (const t of ALLOWED_AFFILIATION_TYPES) {
+      expect(AFFILIATION_LABELS[t]).toBeTruthy();
+      expect(typeof AFFILIATION_LABELS[t]).toBe('string');
+    }
+  });
+
+  test('AFFILIATION_SINGULAR has a singular form for each type', () => {
+    for (const t of ALLOWED_AFFILIATION_TYPES) {
+      expect(AFFILIATION_SINGULAR[t]).toBeTruthy();
+    }
+  });
+
+  test('isAffiliationType accepts all valid types', () => {
+    for (const t of ALLOWED_AFFILIATION_TYPES) {
+      expect(isAffiliationType(t)).toBe(true);
+    }
+  });
+
+  test('isAffiliationType rejects unknown values', () => {
+    expect(isAffiliationType('')).toBe(false);
+    expect(isAffiliationType('club')).toBe(false);
+    expect(isAffiliationType('SCHOOL')).toBe(false);
+    expect(isAffiliationType("school'; DROP TABLE")).toBe(false);
+    expect(isAffiliationType('undefined')).toBe(false);
+  });
+
+  test('coerceAffiliationType passes valid values through', () => {
+    expect(coerceAffiliationType('school')).toBe('school');
+    expect(coerceAffiliationType('organisation')).toBe('organisation');
+    expect(coerceAffiliationType('community')).toBe('community');
+  });
+
+  test('coerceAffiliationType defaults unknown values to "school"', () => {
+    expect(coerceAffiliationType(undefined)).toBe('school');
+    expect(coerceAffiliationType('')).toBe('school');
+    expect(coerceAffiliationType('club')).toBe('school');
+    expect(coerceAffiliationType('Organisation')).toBe('school'); // case-sensitive
+    expect(coerceAffiliationType("'; DROP TABLE")).toBe('school');
+  });
+});
+
+// ─────────── 3. addSchoolAffiliation server action ───────────
+
+describe('KAN-220: addSchoolAffiliation — affiliation_type handling', () => {
+  test('inserts with affiliation_type=school by default (pre-KAN-220 caller compat)', async () => {
+    const result = await addSchoolAffiliation({
+      school_name: 'Greenfield Primary',
+    });
+    expect(result).toEqual({ success: true });
+    expect(mockInsertCapture).toHaveBeenCalledWith(
+      expect.objectContaining({
+        affiliation_type: 'school',
+        school_name: 'Greenfield Primary',
+      }),
+    );
+  });
+
+  test('accepts affiliation_type=organisation', async () => {
+    await addSchoolAffiliation({
+      school_name: 'Acme Ltd',
+      affiliation_type: 'organisation',
+    });
+    expect(mockInsertCapture).toHaveBeenCalledWith(
+      expect.objectContaining({ affiliation_type: 'organisation', school_name: 'Acme Ltd' }),
+    );
+  });
+
+  test('accepts affiliation_type=community', async () => {
+    await addSchoolAffiliation({
+      school_name: 'Local running club',
+      affiliation_type: 'community',
+    });
+    expect(mockInsertCapture).toHaveBeenCalledWith(
+      expect.objectContaining({ affiliation_type: 'community' }),
+    );
+  });
+
+  test('coerces unknown affiliation_type to "school" (defence in depth alongside DB CHECK)', async () => {
+    await addSchoolAffiliation({
+      school_name: 'Attempted bypass',
+      affiliation_type: 'club',
+    });
+    expect(mockInsertCapture).toHaveBeenCalledWith(
+      expect.objectContaining({ affiliation_type: 'school' }),
+    );
+  });
+
+  test('still sanitises school_name + location alongside affiliation_type', async () => {
+    await addSchoolAffiliation({
+      school_name: 'School <b>name</b>',
+      school_location: '<p>London</p>',
+      affiliation_type: 'school',
+    });
+    expect(mockInsertCapture).toHaveBeenCalledWith(
+      expect.objectContaining({
+        school_name: 'School name',
+        school_location: 'London',
+        affiliation_type: 'school',
+      }),
+    );
+  });
+
+  test('relationship defaults to "parent" alongside affiliation_type=school', async () => {
+    await addSchoolAffiliation({
+      school_name: 'Primary',
+      affiliation_type: 'school',
+    });
+    expect(mockInsertCapture).toHaveBeenCalledWith(
+      expect.objectContaining({ relationship: 'parent', affiliation_type: 'school' }),
+    );
+  });
+});
+
+// ─────────── 1. Static-grep regression guards ───────────
+
+describe('KAN-220: surface-area regression guards', () => {
+  test('migration file exists with the affiliation_type CHECK constraint', () => {
+    const src = readFileSync(
+      resolve(ROOT, 'supabase/migrations/20260517010000_affiliation_type.sql'),
+      'utf-8',
+    );
+    expect(src).toMatch(/add column affiliation_type/i);
+    expect(src).toMatch(/check \(affiliation_type in \('school',\s*'organisation',\s*'community'\)\)/i);
+    expect(src).toMatch(/school_affiliations_profile_type_idx/);
+    // Rollback documented in the file comment per CLAUDE.md
+    expect(src).toMatch(/rollback/i);
+  });
+
+  test('affiliation-fields module exists and exports the right surface', () => {
+    const path = resolve(ROOT, 'src/app/dashboard/profile/affiliation-fields.ts');
+    expect(existsSync(path)).toBe(true);
+    const src = readFileSync(path, 'utf-8');
+    expect(src).toMatch(/export const ALLOWED_AFFILIATION_TYPES/);
+    expect(src).toMatch(/export function coerceAffiliationType/);
+    expect(src).toMatch(/export function isAffiliationType/);
+    expect(src).toMatch(/export const AFFILIATION_LABELS/);
+  });
+
+  test('actions.ts addSchoolAffiliation accepts affiliation_type', () => {
+    const src = readFileSync(
+      resolve(ROOT, 'src/app/dashboard/profile/actions.ts'),
+      'utf-8',
+    );
+    expect(src).toMatch(/affiliation_type\?:\s*string/);
+    expect(src).toMatch(/coerceAffiliationType/);
+  });
+
+  test('WizardSchool type declares affiliation_type', () => {
+    const src = readFileSync(
+      resolve(ROOT, 'src/app/dashboard/profile/steps/types.tsx'),
+      'utf-8',
+    );
+    // Type now carries affiliation_type — KAN-220 schools/orgs/communities split
+    expect(src).toMatch(/affiliation_type:\s*string/);
+  });
+
+  test('new section components exist', () => {
+    for (const name of [
+      'basic-info-section.tsx',
+      'bio-section.tsx',
+      'manual-of-me-section.tsx',
+      'affiliations-section.tsx',
+      'use-auto-save.tsx',
+      'index.ts',
+    ]) {
+      const p = resolve(ROOT, `src/app/dashboard/profile/sections/${name}`);
+      expect(existsSync(p)).toBe(true);
+    }
+  });
+
+  test('edit-profile-form orchestrator imports all four new sections + uses ItemsStep for lists', () => {
+    const src = readFileSync(
+      resolve(ROOT, 'src/app/dashboard/profile/edit-profile-form.tsx'),
+      'utf-8',
+    );
+    expect(src).toMatch(/BasicInfoSection/);
+    expect(src).toMatch(/BioSection/);
+    expect(src).toMatch(/ManualOfMeSection/);
+    expect(src).toMatch(/AffiliationsSection/);
+    expect(src).toMatch(/ItemsStep/);  // reused from legacy steps
+    expect(src).toMatch(/LinksStep/);
+    expect(src).toMatch(/FilesStep/);
+    expect(src).toMatch(/ConversationStartersSection|ConversationStartersStep/);
+  });
+
+  test('useAutoSave hook is referenced by the autosave sections', () => {
+    for (const name of [
+      'basic-info-section.tsx',
+      'bio-section.tsx',
+      'manual-of-me-section.tsx',
+    ]) {
+      const src = readFileSync(
+        resolve(ROOT, `src/app/dashboard/profile/sections/${name}`),
+        'utf-8',
+      );
+      expect(src).toMatch(/useAutoSave/);
+    }
+  });
+
+  test('legacy wizard route exists at /dashboard/profile/legacy', () => {
+    const p = resolve(ROOT, 'src/app/dashboard/profile/legacy/page.tsx');
+    expect(existsSync(p)).toBe(true);
+    const src = readFileSync(p, 'utf-8');
+    expect(src).toMatch(/ProfileWizard/);
+    expect(src).toMatch(/robots:\s*\{[^}]*index:\s*false/); // SEO-hidden — should not be indexed
+  });
+
+  test('main /dashboard/profile route renders EditProfileForm (new single-page editor)', () => {
+    const src = readFileSync(
+      resolve(ROOT, 'src/app/dashboard/profile/page.tsx'),
+      'utf-8',
+    );
+    expect(src).toMatch(/EditProfileForm/);
+    expect(src).not.toMatch(/ProfileWizard/); // wizard moved to /legacy
+  });
+
+  test('main /dashboard/profile page.tsx still fetches conversation starter data (KAN-181 guard)', () => {
+    // The KAN-181 regression guard greps page.tsx directly. After the
+    // KAN-220 refactor I'd briefly extracted data fetching into a shared
+    // module, which broke that test by hiding the strings — reverted.
+    // This sibling assertion documents the intent.
+    const src = readFileSync(
+      resolve(ROOT, 'src/app/dashboard/profile/page.tsx'),
+      'utf-8',
+    );
+    expect(src).toMatch(/conversation_starter_prompts/);
+    expect(src).toMatch(/profile_conversation_starters/);
+  });
+
+  test('legacy /dashboard/profile/legacy page also fetches the full dataset', () => {
+    const src = readFileSync(
+      resolve(ROOT, 'src/app/dashboard/profile/legacy/page.tsx'),
+      'utf-8',
+    );
+    expect(src).toMatch(/conversation_starter_prompts/);
+    expect(src).toMatch(/profile_conversation_starters/);
+    expect(src).toMatch(/school_affiliations/);
+  });
+
+  test('public profile [slug]/page.tsx groups Schools / Orgs / Communities', () => {
+    const src = readFileSync(
+      resolve(ROOT, 'src/app/[slug]/page.tsx'),
+      'utf-8',
+    );
+    // The render groups by affiliation_type — checking distinctive strings
+    expect(src).toMatch(/affiliation_type/);
+    expect(src).toMatch(/Organisations/);
+    expect(src).toMatch(/Communities/);
+  });
+
+  test('legacy wizard.tsx left untouched (preserves profile-sections.test.js assertions)', () => {
+    const src = readFileSync(
+      resolve(ROOT, 'src/app/dashboard/profile/wizard.tsx'),
+      'utf-8',
+    );
+    // These strings are still expected by tests/unit/profile-sections.test.js
+    expect(src).toMatch(/'Books & Media'/);
+    expect(src).toMatch(/'Causes & Quotes'/);
+    expect(src).toMatch(/More about you/);
+  });
+});

--- a/tests/unit/profile-item-url.test.ts
+++ b/tests/unit/profile-item-url.test.ts
@@ -1,0 +1,281 @@
+/**
+ * KAN-219: URL field on profile items.
+ *
+ * Two layers of coverage:
+ *
+ * 1. Behavioural tests for `addProfileItem` — verify the URL is sanitised
+ *    via `sanitiseUrl` (the same helper external_links uses) and that
+ *    invalid URLs are REJECTED with an error rather than silently dropped.
+ *    This is the security guarantee — `javascript:` / `data:` / malformed
+ *    inputs cannot reach the DB column.
+ *
+ * 2. Static-grep regression guards — cheap checks that the UI components
+ *    and public-profile renderer reference the URL plumbing, so a future
+ *    refactor can't accidentally remove the field without a test failing.
+ *    Same pattern as KAN-181 (conversation-starters.test.ts) and KAN-182
+ *    (current-problems-category.test.ts).
+ *
+ * Why URL on items? Python `lyra-app/templates/edit_profile.html` shipped
+ * a Link input alongside Title + Description for every item — the user
+ * could attach a buy-it-here URL to a gift idea, an Amazon link to a
+ * favourite book, etc. The Next.js wizard inherited the `url` DB column
+ * but never wrote to it; this restores the missing surface.
+ */
+
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+// ───────────── Mocks ─────────────
+
+const mockInsertCapture = jest.fn();
+const mockRevalidatePath = jest.fn();
+
+jest.mock('next/cache', () => ({
+  revalidatePath: (...args: unknown[]) => mockRevalidatePath(...args),
+}));
+
+// addProfileItem invokes the chain
+//   .from('profiles').select('id').eq('user_id', x).single() → look up profile_id
+//   .from('profile_items').insert({...})                     → write the item
+// Dispatch on the table name so each chain returns the right shape.
+jest.mock('@/lib/supabase-server', () => ({
+  createClient: jest.fn().mockResolvedValue({
+    auth: {
+      getUser: jest.fn().mockResolvedValue({
+        data: { user: { id: 'test-user-id' } },
+      }),
+    },
+    from: jest.fn().mockImplementation((tableName: string) => {
+      if (tableName === 'profiles') {
+        return {
+          select: () => ({
+            eq: () => ({
+              single: () => Promise.resolve({ data: { id: 'test-profile-id' } }),
+            }),
+          }),
+        };
+      }
+      if (tableName === 'profile_items') {
+        return {
+          insert: (data: unknown) => {
+            mockInsertCapture(data);
+            return Promise.resolve({ error: null });
+          },
+        };
+      }
+      throw new Error(`Unexpected table in mock: ${tableName}`);
+    }),
+  }),
+}));
+
+import { addProfileItem } from '@/app/dashboard/profile/actions';
+
+beforeEach(() => {
+  mockInsertCapture.mockClear();
+  mockRevalidatePath.mockClear();
+});
+
+// ───────────── Behavioural tests ─────────────
+
+describe('KAN-219: addProfileItem — URL handling', () => {
+  test('persists a valid https URL', async () => {
+    const result = await addProfileItem({
+      category: 'favourite_books',
+      title: 'The Hobbit',
+      url: 'https://example.com/hobbit',
+    });
+    expect(result).toEqual({ success: true });
+    expect(mockInsertCapture).toHaveBeenCalledWith(
+      expect.objectContaining({
+        url: 'https://example.com/hobbit',
+        title: 'The Hobbit',
+        category: 'favourite_books',
+      }),
+    );
+    expect(mockRevalidatePath).toHaveBeenCalledWith('/dashboard/profile');
+  });
+
+  test('persists a valid http URL (not just https)', async () => {
+    await addProfileItem({
+      category: 'life_hacks',
+      title: 'Old recipe site',
+      url: 'http://example.com/recipe',
+    });
+    expect(mockInsertCapture).toHaveBeenCalledWith(
+      expect.objectContaining({ url: 'http://example.com/recipe' }),
+    );
+  });
+
+  test('REJECTS a javascript: URL with a clear error', async () => {
+    const result = await addProfileItem({
+      category: 'likes',
+      title: 'Sneaky',
+      url: 'javascript:alert(1)',
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error).toMatch(/invalid url/i);
+    }
+    // Critical: no DB write happened — the bad URL never reaches the column
+    expect(mockInsertCapture).not.toHaveBeenCalled();
+    expect(mockRevalidatePath).not.toHaveBeenCalled();
+  });
+
+  test('REJECTS a data: URL', async () => {
+    const result = await addProfileItem({
+      category: 'likes',
+      title: 'Embedded',
+      url: 'data:text/html,<script>alert(1)</script>',
+    });
+    expect(result.success).toBe(false);
+    expect(mockInsertCapture).not.toHaveBeenCalled();
+  });
+
+  test('REJECTS a malformed URL', async () => {
+    const result = await addProfileItem({
+      category: 'likes',
+      title: 'Broken',
+      url: 'not-a-url',
+    });
+    expect(result.success).toBe(false);
+    expect(mockInsertCapture).not.toHaveBeenCalled();
+  });
+
+  test('REJECTS a file:// URL', async () => {
+    const result = await addProfileItem({
+      category: 'likes',
+      title: 'Local file',
+      url: 'file:///etc/passwd',
+    });
+    expect(result.success).toBe(false);
+    expect(mockInsertCapture).not.toHaveBeenCalled();
+  });
+
+  test('stores NULL when url is omitted (backward compat with pre-KAN-219 callers)', async () => {
+    await addProfileItem({
+      category: 'likes',
+      title: 'No link here',
+    });
+    expect(mockInsertCapture).toHaveBeenCalledWith(
+      expect.objectContaining({ url: null, title: 'No link here' }),
+    );
+  });
+
+  test('stores NULL when url is an empty string', async () => {
+    await addProfileItem({
+      category: 'likes',
+      title: 'Also no link',
+      url: '',
+    });
+    expect(mockInsertCapture).toHaveBeenCalledWith(
+      expect.objectContaining({ url: null }),
+    );
+  });
+
+  test('stores NULL when url is whitespace only', async () => {
+    await addProfileItem({
+      category: 'likes',
+      title: 'Spaces only',
+      url: '   ',
+    });
+    expect(mockInsertCapture).toHaveBeenCalledWith(
+      expect.objectContaining({ url: null }),
+    );
+  });
+
+  test('still sanitises title + description alongside the URL', async () => {
+    // sanitiseText strips HTML tags but preserves text between them (React
+    // also auto-escapes on render). We're checking that the title/description
+    // path is unchanged by the addition of the url param — not testing
+    // sanitiseText itself.
+    await addProfileItem({
+      category: 'gift_ideas',
+      title: 'Camera <b>fancy</b>',
+      description: '<p>Nice shot</p>',
+      url: 'https://example.com/camera',
+    });
+    expect(mockInsertCapture).toHaveBeenCalledWith(
+      expect.objectContaining({
+        title: 'Camera fancy',
+        description: 'Nice shot',
+        url: 'https://example.com/camera',
+      }),
+    );
+  });
+});
+
+// ───────────── Static-grep regression guards ─────────────
+
+describe('KAN-219: surface-area regression guards', () => {
+  const ROOT = resolve(__dirname, '../..');
+
+  test('items-step.tsx renders a Link input with type="url"', () => {
+    const src = readFileSync(
+      resolve(ROOT, 'src/app/dashboard/profile/steps/items-step.tsx'),
+      'utf-8',
+    );
+    expect(src).toMatch(/Link \(optional\)/);
+    expect(src).toMatch(/type="url"/);
+    expect(src).toMatch(/itemUrl/);
+  });
+
+  test('items-step.tsx handleAdd passes the trimmed URL in onAdd payload', () => {
+    const src = readFileSync(
+      resolve(ROOT, 'src/app/dashboard/profile/steps/items-step.tsx'),
+      'utf-8',
+    );
+    expect(src).toMatch(/trimmedUrl/);
+    expect(src).toMatch(/url: trimmedUrl/);
+  });
+
+  test('items-step.tsx renders ↗ link on saved items when url is present', () => {
+    const src = readFileSync(
+      resolve(ROOT, 'src/app/dashboard/profile/steps/items-step.tsx'),
+      'utf-8',
+    );
+    expect(src).toMatch(/item\.url/);
+    expect(src).toMatch(/rel="noopener noreferrer"/);
+  });
+
+  test('actions.ts addProfileItem accepts url param and uses sanitiseUrl', () => {
+    const src = readFileSync(
+      resolve(ROOT, 'src/app/dashboard/profile/actions.ts'),
+      'utf-8',
+    );
+    // url is an optional param on the addProfileItem data type
+    expect(src).toMatch(/url\?:\s*string/);
+    // url is sanitised via sanitiseUrl (same helper external_links uses)
+    expect(src).toMatch(/sanitiseUrl\(data\.url\)/);
+    // The rejection path returns a clear error rather than silently dropping
+    expect(src).toMatch(/Invalid URL/);
+  });
+
+  test('public profile [slug]/page.tsx renders item URLs as clickable links', () => {
+    const src = readFileSync(
+      resolve(ROOT, 'src/app/[slug]/page.tsx'),
+      'utf-8',
+    );
+    // The ProfileItem interface declares the url column
+    expect(src).toMatch(/url:\s*string\s*\|\s*null/);
+    // The chip and Q&A renderers branch on item.url
+    expect(src).toMatch(/item\.url \?/);
+    // Outbound links use rel="noopener noreferrer" to prevent tab-nabbing
+    expect(src).toMatch(/rel="noopener noreferrer"/);
+  });
+
+  test('wizard.tsx uses the richer Python lyra-app prompts', () => {
+    const src = readFileSync(
+      resolve(ROOT, 'src/app/dashboard/profile/wizard.tsx'),
+      'utf-8',
+    );
+    // Replaces the terse one-liners with the Python predecessor's longer
+    // prompts. We check for distinctive phrases that wouldn't appear by
+    // accident, not the entire string, so minor copy edits won't break.
+    expect(src).toMatch(/Tastes, interests, and favourites/);
+    expect(src).toMatch(/luxuries you don't give yourself/);
+    expect(src).toMatch(/things that help people respect/);
+    expect(src).toMatch(/screen favourites that shaped you/);
+    expect(src).toMatch(/Causes and charities you care about/);
+    expect(src).toMatch(/billboard message/);
+  });
+});


### PR DESCRIPTION
## Summary

Phase 2 of [KAN-218](https://checklyra.atlassian.net/browse/KAN-218) — replaces the 14-step wizard at `/dashboard/profile` with the **single-page form layout** from the Python predecessor `lyra-app/templates/edit_profile.html`. Also adds the **Schools / Organisations / Communities split** Luisa highlighted, and field-level **autosave** on all free-text sections.

> ⚠️ **Stacks on #227 (KAN-219 Phase 1).** Don't merge this before that — it'll show extra commits in the diff until then. Once #227 lands, GitHub will rebase the base of this PR automatically.

## What's in this PR

**Data layer**
- Migration `20260517010000_affiliation_type.sql` — adds `affiliation_type` to `school_affiliations` (CHECK: school|organisation|community, default 'school'). **Already applied to dev Supabase** (`ilprytcrnqyrsbsrfujj`). Composite index on `(profile_id, affiliation_type)`.
- `affiliation-fields.ts` — sibling module (BUGS-12 safe) with `ALLOWED_AFFILIATION_TYPES`, `coerceAffiliationType`, labels.
- `actions.ts → addSchoolAffiliation` — accepts optional `affiliation_type`; coerced to 'school' for anything outside the allowlist.
- `steps/types.tsx → WizardSchool` — gains `affiliation_type: string`.

**UI**
- New `sections/` directory: four autosave-enabled section components (`BasicInfoSection`, `BioSection`, `ManualOfMeSection`, `AffiliationsSection`) plus a shared `useAutoSave` hook (800ms debounce, status indicator).
- New `edit-profile-form.tsx` — the orchestrator. Sidebar ToC on desktop (sticky, jumps via anchors). Each section is a controlled collapsible. Mobile: only Basic Info expanded on mount via matchMedia. Sticky bottom bar with `Save & re-publish`.
- `dashboard/profile/page.tsx` — now renders `EditProfileForm`.
- `dashboard/profile/legacy/page.tsx` — preserved wizard route for one release as a rollback path. `robots: { index: false }`.
- `[slug]/page.tsx` — public profile now groups Schools / Organisations / Communities under their own headings; older rows pre-migration default to Schools.

**Tests** — `tests/unit/affiliations-and-autosave.test.ts` (26 new)
- `affiliation-fields` helpers: allowlist matches DB CHECK exactly, labels for each type, coercion of unknown / SQL-injection-style strings to 'school'.
- `addSchoolAffiliation` behaviour: accepts each type, coerces unknown, sanitises, backward-compat without the param.
- Surface-area regression guards across all 15 touched files (migration content, section components exist, hooks imported, legacy route SEO-hidden, etc.).

## Test plan

- [x] `npx jest` — **872 ✅** (was 846; +26 new)
- [x] `npm run lint` — 0 errors
- [x] `npm run build` — green, `/dashboard/profile` + `/dashboard/profile/legacy` both build
- [x] Pre-merge grep checks — no new silent-skips, empty bodies, or workflow patterns
- [x] Migration applied to dev Supabase via apply_migration MCP
- [ ] Manual on dev.checklyra.com after merge:
  - [ ] Visit `/dashboard/profile`, see single-page form with sidebar ToC on desktop
  - [ ] Resize to mobile width — sections collapse (refresh required)
  - [ ] Type into Bio → "Saving…" → "Saved" indicator
  - [ ] Add a school, then an organisation, then a community — each lands in its own group on the public profile
  - [ ] Click `Use legacy wizard` → wizard at `/dashboard/profile/legacy` still works
  - [ ] Click `Save & publish` → profile published, redirected to dashboard

## What's deliberately preserved (Test Integrity Policy)

- `wizard.tsx` unchanged — `profile-sections.test.js` regression guards still pass.
- `IdentityStep`, `BioStep`, `ManualOfMeStep`, `SchoolStep` unchanged — used only by the legacy route now.
- KAN-181 conversation-starter test guard: data fetching deliberately inlined in both `page.tsx` and `legacy/page.tsx` (rather than extracted to a shared module). Slight duplication, no test breakage.

## Where this fits

| Phase | Ticket | Status |
|---|---|---|
| 1 — URL field + rich prompts | [KAN-219](https://checklyra.atlassian.net/browse/KAN-219) | PR #227 — pending merge |
| **2 — Single-page editor** | [KAN-220](https://checklyra.atlassian.net/browse/KAN-220) | **this PR** |
| 3 — Hybrid visibility | [KAN-221](https://checklyra.atlassian.net/browse/KAN-221) | next (gates on this) |

Other tickets filed overnight from the Python `lyra-app` feature audit:
- [KAN-225](https://checklyra.atlassian.net/browse/KAN-225) — Forgot/Reset password UI (Python had it, Next.js doesn't; Supabase Auth has the primitives).

## Migration rollback

```sql
drop index if exists public.school_affiliations_profile_type_idx;
alter table public.school_affiliations drop column if exists affiliation_type;
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[KAN-218]: https://checklyra.atlassian.net/browse/KAN-218?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[KAN-219]: https://checklyra.atlassian.net/browse/KAN-219?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ