### PR TITLE
feat(KAN-236): Convene P4 UI — gatherings list + detail + actions

### DIFF
--- a/src/app/dashboard/convene/gatherings/[id]/actions.ts
+++ b/src/app/dashboard/convene/gatherings/[id]/actions.ts
@@ -1,0 +1,145 @@
+'use server';
+
+/**
+ * KAN-236 — server actions for the gathering detail page.
+ *
+ * - addToHostCalendar: uses the existing src/lib/convene/calendar/google.ts
+ *   adapter to create a calendar event on the host's connected Google
+ *   calendar. Records `calendar_event_added` in gathering_events_log on
+ *   success.
+ * - cancelGathering: transitions status to 'cancelled' via the state machine,
+ *   appends gathering_cancelled to the audit log.
+ *
+ * All actions validate `host_user_id = auth.uid()` independent of RLS.
+ */
+
+import { createClient } from '@/lib/supabase-server';
+import { createClient as createSupabaseAdmin } from '@supabase/supabase-js';
+import { env } from '@/lib/env';
+import { applyTransition, type GatheringStatus } from '@/lib/convene/gatherings/state-machine';
+import { adapterFor } from '@/lib/convene/calendar';
+import { getConnectionForUser } from '@/lib/convene/oauth-connections';
+
+type Result = { ok: true } | { ok: false; error: string };
+
+function admin() {
+  return createSupabaseAdmin(env.supabaseUrl(), env.supabaseServiceRoleKey(), {
+    auth: { persistSession: false },
+  });
+}
+
+async function authedUser(): Promise<{ userId: string } | { error: string }> {
+  const sb = await createClient();
+  const { data: { user } } = await sb.auth.getUser();
+  if (!user) return { error: 'Not signed in' };
+  return { userId: user.id };
+}
+
+async function appendEvent(
+  gatheringId: string,
+  actorUserId: string,
+  eventType: string,
+  metadata: Record<string, unknown> = {}
+) {
+  const sb = admin();
+  // ownership-ok: caller has already verified host_user_id matches (KAN-236)
+  await sb.from('gathering_events_log').insert({
+    gathering_id: gatheringId,
+    actor_user_id: actorUserId,
+    event_type: eventType,
+    subject_kind: 'gathering',
+    subject_id: gatheringId,
+    metadata,
+  });
+}
+
+export async function addToHostCalendar(gatheringId: string): Promise<Result> {
+  const a = await authedUser();
+  if ('error' in a) return { ok: false, error: a.error };
+  const userId = a.userId;
+
+  const sb = admin();
+  // ownership-ok: explicit host_user_id filter (KAN-236)
+  const { data: g, error: gErr } = await sb
+    .from('gatherings')
+    .select('id, title, description, finalised_slot_start, finalised_slot_end, venue_id, status')
+    .eq('id', gatheringId)
+    .eq('host_user_id', userId)
+    .is('deleted_at', null)
+    .maybeSingle();
+  if (gErr || !g) return { ok: false, error: 'Gathering not found' };
+  if (g.status !== 'live') return { ok: false, error: 'Gathering must be live to add to calendar' };
+  if (!g.finalised_slot_start || !g.finalised_slot_end) {
+    return { ok: false, error: 'Gathering has no finalised slot' };
+  }
+
+  const connection = await getConnectionForUser(userId, 'google');
+  if (!connection) {
+    return { ok: false, error: 'No active Google calendar connection. Connect one first under Calendar Connections.' };
+  }
+
+  let venueName: string | null = null;
+  if (g.venue_id) {
+    const { data: v } = await sb.from('venues').select('name, city').eq('id', g.venue_id).maybeSingle();
+    venueName = v ? `${v.name}${v.city ? ` — ${v.city}` : ''}` : null;
+  }
+
+  try {
+    const adapter = adapterFor('google');
+    const result = await adapter.createEvent(connection.id, {
+      title: g.title as string,
+      description: (g.description as string) ?? undefined,
+      startISO: g.finalised_slot_start as string,
+      endISO: g.finalised_slot_end as string,
+      location: venueName ?? undefined,
+    });
+    await appendEvent(gatheringId, userId, 'calendar_event_added', {
+      provider: 'google',
+      provider_event_id: result.providerEventId,
+    });
+    return { ok: true };
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : 'unknown error';
+    await appendEvent(gatheringId, userId, 'calendar_event_failed', { error: msg.slice(0, 200) });
+    return { ok: false, error: msg };
+  }
+}
+
+export async function cancelGathering(gatheringId: string): Promise<Result> {
+  const a = await authedUser();
+  if ('error' in a) return { ok: false, error: a.error };
+  const userId = a.userId;
+
+  const sb = admin();
+  // ownership-ok: host_user_id filter (KAN-236)
+  const { data: g, error: gErr } = await sb
+    .from('gatherings')
+    .select('id, status')
+    .eq('id', gatheringId)
+    .eq('host_user_id', userId)
+    .is('deleted_at', null)
+    .maybeSingle();
+  if (gErr || !g) return { ok: false, error: 'Gathering not found' };
+
+  let nextStatus: GatheringStatus;
+  try {
+    nextStatus = applyTransition(g.status as GatheringStatus, 'cancel');
+  } catch (e) {
+    return { ok: false, error: e instanceof Error ? e.message : 'Invalid transition' };
+  }
+
+  // ownership-ok: explicit host_user_id filter (KAN-236)
+  const { error: upErr } = await sb
+    .from('gatherings')
+    .update({ status: nextStatus })
+    .eq('id', gatheringId)
+    .eq('host_user_id', userId);
+  if (upErr) return { ok: false, error: upErr.message };
+
+  await appendEvent(gatheringId, userId, 'gathering_cancelled', {
+    from_status: g.status,
+    to_status: nextStatus,
+  });
+
+  return { ok: true };
+}

--- a/src/app/dashboard/convene/gatherings/[id]/gathering-actions.tsx
+++ b/src/app/dashboard/convene/gatherings/[id]/gathering-actions.tsx
@@ -1,0 +1,93 @@
+'use client';
+
+import { useState, useTransition } from 'react';
+import { useRouter } from 'next/navigation';
+import type { GatheringStatus, GatheringTransition } from '@/lib/convene/gatherings/state-machine';
+import { addToHostCalendar, cancelGathering } from './actions';
+
+interface Props {
+  gatheringId: string;
+  status: GatheringStatus;
+  transitions: GatheringTransition[];
+  calendarAdded: boolean;
+}
+
+export function GatheringActions({ gatheringId, status, transitions, calendarAdded }: Props) {
+  const [error, setError] = useState<string | null>(null);
+  const [success, setSuccess] = useState<string | null>(null);
+  const [pending, startTransition] = useTransition();
+  const router = useRouter();
+
+  const canCancel = transitions.includes('cancel');
+  const canAddToCalendar = status === 'live' && !calendarAdded;
+
+  async function handleAddToCalendar() {
+    if (!confirm('Add this gathering to your connected Google Calendar?')) return;
+    setError(null);
+    setSuccess(null);
+    startTransition(async () => {
+      const result = await addToHostCalendar(gatheringId);
+      if (result.ok) {
+        setSuccess('Added to your calendar.');
+        router.refresh();
+      } else {
+        setError(result.error);
+      }
+    });
+  }
+
+  async function handleCancel() {
+    if (!confirm('Cancel this gathering? This will be visible in the audit log; invitees won\'t be notified automatically in this version.')) return;
+    setError(null);
+    setSuccess(null);
+    startTransition(async () => {
+      const result = await cancelGathering(gatheringId);
+      if (result.ok) {
+        setSuccess('Gathering cancelled.');
+        router.refresh();
+      } else {
+        setError(result.error);
+      }
+    });
+  }
+
+  if (!canCancel && !canAddToCalendar) return null;
+
+  return (
+    <div className="bg-white rounded-xl border border-stone-200 p-6">
+      <h2 className="text-lg font-medium text-[var(--color-ink)] mb-3">Actions</h2>
+      <div className="flex flex-wrap gap-2">
+        {canAddToCalendar && (
+          <button
+            type="button"
+            onClick={handleAddToCalendar}
+            disabled={pending}
+            className="px-4 py-2 rounded-lg bg-[var(--color-sage)] text-white text-sm font-medium hover:opacity-90 disabled:opacity-50"
+          >
+            {pending ? 'Working…' : '+ Add to my Google Calendar'}
+          </button>
+        )}
+        {canCancel && (
+          <button
+            type="button"
+            onClick={handleCancel}
+            disabled={pending}
+            className="px-4 py-2 rounded-lg border border-rose-300 text-rose-700 text-sm font-medium hover:bg-rose-50 disabled:opacity-50"
+          >
+            {pending ? 'Working…' : 'Cancel gathering'}
+          </button>
+        )}
+      </div>
+      {error && (
+        <div className="mt-3 bg-rose-50 border border-rose-200 rounded-lg px-3 py-2 text-sm text-rose-900">
+          {error}
+        </div>
+      )}
+      {success && (
+        <div className="mt-3 bg-emerald-50 border border-emerald-200 rounded-lg px-3 py-2 text-sm text-emerald-900">
+          {success}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/app/dashboard/convene/gatherings/[id]/page.tsx
+++ b/src/app/dashboard/convene/gatherings/[id]/page.tsx
@@ -1,0 +1,244 @@
+/**
+ * /dashboard/convene/gatherings/[id] — KAN-236 (Convene P4 UI).
+ *
+ * Detail view: status, slot, venue, invitees, proposed slots, audit log.
+ * Action buttons gated by state-machine transitions:
+ *   - "Add to my calendar" when status=live and not yet added
+ *   - "Cancel gathering" when in any non-terminal state
+ * Buttons call server actions in ./actions.ts.
+ */
+
+import { createClient } from '@/lib/supabase-server';
+import { redirect, notFound } from 'next/navigation';
+import Link from 'next/link';
+import Image from 'next/image';
+import { isConveneEnabled } from '@/lib/convene/flags';
+import {
+  availableTransitions,
+  type GatheringStatus,
+} from '@/lib/convene/gatherings/state-machine';
+import { GatheringActions } from './gathering-actions';
+
+interface InviteeRow {
+  id: string;
+  status: string;
+  invited_at: string | null;
+  responded_at: string | null;
+  contact: { display_name: string; city: string | null } | null;
+}
+
+interface SlotRow {
+  id: string;
+  slot_start: string;
+  slot_end: string;
+  score: number | null;
+}
+
+interface EventRow {
+  id: string;
+  event_type: string;
+  metadata: Record<string, unknown>;
+  created_at: string;
+}
+
+interface VenueRow {
+  id: string;
+  name: string;
+  venue_type: string;
+  city: string | null;
+  postcode: string | null;
+}
+
+function fmtDate(iso: string | null): string {
+  if (!iso) return '—';
+  return new Date(iso).toLocaleString('en-GB', { dateStyle: 'medium', timeStyle: 'short' });
+}
+
+const STATUS_LABELS: Record<string, { label: string; tone: string }> = {
+  draft: { label: 'Draft', tone: 'bg-stone-100 text-stone-700 border-stone-300' },
+  awaiting_responses: { label: 'Awaiting RSVPs', tone: 'bg-amber-50 text-amber-900 border-amber-200' },
+  live: { label: 'Live', tone: 'bg-emerald-50 text-emerald-900 border-emerald-200' },
+  rescheduled: { label: 'Rescheduled', tone: 'bg-sky-50 text-sky-900 border-sky-200' },
+  cancelled: { label: 'Cancelled', tone: 'bg-stone-100 text-stone-500 border-stone-300' },
+  completed: { label: 'Completed', tone: 'bg-stone-50 text-stone-500 border-stone-200' },
+};
+
+export default async function GatheringDetailPage({ params }: { params: Promise<{ id: string }> }) {
+  if (!isConveneEnabled()) {
+    return (
+      <main className="min-h-screen bg-stone-50 flex items-center justify-center">
+        <p className="text-[var(--color-muted)]">Convene is not enabled.</p>
+      </main>
+    );
+  }
+
+  const { id } = await params;
+  const supabase = await createClient();
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) redirect(`/login?next=/dashboard/convene/gatherings/${id}`);
+
+  const { data: g } = await supabase
+    .from('gatherings')
+    .select('*')
+    .eq('id', id)
+    .eq('host_user_id', user.id)
+    .is('deleted_at', null)
+    .maybeSingle();
+  if (!g) notFound();
+
+  const [invitees, slots, events, venue, calendarAdded] = await Promise.all([
+    supabase
+      .from('gathering_invitees')
+      .select('id, status, invited_at, responded_at, contact:contacts(display_name, city)')
+      .eq('gathering_id', id)
+      .order('invited_at', { ascending: true, nullsFirst: true })
+      .then((r) => (r.data as unknown as InviteeRow[]) ?? []),
+    supabase
+      .from('gathering_proposed_slots')
+      .select('id, slot_start, slot_end, score')
+      .eq('gathering_id', id)
+      .order('score', { ascending: false, nullsFirst: false })
+      .then((r) => (r.data as SlotRow[]) ?? []),
+    supabase
+      .from('gathering_events_log')
+      .select('id, event_type, metadata, created_at')
+      .eq('gathering_id', id)
+      .order('created_at', { ascending: false })
+      .limit(20)
+      .then((r) => (r.data as EventRow[]) ?? []),
+    g.venue_id
+      ? supabase.from('venues').select('id, name, venue_type, city, postcode').eq('id', g.venue_id).maybeSingle().then((r) => r.data as VenueRow | null)
+      : Promise.resolve<VenueRow | null>(null),
+    supabase
+      .from('gathering_events_log')
+      .select('id')
+      .eq('gathering_id', id)
+      .eq('event_type', 'calendar_event_added')
+      .limit(1)
+      .then((r) => (r.data?.length ?? 0) > 0),
+  ]);
+
+  const tone = STATUS_LABELS[g.status as string] ?? { label: g.status, tone: 'bg-stone-100' };
+  const transitions = availableTransitions(g.status as GatheringStatus);
+
+  return (
+    <main className="min-h-screen bg-stone-50">
+      <header className="border-b border-stone-200 bg-white">
+        <div className="max-w-4xl mx-auto px-4 py-4 flex items-center justify-between">
+          <Link href="/dashboard" className="flex items-center">
+            <Image src="/lyra-logo.png" alt="Lyra" width={32} height={32} className="h-8 w-auto" />
+          </Link>
+          <span className="text-sm text-[var(--color-muted)]">Gathering Detail</span>
+        </div>
+      </header>
+
+      <div className="max-w-4xl mx-auto px-4 py-8 space-y-6">
+        <div>
+          <Link href="/dashboard/convene/gatherings" className="text-sm text-[var(--color-sage)] hover:underline">
+            ← All gatherings
+          </Link>
+        </div>
+
+        <div className="bg-white rounded-xl border border-stone-200 p-6">
+          <div className="flex items-center gap-2 mb-2">
+            <span className={`inline-block px-2 py-0.5 rounded-md border text-xs font-medium ${tone.tone}`}>
+              {tone.label}
+            </span>
+            <span className="text-xs text-[var(--color-muted)]">{g.gathering_type as string}</span>
+          </div>
+          <h1 className="text-2xl font-medium text-[var(--color-ink)]">{g.title as string}</h1>
+          {g.description && <p className="text-[var(--color-muted)] mt-2">{g.description as string}</p>}
+          <div className="mt-4 grid grid-cols-1 sm:grid-cols-2 gap-3 text-sm">
+            <div>
+              <p className="text-xs text-[var(--color-muted)] uppercase">When</p>
+              <p className="text-[var(--color-ink)]">
+                {g.finalised_slot_start
+                  ? `${fmtDate(g.finalised_slot_start as string)} → ${new Date(g.finalised_slot_end as string).toLocaleTimeString('en-GB', { hour: '2-digit', minute: '2-digit' })}`
+                  : g.target_window_start
+                    ? `Aiming for ${fmtDate(g.target_window_start as string)}`
+                    : '—'}
+              </p>
+            </div>
+            <div>
+              <p className="text-xs text-[var(--color-muted)] uppercase">Where</p>
+              <p className="text-[var(--color-ink)]">
+                {venue ? `${venue.name}${venue.city ? ` — ${venue.city}` : ''}` : '— not set —'}
+              </p>
+            </div>
+            <div>
+              <p className="text-xs text-[var(--color-muted)] uppercase">Capacity</p>
+              <p className="text-[var(--color-ink)]">
+                {g.capacity_min ?? '?'} – {g.capacity_max ?? '?'}
+              </p>
+            </div>
+            <div>
+              <p className="text-xs text-[var(--color-muted)] uppercase">Created</p>
+              <p className="text-[var(--color-ink)]">{fmtDate(g.created_at as string)}</p>
+            </div>
+          </div>
+          {g.notes && (
+            <div className="mt-4">
+              <p className="text-xs text-[var(--color-muted)] uppercase">Host notes</p>
+              <p className="text-sm text-[var(--color-ink)] whitespace-pre-wrap">{g.notes as string}</p>
+            </div>
+          )}
+        </div>
+
+        <GatheringActions
+          gatheringId={id}
+          status={g.status as GatheringStatus}
+          transitions={transitions}
+          calendarAdded={calendarAdded}
+        />
+
+        {invitees.length > 0 && (
+          <div className="bg-white rounded-xl border border-stone-200 p-6">
+            <h2 className="text-lg font-medium text-[var(--color-ink)] mb-3">Invitees ({invitees.length})</h2>
+            <ul className="space-y-2">
+              {invitees.map((i) => (
+                <li key={i.id} className="flex items-center justify-between text-sm">
+                  <span className="text-[var(--color-ink)]">
+                    {i.contact?.display_name ?? '(unknown)'}
+                    {i.contact?.city && <span className="text-[var(--color-muted)]"> — {i.contact.city}</span>}
+                  </span>
+                  <span className="text-xs text-[var(--color-muted)]">{i.status}</span>
+                </li>
+              ))}
+            </ul>
+          </div>
+        )}
+
+        {slots.length > 0 && g.status === 'draft' && (
+          <div className="bg-white rounded-xl border border-stone-200 p-6">
+            <h2 className="text-lg font-medium text-[var(--color-ink)] mb-3">Proposed slots</h2>
+            <ul className="space-y-1 text-sm">
+              {slots.map((s) => (
+                <li key={s.id} className="flex justify-between text-[var(--color-ink)]">
+                  <span>{fmtDate(s.slot_start)} → {new Date(s.slot_end).toLocaleTimeString('en-GB', { hour: '2-digit', minute: '2-digit' })}</span>
+                  {s.score != null && <span className="text-xs text-[var(--color-muted)]">score {s.score.toFixed(2)}</span>}
+                </li>
+              ))}
+            </ul>
+          </div>
+        )}
+
+        <div className="bg-white rounded-xl border border-stone-200 p-6">
+          <h2 className="text-lg font-medium text-[var(--color-ink)] mb-3">Activity</h2>
+          <ul className="space-y-1.5 text-sm">
+            {events.length === 0 ? (
+              <li className="text-[var(--color-muted)]">No activity yet</li>
+            ) : (
+              events.map((e) => (
+                <li key={e.id} className="text-[var(--color-muted)]">
+                  <span className="font-mono text-xs">{new Date(e.created_at).toLocaleString('en-GB')}</span>
+                  <span className="mx-2">·</span>
+                  <span className="text-[var(--color-ink)]">{e.event_type}</span>
+                </li>
+              ))
+            )}
+          </ul>
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/src/app/dashboard/convene/gatherings/page.tsx
+++ b/src/app/dashboard/convene/gatherings/page.tsx
@@ -1,0 +1,154 @@
+/**
+ * /dashboard/convene/gatherings — KAN-236 (Convene P4 UI).
+ *
+ * Lists the host's gatherings. Status badge, type, finalised slot or target
+ * window, invitee count, venue (if any). Links into the detail page.
+ */
+
+import { createClient } from '@/lib/supabase-server';
+import { redirect } from 'next/navigation';
+import Link from 'next/link';
+import Image from 'next/image';
+import { isConveneEnabled } from '@/lib/convene/flags';
+
+export const metadata = {
+  title: 'Convene Gatherings — Lyra',
+  description: 'Your AI-orchestrated gatherings.',
+};
+
+interface GatheringRow {
+  id: string;
+  title: string;
+  gathering_type: string;
+  status: string;
+  target_window_start: string | null;
+  finalised_slot_start: string | null;
+  finalised_slot_end: string | null;
+  venue_id: string | null;
+  created_at: string;
+  invitee_count: { count: number }[] | null;
+  venue: { name: string; city: string | null } | null;
+}
+
+const STATUS_LABELS: Record<string, { label: string; tone: string }> = {
+  draft: { label: 'Draft', tone: 'bg-stone-100 text-stone-700 border-stone-300' },
+  awaiting_responses: { label: 'Awaiting RSVPs', tone: 'bg-amber-50 text-amber-900 border-amber-200' },
+  live: { label: 'Live', tone: 'bg-emerald-50 text-emerald-900 border-emerald-200' },
+  rescheduled: { label: 'Rescheduled', tone: 'bg-sky-50 text-sky-900 border-sky-200' },
+  cancelled: { label: 'Cancelled', tone: 'bg-stone-100 text-stone-500 border-stone-300' },
+  completed: { label: 'Completed', tone: 'bg-stone-50 text-stone-500 border-stone-200' },
+};
+
+function formatDate(iso: string | null): string {
+  if (!iso) return '—';
+  return new Date(iso).toLocaleString('en-GB', { dateStyle: 'medium', timeStyle: 'short' });
+}
+
+export default async function GatheringsListPage() {
+  if (!isConveneEnabled()) {
+    return (
+      <main className="min-h-screen bg-stone-50 flex items-center justify-center">
+        <p className="text-[var(--color-muted)]">Convene is not enabled.</p>
+      </main>
+    );
+  }
+
+  const supabase = await createClient();
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) redirect('/login?next=/dashboard/convene/gatherings');
+
+  const { data: gatherings } = await supabase
+    .from('gatherings')
+    .select(`
+      id, title, gathering_type, status,
+      target_window_start, finalised_slot_start, finalised_slot_end,
+      venue_id, created_at,
+      invitee_count:gathering_invitees(count),
+      venue:venues(name, city)
+    `)
+    .eq('host_user_id', user.id)
+    .is('deleted_at', null)
+    .order('created_at', { ascending: false })
+    .limit(50);
+
+  const rows = (gatherings ?? []) as unknown as GatheringRow[];
+
+  return (
+    <main className="min-h-screen bg-stone-50">
+      <header className="border-b border-stone-200 bg-white">
+        <div className="max-w-4xl mx-auto px-4 py-4 flex items-center justify-between">
+          <Link href="/dashboard" className="flex items-center">
+            <Image src="/lyra-logo.png" alt="Lyra" width={32} height={32} className="h-8 w-auto" />
+          </Link>
+          <span className="text-sm text-[var(--color-muted)]">Convene Gatherings</span>
+        </div>
+      </header>
+
+      <div className="max-w-4xl mx-auto px-4 py-8 space-y-6">
+        <div>
+          <h1 className="text-2xl font-medium text-[var(--color-ink)]">Gatherings</h1>
+          <p className="text-[var(--color-muted)] mt-1">
+            What you (or your AI agent) have set in motion. Talk to Lyra in any MCP client to create new ones — the dashboard is for review and action.
+          </p>
+        </div>
+
+        {rows.length === 0 ? (
+          <div className="bg-white rounded-xl border border-stone-200 p-8 text-center">
+            <h2 className="text-lg font-medium text-[var(--color-ink)]">No gatherings yet</h2>
+            <p className="text-sm text-[var(--color-muted)] mt-2 max-w-md mx-auto">
+              Ask Lyra in any MCP client: <em>&ldquo;Lyra, create a draft coffee gathering for next Saturday&rdquo;</em>. It&apos;ll appear here.
+            </p>
+          </div>
+        ) : (
+          <div className="space-y-3">
+            {rows.map((g) => {
+              const tone = STATUS_LABELS[g.status] ?? { label: g.status, tone: 'bg-stone-100' };
+              const slot = g.finalised_slot_start
+                ? `${formatDate(g.finalised_slot_start)} → ${new Date(g.finalised_slot_end!).toLocaleTimeString('en-GB', { hour: '2-digit', minute: '2-digit' })}`
+                : g.target_window_start
+                  ? `Aiming for ${formatDate(g.target_window_start)}`
+                  : 'No time set yet';
+              const venueText = g.venue
+                ? `${g.venue.name}${g.venue.city ? ` — ${g.venue.city}` : ''}`
+                : null;
+              const inviteeCount = g.invitee_count?.[0]?.count ?? 0;
+
+              return (
+                <Link
+                  key={g.id}
+                  href={`/dashboard/convene/gatherings/${g.id}`}
+                  className="block bg-white rounded-xl border border-stone-200 p-5 hover:border-stone-400 transition"
+                >
+                  <div className="flex items-start justify-between gap-4">
+                    <div className="flex-1 min-w-0">
+                      <div className="flex items-center gap-2 mb-1">
+                        <span className={`inline-block px-2 py-0.5 rounded-md border text-xs font-medium ${tone.tone}`}>
+                          {tone.label}
+                        </span>
+                        <span className="text-xs text-[var(--color-muted)]">{g.gathering_type}</span>
+                      </div>
+                      <h3 className="text-base font-medium text-[var(--color-ink)] truncate">{g.title}</h3>
+                      <p className="text-sm text-[var(--color-muted)] mt-1">{slot}</p>
+                      {venueText && <p className="text-sm text-[var(--color-muted)]">📍 {venueText}</p>}
+                    </div>
+                    <div className="shrink-0 text-right">
+                      <p className="text-xs text-[var(--color-muted)]">
+                        {inviteeCount} {inviteeCount === 1 ? 'invitee' : 'invitees'}
+                      </p>
+                    </div>
+                  </div>
+                </Link>
+              );
+            })}
+          </div>
+        )}
+
+        <div className="text-sm text-[var(--color-muted)]">
+          <Link href="/dashboard" className="text-[var(--color-sage)] hover:underline">← Back to dashboard</Link>
+          <span className="mx-2">·</span>
+          <Link href="/dashboard/convene/connections" className="text-[var(--color-sage)] hover:underline">Calendar connections</Link>
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/tests/unit/convene/gathering-ui.test.ts
+++ b/tests/unit/convene/gathering-ui.test.ts
@@ -1,0 +1,77 @@
+/**
+ * KAN-236 — gathering UI structural tests.
+ *
+ * Verifies page + actions files exist and carry the expected gates.
+ */
+
+import fs from 'fs';
+import path from 'path';
+
+const ROOT = path.join(__dirname, '..', '..', '..');
+
+describe('Convene gatherings UI (KAN-236)', () => {
+  const listPath = path.join(ROOT, 'src/app/dashboard/convene/gatherings/page.tsx');
+  const detailPath = path.join(ROOT, 'src/app/dashboard/convene/gatherings/[id]/page.tsx');
+  const actionsPath = path.join(ROOT, 'src/app/dashboard/convene/gatherings/[id]/actions.ts');
+  const clientPath = path.join(ROOT, 'src/app/dashboard/convene/gatherings/[id]/gathering-actions.tsx');
+
+  test('all four files exist', () => {
+    expect(fs.existsSync(listPath)).toBe(true);
+    expect(fs.existsSync(detailPath)).toBe(true);
+    expect(fs.existsSync(actionsPath)).toBe(true);
+    expect(fs.existsSync(clientPath)).toBe(true);
+  });
+
+  describe('list page', () => {
+    const src = fs.readFileSync(listPath, 'utf8');
+    test('gates on isConveneEnabled', () => expect(src).toMatch(/isConveneEnabled\(\)/));
+    test('redirects unauthenticated users to /login', () => expect(src).toMatch(/redirect\(['"]\/login/));
+    test('filters by host_user_id', () => expect(src).toMatch(/\.eq\(['"]host_user_id['"],\s*user\.id\)/));
+    test('soft-deleted gatherings excluded', () => expect(src).toMatch(/\.is\(['"]deleted_at['"],\s*null\)/));
+  });
+
+  describe('detail page', () => {
+    const src = fs.readFileSync(detailPath, 'utf8');
+    test('gates on isConveneEnabled', () => expect(src).toMatch(/isConveneEnabled\(\)/));
+    test('filters main gathering query by host_user_id', () => expect(src).toMatch(/\.eq\(['"]host_user_id['"],\s*user\.id\)/));
+    test('returns 404 (notFound) on missing or non-owned gathering', () => expect(src).toMatch(/notFound\(\)/));
+    test('uses state-machine availableTransitions to gate buttons', () => expect(src).toMatch(/availableTransitions/));
+    test('queries gathering_events_log for calendar_event_added', () => expect(src).toMatch(/calendar_event_added/));
+  });
+
+  describe('server actions', () => {
+    const src = fs.readFileSync(actionsPath, 'utf8');
+    test("'use server' directive at top", () => expect(src).toMatch(/^['"]use server['"]/m));
+    test('addToHostCalendar validates host_user_id', () => {
+      const fn = src.slice(src.indexOf('addToHostCalendar'));
+      expect(fn).toMatch(/\.eq\(['"]host_user_id['"],\s*userId\)/);
+    });
+    test('addToHostCalendar requires status=live', () => {
+      expect(src).toMatch(/status !== ['"]live['"]/);
+    });
+    test('addToHostCalendar uses adapterFor', () => {
+      expect(src).toMatch(/adapterFor\(/);
+    });
+    test('addToHostCalendar appends calendar_event_added on success', () => {
+      expect(src).toMatch(/calendar_event_added/);
+    });
+    test('cancelGathering uses applyTransition with cancel', () => {
+      expect(src).toMatch(/applyTransition\([^,]+,\s*['"]cancel['"]/);
+    });
+    test('cancelGathering appends gathering_cancelled to audit log', () => {
+      expect(src).toMatch(/gathering_cancelled/);
+    });
+  });
+
+  describe('client action component', () => {
+    const src = fs.readFileSync(clientPath, 'utf8');
+    test("'use client' directive at top", () => expect(src).toMatch(/^['"]use client['"]/m));
+    test('confirm before destructive cancel', () => {
+      const fn = src.slice(src.indexOf('handleCancel'));
+      expect(fn).toMatch(/confirm\(/);
+    });
+    test('add-to-calendar gated on status=live and not already added', () => {
+      expect(src).toMatch(/status === ['"]live['"][\s\S]*?!calendarAdded/);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Closes the visibility gap left by P4: hosts can now see what their AI agent has set in motion + take action from the dashboard.

## What's in this PR

### Pages
- `/dashboard/convene/gatherings` — list (status badges, type, slot, venue, invitee count)
- `/dashboard/convene/gatherings/[id]` — detail (full record, invitees, proposed slots, audit log)

### Actions (server actions)
- **Add to my Google Calendar** — gated on `status=live`, calls the existing P2 adapter (`adapterFor('google').createEvent`), appends `calendar_event_added` audit entry.
- **Cancel gathering** — gated by state-machine `availableTransitions()`; uses `applyTransition(_, 'cancel')`; appends `gathering_cancelled` audit entry.

### Client component
- Confirm dialog before destructive cancel.
- Disabled state during transitions.
- Success/error flash banners.

## Test plan

- [x] Typecheck clean
- [x] 20 new structural tests (auth gate, ownership filter, server-action correctness, state-machine gating)
- [ ] Manual after merge: visit `/dashboard/convene/gatherings` on dev → see the smoke-test gathering `0f4f8220-...` → click into detail → "Add to my calendar" → event appears on your Google Calendar

## MCP coverage (KAN-222)

Not applicable — UI + lyra-only server actions. Agent surface unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)