### PR TITLE
fix(KAN-184): allow /api/recommendations/ through the maintenance worker

### DIFF
--- a/scripts/lyra-maintenance-worker.js
+++ b/scripts/lyra-maintenance-worker.js
@@ -279,7 +279,16 @@ export default {
       // block the approval flow.
       '/partners',
       '/auth/',
-      '/api/health'
+      '/api/health',
+      // KAN-184: the affiliate recommendation API needs to be reachable
+      // from outside the gate so the lyra-mcp-server (at mcp.checklyra.com)
+      // can call it server-side. Without this allowlist entry, the MCP
+      // server's fetch of /api/recommendations/v2/{slug} gets the
+      // "Coming Soon" HTML and falls back to legacy (v1) mode.
+      // V1 (/api/recommendations/{slug}) is covered by the same prefix so
+      // both endpoints work; both are read-only, public, and return data
+      // that's already public via /[slug] anyway.
+      '/api/recommendations/'
     ];
 
     const path = url.pathname;

--- a/tests/unit/maintenance-page.test.js
+++ b/tests/unit/maintenance-page.test.js
@@ -170,4 +170,14 @@ describe('KAN-129: Worker code file integrity', () => {
     const content = fs.readFileSync(workerPath, 'utf8');
     expect(content).toMatch(/allowedPaths\s*=\s*\[[\s\S]*?['"]\/partners['"][\s\S]*?\]/);
   });
+
+  // KAN-184: /api/recommendations/ must be in the worker allowlist so the
+  // lyra-mcp-server can call it server-side from mcp.checklyra.com.
+  // Without this entry the MCP server's fetch falls back to legacy v1 mode
+  // and AI assistants get raw profile data instead of monetised
+  // recommendations.
+  test('worker allowlist includes /api/recommendations/ (MCP server end-to-end)', () => {
+    const content = fs.readFileSync(workerPath, 'utf8');
+    expect(content).toMatch(/allowedPaths\s*=\s*\[[\s\S]*?['"]\/api\/recommendations\/['"][\s\S]*?\]/);
+  });
 });


### PR DESCRIPTION
## Summary
The MCP server's `lyra_recommend_gifts` tool (KAN-201) calls `${LYRA_APP_URL}/api/recommendations/v2/{slug}` server-side. That fetch goes through Cloudflare and the maintenance worker returns the "Coming Soon" HTML instead of JSON, so the MCP tool silently falls back to legacy v1 mode.

Confirmed live just now on prod: the MCP `lyra_recommend_gifts` call returned `version: "v1"` (legacy fallback) for an authenticated request, with the new KAN-201 schema present (disclosure_global, buyer_context echoed back) but no `recommendations[]` because the V2 endpoint wasn't reachable.

Adding `/api/recommendations/` to the worker allowlist (prefix match — covers both v1 and v2 endpoints).

## After this lands
1. Cloudflare Builds creates a new `lyra-maintenance` worker version
2. **Luisa: click Promote on the new version in the CF dashboard** (gotcha #15)
3. Re-run: `curl ... mcp.checklyra.com lyra_recommend_gifts ...` → response shows `version: "v2"`

## Test plan
- [x] 18 maintenance-page tests pass (new regression guard included)

## Related
KAN-184, KAN-201, KAN-200

🤖 Generated with [Claude Code](https://claude.com/claude-code)