### PR TITLE
fix(BUGS-20): raise CI poll budget on promote workflows (10→30 attempts)

### DIFF
--- a/.github/workflows/promote-staging-to-beta.yml
+++ b/.github/workflows/promote-staging-to-beta.yml
@@ -55,7 +55,11 @@ jobs:
           echo "staging HEAD: $STAGING_SHA"
           echo "staging_sha=$STAGING_SHA" >> "$GITHUB_OUTPUT"
 
-          MAX_ATTEMPTS=10
+          # BUGS-20 (2026-05-17): budget raised 10→30 attempts. Staging CI
+          # takes 3–5 minutes; the prior 10×15s = 150s budget was tight
+          # enough to time out same-day promotes. 30×15s = 7.5 min is
+          # comfortable. Mirror of the fix on promote-to-production.yml.
+          MAX_ATTEMPTS=30
           ATTEMPT=0
           while [ $ATTEMPT -lt $MAX_ATTEMPTS ]; do
             ATTEMPT=$((ATTEMPT + 1))

--- a/.github/workflows/promote-to-production.yml
+++ b/.github/workflows/promote-to-production.yml
@@ -86,7 +86,16 @@ jobs:
 
           # BUGS-4: filter by headSha to avoid matching stale runs.
           # KAN-175: source is now `beta` and CI workflow is `deploy-beta.yml`.
-          MAX_ATTEMPTS=10
+          # BUGS-20 (2026-05-17): budget raised 10→30 attempts. Beta CI
+          # (build + lint + unit + audit + deploy) typically takes 3–5
+          # minutes. With sleep 15s the previous 10-attempt budget gave
+          # only 150s, which was tight enough that a same-day chain
+          # promote often timed out on the first try. 30 attempts × 15s
+          # = 7.5 min budget — comfortably covers a normal beta CI run
+          # without making real failures wait unreasonably long. If beta
+          # CI ever genuinely takes >7.5 min, fix the build, not this
+          # budget.
+          MAX_ATTEMPTS=30
           ATTEMPT=0
           while [ $ATTEMPT -lt $MAX_ATTEMPTS ]; do
             ATTEMPT=$((ATTEMPT + 1))

--- a/.github/workflows/promote-to-staging.yml
+++ b/.github/workflows/promote-to-staging.yml
@@ -48,7 +48,11 @@ jobs:
           # previous (since-superseded) commit. The previous code took
           # --limit 1 unconditionally, which means a green run for an OLD
           # commit could mask CI failures or non-runs for the current HEAD.
-          MAX_ATTEMPTS=10
+          # BUGS-20 (2026-05-17): budget raised 10→30 attempts. Dev CI
+          # takes 3–5 minutes; the prior 10×15s = 150s budget was tight
+          # enough to time out same-day promotes. 30×15s = 7.5 min is
+          # comfortable. Mirror of the fix on promote-to-production.yml.
+          MAX_ATTEMPTS=30
           ATTEMPT=0
           while [ $ATTEMPT -lt $MAX_ATTEMPTS ]; do
             ATTEMPT=$((ATTEMPT + 1))


### PR DESCRIPTION
## Summary

Closes BUGS-20. All three promote workflows polled upstream CI with a 10×15s = 150s budget; CI typically takes 3–5 min, so same-day chain promotes frequently timed out on the first try. Bumping to 30×15s = 7.5 min eliminates the false-failure mode without changing any correctness properties.

## Observed yesterday (BUGS-20 ticket)

```
Attempt 1/10: beta CI for cba50e43 = in_progress / pending
…
Attempt 10/10: beta CI for cba50e43 = in_progress / pending
##[error]Could not verify beta CI for cba50e43 after 10 attempts.
```

Auto-rollback fired but was a no-op (main was already at pre-merge SHA → Vercel 409). I retried 2 min later — succeeded.

## What changed

| File | Step | Before | After |
|---|---|---|---|
| `promote-to-production.yml` | "Verify beta pipeline passed at HEAD" | 10 attempts | 30 attempts |
| `promote-staging-to-beta.yml` | "Verify staging pipeline passed at HEAD" | 10 attempts | 30 attempts |
| `promote-to-staging.yml` | "Verify dev pipeline passed at HEAD" | 10 attempts | 30 attempts |

Each gets a BUGS-20 inline comment explaining the budget rationale.

**Deliberately NOT touched:** the Vercel-deployment-match polls (MAX_ATTEMPTS=6 elsewhere in each file) — those poll the Vercel API for deployment-by-SHA matching and have different dynamics. Not the failure mode reported.

## Failure-mode preservation

Widening the budget only buys patience for the `in_progress` case. A real CI failure still fails the gate on the same poll iteration:

```bash
elif [ "$STATUS" = "completed" ] && [ "$CONCLUSION" != "success" ]; then
  echo "::error::CI for $SHA concluded $CONCLUSION (run $RUN_ID). Fix before promoting."
  exit 1
fi
```

That branch is unchanged.

## Pre-merge greps (per CLAUDE.md workflow-integrity policy)

- ✅ No new silent-skip patterns (`if: env.X != ''`)
- ✅ No new `|| echo` lossy fallbacks (existing two at lines 339/394 of promote-to-production.yml are pre-existing legitimate HTTP/git-describe defaults, outside change scope)
- ✅ No `continue-on-error: true`
- ✅ All multi-line `run:` blocks unchanged (none added)

## Authored from worktree

Per KAN-216/217: isolated worktree `../lyra-claude-isolated` off `origin/develop`, branch `bugs-20/promote-poll-budget`. Pre-commit safety check passed.

## Test plan

- [x] All 3 files diff cleanly to MAX_ATTEMPTS=30 + BUGS-20 comment
- [ ] CI green on this PR
- [ ] First chain promote after merge succeeds on first try (will be exercised in this very session as soon as this PR lands)

🤖 Generated with [Claude Code](https://claude.com/claude-code)