### PR TITLE
feat(KAN-234): Phase 3 UI — wire hybrid visibility into editor + public profile

### DIFF
--- a/src/app/[slug]/page.tsx
+++ b/src/app/[slug]/page.tsx
@@ -5,7 +5,16 @@ import Image from 'next/image';
 import type { Metadata } from 'next';
 import { env } from '@/lib/env';
 import { createClient as createSupabaseServerClient } from '@/lib/supabase-server';
-import { filterItemsByVisibility } from '@/app/dashboard/profile/visibility';
+// KAN-234: replaced `filterItemsByVisibility` (KAN-143) with the
+// hybrid-visibility filter from `section-visibility.ts`. The new helper
+// resolves item.visibility against the section default before applying
+// the anonymous/authenticated test. The KAN-143 helper is still exported
+// (other modules and the unit suite use it directly) but isn't needed
+// here any more.
+import {
+  coerceSectionVisibility,
+  isItemVisibleUnderHybridModel,
+} from '@/app/dashboard/profile/section-visibility';
 import {
   isManualOfMeEmpty,
   type ManualOfMe,
@@ -60,6 +69,10 @@ interface ProfileData {
   country: string | null;
   is_published: boolean;
   avatar_url: string | null;
+  // KAN-234 / KAN-221: hybrid visibility — per-section defaults that items
+  // inherit when their own `visibility` is NULL. Already selected by the
+  // `*` query above; coerced via `coerceSectionVisibility` before use.
+  section_visibility: Record<string, string> | null;
 }
 
 interface ProfileItem {
@@ -71,7 +84,10 @@ interface ProfileItem {
   // selected by the `*` query; surfaced in the chip + Q&A rendering as a
   // clickable link when present.
   url: string | null;
-  visibility: string;
+  // KAN-234: nullable to allow "inherit from section default". When NULL,
+  // effective visibility comes from `profile.section_visibility[sectionKey]`
+  // — see `isItemVisibleUnderHybridModel`.
+  visibility: string | null;
 }
 
 interface SchoolAffiliation {
@@ -178,9 +194,18 @@ export default async function PublicProfilePage({ params }: Props) {
   const { data: { user: viewer } } = await cookieClient.auth.getUser();
   const isAuthenticated = viewer !== null;
 
-  // Fetch ALL non-draft visibility levels we might show, then filter in
-  // application code. This keeps the visibility decision in one place
-  // (`filterItemsByVisibility`) shared with the unit tests.
+  // KAN-234: with hybrid visibility, items with NULL `visibility` must
+  // ALSO be considered (they inherit from the section default — which
+  // could be 'public', 'members_only', or 'draft'). The previous
+  // `.in('visibility', ['public', 'members_only'])` query filter would
+  // wrongly exclude every NULL row, hiding inherited items. Fetch all,
+  // filter in application code via the hybrid helper. Per-profile item
+  // counts are bounded (low hundreds at most), so the extra rows are
+  // negligible.
+  //
+  // The non-item resources (profile_files, conversation_starters, etc.)
+  // still use the KAN-143 explicit-visibility query filter because they
+  // don't participate in the hybrid model.
   const allowedVisibility = isAuthenticated
     ? ['public', 'members_only']
     : ['public'];
@@ -189,14 +214,14 @@ export default async function PublicProfilePage({ params }: Props) {
     .from('profile_items')
     .select('*')
     .eq('profile_id', typedProfile.id)
-    .in('visibility', allowedVisibility)
     .order('created_at', { ascending: true });
 
-  // Defence in depth — apply the same filter in application code so a query
-  // bug, a future schema change, or a manually-edited row can't leak a draft.
-  const visibleItems = filterItemsByVisibility(
-    (items || []) as ProfileItem[],
-    isAuthenticated,
+  // KAN-234: defence in depth — application-side filter using the hybrid
+  // visibility model. `coerceSectionVisibility` drops unknown keys/values
+  // before we use the map, so a malformed JSONB cell can't leak items.
+  const sectionVisibility = coerceSectionVisibility(typedProfile.section_visibility);
+  const visibleItems = ((items || []) as ProfileItem[]).filter((item) =>
+    isItemVisibleUnderHybridModel(item, sectionVisibility, isAuthenticated),
   );
 
   const { data: schools } = await getSupabase()

--- a/src/app/dashboard/profile/actions.ts
+++ b/src/app/dashboard/profile/actions.ts
@@ -108,6 +108,14 @@ export async function addProfileItem(data: {
     sanitisedUrl = cleaned;
   }
 
+  // KAN-234: empty / null / undefined visibility → NULL in the DB, which
+  // means "inherit from section default" per the hybrid visibility model
+  // (see section-visibility.ts → getEffectiveItemVisibility). Otherwise
+  // coerce to one of the three real values (KAN-143).
+  const visibility = data.visibility && data.visibility !== ''
+    ? coerceVisibility(data.visibility)
+    : null;
+
   const { error } = await supabase
     .from('profile_items')
     .insert({
@@ -116,9 +124,7 @@ export async function addProfileItem(data: {
       title: sanitiseText(data.title, 200),
       description: data.description ? sanitiseText(data.description, 1000) : null,
       url: sanitisedUrl,
-      // Coerce to one of the allowed visibility levels — anything else falls
-      // back to 'public'. KAN-143.
-      visibility: coerceVisibility(data.visibility),
+      visibility,
     });
 
   if (error) return { success: false, error: error.message };
@@ -134,10 +140,17 @@ export async function updateProfileItemVisibility(
   if (authError) return { success: false, error: authError };
 
   // RLS confines the UPDATE to items the caller owns — no need to filter
-  // by user_id here. Coerce the input to one of the allowed levels.
+  // by user_id here.
+  //
+  // KAN-234: empty string → NULL = "inherit from section default" (hybrid
+  // visibility model). Otherwise coerce to one of the three real values.
+  const visibilityValue = visibility && visibility !== ''
+    ? coerceVisibility(visibility)
+    : null;
+
   const { error } = await supabase
     .from('profile_items')
-    .update({ visibility: coerceVisibility(visibility) })
+    .update({ visibility: visibilityValue })
     .eq('id', itemId);
 
   if (error) return { success: false, error: error.message };

--- a/src/app/dashboard/profile/edit-profile-form.tsx
+++ b/src/app/dashboard/profile/edit-profile-form.tsx
@@ -44,7 +44,13 @@ import {
   addExternalLink,
   removeExternalLink,
   publishProfile,
+  updateSectionVisibility,
 } from './actions';
+import {
+  isControllableSectionKey,
+  coerceSectionVisibility,
+  type SectionVisibility,
+} from './section-visibility';
 import {
   ItemsStep,
   LinksStep,
@@ -146,6 +152,13 @@ export function EditProfileForm({
     });
   };
 
+  // KAN-234: derived once per render — section visibility defaults the
+  // section-header toggles display. Defence in depth: coerceSectionVisibility
+  // drops unknown keys/values from the JSONB column.
+  const currentSectionVisibility: SectionVisibility = coerceSectionVisibility(
+    profile.section_visibility,
+  );
+
   const renderItemsSection = (
     sectionId: string,
     title: string,
@@ -241,20 +254,56 @@ export function EditProfileForm({
                 id={s.id}
                 className="bg-white rounded-lg border border-stone-200 overflow-hidden scroll-mt-4"
               >
-                <button
-                  type="button"
-                  aria-expanded={isOpen}
-                  aria-controls={`${s.id}-body`}
-                  onClick={() => toggleSection(s.id)}
-                  className="w-full flex items-center justify-between px-4 py-3 text-left hover:bg-stone-50 transition-colors"
-                >
-                  <span className="text-base font-medium text-[var(--color-ink)]">
-                    <span className="mr-2">{s.icon}</span> {s.label}
-                  </span>
-                  <span aria-hidden className="text-[var(--color-muted)] text-sm">
-                    {isOpen ? '▾' : '▸'}
-                  </span>
-                </button>
+                <div className="flex items-center justify-between px-4 py-3 hover:bg-stone-50 transition-colors">
+                  <button
+                    type="button"
+                    aria-expanded={isOpen}
+                    aria-controls={`${s.id}-body`}
+                    onClick={() => toggleSection(s.id)}
+                    className="flex items-center text-left flex-1 cursor-pointer"
+                  >
+                    <span className="text-base font-medium text-[var(--color-ink)]">
+                      <span className="mr-2">{s.icon}</span> {s.label}
+                    </span>
+                  </button>
+                  <div className="flex items-center gap-2">
+                    {/* KAN-234: section-level visibility toggle for the 6
+                        controllable sections (likes / gifts / boundaries /
+                        books-media / causes-quotes / more). Items in these
+                        sections that have NULL visibility inherit this
+                        default at render time. */}
+                    {isControllableSectionKey(s.id) && (
+                      <label className="flex items-center gap-1.5" onClick={(e) => e.stopPropagation()}>
+                        <span className="sr-only">Visibility for {s.label}</span>
+                        <select
+                          value={currentSectionVisibility[s.id] ?? 'public'}
+                          onChange={(e) => {
+                            const next = e.target.value;
+                            startTransition(async () => {
+                              await updateSectionVisibility(s.id, next);
+                              router.refresh();
+                            });
+                          }}
+                          disabled={isPending}
+                          aria-label={`Section visibility for ${s.label}`}
+                          className="text-xs px-2 py-1 rounded border border-stone-300 bg-white text-[var(--color-ink)]"
+                        >
+                          <option value="public">🌍 Public</option>
+                          <option value="members_only">🔒 Members</option>
+                          <option value="draft">✏️ Draft</option>
+                        </select>
+                      </label>
+                    )}
+                    <button
+                      type="button"
+                      onClick={() => toggleSection(s.id)}
+                      aria-label={isOpen ? `Collapse ${s.label}` : `Expand ${s.label}`}
+                      className="text-[var(--color-muted)] text-sm px-1"
+                    >
+                      {isOpen ? '▾' : '▸'}
+                    </button>
+                  </div>
+                </div>
                 {isOpen && (
                   <div id={`${s.id}-body`} className="px-4 pb-5 pt-1 border-t border-stone-200">
                     {s.id === 'basic-info' && <BasicInfoSection profile={profile} />}

--- a/src/app/dashboard/profile/steps/items-step.tsx
+++ b/src/app/dashboard/profile/steps/items-step.tsx
@@ -5,7 +5,13 @@ import { Field, SaveButton, type WizardItem } from './types';
 
 // KAN-143 — UI-visible visibility levels. Keep in sync with
 // src/app/dashboard/profile/visibility.ts (VISIBILITY_LEVELS).
+//
+// KAN-234: extended with a 4th "inherit" option (value=''). When chosen,
+// the server writes NULL to profile_items.visibility, and the item's
+// effective visibility is computed from the section default at render
+// time (see section-visibility.ts → getEffectiveItemVisibility).
 const VISIBILITY_OPTIONS: { value: string; label: string }[] = [
+  { value: '', label: '↗ Use section default' },
   { value: 'public', label: '🌍 Public — anyone with the link' },
   { value: 'members_only', label: '🔒 Members only — signed-in users' },
   { value: 'draft', label: '✏️ Draft — only you can see this' },
@@ -18,6 +24,9 @@ const visibilityShort: Record<string, string> = {
   // 'private' is the legacy enum value (pre-KAN-143). Render as draft.
   private: '✏️ Draft',
 };
+
+// KAN-234: short label for the NULL/inherit case in the per-item selector.
+const INHERIT_SHORT = '↗ Inherit';
 
 export function ItemsStep({ title, description, categories, items, onAdd, onRemove, onUpdateVisibility, onNext, isPending }: {
   title: string; description: string; categories: string[]; items: WizardItem[];
@@ -34,7 +43,8 @@ export function ItemsStep({ title, description, categories, items, onAdd, onRemo
   const [itemTitle, setItemTitle] = useState('');
   const [itemDesc, setItemDesc] = useState('');
   const [itemUrl, setItemUrl] = useState('');
-  const [itemVisibility, setItemVisibility] = useState<string>('public');
+  // KAN-234: new items default to '' (inherit from section default).
+  const [itemVisibility, setItemVisibility] = useState<string>('');
 
   const categoryLabels: Record<string, string> = {
     likes: '💚 Like', dislikes: '💔 Dislike',
@@ -62,7 +72,7 @@ export function ItemsStep({ title, description, categories, items, onAdd, onRemo
     setItemTitle('');
     setItemDesc('');
     setItemUrl('');
-    setItemVisibility('public');
+    setItemVisibility(''); // KAN-234: reset to inherit
   };
 
   return (
@@ -99,13 +109,23 @@ export function ItemsStep({ title, description, categories, items, onAdd, onRemo
                 <select
                   id={`vis-${item.id}`}
                   aria-label={`Visibility for ${item.title}`}
-                  value={visibilityShort[item.visibility] ? item.visibility : 'public'}
+                  // KAN-234: NULL stored visibility → '' in the form = inherit.
+                  // Known string → its real value. Unknown string → 'public' (defence).
+                  value={
+                    item.visibility == null || item.visibility === ''
+                      ? ''
+                      : visibilityShort[item.visibility]
+                        ? item.visibility
+                        : 'public'
+                  }
                   onChange={(e) => onUpdateVisibility(item.id, e.target.value)}
                   disabled={isPending}
                   className="text-xs px-2 py-1 rounded border border-stone-300 bg-white text-[var(--color-ink)]"
                 >
                   {VISIBILITY_OPTIONS.map((opt) => (
-                    <option key={opt.value} value={opt.value}>{visibilityShort[opt.value]}</option>
+                    <option key={opt.value || 'inherit'} value={opt.value}>
+                      {opt.value === '' ? INHERIT_SHORT : visibilityShort[opt.value]}
+                    </option>
                   ))}
                 </select>
                 <button onClick={() => onRemove(item.id)} disabled={isPending} className="text-xs text-red-400 hover:text-red-600">Remove</button>

--- a/src/app/dashboard/profile/steps/types.tsx
+++ b/src/app/dashboard/profile/steps/types.tsx
@@ -14,6 +14,10 @@ export interface WizardProfile {
   delivery_country_code: string | null;
   is_published: boolean;
   avatar_url: string | null;
+  // KAN-234 / KAN-221: hybrid visibility. Per-section default ({} when
+  // unset) that items inherit when their own `visibility` is NULL.
+  // Keys live in `section-visibility.ts → CONTROLLABLE_SECTION_KEYS`.
+  section_visibility: Record<string, string> | null;
 }
 
 export interface WizardItem {
@@ -22,7 +26,10 @@ export interface WizardItem {
   title: string;
   description: string | null;
   url: string | null;
-  visibility: string;
+  // KAN-234 / KAN-221: nullable to allow "inherit from section default".
+  // Older rows from before KAN-221 always had an explicit value; new items
+  // default to NULL when the form chooses "Use section default".
+  visibility: string | null;
 }
 
 export interface WizardSchool {

--- a/tests/unit/phase3-ui-integration.test.ts
+++ b/tests/unit/phase3-ui-integration.test.ts
@@ -1,0 +1,255 @@
+/**
+ * KAN-234: Phase 3 UI integration tests.
+ *
+ * Two layers:
+ *
+ *  1. **Behavioural** — `addProfileItem` and `updateProfileItemVisibility`
+ *     now treat empty/null visibility as "inherit from section default"
+ *     (writes NULL). Explicit values continue to be coerced as before
+ *     (KAN-143 behaviour preserved). These tests prove the contract
+ *     that the items-step UI ("Use section default" option) relies on.
+ *
+ *  2. **Static regression guards** — items-step renders the new option,
+ *     edit-profile-form imports the section-visibility helpers and
+ *     uses them in the section-header toggle, [slug]/page.tsx uses
+ *     `isItemVisibleUnderHybridModel` for the filter. Same cheap-coverage
+ *     pattern as KAN-181 / KAN-182.
+ *
+ * `useTransition`-driven section-header toggle round-trip is covered
+ * indirectly by KAN-221's `updateSectionVisibility` unit tests (server
+ * action behaviour) + the static-grep assertions here (wiring).
+ */
+
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const ROOT = resolve(__dirname, '../..');
+
+// ───────────── Mocks for action behaviour tests ─────────────
+
+const mockInsertCapture = jest.fn();
+const mockUpdateCapture = jest.fn();
+const mockRevalidatePath = jest.fn();
+
+jest.mock('next/cache', () => ({
+  revalidatePath: (...args: unknown[]) => mockRevalidatePath(...args),
+}));
+
+jest.mock('@/lib/supabase-server', () => ({
+  createClient: jest.fn().mockResolvedValue({
+    auth: {
+      getUser: jest.fn().mockResolvedValue({
+        data: { user: { id: 'test-user-id' } },
+      }),
+    },
+    from: jest.fn().mockImplementation((tableName: string) => {
+      if (tableName === 'profiles') {
+        return {
+          select: () => ({
+            eq: () => ({
+              single: () => Promise.resolve({ data: { id: 'test-profile-id' } }),
+            }),
+          }),
+        };
+      }
+      if (tableName === 'profile_items') {
+        return {
+          insert: (data: unknown) => {
+            mockInsertCapture(data);
+            return Promise.resolve({ error: null });
+          },
+          update: (data: unknown) => {
+            mockUpdateCapture(data);
+            return { eq: () => Promise.resolve({ error: null }) };
+          },
+        };
+      }
+      throw new Error(`Unexpected table in mock: ${tableName}`);
+    }),
+  }),
+}));
+
+import {
+  addProfileItem,
+  updateProfileItemVisibility,
+} from '@/app/dashboard/profile/actions';
+
+beforeEach(() => {
+  mockInsertCapture.mockClear();
+  mockUpdateCapture.mockClear();
+  mockRevalidatePath.mockClear();
+});
+
+// ───────────── 1. addProfileItem — visibility=inherit ─────────────
+
+describe('KAN-234: addProfileItem inserts NULL visibility for inherit', () => {
+  test('omitted visibility → NULL (inherits section default)', async () => {
+    await addProfileItem({
+      category: 'gift_ideas',
+      title: 'Espresso machine',
+    });
+    expect(mockInsertCapture).toHaveBeenCalledWith(
+      expect.objectContaining({ visibility: null, title: 'Espresso machine' }),
+    );
+  });
+
+  test('empty-string visibility → NULL', async () => {
+    await addProfileItem({
+      category: 'gift_ideas',
+      title: 'Empty viz',
+      visibility: '',
+    });
+    expect(mockInsertCapture).toHaveBeenCalledWith(
+      expect.objectContaining({ visibility: null }),
+    );
+  });
+
+  test('explicit "public" → "public" (KAN-143 behaviour preserved)', async () => {
+    await addProfileItem({
+      category: 'likes',
+      title: 'Coffee',
+      visibility: 'public',
+    });
+    expect(mockInsertCapture).toHaveBeenCalledWith(
+      expect.objectContaining({ visibility: 'public' }),
+    );
+  });
+
+  test('explicit "members_only" → "members_only"', async () => {
+    await addProfileItem({
+      category: 'boundaries',
+      title: 'No phone after 9pm',
+      visibility: 'members_only',
+    });
+    expect(mockInsertCapture).toHaveBeenCalledWith(
+      expect.objectContaining({ visibility: 'members_only' }),
+    );
+  });
+
+  test('explicit "draft" → "draft"', async () => {
+    await addProfileItem({
+      category: 'questions',
+      title: 'Why?',
+      visibility: 'draft',
+    });
+    expect(mockInsertCapture).toHaveBeenCalledWith(
+      expect.objectContaining({ visibility: 'draft' }),
+    );
+  });
+
+  test('unknown visibility value → coerced to "public" (KAN-143 fail-safe)', async () => {
+    await addProfileItem({
+      category: 'likes',
+      title: 'Test',
+      visibility: 'totally_invalid',
+    });
+    expect(mockInsertCapture).toHaveBeenCalledWith(
+      expect.objectContaining({ visibility: 'public' }),
+    );
+  });
+});
+
+// ───────────── 2. updateProfileItemVisibility ─────────────
+
+describe('KAN-234: updateProfileItemVisibility writes NULL for inherit', () => {
+  test('empty string → writes NULL', async () => {
+    await updateProfileItemVisibility('item-1', '');
+    expect(mockUpdateCapture).toHaveBeenCalledWith({ visibility: null });
+  });
+
+  test('explicit "public" still writes "public"', async () => {
+    await updateProfileItemVisibility('item-1', 'public');
+    expect(mockUpdateCapture).toHaveBeenCalledWith({ visibility: 'public' });
+  });
+
+  test('explicit "members_only" still writes "members_only"', async () => {
+    await updateProfileItemVisibility('item-1', 'members_only');
+    expect(mockUpdateCapture).toHaveBeenCalledWith({ visibility: 'members_only' });
+  });
+
+  test('explicit "draft" still writes "draft"', async () => {
+    await updateProfileItemVisibility('item-1', 'draft');
+    expect(mockUpdateCapture).toHaveBeenCalledWith({ visibility: 'draft' });
+  });
+
+  test('unknown value coerces to "public" (KAN-143 fail-safe preserved)', async () => {
+    await updateProfileItemVisibility('item-1', 'bogus');
+    expect(mockUpdateCapture).toHaveBeenCalledWith({ visibility: 'public' });
+  });
+});
+
+// ───────────── 3. Static regression guards ─────────────
+
+describe('KAN-234: surface-area regression guards', () => {
+  test('items-step.tsx has the "Use section default" option (empty value)', () => {
+    const src = readFileSync(
+      resolve(ROOT, 'src/app/dashboard/profile/steps/items-step.tsx'),
+      'utf-8',
+    );
+    // The option's value is the empty string — distinctive label too.
+    expect(src).toMatch(/Use section default/);
+    // New-item form defaults to '' (inherit), not 'public'.
+    expect(src).toMatch(/setItemVisibility\(['"]['"]\)/);
+  });
+
+  test('items-step.tsx handles null/undefined item.visibility in the per-item selector', () => {
+    const src = readFileSync(
+      resolve(ROOT, 'src/app/dashboard/profile/steps/items-step.tsx'),
+      'utf-8',
+    );
+    // The select value derives '' from a null/undefined item.visibility.
+    expect(src).toMatch(/item\.visibility == null/);
+  });
+
+  test('WizardProfile and WizardItem types declare section_visibility / nullable visibility', () => {
+    const src = readFileSync(
+      resolve(ROOT, 'src/app/dashboard/profile/steps/types.tsx'),
+      'utf-8',
+    );
+    expect(src).toMatch(/section_visibility:\s*Record<string,\s*string>\s*\|\s*null/);
+    // Per-item visibility is now nullable in the type
+    expect(src).toMatch(/visibility:\s*string\s*\|\s*null/);
+  });
+
+  test('edit-profile-form.tsx renders section-header visibility toggles via updateSectionVisibility', () => {
+    const src = readFileSync(
+      resolve(ROOT, 'src/app/dashboard/profile/edit-profile-form.tsx'),
+      'utf-8',
+    );
+    expect(src).toMatch(/updateSectionVisibility/);
+    expect(src).toMatch(/isControllableSectionKey/);
+    expect(src).toMatch(/coerceSectionVisibility/);
+    // The select's options are the three real values
+    expect(src).toMatch(/<option value="public">/);
+    expect(src).toMatch(/<option value="members_only">/);
+    expect(src).toMatch(/<option value="draft">/);
+  });
+
+  test('[slug]/page.tsx uses the hybrid filter (isItemVisibleUnderHybridModel)', () => {
+    const src = readFileSync(
+      resolve(ROOT, 'src/app/[slug]/page.tsx'),
+      'utf-8',
+    );
+    expect(src).toMatch(/isItemVisibleUnderHybridModel/);
+    expect(src).toMatch(/coerceSectionVisibility/);
+    // ProfileData now declares section_visibility
+    expect(src).toMatch(/section_visibility:\s*Record<string,\s*string>\s*\|\s*null/);
+    // ProfileItem.visibility is nullable
+    expect(src).toMatch(/visibility:\s*string\s*\|\s*null/);
+  });
+
+  test('[slug]/page.tsx removes the .in("visibility", [...]) query filter (hybrid model needs NULL rows too)', () => {
+    const src = readFileSync(
+      resolve(ROOT, 'src/app/[slug]/page.tsx'),
+      'utf-8',
+    );
+    // The previous query had `.in('visibility', allowedVisibility)` — that
+    // line is now gone for profile_items (the rest of the resources keep
+    // their explicit filter).
+    const itemsBlock = src.match(/\.from\(['"]profile_items['"][\s\S]*?\.order\([^)]+\)/);
+    expect(itemsBlock).not.toBeNull();
+    if (itemsBlock) {
+      expect(itemsBlock[0]).not.toMatch(/\.in\(['"]visibility['"]/);
+    }
+  });
+});

--- a/tests/unit/profile-items-visibility-migration.test.js
+++ b/tests/unit/profile-items-visibility-migration.test.js
@@ -76,8 +76,15 @@ describe('KAN-143 — public profile page filters by visibility', () => {
   const pagePath = path.join(root, 'src/app/[slug]/page.tsx');
   const content = fs.readFileSync(pagePath, 'utf8');
 
-  test('imports the shared visibility filter', () => {
-    expect(content).toMatch(/import\s*{[^}]*filterItemsByVisibility[^}]*}/);
+  // KAN-234: filter helper switched to `isItemVisibleUnderHybridModel`
+  // (resolves item.visibility against the section default before applying
+  // the anonymous/authenticated test). The KAN-143 security guarantees are
+  // preserved — defence in depth still runs application-side. The DB-level
+  // `.in('visibility', …)` query filter is intentionally removed because
+  // the hybrid model needs to fetch NULL-visibility rows too (they inherit
+  // from the section default).
+  test('imports the hybrid visibility filter (KAN-234 replaces KAN-143 filter)', () => {
+    expect(content).toMatch(/import\s*{[^}]*isItemVisibleUnderHybridModel[^}]*}/);
   });
 
   test('checks viewer auth state before fetching items', () => {
@@ -85,16 +92,18 @@ describe('KAN-143 — public profile page filters by visibility', () => {
     expect(content).toMatch(/isAuthenticated/);
   });
 
-  test('fetches members_only for authenticated viewers, public-only otherwise', () => {
+  test('references the two visibility levels viewers can see', () => {
+    // 'draft' is never visible to viewers; the page renders 'public' for
+    // anonymous and 'public'+'members_only' for authenticated. KAN-234
+    // moved the filter from a DB query to an app-side call; the literal
+    // strings still appear in the page for the allowed-visibility list
+    // computation and for the section-default fallback.
     expect(content).toContain("'members_only'");
     expect(content).toContain("'public'");
-    // The narrow query filter uses .in('visibility', ...) so draft rows are
-    // never even returned by the DB.
-    expect(content).toMatch(/\.in\(\s*['"]visibility['"]/);
   });
 
-  test('applies application-level filter in addition to the DB query (defence in depth)', () => {
-    expect(content).toMatch(/filterItemsByVisibility\(/);
+  test('applies application-level filter via the hybrid helper (defence in depth, KAN-234)', () => {
+    expect(content).toMatch(/isItemVisibleUnderHybridModel\(/);
   });
 });
 
@@ -119,8 +128,11 @@ describe('KAN-143 — items step UI exposes visibility selector', () => {
     expect(content).not.toMatch(/value:\s*['"]private['"]/);
   });
 
-  test('default visibility for new items is "public"', () => {
-    expect(content).toMatch(/useState<string>\(['"]public['"]\)/);
+  test('default visibility for new items is "" (inherit from section default — KAN-234)', () => {
+    // KAN-234: new items default to '' (inherit) so they pick up whatever
+    // the user has set as the section visibility default. Existing items
+    // keep their stored value. Pre-KAN-234 this defaulted to 'public'.
+    expect(content).toMatch(/useState<string>\(['"]['"]\)/);
   });
 
   test('exposes an onUpdateVisibility callback so existing items can be re-classified', () => {
@@ -146,7 +158,12 @@ describe('KAN-143 — actions.ts wiring', () => {
   test('addProfileItem coerces visibility through the shared helper', () => {
     // No more raw `data.visibility || 'public'` — that would let an attacker
     // write any string into the column.
-    expect(content).toMatch(/visibility:\s*coerceVisibility\(/);
+    //
+    // KAN-234: the pattern is now wrapped in a ternary so empty/null values
+    // become NULL (= inherit from section). The security guarantee is
+    // unchanged: any non-empty value flows through coerceVisibility, which
+    // rejects strings outside the allowlist.
+    expect(content).toMatch(/coerceVisibility\(data\.visibility\)/);
     expect(content).not.toMatch(/visibility:\s*data\.visibility\s*\|\|\s*['"]public['"]/);
   });
 });


### PR DESCRIPTION
## Summary

Completes [KAN-218](https://checklyra.atlassian.net/browse/KAN-218) by wiring the [KAN-221](https://checklyra.atlassian.net/browse/KAN-221) foundation (DB column + helpers + server action — already on beta) through to the actual editor UI and public-profile filter.

After this lands, users can set a section-level visibility default in the profile editor (a small select beside each of the 6 controllable section headers), and items inherit that default unless explicitly overridden via the per-item selector's "Use section default" option.

## What's in this PR

**Types** (`steps/types.tsx`)
- `WizardProfile.section_visibility: Record<string, string> | null` — the JSONB column from KAN-221
- `WizardItem.visibility: string | null` — nullable to unlock "inherit" semantics

**Server actions** (`actions.ts`)
- `addProfileItem` — empty / null / undefined visibility writes **NULL** (= inherit). Explicit values flow through `coerceVisibility` as before.
- `updateProfileItemVisibility` — same model: `''` writes NULL, explicit values coerced.

**Editor UI** (`edit-profile-form.tsx`)
- Each of the 6 `CONTROLLABLE_SECTION_KEYS` section headers gets a small visibility selector beside the chevron (Public / Members / Draft).
- Wired to `updateSectionVisibility(sectionKey, value)` via `useTransition`.
- `coerceSectionVisibility` runs once per render so unknown keys/values from the JSONB column never reach the UI.

**Items form** (`items-step.tsx`)
- 4th visibility option: **"↗ Use section default"** (value=`''`).
- New items default to this option (so creating an item without thinking about visibility just inherits whatever the section is set to).
- Existing items render their stored value unchanged.

**Public profile** (`[slug]/page.tsx`)
- `ProfileData.section_visibility` + `ProfileItem.visibility: string | null`.
- DB-level `.in('visibility', allowed)` filter **removed** for `profile_items` (the hybrid model needs NULL rows to be fetched too — they inherit from section default).
- Application-side filter switched from KAN-143's `filterItemsByVisibility` to KAN-221's `isItemVisibleUnderHybridModel`.
- Defence-in-depth preserved: app-side filter is still the source of truth.

## Test plan

- [x] `npx jest` — **969 ✅** (+17 new in `phase3-ui-integration.test.ts`)
- [x] `npm run lint` — 0 errors
- [x] `npm run build` — green; `/dashboard/profile` + `/dashboard/profile/legacy` both compile
- [x] **Test Integrity Policy** — 5 KAN-143 regression-guard assertions in `profile-items-visibility-migration.test.js` reframed to track the new patterns. Luisa signed off in chat transcript before changes were made; security guarantees those assertions defended are unchanged and re-asserted in `phase3-ui-integration.test.ts`.

After merge, on dev.checklyra.com:
- Visit `/dashboard/profile`, see new visibility selector beside 6 section headers
- Set "Gift ideas" section to Members only → save
- Add a gift idea without changing its visibility (defaults to inherit)
- Log out, visit `/<your-slug>` in incognito → gift idea hidden
- Log back in → gift idea visible
- Now flip the item's per-item selector to Public → log out → gift idea visible (override beats section default)

## What's NOT in this PR

- **Non-item sections** (`basic-info`, `affiliations`, `bio`, `manual-of-me`, `links`, `files`, `starters`) have no section-visibility toggle. Decided in KAN-221 design — section visibility for free-text sections is a different conversation about hiding entire bios from anonymous viewers, which the Python predecessor allowed but adds significant UX complexity. Filed as future work if you want it.
- **Migration** — none needed; `section_visibility` already exists on dev/staging/prod from KAN-221.

## Where this fits

| Ticket | Status |
|---|---|
| [KAN-218](https://checklyra.atlassian.net/browse/KAN-218) (parent Story) | Will close once this lands + the next promote chain runs |
| [KAN-219](https://checklyra.atlassian.net/browse/KAN-219) Phase 1 | ✅ Done (on beta) |
| [KAN-220](https://checklyra.atlassian.net/browse/KAN-220) Phase 2 | ✅ Done (on beta) |
| [KAN-221](https://checklyra.atlassian.net/browse/KAN-221) Phase 3 foundation | ✅ Done (on beta) |
| **[KAN-234](https://checklyra.atlassian.net/browse/KAN-234) Phase 3 UI integration** | **this PR** |
| [KAN-225](https://checklyra.atlassian.net/browse/KAN-225) Forgot/Reset password | next |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[KAN-218]: https://checklyra.atlassian.net/browse/KAN-218?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[KAN-221]: https://checklyra.atlassian.net/browse/KAN-221?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[KAN-218]: https://checklyra.atlassian.net/browse/KAN-218?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ