### PR TITLE
feat(KAN-207): Convene P3 — scoreAttendee + scoreVenue pure scorers

### DIFF
--- a/src/lib/recommend/convene/score-attendee.ts
+++ b/src/lib/recommend/convene/score-attendee.ts
@@ -1,0 +1,191 @@
+/**
+ * scoreAttendee — KAN-207 (Phase 3).
+ *
+ * Ranks a candidate contact for inclusion in a gathering based on:
+ *   tribe fit          — does the contact belong to a tribe whose name matches
+ *                        the gathering's vibe? ("coffee" → "uni friends" boosts;
+ *                        "kids_party" → "school parents" boosts)
+ *   recency            — time since last attended together (sweet spot: 1-6
+ *                        months ago; very recent dampens to avoid over-asking,
+ *                        very old re-engages)
+ *   response history   — accept/attend rate boosts; silent/no-show dampens
+ *   type fit           — has the contact attended this gathering_type before?
+ *   diversity          — don't keep proposing the same person across all
+ *                        gathering types this week
+ *
+ * V1: relationship_signals is the primary signal source. Tribe-fit uses a
+ * simple keyword map (intent → tribe-name keywords). Future iterations can
+ * incorporate profile-level data (dietary, mobility, distance) once invitees
+ * routinely have linked Lyra profiles.
+ *
+ * Weights chosen for clarity, not science. Tune as evidence accumulates.
+ */
+
+import {
+  type AttendeeCandidate,
+  type AttendeeContext,
+  type AttendeeScore,
+  type RelationshipSignals,
+  type GatheringType,
+  clamp01,
+  weightedAverage,
+} from './types';
+
+const WEIGHTS = {
+  tribeFit: 0.30,
+  recency: 0.20,
+  responseHistory: 0.25,
+  typeFit: 0.15,
+  diversity: 0.10,
+};
+
+/**
+ * Map of intent → keywords that match tribe names. Multiple keywords per intent
+ * give a boost if any one matches (case-insensitive substring).
+ */
+const TRIBE_KEYWORDS_BY_INTENT: Record<GatheringType, string[]> = {
+  coffee: ['friends', 'colleagues', 'uni', 'school', 'book', 'mums', 'parents'],
+  lunch: ['friends', 'colleagues', 'team'],
+  dinner: ['friends', 'family', 'date'],
+  drinks: ['friends', 'colleagues', 'uni'],
+  party: ['friends', 'family', 'birthday'],
+  kids_party: ['parents', 'school', 'class', 'mums', 'dads'],
+  meeting: ['colleagues', 'team', 'mentors'],
+  date: ['date'],
+  walk: ['friends', 'family', 'dog'],
+  cinema: ['friends', 'family', 'date'],
+  other: [],
+};
+
+function scoreTribeFit(candidate: AttendeeCandidate, intent: GatheringType): { score: number; reason: string | null } {
+  if (candidate.tribeNames.length === 0) {
+    return { score: 0.3, reason: null }; // neutral — no tribe info
+  }
+  const keywords = TRIBE_KEYWORDS_BY_INTENT[intent];
+  if (keywords.length === 0) {
+    return { score: 0.4, reason: null };
+  }
+  const hitTribes = candidate.tribeNames.filter((t) =>
+    keywords.some((k) => t.toLowerCase().includes(k))
+  );
+  if (hitTribes.length === 0) return { score: 0.25, reason: null };
+  return {
+    score: clamp01(0.6 + 0.2 * Math.min(hitTribes.length, 2)),
+    reason: `In tribe(s) ${hitTribes.join(', ')} — fits the "${intent}" intent`,
+  };
+}
+
+function scoreRecency(
+  signals: RelationshipSignals | undefined,
+  nowMs: number
+): { score: number; reason: string | null } {
+  if (!signals || !signals.lastAttendedAt) {
+    return { score: 0.5, reason: 'Never attended together — neutral baseline' };
+  }
+  const lastMs = new Date(signals.lastAttendedAt).getTime();
+  const daysSince = (nowMs - lastMs) / (1000 * 60 * 60 * 24);
+
+  // Sweet spot: 30-180 days ago = 1.0
+  // Very recent (<14 days) = 0.4 (avoid over-asking)
+  // 180-365 days = 0.8 (re-engagement)
+  // >365 days = 0.6 (long gap — uncertain)
+  if (daysSince < 7) return { score: 0.3, reason: `Seen ${Math.round(daysSince)} days ago — recent, avoid over-asking` };
+  if (daysSince < 14) return { score: 0.5, reason: 'Seen within the last fortnight' };
+  if (daysSince < 30) return { score: 0.85, reason: `Seen ${Math.round(daysSince)} days ago — sweet spot for follow-up` };
+  if (daysSince < 180) return { score: 1.0, reason: `Last gathered ${Math.round(daysSince)} days ago` };
+  if (daysSince < 365) return { score: 0.75, reason: `Haven't gathered in ${Math.round(daysSince)} days — overdue` };
+  return { score: 0.55, reason: `Last gathered >1 year ago — long gap` };
+}
+
+function scoreResponseHistory(signals: RelationshipSignals | undefined): {
+  score: number;
+  reason: string | null;
+} {
+  if (!signals || signals.totalInvites === 0) {
+    return { score: 0.5, reason: null };
+  }
+  const accepts = signals.totalAccepted + signals.totalAttended;
+  const negatives = signals.totalDeclined + signals.totalSilent + signals.totalNoShows;
+  const ratio = accepts / Math.max(1, accepts + negatives);
+  if (signals.totalNoShows > 2) {
+    return { score: 0.2, reason: `${signals.totalNoShows} no-shows — flaky reputation` };
+  }
+  if (ratio > 0.8 && signals.totalInvites >= 3) {
+    return { score: 1.0, reason: `Reliable — accepted ${Math.round(ratio * 100)}% of past invites` };
+  }
+  if (ratio > 0.5) {
+    return { score: 0.7 + (ratio - 0.5) * 0.6, reason: null };
+  }
+  return { score: clamp01(0.3 + ratio * 0.4), reason: `Lower attendance rate (${Math.round(ratio * 100)}%)` };
+}
+
+function scoreTypeFit(signals: RelationshipSignals | undefined, intent: GatheringType): { score: number; reason: string | null } {
+  if (!signals || signals.gatheringTypesSeen.length === 0) {
+    return { score: 0.4, reason: null };
+  }
+  if (signals.gatheringTypesSeen.includes(intent)) {
+    return {
+      score: 0.95,
+      reason: `You've done "${intent}" together before`,
+    };
+  }
+  if (signals.gatheringTypesSeen.length >= 2) {
+    return { score: 0.7, reason: 'Range of past gathering types' };
+  }
+  return { score: 0.5, reason: null };
+}
+
+function scoreDiversity(signals: RelationshipSignals | undefined): { score: number; reason: string | null } {
+  if (!signals || signals.totalInvites === 0) {
+    return { score: 1.0, reason: null }; // new candidates are diverse by definition
+  }
+  if (signals.totalInvites > 5) {
+    // The host already over-relies on this contact. Damp slightly.
+    return { score: 0.55, reason: `Invited ${signals.totalInvites} times before — consider mixing it up` };
+  }
+  return { score: 0.85, reason: null };
+}
+
+export function scoreAttendee(
+  candidate: AttendeeCandidate,
+  context: AttendeeContext,
+  nowMs: number = Date.now()
+): AttendeeScore {
+  // Hard exclusion: already invited to this gathering.
+  if (context.existingInviteeContactIds.includes(candidate.contactId)) {
+    return {
+      contactId: candidate.contactId,
+      score: 0,
+      reasons: ['Already on the invite list'],
+      breakdown: { tribeFit: 0, recency: 0, responseHistory: 0, typeFit: 0, diversity: 0 },
+      excluded: true,
+      excludedReason: 'already_invited',
+    };
+  }
+
+  const tribeFit = scoreTribeFit(candidate, context.intent);
+  const recency = scoreRecency(candidate.signals, nowMs);
+  const responseHistory = scoreResponseHistory(candidate.signals);
+  const typeFit = scoreTypeFit(candidate.signals, context.intent);
+  const diversity = scoreDiversity(candidate.signals);
+
+  const breakdown = {
+    tribeFit: tribeFit.score,
+    recency: recency.score,
+    responseHistory: responseHistory.score,
+    typeFit: typeFit.score,
+    diversity: diversity.score,
+  };
+
+  const reasons = [tribeFit.reason, recency.reason, responseHistory.reason, typeFit.reason, diversity.reason]
+    .filter((r): r is string => Boolean(r));
+
+  return {
+    contactId: candidate.contactId,
+    score: weightedAverage(breakdown, WEIGHTS),
+    reasons,
+    breakdown,
+  };
+}
+
+export const _internal = { WEIGHTS, TRIBE_KEYWORDS_BY_INTENT };

--- a/src/lib/recommend/convene/score-venue.ts
+++ b/src/lib/recommend/convene/score-venue.ts
@@ -1,0 +1,292 @@
+/**
+ * scoreVenue — KAN-207 (Phase 3).
+ *
+ * Ranks a candidate venue for a gathering. Pure function — takes the
+ * candidate + context and returns a 0..1 score with reasons + breakdown.
+ * Candidate sourcing (Google Places, the venues table) is a separate concern
+ * (see venue-candidates.ts in this folder, where the Places adapter lives).
+ *
+ * Hard filters (return hardFilterFailed):
+ *   - capacity:     candidate.capacityEstimate < context.capacityRequired
+ *   - accessibility: candidate doesn't satisfy ALL required accessibility flags
+ *   - dietary:      candidate has zero overlap with required dietary flags
+ *
+ * Soft factors (each scored 0..1, weighted-averaged into final score):
+ *   typeFit, distance, dietaryFit, capacity, openingHours, priceTier,
+ *   accessibility, priorVisits, diversityPenalty, externalRating
+ *
+ * Distance scoring is approximate when only postcodes are available — proper
+ * travel-time ranking arrives in a follow-up using Google Distance Matrix.
+ */
+
+import {
+  type VenueCandidate,
+  type VenueContext,
+  type VenueScore,
+  type GatheringType,
+  clamp01,
+  weightedAverage,
+} from './types';
+
+const WEIGHTS = {
+  typeFit: 0.20,
+  distance: 0.20,
+  dietaryFit: 0.10,
+  capacity: 0.05,
+  openingHours: 0.05,
+  priceTier: 0.05,
+  accessibility: 0.05,
+  priorVisits: 0.10,
+  diversityPenalty: 0.10,
+  externalRating: 0.10,
+};
+
+/** Map of intent → venue_type values that are a natural fit. */
+const TYPE_FIT_BY_INTENT: Record<GatheringType, Set<string>> = {
+  coffee: new Set(['cafe']),
+  lunch: new Set(['cafe', 'restaurant']),
+  dinner: new Set(['restaurant', 'home']),
+  drinks: new Set(['bar', 'pub', 'restaurant']),
+  party: new Set(['event_space', 'bar', 'home', 'restaurant']),
+  kids_party: new Set(['soft_play', 'park', 'event_space', 'home']),
+  meeting: new Set(['cafe', 'office', 'event_space']),
+  date: new Set(['restaurant', 'bar', 'cafe', 'cinema']),
+  walk: new Set(['park']),
+  cinema: new Set(['cinema']),
+  other: new Set([]),
+};
+
+function scoreTypeFit(candidate: VenueCandidate, intent: GatheringType): { score: number; reason: string | null } {
+  const goodTypes = TYPE_FIT_BY_INTENT[intent];
+  if (goodTypes.size === 0) return { score: 0.5, reason: null };
+  if (goodTypes.has(candidate.venueType)) {
+    return { score: 1.0, reason: `${candidate.venueType} suits "${intent}"` };
+  }
+  return { score: 0.25, reason: `${candidate.venueType} is unusual for "${intent}"` };
+}
+
+/**
+ * Approximate distance score. If both candidate and anchor have lat/lng we
+ * use the Haversine; otherwise we fall back to postcode prefix matching
+ * (UK-centric — close enough for v1, replaced by Distance Matrix in v2).
+ */
+function scoreDistance(
+  candidate: VenueCandidate,
+  context: VenueContext
+): { score: number; reason: string | null } {
+  if (!context.anchor) return { score: 0.5, reason: null };
+
+  // Lat/lng anchor support: "51.5074,-0.1278"
+  const latlng = context.anchor.match(/^\s*(-?\d+(?:\.\d+)?)\s*,\s*(-?\d+(?:\.\d+)?)\s*$/);
+  if (latlng && candidate.lat != null && candidate.lng != null) {
+    const aLat = parseFloat(latlng[1]);
+    const aLng = parseFloat(latlng[2]);
+    const km = haversineKm(aLat, aLng, candidate.lat, candidate.lng);
+    if (km < 1) return { score: 1.0, reason: 'Walking distance' };
+    if (km < 3) return { score: 0.9, reason: `${km.toFixed(1)}km from anchor` };
+    if (km < 8) return { score: 0.7, reason: `${km.toFixed(1)}km from anchor` };
+    if (km < 20) return { score: 0.45, reason: `${km.toFixed(0)}km — a journey` };
+    return { score: 0.15, reason: `${km.toFixed(0)}km — quite far` };
+  }
+
+  // Postcode-prefix fallback (UK). Compare outward codes.
+  const candidateOut = (candidate.postcode || '').split(' ')[0]?.toUpperCase() ?? '';
+  const anchorOut = context.anchor.split(' ')[0]?.toUpperCase() ?? '';
+  if (candidateOut && anchorOut) {
+    if (candidateOut === anchorOut) return { score: 0.95, reason: `Same postcode (${candidateOut})` };
+    // Same area prefix (first 2 chars): SW, NW, EC, etc.
+    if (candidateOut.slice(0, 2) === anchorOut.slice(0, 2)) {
+      return { score: 0.65, reason: `Same postcode area (${candidateOut.slice(0, 2)})` };
+    }
+  }
+  return { score: 0.4, reason: null };
+}
+
+function haversineKm(lat1: number, lng1: number, lat2: number, lng2: number): number {
+  const R = 6371;
+  const toRad = (d: number) => (d * Math.PI) / 180;
+  const dLat = toRad(lat2 - lat1);
+  const dLng = toRad(lng2 - lng1);
+  const a =
+    Math.sin(dLat / 2) ** 2 +
+    Math.cos(toRad(lat1)) * Math.cos(toRad(lat2)) * Math.sin(dLng / 2) ** 2;
+  return 2 * R * Math.asin(Math.sqrt(a));
+}
+
+function scoreDietary(candidate: VenueCandidate, context: VenueContext): { score: number; reason: string | null } {
+  const required = context.required.dietary ?? [];
+  if (required.length === 0) return { score: 1.0, reason: null };
+  const matches = required.filter((r) => candidate.dietaryFlags.includes(r));
+  if (matches.length === required.length) {
+    return { score: 1.0, reason: `Caters to ${required.join(' + ')}` };
+  }
+  if (matches.length === 0) {
+    return { score: 0.2, reason: `Doesn't advertise ${required.join(', ')} options` };
+  }
+  return { score: 0.3 + (0.7 * matches.length) / required.length, reason: null };
+}
+
+function scoreCapacity(candidate: VenueCandidate, context: VenueContext): { score: number; reason: string | null } {
+  if (candidate.capacityEstimate == null) return { score: 0.6, reason: null };
+  const slack = candidate.capacityEstimate - context.capacityRequired;
+  if (slack < 0) return { score: 0, reason: 'Too small' };
+  if (slack < 3) return { score: 0.7, reason: 'Just-right size' };
+  if (slack < 20) return { score: 1.0, reason: 'Comfortable size' };
+  return { score: 0.6, reason: 'Might feel empty' };
+}
+
+function scoreOpeningHours(): { score: number; reason: string | null } {
+  // Placeholder: real implementation will consult opening_hours JSON against
+  // the proposed slot. For v1 we treat as neutral.
+  return { score: 0.6, reason: null };
+}
+
+function scorePriceTier(candidate: VenueCandidate, context: VenueContext): { score: number; reason: string | null } {
+  const preferred = context.preferred.priceTier;
+  if (preferred == null || candidate.priceTier == null) {
+    return { score: 0.6, reason: null };
+  }
+  const diff = Math.abs(candidate.priceTier - preferred);
+  if (diff === 0) return { score: 1.0, reason: `Price tier matches (${'£'.repeat(preferred)})` };
+  if (diff === 1) return { score: 0.7, reason: null };
+  return { score: 0.35, reason: 'Off-budget price tier' };
+}
+
+function scoreAccessibilityFit(candidate: VenueCandidate, context: VenueContext): { score: number; reason: string | null } {
+  const required = context.required.accessibility ?? [];
+  if (required.length === 0) return { score: 1.0, reason: null };
+  const missing = required.filter((r) => !candidate.accessibilityFlags.includes(r));
+  if (missing.length === 0) return { score: 1.0, reason: `Accessibility: ${required.join(', ')} ✓` };
+  // Hard filter is handled in scoreVenue; this only fires if caller chose
+  // to keep the candidate anyway.
+  return { score: 0.0, reason: `Missing: ${missing.join(', ')}` };
+}
+
+function scorePriorVisits(candidate: VenueCandidate): { score: number; reason: string | null } {
+  const visits = candidate.priorVisits ?? 0;
+  if (visits === 0) return { score: 0.6, reason: null };
+  if (visits === 1) return { score: 0.85, reason: "You've been here before" };
+  if (visits < 4) return { score: 1.0, reason: `Familiar — ${visits} past visits` };
+  return { score: 0.7, reason: `Frequent (${visits} past visits) — consider somewhere new` };
+}
+
+function scoreDiversityPenalty(candidate: VenueCandidate, nowMs: number): { score: number; reason: string | null } {
+  if (!candidate.lastVisitedAt) return { score: 1.0, reason: null };
+  const daysSince = (nowMs - new Date(candidate.lastVisitedAt).getTime()) / 86400_000;
+  if (daysSince < 7) return { score: 0.3, reason: `Visited ${Math.round(daysSince)} days ago — try somewhere new` };
+  if (daysSince < 21) return { score: 0.6, reason: `Recent (${Math.round(daysSince)} days ago)` };
+  return { score: 1.0, reason: null };
+}
+
+function scoreExternalRating(candidate: VenueCandidate): { score: number; reason: string | null } {
+  if (candidate.hostRating != null) {
+    // Host's own rating dominates if present.
+    return {
+      score: clamp01(candidate.hostRating / 5),
+      reason: candidate.hostRating >= 4 ? `Your rating: ${candidate.hostRating}/5` : null,
+    };
+  }
+  if (candidate.externalRating == null) return { score: 0.55, reason: null };
+  return {
+    score: clamp01(candidate.externalRating / 5),
+    reason: candidate.externalRating >= 4.5 ? `Highly rated (${candidate.externalRating}/5)` : null,
+  };
+}
+
+export function scoreVenue(
+  candidate: VenueCandidate,
+  context: VenueContext,
+  nowMs: number = Date.now()
+): VenueScore {
+  // Hard filters — return early with hardFilterFailed set.
+  if (candidate.capacityEstimate != null && candidate.capacityEstimate < context.capacityRequired) {
+    return {
+      venueId: candidate.venueId,
+      score: 0,
+      reasons: [`Capacity ${candidate.capacityEstimate} < required ${context.capacityRequired}`],
+      breakdown: zeroBreakdown(),
+      hardFilterFailed: 'capacity',
+    };
+  }
+
+  const requiredAccessibility = context.required.accessibility ?? [];
+  const missingAcc = requiredAccessibility.filter((r) => !candidate.accessibilityFlags.includes(r));
+  if (missingAcc.length > 0) {
+    return {
+      venueId: candidate.venueId,
+      score: 0,
+      reasons: [`Missing accessibility: ${missingAcc.join(', ')}`],
+      breakdown: zeroBreakdown(),
+      hardFilterFailed: 'accessibility',
+    };
+  }
+
+  // Dietary hard-filter: zero overlap with required = hard fail.
+  const requiredDietary = context.required.dietary ?? [];
+  if (requiredDietary.length > 0) {
+    const overlap = requiredDietary.filter((r) => candidate.dietaryFlags.includes(r));
+    if (overlap.length === 0) {
+      return {
+        venueId: candidate.venueId,
+        score: 0,
+        reasons: [`No dietary match for ${requiredDietary.join(', ')}`],
+        breakdown: zeroBreakdown(),
+        hardFilterFailed: 'dietary',
+      };
+    }
+  }
+
+  const factors = {
+    typeFit: scoreTypeFit(candidate, context.intent),
+    distance: scoreDistance(candidate, context),
+    dietaryFit: scoreDietary(candidate, context),
+    capacity: scoreCapacity(candidate, context),
+    openingHours: scoreOpeningHours(),
+    priceTier: scorePriceTier(candidate, context),
+    accessibility: scoreAccessibilityFit(candidate, context),
+    priorVisits: scorePriorVisits(candidate),
+    diversityPenalty: scoreDiversityPenalty(candidate, nowMs),
+    externalRating: scoreExternalRating(candidate),
+  };
+
+  const breakdown = {
+    typeFit: factors.typeFit.score,
+    distance: factors.distance.score,
+    dietaryFit: factors.dietaryFit.score,
+    capacity: factors.capacity.score,
+    openingHours: factors.openingHours.score,
+    priceTier: factors.priceTier.score,
+    accessibility: factors.accessibility.score,
+    priorVisits: factors.priorVisits.score,
+    diversityPenalty: factors.diversityPenalty.score,
+    externalRating: factors.externalRating.score,
+  };
+
+  const reasons = Object.values(factors)
+    .map((f) => f.reason)
+    .filter((r): r is string => Boolean(r));
+
+  return {
+    venueId: candidate.venueId,
+    score: weightedAverage(breakdown, WEIGHTS),
+    reasons,
+    breakdown,
+  };
+}
+
+function zeroBreakdown() {
+  return {
+    typeFit: 0,
+    distance: 0,
+    dietaryFit: 0,
+    capacity: 0,
+    openingHours: 0,
+    priceTier: 0,
+    accessibility: 0,
+    priorVisits: 0,
+    diversityPenalty: 0,
+    externalRating: 0,
+  };
+}
+
+export const _internal = { WEIGHTS, TYPE_FIT_BY_INTENT, haversineKm };

--- a/src/lib/recommend/convene/types.ts
+++ b/src/lib/recommend/convene/types.ts
@@ -1,0 +1,169 @@
+/**
+ * Convene recommendation types — KAN-207 (Phase 3).
+ *
+ * Two recommenders:
+ *   scoreAttendee(candidate, intent, host, existingInvitees)
+ *   scoreVenue(candidate, intent, attendees, anchor, constraints)
+ *
+ * Both return a normalised score in [0, 1] plus a `reasons[]` array surfaced
+ * to the agent ("why this person", "why this venue") and a `breakdown` map
+ * keyed by factor name for debugging + admin UI.
+ *
+ * Alignment with KAN-199 (v2 gift recommender): same structural pattern —
+ * score + breakdown + reasons — but a different domain (people/places vs.
+ * products). When the holistic ranker design from KAN-199 lands, this module
+ * will adopt its weights/normalisation helpers.
+ */
+
+export type GatheringType =
+  | 'coffee'
+  | 'lunch'
+  | 'dinner'
+  | 'drinks'
+  | 'party'
+  | 'kids_party'
+  | 'meeting'
+  | 'date'
+  | 'walk'
+  | 'cinema'
+  | 'other';
+
+// ─── Attendee scoring ────────────────────────────────────────────────────
+
+export interface AttendeeContext {
+  intent: GatheringType;
+  /** ISO timestamp of the start of the proposed gathering window. */
+  gatheringStartISO?: string;
+  /** Other contacts already on the invite list (so we don't re-suggest them). */
+  existingInviteeContactIds: string[];
+}
+
+export interface AttendeeCandidate {
+  contactId: string;
+  displayName: string;
+  city: string | null;
+  /** Whether this contact has a linked Lyra profile (signals MCP-reachability). */
+  hasLinkedProfile: boolean;
+  /** Tribes the host has assigned this contact to. */
+  tribeNames: string[];
+  /** Signals from public.relationship_signals (per (host, contact)). */
+  signals?: RelationshipSignals;
+}
+
+export interface RelationshipSignals {
+  totalInvites: number;
+  totalAccepted: number;
+  totalAttended: number;
+  totalDeclined: number;
+  totalSilent: number;
+  totalNoShows: number;
+  lastAttendedAt: string | null;
+  lastInvitedAt: string | null;
+  gatheringTypeDiversity: number;
+  gatheringTypesSeen: string[];
+}
+
+export interface AttendeeScore {
+  contactId: string;
+  score: number;
+  reasons: string[];
+  breakdown: {
+    tribeFit: number;
+    recency: number;
+    responseHistory: number;
+    typeFit: number;
+    diversity: number;
+  };
+  /** When true, candidate is hard-excluded (already on invite list, etc.). */
+  excluded?: boolean;
+  excludedReason?: string;
+}
+
+// ─── Venue scoring ───────────────────────────────────────────────────────
+
+export interface VenueContext {
+  intent: GatheringType;
+  /** Postcode or "lat,lng" string anchoring the search. */
+  anchor: string | null;
+  /** Max travel time minutes (host-level pref; default 30 if unset). */
+  maxTravelMinutes?: number;
+  /** Required headcount (min). */
+  capacityRequired: number;
+  /** Hard requirements that filter out non-matching venues. */
+  required: {
+    accessibility?: string[];
+    dietary?: string[];
+  };
+  /** Soft preferences (boost only). */
+  preferred: {
+    priceTier?: 1 | 2 | 3 | 4;
+    cuisine?: string;
+  };
+}
+
+export interface VenueCandidate {
+  venueId: string;
+  name: string;
+  venueType: string;
+  city: string | null;
+  postcode: string | null;
+  lat: number | null;
+  lng: number | null;
+  priceTier: number | null;
+  capacityEstimate: number | null;
+  accessibilityFlags: string[];
+  dietaryFlags: string[];
+  externalRating: number | null;
+  /** Whether the host has visited this venue for a similar gathering before. */
+  priorVisits?: number;
+  /** Most recent visit timestamp — used for diversity damping. */
+  lastVisitedAt?: string | null;
+  /** Host's own rating, if any. */
+  hostRating?: number | null;
+}
+
+export interface VenueScore {
+  venueId: string;
+  score: number;
+  reasons: string[];
+  breakdown: {
+    typeFit: number;
+    distance: number;
+    dietaryFit: number;
+    capacity: number;
+    openingHours: number;
+    priceTier: number;
+    accessibility: number;
+    priorVisits: number;
+    diversityPenalty: number;
+    externalRating: number;
+  };
+  /** When set, candidate is hard-filtered out (caller should skip it). */
+  hardFilterFailed?: 'accessibility' | 'capacity' | 'dietary';
+}
+
+// ─── Shared utilities ────────────────────────────────────────────────────
+
+/** Clamp a number to [0, 1]. */
+export function clamp01(n: number): number {
+  if (Number.isNaN(n)) return 0;
+  if (n < 0) return 0;
+  if (n > 1) return 1;
+  return n;
+}
+
+/** Weighted-average a breakdown into a single 0..1 score. */
+export function weightedAverage(
+  breakdown: Record<string, number>,
+  weights: Record<string, number>
+): number {
+  let totalWeight = 0;
+  let totalScore = 0;
+  for (const key of Object.keys(breakdown)) {
+    const w = weights[key] ?? 0;
+    totalWeight += w;
+    totalScore += clamp01(breakdown[key]) * w;
+  }
+  return totalWeight > 0 ? clamp01(totalScore / totalWeight) : 0;
+}
+

--- a/tests/unit/convene/score-attendee.test.ts
+++ b/tests/unit/convene/score-attendee.test.ts
@@ -1,0 +1,229 @@
+/**
+ * KAN-207 — scoreAttendee tests.
+ *
+ * Table-driven: each test sets up a candidate + context, asserts the score
+ * range OR the dominant reason fragment. The exact weights are not asserted
+ * (they'll evolve); we test the BEHAVIOUR — does a recent no-show drop
+ * below 0.3? Does a sweet-spot recency push above 0.7? Etc.
+ */
+
+import { scoreAttendee, _internal } from '@/lib/recommend/convene/score-attendee';
+import type {
+  AttendeeCandidate,
+  AttendeeContext,
+  RelationshipSignals,
+} from '@/lib/recommend/convene/types';
+
+const NOW = new Date('2026-06-01T12:00:00Z').getTime();
+
+function daysAgo(d: number): string {
+  return new Date(NOW - d * 86400_000).toISOString();
+}
+
+function baseCandidate(overrides: Partial<AttendeeCandidate> = {}): AttendeeCandidate {
+  return {
+    contactId: 'c1',
+    displayName: 'Alice',
+    city: 'London',
+    hasLinkedProfile: false,
+    tribeNames: [],
+    ...overrides,
+  };
+}
+
+function baseContext(overrides: Partial<AttendeeContext> = {}): AttendeeContext {
+  return {
+    intent: 'coffee',
+    existingInviteeContactIds: [],
+    ...overrides,
+  };
+}
+
+function baseSignals(overrides: Partial<RelationshipSignals> = {}): RelationshipSignals {
+  return {
+    totalInvites: 0,
+    totalAccepted: 0,
+    totalAttended: 0,
+    totalDeclined: 0,
+    totalSilent: 0,
+    totalNoShows: 0,
+    lastAttendedAt: null,
+    lastInvitedAt: null,
+    gatheringTypeDiversity: 0,
+    gatheringTypesSeen: [],
+    ...overrides,
+  };
+}
+
+describe('scoreAttendee — KAN-207', () => {
+  describe('exclusion', () => {
+    test('already on invite list → score 0 + excluded=true', () => {
+      const ctx = baseContext({ existingInviteeContactIds: ['c1'] });
+      const out = scoreAttendee(baseCandidate(), ctx, NOW);
+      expect(out.score).toBe(0);
+      expect(out.excluded).toBe(true);
+      expect(out.excludedReason).toBe('already_invited');
+    });
+  });
+
+  describe('tribe fit', () => {
+    test('tribe name matches intent keyword → boost', () => {
+      const c = baseCandidate({ tribeNames: ['uni friends'] });
+      const out = scoreAttendee(c, baseContext({ intent: 'coffee' }), NOW);
+      expect(out.breakdown.tribeFit).toBeGreaterThan(0.5);
+      expect(out.reasons.some((r) => r.includes('uni friends'))).toBe(true);
+    });
+
+    test('kids_party + "school parents" tribe → strong boost', () => {
+      const c = baseCandidate({ tribeNames: ['school parents'] });
+      const out = scoreAttendee(c, baseContext({ intent: 'kids_party' }), NOW);
+      expect(out.breakdown.tribeFit).toBeGreaterThanOrEqual(0.6);
+    });
+
+    test('no relevant tribe → mid-low tribeFit', () => {
+      const c = baseCandidate({ tribeNames: ['neighbours'] });
+      const out = scoreAttendee(c, baseContext({ intent: 'coffee' }), NOW);
+      expect(out.breakdown.tribeFit).toBeLessThan(0.5);
+    });
+  });
+
+  describe('recency', () => {
+    test('recent (5 days) → dampens to avoid over-asking', () => {
+      const c = baseCandidate({
+        signals: baseSignals({ lastAttendedAt: daysAgo(5), totalAttended: 1, totalInvites: 1, totalAccepted: 1 }),
+      });
+      const out = scoreAttendee(c, baseContext(), NOW);
+      expect(out.breakdown.recency).toBeLessThan(0.5);
+      expect(out.reasons.some((r) => /recent/i.test(r))).toBe(true);
+    });
+
+    test('sweet spot (60 days) → strong recency score', () => {
+      const c = baseCandidate({
+        signals: baseSignals({ lastAttendedAt: daysAgo(60), totalAttended: 1, totalInvites: 1, totalAccepted: 1 }),
+      });
+      const out = scoreAttendee(c, baseContext(), NOW);
+      expect(out.breakdown.recency).toBeGreaterThan(0.9);
+    });
+
+    test('overdue (220 days) → re-engagement boost', () => {
+      const c = baseCandidate({
+        signals: baseSignals({ lastAttendedAt: daysAgo(220), totalAttended: 1, totalInvites: 1, totalAccepted: 1 }),
+      });
+      const out = scoreAttendee(c, baseContext(), NOW);
+      expect(out.breakdown.recency).toBeGreaterThan(0.6);
+      expect(out.reasons.some((r) => /overdue/i.test(r))).toBe(true);
+    });
+
+    test('never gathered → neutral baseline', () => {
+      const c = baseCandidate({ signals: baseSignals({ lastAttendedAt: null }) });
+      const out = scoreAttendee(c, baseContext(), NOW);
+      expect(out.breakdown.recency).toBeCloseTo(0.5, 1);
+    });
+  });
+
+  describe('response history', () => {
+    test('high acceptance ratio + ≥3 invites → boosts to 1.0', () => {
+      const c = baseCandidate({
+        signals: baseSignals({
+          totalInvites: 5,
+          totalAccepted: 5,
+          totalAttended: 5,
+          gatheringTypesSeen: ['coffee'],
+        }),
+      });
+      const out = scoreAttendee(c, baseContext(), NOW);
+      expect(out.breakdown.responseHistory).toBeGreaterThanOrEqual(0.9);
+    });
+
+    test('multiple no-shows → dampens hard', () => {
+      const c = baseCandidate({
+        signals: baseSignals({ totalInvites: 5, totalAccepted: 5, totalAttended: 2, totalNoShows: 3 }),
+      });
+      const out = scoreAttendee(c, baseContext(), NOW);
+      expect(out.breakdown.responseHistory).toBeLessThanOrEqual(0.3);
+      expect(out.reasons.some((r) => /flaky/i.test(r))).toBe(true);
+    });
+  });
+
+  describe('type fit', () => {
+    test('has done this type before → strong fit', () => {
+      const c = baseCandidate({
+        signals: baseSignals({ totalInvites: 1, totalAttended: 1, gatheringTypesSeen: ['coffee'] }),
+      });
+      const out = scoreAttendee(c, baseContext({ intent: 'coffee' }), NOW);
+      expect(out.breakdown.typeFit).toBeGreaterThanOrEqual(0.9);
+    });
+
+    test('has done other types but not this one → moderate', () => {
+      const c = baseCandidate({
+        signals: baseSignals({ totalInvites: 2, totalAttended: 2, gatheringTypesSeen: ['dinner', 'lunch'] }),
+      });
+      const out = scoreAttendee(c, baseContext({ intent: 'coffee' }), NOW);
+      expect(out.breakdown.typeFit).toBeGreaterThan(0.5);
+      expect(out.breakdown.typeFit).toBeLessThan(0.9);
+    });
+  });
+
+  describe('diversity', () => {
+    test('invited many times → diversity dampens', () => {
+      const c = baseCandidate({
+        signals: baseSignals({ totalInvites: 10, totalAccepted: 8, totalAttended: 8, lastAttendedAt: daysAgo(60) }),
+      });
+      const out = scoreAttendee(c, baseContext(), NOW);
+      expect(out.breakdown.diversity).toBeLessThanOrEqual(0.6);
+      expect(out.reasons.some((r) => /mixing it up/i.test(r))).toBe(true);
+    });
+
+    test('new candidate → max diversity', () => {
+      const c = baseCandidate({ signals: baseSignals() });
+      const out = scoreAttendee(c, baseContext(), NOW);
+      expect(out.breakdown.diversity).toBe(1.0);
+    });
+  });
+
+  describe('overall composite', () => {
+    test('ideal candidate (tribe + recency sweet spot + reliable + same type before) → top of range', () => {
+      const c = baseCandidate({
+        tribeNames: ['uni friends'],
+        signals: baseSignals({
+          totalInvites: 4,
+          totalAccepted: 4,
+          totalAttended: 4,
+          gatheringTypesSeen: ['coffee'],
+          lastAttendedAt: daysAgo(60),
+        }),
+      });
+      const out = scoreAttendee(c, baseContext({ intent: 'coffee' }), NOW);
+      expect(out.score).toBeGreaterThan(0.8);
+      expect(out.reasons.length).toBeGreaterThan(2);
+    });
+
+    test('weak candidate (no tribe + no history + new) → mid-range', () => {
+      const c = baseCandidate({ tribeNames: [], signals: undefined });
+      const out = scoreAttendee(c, baseContext({ intent: 'other' }), NOW);
+      expect(out.score).toBeGreaterThan(0.2);
+      expect(out.score).toBeLessThan(0.7);
+    });
+
+    test('flaky candidate (no-shows + over-invited) → low score', () => {
+      const c = baseCandidate({
+        signals: baseSignals({
+          totalInvites: 8,
+          totalAccepted: 5,
+          totalAttended: 2,
+          totalNoShows: 3,
+          lastAttendedAt: daysAgo(300),
+        }),
+      });
+      const out = scoreAttendee(c, baseContext({ intent: 'coffee' }), NOW);
+      expect(out.score).toBeLessThan(0.5);
+    });
+  });
+
+  describe('weights sum sanity', () => {
+    test('weights add up to 1.0', () => {
+      const sum = Object.values(_internal.WEIGHTS).reduce((a, b) => a + b, 0);
+      expect(sum).toBeCloseTo(1.0, 2);
+    });
+  });
+});

--- a/tests/unit/convene/score-venue.test.ts
+++ b/tests/unit/convene/score-venue.test.ts
@@ -1,0 +1,241 @@
+/**
+ * KAN-207 — scoreVenue tests.
+ *
+ * Covers: type fit per intent, hard filters (capacity, accessibility,
+ * dietary), distance scoring with both lat/lng and postcode fallbacks,
+ * price tier match, prior-visits boost, diversity penalty on recent visits,
+ * host rating overriding external rating.
+ */
+
+import { scoreVenue, _internal } from '@/lib/recommend/convene/score-venue';
+import type { VenueCandidate, VenueContext } from '@/lib/recommend/convene/types';
+
+const NOW = new Date('2026-06-01T12:00:00Z').getTime();
+const DAY = 86400_000;
+
+function baseCandidate(o: Partial<VenueCandidate> = {}): VenueCandidate {
+  return {
+    venueId: 'v1',
+    name: 'Test Cafe',
+    venueType: 'cafe',
+    city: 'London',
+    postcode: 'SW1A 1AA',
+    lat: 51.5014,
+    lng: -0.1419,
+    priceTier: 2,
+    capacityEstimate: 30,
+    accessibilityFlags: [],
+    dietaryFlags: [],
+    externalRating: 4.0,
+    ...o,
+  };
+}
+
+function baseContext(o: Partial<VenueContext> = {}): VenueContext {
+  return {
+    intent: 'coffee',
+    anchor: 'SW1A 1AA',
+    capacityRequired: 4,
+    required: {},
+    preferred: {},
+    ...o,
+  };
+}
+
+describe('scoreVenue — hard filters (KAN-207)', () => {
+  test('capacity too small → hardFilterFailed=capacity, score=0', () => {
+    const c = baseCandidate({ capacityEstimate: 2 });
+    const out = scoreVenue(c, baseContext({ capacityRequired: 6 }));
+    expect(out.hardFilterFailed).toBe('capacity');
+    expect(out.score).toBe(0);
+  });
+
+  test('missing required accessibility → hardFilterFailed=accessibility', () => {
+    const c = baseCandidate({ accessibilityFlags: [] });
+    const out = scoreVenue(
+      c,
+      baseContext({ required: { accessibility: ['step_free'] } })
+    );
+    expect(out.hardFilterFailed).toBe('accessibility');
+    expect(out.reasons[0]).toContain('step_free');
+  });
+
+  test('no dietary overlap → hardFilterFailed=dietary', () => {
+    const c = baseCandidate({ dietaryFlags: ['halal'] });
+    const out = scoreVenue(c, baseContext({ required: { dietary: ['vegan', 'kosher'] } }));
+    expect(out.hardFilterFailed).toBe('dietary');
+  });
+
+  test('partial dietary overlap → passes hard filter, lower dietaryFit', () => {
+    const c = baseCandidate({ dietaryFlags: ['vegan'] });
+    const out = scoreVenue(c, baseContext({ required: { dietary: ['vegan', 'gluten_free'] } }));
+    expect(out.hardFilterFailed).toBeUndefined();
+    expect(out.breakdown.dietaryFit).toBeLessThan(1);
+    expect(out.breakdown.dietaryFit).toBeGreaterThan(0.3);
+  });
+});
+
+describe('scoreVenue — type fit', () => {
+  test('cafe + coffee → typeFit 1.0', () => {
+    const c = baseCandidate({ venueType: 'cafe' });
+    const out = scoreVenue(c, baseContext({ intent: 'coffee' }));
+    expect(out.breakdown.typeFit).toBe(1.0);
+  });
+
+  test('pub + kids_party → typeFit low', () => {
+    const c = baseCandidate({ venueType: 'pub' });
+    const out = scoreVenue(c, baseContext({ intent: 'kids_party' }));
+    expect(out.breakdown.typeFit).toBeLessThan(0.5);
+  });
+
+  test('soft_play + kids_party → typeFit 1.0', () => {
+    const c = baseCandidate({ venueType: 'soft_play' });
+    const out = scoreVenue(c, baseContext({ intent: 'kids_party' }));
+    expect(out.breakdown.typeFit).toBe(1.0);
+  });
+});
+
+describe('scoreVenue — distance', () => {
+  test('lat/lng anchor — walking distance → distance 1.0', () => {
+    const c = baseCandidate({ lat: 51.5014, lng: -0.1419 });
+    const out = scoreVenue(c, baseContext({ anchor: '51.5014,-0.1419' }));
+    expect(out.breakdown.distance).toBe(1.0);
+  });
+
+  test('lat/lng anchor — 30km away → distance very low', () => {
+    const c = baseCandidate({ lat: 51.5014, lng: -0.1419 });
+    const out = scoreVenue(c, baseContext({ anchor: '51.75,-0.15' })); // ~28km north
+    expect(out.breakdown.distance).toBeLessThanOrEqual(0.2);
+  });
+
+  test('postcode fallback — same outward code → high distance', () => {
+    const c = baseCandidate({ postcode: 'SW1A 2BB', lat: null, lng: null });
+    const out = scoreVenue(c, baseContext({ anchor: 'SW1A 1AA' }));
+    expect(out.breakdown.distance).toBeGreaterThanOrEqual(0.9);
+  });
+
+  test('postcode fallback — same area prefix (SW vs SW) → moderate', () => {
+    const c = baseCandidate({ postcode: 'SW7 2BB', lat: null, lng: null });
+    const out = scoreVenue(c, baseContext({ anchor: 'SW1A 1AA' }));
+    expect(out.breakdown.distance).toBeGreaterThan(0.5);
+    expect(out.breakdown.distance).toBeLessThan(0.8);
+  });
+
+  test('no anchor → neutral distance score', () => {
+    const c = baseCandidate();
+    const out = scoreVenue(c, baseContext({ anchor: null }));
+    expect(out.breakdown.distance).toBeCloseTo(0.5, 1);
+  });
+});
+
+describe('scoreVenue — price tier preference', () => {
+  test('exact match → 1.0', () => {
+    const c = baseCandidate({ priceTier: 2 });
+    const out = scoreVenue(c, baseContext({ preferred: { priceTier: 2 } }));
+    expect(out.breakdown.priceTier).toBe(1.0);
+  });
+
+  test('one tier off → 0.7', () => {
+    const c = baseCandidate({ priceTier: 3 });
+    const out = scoreVenue(c, baseContext({ preferred: { priceTier: 2 } }));
+    expect(out.breakdown.priceTier).toBe(0.7);
+  });
+
+  test('two+ tiers off → low', () => {
+    const c = baseCandidate({ priceTier: 4 });
+    const out = scoreVenue(c, baseContext({ preferred: { priceTier: 1 } }));
+    expect(out.breakdown.priceTier).toBeLessThan(0.5);
+  });
+});
+
+describe('scoreVenue — prior visits + diversity', () => {
+  test('1 prior visit → familiar boost', () => {
+    const c = baseCandidate({ priorVisits: 1 });
+    const out = scoreVenue(c, baseContext());
+    expect(out.breakdown.priorVisits).toBeGreaterThan(0.7);
+    expect(out.reasons.some((r) => /been here before/i.test(r))).toBe(true);
+  });
+
+  test('many prior visits → diversity damping', () => {
+    const c = baseCandidate({ priorVisits: 6 });
+    const out = scoreVenue(c, baseContext());
+    expect(out.breakdown.priorVisits).toBeLessThan(0.8);
+    expect(out.reasons.some((r) => /consider somewhere new/i.test(r))).toBe(true);
+  });
+
+  test('visited 3 days ago → diversityPenalty drops', () => {
+    const c = baseCandidate({ lastVisitedAt: new Date(NOW - 3 * DAY).toISOString() });
+    const out = scoreVenue(c, baseContext(), NOW);
+    expect(out.breakdown.diversityPenalty).toBeLessThan(0.5);
+  });
+
+  test('not visited recently → diversityPenalty 1.0', () => {
+    const c = baseCandidate({ lastVisitedAt: null });
+    const out = scoreVenue(c, baseContext(), NOW);
+    expect(out.breakdown.diversityPenalty).toBe(1.0);
+  });
+});
+
+describe('scoreVenue — ratings', () => {
+  test('host rating overrides external rating', () => {
+    const c = baseCandidate({ externalRating: 2.0, hostRating: 5 });
+    const out = scoreVenue(c, baseContext());
+    expect(out.breakdown.externalRating).toBe(1.0);
+    expect(out.reasons.some((r) => /Your rating/i.test(r))).toBe(true);
+  });
+
+  test('high external rating + no host rating → high score', () => {
+    const c = baseCandidate({ externalRating: 4.7, hostRating: null });
+    const out = scoreVenue(c, baseContext());
+    expect(out.breakdown.externalRating).toBeGreaterThan(0.9);
+  });
+});
+
+describe('scoreVenue — weights sanity', () => {
+  test('weights sum to 1.0', () => {
+    const sum = Object.values(_internal.WEIGHTS).reduce((a, b) => a + b, 0);
+    expect(sum).toBeCloseTo(1.0, 2);
+  });
+});
+
+describe('haversineKm internal', () => {
+  test('London to Paris ≈ 343 km', () => {
+    const km = _internal.haversineKm(51.5074, -0.1278, 48.8566, 2.3522);
+    expect(km).toBeGreaterThan(340);
+    expect(km).toBeLessThan(346);
+  });
+  test('Identical points → 0', () => {
+    expect(_internal.haversineKm(51.5, -0.1, 51.5, -0.1)).toBe(0);
+  });
+});
+
+describe('scoreVenue — overall composite', () => {
+  test('ideal venue — cafe in same postcode, comfortable size, no constraints → top score', () => {
+    const c = baseCandidate({
+      venueType: 'cafe',
+      postcode: 'SW1A 1AA',
+      capacityEstimate: 25,
+      priceTier: 2,
+      externalRating: 4.6,
+    });
+    const out = scoreVenue(
+      c,
+      baseContext({ anchor: 'SW1A 1AA', preferred: { priceTier: 2 }, capacityRequired: 4 })
+    );
+    expect(out.score).toBeGreaterThan(0.8);
+  });
+
+  test('wrong venue type far away → mediocre score', () => {
+    const c = baseCandidate({
+      venueType: 'pub',
+      postcode: 'EH1 1AA',
+      lat: 55.953,
+      lng: -3.188,
+      externalRating: 3.0,
+    });
+    const out = scoreVenue(c, baseContext({ anchor: '51.5014,-0.1419', intent: 'coffee' }));
+    // Wrong type + far away should land in mediocre territory (< 0.6); we tune
+    // for behaviour, not pinpoint thresholds.
+    expect(out.score).toBeLessThan(0.6);
+  });
+});


### PR DESCRIPTION
## Summary

Two pure scoring functions — the foundation of Convene's recommendation engine. No external API dependencies. Candidate sourcing (Google Places, venues table) ships separately once GCP billing + Places API key are in place.

## scoreAttendee

5 factors, weighted average:

| Factor | Weight | What it does |
|---|---|---|
| `tribeFit` | 30% | Intent → tribe-name keyword map (coffee → uni/friends; kids_party → parents/school) |
| `recency` | 20% | Sweet spot at 30-180 days; very recent dampens, overdue boosts |
| `responseHistory` | 25% | Accept/attend ratio from `relationship_signals`; ≥3 no-shows damps hard |
| `typeFit` | 15% | Has the contact attended this `gathering_type` before? |
| `diversity` | 10% | Don't keep proposing the same person |

Hard exclusion if contact already invited (returns score=0 + `excluded=true`).

## scoreVenue

10 factors + 3 hard filters:

**Hard filters** (return `hardFilterFailed` → caller skips):
- `capacity`: `capacityEstimate < capacityRequired`
- `accessibility`: missing any required flag
- `dietary`: zero overlap with required dietary flags

**Soft factors:** typeFit, distance (Haversine for lat/lng, postcode-prefix fallback), dietaryFit, capacity slack, openingHours (placeholder), priceTier, accessibility match, priorVisits familiarity, diversityPenalty (recent visits damp), externalRating (host rating overrides).

## Tests

44 new tests, behaviour-driven (asserts score ranges + dominant reasons rather than pinpoint weights).

- 18 for scoreAttendee covering each factor + hard exclusion + composite ideal/weak/flaky candidates
- 26 for scoreVenue covering hard filters, type-fit per intent, Haversine + postcode distance, price tier, prior visits, host vs external rating, weights sanity

Full Convene suite this branch: **108 passing**.

## What this PR doesn't include

- MCP tools (`lyra_propose_attendees`, `lyra_suggest_venues`) — paired PR once Places API key is wired.
- Google Places candidate-sourcing adapter — blocked on Luisa's GCP billing setup.
- Distance Matrix travel-time-weighted ranking — currently Haversine fallback.
- KAN-199 holistic-ranker conformance — their architecture is still in progress; will align in a follow-up.

## MCP coverage (KAN-222)

Not applicable for this PR — pure library, no agent-facing surface. Paired MCP-tools PR will carry the coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)