### PR TITLE
feat(KAN-208): Convene P4 — gathering state machine

### DIFF
--- a/src/lib/convene/gatherings/state-machine.ts
+++ b/src/lib/convene/gatherings/state-machine.ts
@@ -1,0 +1,101 @@
+/**
+ * Convene gathering state machine — KAN-208 (Phase 4).
+ *
+ * Canonical states + transitions for a gathering. Used by:
+ *   - lyra_create_gathering (initial state: draft)
+ *   - lyra_update_gathering (must be in draft|live to edit fields)
+ *   - lyra_finalise_gathering (draft → live, with slot + venue locked)
+ *   - lyra_reschedule_gathering (P6: live → live with new slot)
+ *   - lyra_cancel_gathering (P6: any non-terminal → cancelled)
+ *   - post-event reconciliation (P8: live → completed)
+ *
+ * Reject invalid transitions with a structured error so the agent gets a
+ * clear "you can't do X from state Y" instead of a corrupted DB.
+ */
+
+export type GatheringStatus =
+  | 'draft'
+  | 'awaiting_responses'
+  | 'live'
+  | 'rescheduled'
+  | 'cancelled'
+  | 'completed';
+
+export type GatheringTransition =
+  | 'finalise' //  draft → awaiting_responses | live
+  | 'mark_live' //  awaiting_responses → live (when invite threshold hit / P5)
+  | 'reschedule' //  live → rescheduled  (P6)
+  | 'cancel' //    any non-terminal → cancelled
+  | 'complete' //  live → completed (P8, after the event)
+  | 'reopen' //    rescheduled → live (after new slot accepted, P6);
+
+const VALID: Record<GatheringStatus, Partial<Record<GatheringTransition, GatheringStatus>>> = {
+  draft: {
+    finalise: 'live', // P4: skip awaiting_responses; P5 will introduce it
+    cancel: 'cancelled',
+  },
+  awaiting_responses: {
+    mark_live: 'live',
+    cancel: 'cancelled',
+  },
+  live: {
+    reschedule: 'rescheduled',
+    cancel: 'cancelled',
+    complete: 'completed',
+  },
+  rescheduled: {
+    reopen: 'live',
+    cancel: 'cancelled',
+  },
+  cancelled: {}, // terminal
+  completed: {}, // terminal
+};
+
+export class InvalidTransitionError extends Error {
+  readonly from: GatheringStatus;
+  readonly transition: GatheringTransition;
+
+  constructor(from: GatheringStatus, transition: GatheringTransition) {
+    super(`Invalid transition "${transition}" from state "${from}"`);
+    this.from = from;
+    this.transition = transition;
+    this.name = 'InvalidTransitionError';
+  }
+}
+
+/**
+ * Apply a transition. Returns the next status, or throws InvalidTransitionError.
+ */
+export function applyTransition(
+  current: GatheringStatus,
+  transition: GatheringTransition
+): GatheringStatus {
+  const next = VALID[current]?.[transition];
+  if (!next) throw new InvalidTransitionError(current, transition);
+  return next;
+}
+
+/**
+ * Whether a transition is allowed from a given state (no exception).
+ */
+export function canTransition(
+  current: GatheringStatus,
+  transition: GatheringTransition
+): boolean {
+  return VALID[current]?.[transition] !== undefined;
+}
+
+/**
+ * Which transitions are available from this state. Useful for UI button-enable.
+ */
+export function availableTransitions(current: GatheringStatus): GatheringTransition[] {
+  return Object.keys(VALID[current] ?? {}) as GatheringTransition[];
+}
+
+/**
+ * Whether the gathering's *fields* can still be edited via lyra_update_gathering.
+ * Terminal states (cancelled, completed) and rescheduled lock the record.
+ */
+export function isFieldEditable(current: GatheringStatus): boolean {
+  return current === 'draft' || current === 'live' || current === 'awaiting_responses';
+}

--- a/tests/unit/convene/gathering-state-machine.test.ts
+++ b/tests/unit/convene/gathering-state-machine.test.ts
@@ -1,0 +1,113 @@
+/**
+ * KAN-208 — gathering state machine tests.
+ *
+ * Covers every valid transition and a representative sample of invalid
+ * ones. Static — pure functions, no DB.
+ */
+
+import {
+  applyTransition,
+  canTransition,
+  availableTransitions,
+  isFieldEditable,
+  InvalidTransitionError,
+  type GatheringStatus,
+  type GatheringTransition,
+} from '@/lib/convene/gatherings/state-machine';
+
+describe('gathering state machine (KAN-208)', () => {
+  describe('valid transitions', () => {
+    const cases: Array<[GatheringStatus, GatheringTransition, GatheringStatus]> = [
+      ['draft', 'finalise', 'live'],
+      ['draft', 'cancel', 'cancelled'],
+      ['awaiting_responses', 'mark_live', 'live'],
+      ['awaiting_responses', 'cancel', 'cancelled'],
+      ['live', 'reschedule', 'rescheduled'],
+      ['live', 'cancel', 'cancelled'],
+      ['live', 'complete', 'completed'],
+      ['rescheduled', 'reopen', 'live'],
+      ['rescheduled', 'cancel', 'cancelled'],
+    ];
+    test.each(cases)('%s --%s--> %s', (from, t, expected) => {
+      expect(applyTransition(from, t)).toBe(expected);
+      expect(canTransition(from, t)).toBe(true);
+    });
+  });
+
+  describe('terminal states reject all transitions', () => {
+    const terminals: GatheringStatus[] = ['cancelled', 'completed'];
+    const allTransitions: GatheringTransition[] = [
+      'finalise',
+      'mark_live',
+      'reschedule',
+      'cancel',
+      'complete',
+      'reopen',
+    ];
+    for (const s of terminals) {
+      for (const t of allTransitions) {
+        test(`${s} rejects ${t}`, () => {
+          expect(canTransition(s, t)).toBe(false);
+          expect(() => applyTransition(s, t)).toThrow(InvalidTransitionError);
+        });
+      }
+    }
+  });
+
+  describe('invalid transitions throw structured errors', () => {
+    test('draft cannot complete', () => {
+      try {
+        applyTransition('draft', 'complete');
+        fail('expected throw');
+      } catch (e) {
+        expect(e).toBeInstanceOf(InvalidTransitionError);
+        expect((e as InvalidTransitionError).from).toBe('draft');
+        expect((e as InvalidTransitionError).transition).toBe('complete');
+      }
+    });
+
+    test('live cannot finalise twice', () => {
+      expect(canTransition('live', 'finalise')).toBe(false);
+    });
+
+    test('rescheduled cannot complete directly (must reopen first)', () => {
+      expect(canTransition('rescheduled', 'complete')).toBe(false);
+    });
+
+    test('error message includes both from-state and attempted transition', () => {
+      try {
+        applyTransition('cancelled', 'reopen');
+        fail('expected throw');
+      } catch (e) {
+        expect((e as Error).message).toContain('reopen');
+        expect((e as Error).message).toContain('cancelled');
+      }
+    });
+  });
+
+  describe('availableTransitions', () => {
+    test('returns the right set for draft', () => {
+      expect(availableTransitions('draft').sort()).toEqual(['cancel', 'finalise']);
+    });
+    test('returns the right set for live', () => {
+      expect(availableTransitions('live').sort()).toEqual(['cancel', 'complete', 'reschedule']);
+    });
+    test('terminals return empty', () => {
+      expect(availableTransitions('cancelled')).toEqual([]);
+      expect(availableTransitions('completed')).toEqual([]);
+    });
+  });
+
+  describe('isFieldEditable', () => {
+    test('editable in draft / live / awaiting_responses', () => {
+      expect(isFieldEditable('draft')).toBe(true);
+      expect(isFieldEditable('live')).toBe(true);
+      expect(isFieldEditable('awaiting_responses')).toBe(true);
+    });
+    test('locked in rescheduled / cancelled / completed', () => {
+      expect(isFieldEditable('rescheduled')).toBe(false);
+      expect(isFieldEditable('cancelled')).toBe(false);
+      expect(isFieldEditable('completed')).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

State machine for the Convene gathering lifecycle. Canonical transition table + helpers (applyTransition, canTransition, availableTransitions, isFieldEditable). 30 unit tests.

Consumed by:
- The 3 lifecycle MCP tools in [lyra-mcp-server#34](https://github.com/luisa-sys/lyra-mcp-server/pull/34) (paired PR)
- The future \`/dashboard/convene/gatherings/[id]\` detail page (next iteration)
- The P6 reschedule/cancel/complete flows

## Transitions

\`\`\`
draft               --finalise--> live
draft               --cancel--> cancelled
awaiting_responses  --mark_live--> live           (P5)
awaiting_responses  --cancel--> cancelled
live                --reschedule--> rescheduled   (P6)
live                --cancel--> cancelled
live                --complete--> completed       (P8)
rescheduled         --reopen--> live              (P6)
rescheduled         --cancel--> cancelled
cancelled / completed: terminal
\`\`\`

## What's not in this PR

- UI / detail page — separate PR.
- Calendar event creation on finalise (lyra-side adapter call wired from the future UI).
- Server actions / repository — TBD whether to use server actions vs HTTP routes; deferred to the UI iteration.

## Test plan

- [x] 30 new state-machine tests, all paths covered
- [x] Typecheck clean

## MCP coverage (KAN-222)

Paired with [lyra-mcp-server#34](https://github.com/luisa-sys/lyra-mcp-server/pull/34) which contains the 3 lifecycle MCP tools.

🤖 Generated with [Claude Code](https://claude.com/claude-code)