### PR TITLE
feat(recommender): evergreen always-show fallback when buyer concepts produce nothing

### DIFF
--- a/src/app/[slug]/page.tsx
+++ b/src/app/[slug]/page.tsx
@@ -341,7 +341,7 @@ export default async function PublicProfilePage({ params }: Props) {
     tags: r.tags,
   }));
 
-  const v2Recommendations = await buildV2Recommendations({
+  const v2Result = await buildV2Recommendations({
     concepts: v2Concepts,
     buyerCountry,
     recipientCountry,
@@ -357,6 +357,8 @@ export default async function PublicProfilePage({ params }: Props) {
     recommendationId: `web-${typedProfile.id}`,
     limit: 5,
   });
+  const v2Recommendations = v2Result.recommendations;
+  const v2FellBackToEvergreen = v2Result.fellBackToEvergreen;
 
   const categoryLabels: Record<string, string> = {
     likes: 'Likes',
@@ -793,6 +795,7 @@ export default async function PublicProfilePage({ params }: Props) {
           <V2RecommendationsSection
             displayName={typedProfile.display_name}
             recommendations={v2Recommendations}
+            fellBackToEvergreen={v2FellBackToEvergreen}
           />
         ) : (
           <RecommendationsSection

--- a/src/app/[slug]/v2-recommendations-section.tsx
+++ b/src/app/[slug]/v2-recommendations-section.tsx
@@ -27,15 +27,29 @@ interface V2RecommendationsSectionProps {
   displayName: string;
   /** Output of the V2 pipeline. */
   recommendations: V2Recommendation[];
+  /**
+   * True when the pipeline used evergreen safe-default concepts because
+   * the profile was too sparse / no Tier-1 catalogue matches. Softens
+   * the section heading + copy so viewers know these aren't tailored.
+   */
+  fellBackToEvergreen?: boolean;
 }
 
 export default function V2RecommendationsSection({
   displayName,
   recommendations,
+  fellBackToEvergreen = false,
 }: V2RecommendationsSectionProps) {
   if (recommendations.length === 0) return null;
 
   const first = displayName.split(/\s+/)[0] ?? displayName;
+
+  const heading = fellBackToEvergreen
+    ? 'A few thoughtful defaults'
+    : `Gift ideas for ${first}`;
+  const subhead = fellBackToEvergreen
+    ? `${first}'s profile is light on detail, so these are safe defaults rather than tailored picks. Lyra may earn a commission on some links — `
+    : `Selected based on ${first}’s profile. Lyra may earn a commission on some links — `;
 
   return (
     <section
@@ -47,11 +61,10 @@ export default function V2RecommendationsSection({
           id="v2-recommendations-heading"
           className="text-2xl font-medium text-[var(--color-ink)] font-[family-name:var(--font-serif)]"
         >
-          Gift ideas for {first}
+          {heading}
         </h2>
         <p className="text-sm text-[var(--color-muted)] mt-2">
-          Selected based on {first}&rsquo;s profile. Lyra may earn a commission on
-          some links &mdash;{' '}
+          {subhead}
           <Link href="/partners" className="text-[var(--color-lyra-sage,#5a7a5e)] hover:underline">
             see how this works
           </Link>

--- a/src/app/api/recommendations/v2/[slug]/route.ts
+++ b/src/app/api/recommendations/v2/[slug]/route.ts
@@ -142,7 +142,7 @@ export async function GET(
   const budgetMaxMinor = parseIntegerParam(url.searchParams.get('budget_max'));
 
   // 4. Build V2 recommendations.
-  const recommendations = await buildV2Recommendations({
+  const result = await buildV2Recommendations({
     concepts,
     buyerCountry,
     recipientCountry,
@@ -163,13 +163,15 @@ export async function GET(
       version: 'v2',
       buyerCountry,
       recipientCountry,
-      recommendations,
-      // The recommender will surface fewer than `limit` items if the curated
-      // catalogue + Sovrn (when live) can't satisfy more concepts. That's
-      // intentional — better to be sparse-but-accurate than padded.
+      recommendations: result.recommendations,
+      // The recommender's evergreen fallback (KAN-recommender) substitutes
+      // safe-default concepts when the buyer's own concepts produce zero
+      // candidates. Surfaced here so clients (web cards, MCP) can soften
+      // the heading or label the cards appropriately.
       meta: {
         conceptsConsidered: concepts.length,
         sovrnLive: !!process.env.SOVRN_API_KEY,
+        fellBackToEvergreen: result.fellBackToEvergreen,
       },
     },
     {

--- a/src/lib/recommender/v2/evergreen.ts
+++ b/src/lib/recommender/v2/evergreen.ts
@@ -1,0 +1,92 @@
+/**
+ * Evergreen "always-show" fallback concepts for the V2 recommender.
+ *
+ * Use case: a profile is too sparse for V1 to produce any concepts (e.g.
+ * brand-new profile with no items yet), OR V1 produced concepts but
+ * candidate-sourcing found no catalogue / Sovrn matches in the buyer's
+ * country. Rather than returning an empty list — which means the recipient's
+ * profile-viewer sees nothing useful — we substitute this small set of
+ * generic "thoughtful default" concepts.
+ *
+ * These concepts map cleanly onto the seeded `recommender_catalogue`
+ * categories (KAN-200) so they always find Tier-1 matches:
+ *
+ *   books_reading → Bookshop.org / Amazon Kindle gift cards
+ *   experiences   → John Lewis experience-day voucher
+ *   food_drink    → Selfridges Food Hall gift card
+ *   home_garden   → Notonthehighstreet home gift card
+ *   arts_crafts   → Etsy gift card
+ *
+ * Scores are deliberately low (5) so when the recommender is invoked with
+ * a profile that DID produce real concepts (typical scores 8–20), the real
+ * concepts always rank above the evergreen ones. Evergreen entries only
+ * fill the result list when there's nothing better to surface.
+ *
+ * The concepts are still un-monetised when Sovrn isn't live — they just
+ * go through the same Affiliate Link Service that returns `monetised:false`
+ * and the AffiliateBadge renders "Tracked" rather than "Affiliate" so the
+ * disclosure stays honest. Once Sovrn is live, the same evergreen items
+ * become monetisable opportunistically without any code change.
+ */
+
+import type { ConceptInput } from './types';
+
+export const EVERGREEN_FALLBACK_CONCEPTS: readonly ConceptInput[] = [
+  {
+    categoryKey: 'experiences',
+    conceptTitle: 'A memorable experience',
+    conceptScore: 5,
+    reasons: [
+      "When you're not sure what they'll want, let them choose the experience.",
+    ],
+    tags: ['evergreen', 'safe-default', 'gift-card'],
+  },
+  {
+    categoryKey: 'books_reading',
+    conceptTitle: 'Something to read',
+    conceptScore: 5,
+    reasons: [
+      'A book or reading credit is a thoughtful, low-risk gift for most adults.',
+    ],
+    tags: ['evergreen', 'safe-default', 'books'],
+  },
+  {
+    categoryKey: 'home_garden',
+    conceptTitle: 'Something for the home',
+    conceptScore: 5,
+    reasons: [
+      'A small useful or decorative thing for the home tends to land well.',
+    ],
+    tags: ['evergreen', 'safe-default'],
+  },
+  {
+    categoryKey: 'arts_crafts',
+    conceptTitle: 'Something handmade',
+    conceptScore: 5,
+    reasons: [
+      "Handmade signals care without assuming the recipient's specific taste.",
+    ],
+    tags: ['evergreen', 'safe-default', 'handmade'],
+  },
+  {
+    categoryKey: 'food_drink',
+    conceptTitle: 'Food or drink',
+    conceptScore: 5,
+    reasons: [
+      'Consumable gifts leave space rather than clutter — usually a safe bet.',
+    ],
+    tags: ['evergreen', 'safe-default', 'food'],
+  },
+];
+
+/**
+ * Did the caller fall back to evergreen because there was nothing else?
+ * Returns true if the candidate list looks like it came entirely from the
+ * evergreen pool — used for telemetry and the response's `meta` block.
+ */
+export function isEvergreenFallback(
+  candidates: { concept: ConceptInput }[],
+): boolean {
+  if (candidates.length === 0) return false;
+  return candidates.every((c) => c.concept.tags.includes('evergreen'));
+}

--- a/src/lib/recommender/v2/pipeline.ts
+++ b/src/lib/recommender/v2/pipeline.ts
@@ -23,36 +23,60 @@ import {
 } from './candidate-sourcing';
 import { rankCandidates, type RankerContext } from './rank';
 import { composeRationale } from './explain';
+import { EVERGREEN_FALLBACK_CONCEPTS } from './evergreen';
 import { getAffiliateLink } from '@/lib/affiliate/link-service';
-import type { PipelineRequest, V2Recommendation } from './types';
+import type { PipelineRequest, PipelineResult, V2Recommendation } from './types';
 
 /**
  * Top-level entry. Async because both candidate sourcing and the
  * affiliate-link service hit IO.
+ *
+ * Always-show contract: callers should never see an empty result if the
+ * recommender_catalogue has any active entries — the evergreen fallback
+ * substitutes safe-default concepts when the buyer's own profile-derived
+ * concepts produce nothing.
  */
 export async function buildV2Recommendations(
   req: PipelineRequest,
-): Promise<V2Recommendation[]> {
+): Promise<PipelineResult> {
   const limit = req.limit ?? 5;
   const recipientCountry = req.recipientCountry ?? req.buyerCountry;
-
-  // 1. Source candidates per concept (parallelised across concepts in the
-  //    candidate-sourcing module).
   const sourcingOpts: SourcingOptions = {
     perConceptLimit: 3,
     buyerCountry: req.buyerCountry,
     budgetMinMinor: req.budgetMinMinor,
     budgetMaxMinor: req.budgetMaxMinor,
   };
-  const candidates = await sourceCandidatesForConcepts(
-    req.concepts,
-    sourcingOpts,
-  );
-  if (candidates.length === 0) return [];
 
-  // 2. Rank — pure function, no IO.
-  // EPC + shipping confidence ContextMaps are empty for MVP; populated
-  // from KAN-195 reporting + KAN-187 matrix once those land.
+  // 1. Try the user's own concepts first. Parallelised across concepts
+  //    inside sourceCandidatesForConcepts.
+  let candidates = await sourceCandidatesForConcepts(req.concepts, sourcingOpts);
+  let fellBackToEvergreen = false;
+
+  // 2. Evergreen fallback. Triggers when the user's profile produced
+  //    zero candidates — either because V1 returned no concepts (sparse
+  //    profile) or because none of V1's concepts matched the catalogue +
+  //    Sovrn / LLM stubs. The evergreen pool is deliberately broad and
+  //    maps onto the seeded catalogue categories so it almost always
+  //    returns something. Better to surface a generic "thoughtful default"
+  //    than nothing.
+  if (candidates.length === 0) {
+    candidates = await sourceCandidatesForConcepts(
+      [...EVERGREEN_FALLBACK_CONCEPTS],
+      sourcingOpts,
+    );
+    fellBackToEvergreen = candidates.length > 0;
+  }
+
+  // If even the evergreen pool produces nothing (catalogue empty for the
+  // buyer's country, Sovrn stubbed, no LLM key), genuinely return empty.
+  // The web fallback to V1's RecommendationsSection still catches this
+  // case on the public profile page.
+  if (candidates.length === 0) {
+    return { recommendations: [], fellBackToEvergreen: false };
+  }
+
+  // 3. Rank — pure function, no IO.
   const rankerCtx: RankerContext = {
     budgetMinMinor: req.budgetMinMinor,
     budgetMaxMinor: req.budgetMaxMinor,
@@ -61,7 +85,7 @@ export async function buildV2Recommendations(
   };
   const ranked = rankCandidates(candidates, rankerCtx);
 
-  // 3. Take the top N, then monetise each via the Affiliate Link Service.
+  // 4. Take the top N, then monetise each via the Affiliate Link Service.
   const topN = ranked.slice(0, limit);
   const monetised = await Promise.all(
     topN.map((cand) =>
@@ -78,9 +102,9 @@ export async function buildV2Recommendations(
     ),
   );
 
-  // 4. Compose final results — pair each ranked candidate with its
+  // 5. Compose final results — pair each ranked candidate with its
   //    monetisation outcome and a composed rationale.
-  return topN.map<V2Recommendation>((cand, i) => ({
+  const recommendations = topN.map<V2Recommendation>((cand, i) => ({
     concept: cand.concept,
     product: {
       title: cand.title,
@@ -95,4 +119,6 @@ export async function buildV2Recommendations(
     rationale: composeRationale(cand),
     score: cand.score,
   }));
+
+  return { recommendations, fellBackToEvergreen };
 }

--- a/src/lib/recommender/v2/types.ts
+++ b/src/lib/recommender/v2/types.ts
@@ -92,6 +92,20 @@ export type V2Recommendation = {
   score: number;
 };
 
+/** Top-level pipeline output — recommendations + telemetry meta. */
+export type PipelineResult = {
+  recommendations: V2Recommendation[];
+  /**
+   * True when the pipeline used the evergreen safe-default concepts
+   * because the profile was too sparse (V1 produced 0 concepts) OR no
+   * Tier-1/2/3 candidates were sourced from the user's concepts. Surfaced
+   * to consumers so the web UI can soften the heading ("Some thoughtful
+   * defaults" vs "Gift ideas for Anna") and reporting can track how
+   * often we fall back.
+   */
+  fellBackToEvergreen: boolean;
+};
+
 /** Inputs to the top-level pipeline call. */
 export type PipelineRequest = {
   /** The concepts V1 produced for this profile, in descending V1 score order. */

--- a/tests/unit/recommender-v2-evergreen.test.ts
+++ b/tests/unit/recommender-v2-evergreen.test.ts
@@ -1,0 +1,128 @@
+/**
+ * Tests for the evergreen always-show fallback in the V2 recommender.
+ *
+ * The fallback exists so the recommender NEVER returns an empty list when
+ * the curated catalogue (KAN-200) has at least one matching entry. It
+ * substitutes a fixed set of safe-default concepts when:
+ *   1. V1 produced 0 concepts (sparse profile), OR
+ *   2. V1 produced concepts but candidate-sourcing returned 0 candidates
+ *      (no Tier-1 catalogue match in the buyer's country, Sovrn / LLM
+ *      stubs returning nothing).
+ *
+ * These tests cover the evergreen module's shape + the type guard.
+ * The pipeline integration (which mixes the IO-backed candidate-sourcing
+ * + affiliate link service) is verified by the integration-level functional
+ * tests against dev that exercise the V2 endpoint end-to-end.
+ */
+
+import {
+  EVERGREEN_FALLBACK_CONCEPTS,
+  isEvergreenFallback,
+} from '@/lib/recommender/v2/evergreen';
+import type { ConceptInput, ProductCandidate } from '@/lib/recommender/v2/types';
+
+describe('EVERGREEN_FALLBACK_CONCEPTS — shape invariants', () => {
+  test('has at least 3 concepts so the fallback always produces a reasonable spread', () => {
+    expect(EVERGREEN_FALLBACK_CONCEPTS.length).toBeGreaterThanOrEqual(3);
+  });
+
+  test('every concept is tagged "evergreen" so isEvergreenFallback can detect them', () => {
+    for (const c of EVERGREEN_FALLBACK_CONCEPTS) {
+      expect(c.tags).toContain('evergreen');
+    }
+  });
+
+  test('every concept also tagged "safe-default" — documentary signal for telemetry', () => {
+    for (const c of EVERGREEN_FALLBACK_CONCEPTS) {
+      expect(c.tags).toContain('safe-default');
+    }
+  });
+
+  test('scores are low (≤ 5) so real-profile concepts always outrank evergreen ones', () => {
+    // Real V1 concept scores are typically 8–20. If a profile is rich enough
+    // to produce a real concept at score 7 (rare but possible), the
+    // evergreen entry at score 5 still loses — that's the intent. Don't
+    // raise this above 5 without re-checking V1's scoring distribution.
+    for (const c of EVERGREEN_FALLBACK_CONCEPTS) {
+      expect(c.conceptScore).toBeLessThanOrEqual(5);
+    }
+  });
+
+  test('every category maps onto a seeded recommender_catalogue category', () => {
+    // The seed data (KAN-200 + Phase-1 catalogue migration) covers these
+    // categories. If a future PR drops one, the evergreen fallback for that
+    // category produces 0 candidates and the fallback is less reliable —
+    // catch the drift here.
+    const seededCategories = new Set([
+      'books_reading',
+      'arts_crafts',
+      'experiences',
+      'food_drink',
+      'home_garden',
+    ]);
+    for (const c of EVERGREEN_FALLBACK_CONCEPTS) {
+      expect(seededCategories.has(c.categoryKey)).toBe(true);
+    }
+  });
+
+  test('rationale strings + titles are non-empty so the explainer has something to work with', () => {
+    for (const c of EVERGREEN_FALLBACK_CONCEPTS) {
+      expect(c.conceptTitle.length).toBeGreaterThan(0);
+      expect(c.reasons.length).toBeGreaterThan(0);
+      expect(c.reasons[0].length).toBeGreaterThan(10);
+    }
+  });
+});
+
+// ── isEvergreenFallback ────────────────────────────────────────────────
+
+function fakeCandidate(concept: ConceptInput): ProductCandidate {
+  return {
+    concept,
+    title: 'mock',
+    description: null,
+    imageUrl: null,
+    rawUrl: 'https://example.com/x',
+    merchantId: 'mock',
+    priceMinMinor: null,
+    priceMaxMinor: null,
+    priceCurrency: null,
+    sourceTier: 'curated',
+    rationaleFragment: null,
+    sourceWeight: 0,
+  };
+}
+
+describe('isEvergreenFallback — telemetry helper', () => {
+  test('empty input → false (nothing to fall back from)', () => {
+    expect(isEvergreenFallback([])).toBe(false);
+  });
+
+  test('all candidates from evergreen concepts → true', () => {
+    const candidates = EVERGREEN_FALLBACK_CONCEPTS.map(fakeCandidate);
+    expect(isEvergreenFallback(candidates)).toBe(true);
+  });
+
+  test('mixed real + evergreen → false', () => {
+    const real: ConceptInput = {
+      categoryKey: 'books_reading',
+      conceptTitle: 'A novel about ___',
+      conceptScore: 15,
+      reasons: ['from profile likes'],
+      tags: ['v1-derived'],
+    };
+    const mixed = [fakeCandidate(real), fakeCandidate(EVERGREEN_FALLBACK_CONCEPTS[0])];
+    expect(isEvergreenFallback(mixed)).toBe(false);
+  });
+
+  test('all real concepts → false', () => {
+    const real: ConceptInput = {
+      categoryKey: 'books_reading',
+      conceptTitle: 'A novel about ___',
+      conceptScore: 15,
+      reasons: ['from profile likes'],
+      tags: ['v1-derived'],
+    };
+    expect(isEvergreenFallback([fakeCandidate(real)])).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
The V2 recommender previously returned an empty list when V1's concept layer produced nothing (sparse profile) OR when V1's concepts found no Tier-1/2/3 matches in the buyer's country. That meant a brand-new profile saw no recommendations at all.

This PR adds an evergreen fallback: a small set of 5 safe-default concepts (`experiences` / `books_reading` / `home_garden` / `arts_crafts` / `food_drink`) at low score (5). When the first sourcing pass returns 0 candidates, the pipeline retries with the evergreen concepts — which map cleanly onto the seeded recommender_catalogue so a Tier-1 match is almost always available.

When monetised: 5 affiliate cards. When un-monetised: 5 "Tracked" cards. When neither (catalogue empty for the buyer's country): genuine empty + the page falls back to V1's concept-only section. **The recommender no longer goes silent on sparse profiles.**

## How it surfaces

- **API** (`/api/recommendations/v2/[slug]`): new `meta.fellBackToEvergreen` boolean
- **Public profile page**: heading softens from "Gift ideas for Anna" → "A few thoughtful defaults" + the sub-copy honestly signals these aren't tailored picks
- **MCP**: existing `lyra_recommend_gifts` passes the V2 response through. A small follow-up in lyra-mcp-server can lift `meta.fellBackToEvergreen` into the AI-assistant-visible payload.

## Dev test fixtures (out of PR but related)
Applied directly via SQL to dev Supabase (not promoted):
- 12 deliberately-named `[FIXTURE]` items added to Luisa's dev profile spanning V1 categories her existing items didn't cover (pottery, folk music, yoga, cooking, plants, literary magazines)
- `delivery_country_code='GB'` set on Luisa + Ben so the recommender's recipient-country path is exercised end-to-end

## Test plan
- [x] 10 new unit tests pass (`tests/unit/recommender-v2-evergreen.test.ts`)
- [x] `tsc --noEmit` clean
- [x] `next build` clean — both `/[slug]` and `/api/recommendations/v2/[slug]` compile
- [ ] Manual after promote to dev: visit `dev.checklyra.com/luisa-632df5a4` → see V2 cards with normal "Gift ideas for Luisa" heading (because her dev profile has 29 items now)
- [ ] Manual after promote: visit a sparse-profile slug → see "A few thoughtful defaults" heading

## Worktree-policy compliance (BUGS-17)
Developed in `lyra-kan-recommender-evergreen` (manual worktree off `origin/develop`), pre-commit branch check ran clean, staged by explicit path.

## Related
KAN-200 (V2 pipeline), KAN-199 (V2 design), KAN-191 (web rendering), KAN-201 (MCP — needs the small follow-up)

🤖 Generated with [Claude Code](https://claude.com/claude-code)