### PR TITLE
feat(KAN-209): Convene P5 part 2 — invite send worker

### DIFF
--- a/src/app/api/convene/cron/send-invites/route.ts
+++ b/src/app/api/convene/cron/send-invites/route.ts
@@ -1,0 +1,37 @@
+/**
+ * /api/convene/cron/send-invites — KAN-209 Phase 5 part 2.
+ *
+ * Vercel Cron route. Drains the gathering_invite_messages queue and sends
+ * each one via Resend (gated by CONVENE_INVITE_ALLOWLIST). Schedule lives
+ * in vercel.json (`/api/convene/cron/send-invites` every 10 minutes).
+ *
+ * Auth: `Authorization: Bearer ${CRON_SECRET}` header.
+ * Gate: `CONVENE_ENABLED` must be 'true' or the route 404s — keeps it dark
+ * on every environment except develop until launch.
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { isConveneEnabled } from '@/lib/convene/flags';
+import { dispatchQueuedInvites } from '@/lib/convene/invites/dispatch';
+
+export const maxDuration = 60; // seconds
+
+export async function GET(req: NextRequest) {
+  if (!isConveneEnabled()) {
+    return NextResponse.json({ ok: false, error: 'convene_disabled' }, { status: 404 });
+  }
+
+  const authHeader = req.headers.get('authorization');
+  const expected = process.env.CRON_SECRET;
+  if (!expected || authHeader !== `Bearer ${expected}`) {
+    return NextResponse.json({ ok: false, error: 'unauthorised' }, { status: 401 });
+  }
+
+  try {
+    const summary = await dispatchQueuedInvites();
+    return NextResponse.json({ ok: true, summary });
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : 'unknown';
+    return NextResponse.json({ ok: false, error: msg }, { status: 500 });
+  }
+}

--- a/src/lib/convene/invites/dispatch.ts
+++ b/src/lib/convene/invites/dispatch.ts
@@ -1,0 +1,324 @@
+/**
+ * Invite dispatcher — KAN-209 (Phase 5 part 2).
+ *
+ * Reads queued rows from gathering_invite_messages, joins to invitee +
+ * contact + contact_methods + gathering + venue + host, renders the email
+ * templates, builds the ICS attachment, and calls Resend via sendInviteEmail
+ * (which itself gates on CONVENE_INVITE_ALLOWLIST). On success marks the
+ * row 'sent' and logs gathering_invite_delivered. On allowlist-block leaves
+ * the row 'queued' so it ships once the recipient is allow-listed. On hard
+ * failure marks 'failed' and logs gathering_invite_failed.
+ *
+ * The dispatcher is called from a Vercel cron route every 10 minutes (see
+ * vercel.json) AND can be invoked one-shot from an admin tool later.
+ */
+
+import { createClient, type SupabaseClient } from '@supabase/supabase-js';
+import { env } from '@/lib/env';
+import { sendInviteEmail, type SendResult } from './email';
+import { buildICS } from './ics';
+import {
+  renderInviteSubject,
+  renderInvitePlainText,
+  renderInviteHtml,
+} from './templates';
+
+const SITE_URL = process.env.LYRA_SITE_URL ?? 'https://checklyra.com';
+const DEFAULT_BATCH_SIZE = 25;
+const DEFAULT_CONCURRENCY = 3;
+
+export interface DispatchSummary {
+  scanned: number;
+  sent: number;
+  blocked_by_allowlist: number;
+  failed: number;
+  skipped_unfinalised: number;
+  errors: string[];
+}
+
+interface QueuedRow {
+  id: string;
+  gathering_id: string;
+  invitee_id: string;
+  channel: string;
+  template_name: string;
+}
+
+interface JoinedContext {
+  recipientEmail: string;
+  recipientName: string;
+  rsvpToken: string;
+  rsvpExpires: string | null;
+  gatheringId: string;
+  gatheringTitle: string;
+  gatheringType: string;
+  startISO: string;
+  endISO: string;
+  venueLabel: string | null;
+  hostUserId: string;
+  hostEmail: string;
+  hostDisplayName: string;
+}
+
+function admin(): SupabaseClient {
+  return createClient(env.supabaseUrl(), env.supabaseServiceRoleKey(), {
+    auth: { persistSession: false },
+  });
+}
+
+async function loadContext(
+  sb: SupabaseClient,
+  row: QueuedRow
+): Promise<{ ok: true; ctx: JoinedContext } | { ok: false; reason: string }> {
+  // 1. Invitee + contact + token. ownership-ok: queued row gates this (KAN-209).
+  const { data: invitee, error: iErr } = await sb
+    .from('gathering_invitees')
+    .select(`
+      id, rsvp_token, rsvp_token_expires_at,
+      contact:contacts(id, display_name)
+    `)
+    .eq('id', row.invitee_id)
+    .maybeSingle();
+  if (iErr || !invitee) return { ok: false, reason: `invitee not found: ${iErr?.message ?? 'no row'}` };
+  const inv = invitee as unknown as {
+    id: string;
+    rsvp_token: string | null;
+    rsvp_token_expires_at: string | null;
+    contact: { id: string; display_name: string } | null;
+  };
+  if (!inv.contact) return { ok: false, reason: 'contact link missing' };
+  if (!inv.rsvp_token) return { ok: false, reason: 'rsvp_token missing — re-queue from MCP' };
+
+  // 2. Primary email for the contact.
+  const { data: methods } = await sb
+    .from('contact_methods')
+    .select('value, is_primary')
+    .eq('contact_id', inv.contact.id)
+    .eq('kind', 'email');
+  const allEmails = (methods ?? []) as Array<{ value: string; is_primary: boolean }>;
+  const primary = allEmails.find((m) => m.is_primary) ?? allEmails[0];
+  if (!primary) return { ok: false, reason: 'no email on contact' };
+
+  // 3. Gathering + venue + host.
+  const { data: g, error: gErr } = await sb
+    .from('gatherings')
+    .select(`
+      id, host_user_id, title, gathering_type, status,
+      finalised_slot_start, finalised_slot_end,
+      venue:venues(name, city)
+    `)
+    .eq('id', row.gathering_id)
+    .is('deleted_at', null)
+    .maybeSingle();
+  if (gErr || !g) return { ok: false, reason: `gathering not found: ${gErr?.message ?? 'no row'}` };
+  const gat = g as unknown as {
+    id: string;
+    host_user_id: string;
+    title: string;
+    gathering_type: string;
+    status: string;
+    finalised_slot_start: string | null;
+    finalised_slot_end: string | null;
+    venue: { name: string; city: string | null } | null;
+  };
+  if (!gat.finalised_slot_start || !gat.finalised_slot_end) {
+    return { ok: false, reason: 'not_finalised' };
+  }
+
+  // 4. Host identity — auth.users.email + display name from profiles if present.
+  const { data: hostAuth } = await sb.auth.admin.getUserById(gat.host_user_id);
+  const hostEmail = hostAuth?.user?.email ?? 'host@checklyra.com';
+  const { data: hostProfile } = await sb
+    .from('profiles')
+    .select('display_name')
+    .eq('user_id', gat.host_user_id)
+    .maybeSingle();
+  const hostDisplayName =
+    (hostProfile as { display_name?: string } | null)?.display_name ?? hostEmail.split('@')[0];
+
+  return {
+    ok: true,
+    ctx: {
+      recipientEmail: primary.value,
+      recipientName: inv.contact.display_name,
+      rsvpToken: inv.rsvp_token,
+      rsvpExpires: inv.rsvp_token_expires_at,
+      gatheringId: gat.id,
+      gatheringTitle: gat.title,
+      gatheringType: gat.gathering_type,
+      startISO: gat.finalised_slot_start,
+      endISO: gat.finalised_slot_end,
+      venueLabel: gat.venue ? `${gat.venue.name}${gat.venue.city ? ` — ${gat.venue.city}` : ''}` : null,
+      hostUserId: gat.host_user_id,
+      hostEmail,
+      hostDisplayName,
+    },
+  };
+}
+
+export function buildSendInputs(ctx: JoinedContext) {
+  const rsvpUrl = `${SITE_URL}/r/${ctx.rsvpToken}`;
+  const tpl = {
+    hostName: ctx.hostDisplayName,
+    recipientName: ctx.recipientName,
+    gatheringTitle: ctx.gatheringTitle,
+    gatheringType: ctx.gatheringType,
+    startISO: ctx.startISO,
+    endISO: ctx.endISO,
+    venueLabel: ctx.venueLabel ?? undefined,
+    rsvpUrl,
+  };
+  const subject = renderInviteSubject(tpl);
+  const plainText = renderInvitePlainText(tpl);
+  const html = renderInviteHtml(tpl);
+  const ics = buildICS({
+    uid: `gathering-${ctx.gatheringId}@checklyra.com`,
+    title: ctx.gatheringTitle,
+    startISO: ctx.startISO,
+    endISO: ctx.endISO,
+    location: ctx.venueLabel ?? undefined,
+    organizerEmail: ctx.hostEmail,
+    organizerName: ctx.hostDisplayName,
+    attendeeEmail: ctx.recipientEmail,
+    attendeeName: ctx.recipientName,
+  });
+  return {
+    to: ctx.recipientEmail,
+    fromName: `${ctx.hostDisplayName} via Lyra Convene`,
+    subject,
+    html,
+    plainText,
+    icsContent: ics,
+  };
+}
+
+async function processOne(
+  sb: SupabaseClient,
+  row: QueuedRow,
+  summary: DispatchSummary
+): Promise<void> {
+  const loaded = await loadContext(sb, row);
+  if (!loaded.ok) {
+    if (loaded.reason === 'not_finalised') {
+      summary.skipped_unfinalised++;
+      return;
+    }
+    summary.failed++;
+    summary.errors.push(`${row.id}: ${loaded.reason.slice(0, 120)}`);
+    await sb
+      .from('gathering_invite_messages')
+      .update({ delivery_status: 'failed', bounce_reason: loaded.reason.slice(0, 500) })
+      .eq('id', row.id);
+    await sb.from('gathering_events_log').insert({
+      gathering_id: row.gathering_id,
+      event_type: 'gathering_invite_failed',
+      subject_kind: 'invitee',
+      subject_id: row.invitee_id,
+      metadata: { message_id: row.id, reason: loaded.reason.slice(0, 200) },
+    });
+    return;
+  }
+
+  const send = buildSendInputs(loaded.ctx);
+  let result: SendResult;
+  try {
+    result = await sendInviteEmail(send);
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : 'unknown';
+    summary.failed++;
+    summary.errors.push(`${row.id}: ${msg.slice(0, 120)}`);
+    await sb
+      .from('gathering_invite_messages')
+      .update({ delivery_status: 'failed', bounce_reason: msg.slice(0, 500) })
+      .eq('id', row.id);
+    return;
+  }
+
+  if (result.ok) {
+    summary.sent++;
+    await sb
+      .from('gathering_invite_messages')
+      .update({
+        delivery_status: 'sent',
+        sent_at: new Date().toISOString(),
+        external_message_id: result.messageId,
+      })
+      .eq('id', row.id);
+    await sb.from('gathering_events_log').insert({
+      gathering_id: row.gathering_id,
+      event_type: 'gathering_invite_delivered',
+      subject_kind: 'invitee',
+      subject_id: row.invitee_id,
+      metadata: {
+        message_id: row.id,
+        external_message_id: result.messageId,
+        channel: row.channel,
+      },
+    });
+    return;
+  }
+
+  if (result.code === 'not_in_allowlist') {
+    summary.blocked_by_allowlist++;
+    return;
+  }
+  summary.failed++;
+  const detail = result.detail ?? result.code;
+  summary.errors.push(`${row.id}: ${detail.slice(0, 120)}`);
+  await sb
+    .from('gathering_invite_messages')
+    .update({ delivery_status: 'failed', bounce_reason: detail.slice(0, 500) })
+    .eq('id', row.id);
+  await sb.from('gathering_events_log').insert({
+    gathering_id: row.gathering_id,
+    event_type: 'gathering_invite_failed',
+    subject_kind: 'invitee',
+    subject_id: row.invitee_id,
+    metadata: { message_id: row.id, code: result.code, detail: detail.slice(0, 200) },
+  });
+}
+
+export async function dispatchQueuedInvites(
+  opts: { batchSize?: number; concurrency?: number } = {}
+): Promise<DispatchSummary> {
+  const sb = admin();
+  const batchSize = opts.batchSize ?? DEFAULT_BATCH_SIZE;
+  const concurrency = opts.concurrency ?? DEFAULT_CONCURRENCY;
+
+  const summary: DispatchSummary = {
+    scanned: 0,
+    sent: 0,
+    blocked_by_allowlist: 0,
+    failed: 0,
+    skipped_unfinalised: 0,
+    errors: [],
+  };
+
+  const { data: rows, error } = await sb
+    .from('gathering_invite_messages')
+    .select('id, gathering_id, invitee_id, channel, template_name')
+    .eq('delivery_status', 'queued')
+    .eq('channel', 'email')
+    .order('created_at', { ascending: true })
+    .limit(batchSize);
+  if (error) throw new Error(`queue scan failed: ${error.message}`);
+  const queue = [...((rows as QueuedRow[]) ?? [])];
+  summary.scanned = queue.length;
+
+  const workers: Promise<void>[] = [];
+  for (let i = 0; i < concurrency; i++) {
+    workers.push(
+      (async () => {
+        while (queue.length > 0) {
+          const row = queue.shift();
+          if (!row) break;
+          await processOne(sb, row, summary);
+        }
+      })()
+    );
+  }
+  await Promise.all(workers);
+  return summary;
+}
+
+export const _internal = { loadContext, buildSendInputs };

--- a/tests/unit/convene/dispatch.test.ts
+++ b/tests/unit/convene/dispatch.test.ts
@@ -1,0 +1,132 @@
+/**
+ * KAN-209 P5 part 2 — invite dispatcher tests.
+ *
+ * Covers the pure transformation step (buildSendInputs) plus structural
+ * checks on the cron route + vercel.json wiring. DB-touching paths
+ * (loadContext, dispatchQueuedInvites) are exercised by the existing
+ * smoke-test pattern (real MCP + Vercel) rather than mocked here — the
+ * Supabase client surface is wide enough that mocking it would just be
+ * testing the mock.
+ */
+
+import fs from 'fs';
+import path from 'path';
+
+const ROOT = path.join(__dirname, '..', '..', '..');
+
+import { _internal } from '@/lib/convene/invites/dispatch';
+const { buildSendInputs } = _internal;
+
+describe('buildSendInputs (KAN-209)', () => {
+  const ctx = {
+    recipientEmail: 'ben@example.com',
+    recipientName: 'Ben Stephens',
+    rsvpToken: 'tok_abc123',
+    rsvpExpires: '2026-07-01T00:00:00Z',
+    gatheringId: '11111111-1111-1111-1111-111111111111',
+    gatheringTitle: 'Coffee at Caravan',
+    gatheringType: 'coffee',
+    startISO: '2026-06-01T10:00:00Z',
+    endISO: '2026-06-01T11:00:00Z',
+    venueLabel: 'Caravan — London',
+    hostUserId: '22222222-2222-2222-2222-222222222222',
+    hostEmail: 'luisa@example.com',
+    hostDisplayName: 'Luisa',
+  };
+
+  test('returns subject, html, plainText, icsContent + recipient', () => {
+    const out = buildSendInputs(ctx);
+    expect(out.to).toBe('ben@example.com');
+    expect(out.subject).toContain('Coffee at Caravan');
+    expect(out.plainText).toContain('https://checklyra.com/r/tok_abc123');
+    expect(out.html).toContain('https://checklyra.com/r/tok_abc123');
+    expect(out.icsContent).toMatch(/^BEGIN:VCALENDAR/);
+    expect(out.icsContent).toMatch(/END:VCALENDAR$/);
+  });
+
+  test('ICS uid is stable per gathering', () => {
+    const out = buildSendInputs(ctx);
+    expect(out.icsContent).toContain(`UID:gathering-${ctx.gatheringId}@checklyra.com`);
+  });
+
+  test('ICS includes organizer + attendee mailtos', () => {
+    const out = buildSendInputs(ctx);
+    expect(out.icsContent).toContain('ORGANIZER;CN="Luisa":mailto:luisa@example.com');
+    expect(out.icsContent).toContain('ATTENDEE;CN="Ben Stephens";RSVP=TRUE:mailto:ben@example.com');
+  });
+
+  test('from name marks origin as Lyra Convene', () => {
+    const out = buildSendInputs(ctx);
+    expect(out.fromName).toContain('Lyra Convene');
+    expect(out.fromName).toContain('Luisa');
+  });
+
+  test('venueLabel optional — omitted ICS LOCATION when null', () => {
+    const out = buildSendInputs({ ...ctx, venueLabel: null });
+    expect(out.icsContent).not.toMatch(/LOCATION:/);
+  });
+
+  test('respects LYRA_SITE_URL override in plainText', () => {
+    // Module reads LYRA_SITE_URL at import time, so re-require under a fresh env.
+    jest.resetModules();
+    process.env.LYRA_SITE_URL = 'https://staging.checklyra.com';
+    const { _internal: fresh } = require('@/lib/convene/invites/dispatch');
+    const out = fresh.buildSendInputs(ctx);
+    expect(out.plainText).toContain('https://staging.checklyra.com/r/tok_abc123');
+    delete process.env.LYRA_SITE_URL;
+  });
+});
+
+// ─── cron route shape ──────────────────────────────────────────────────
+
+describe('send-invites cron route (KAN-209)', () => {
+  const routePath = path.join(ROOT, 'src/app/api/convene/cron/send-invites/route.ts');
+
+  test('route file exists', () => {
+    expect(fs.existsSync(routePath)).toBe(true);
+  });
+
+  test('gates on isConveneEnabled + CRON_SECRET', () => {
+    const src = fs.readFileSync(routePath, 'utf8');
+    expect(src).toMatch(/isConveneEnabled\(\)/);
+    expect(src).toMatch(/CRON_SECRET/);
+    expect(src).toMatch(/`Bearer \$\{expected\}`/);
+  });
+
+  test('delegates to dispatchQueuedInvites', () => {
+    const src = fs.readFileSync(routePath, 'utf8');
+    expect(src).toMatch(/dispatchQueuedInvites/);
+  });
+
+  test('declares maxDuration ≥ 30s', () => {
+    const src = fs.readFileSync(routePath, 'utf8');
+    const m = src.match(/maxDuration\s*=\s*(\d+)/);
+    expect(m).not.toBeNull();
+    expect(Number(m![1])).toBeGreaterThanOrEqual(30);
+  });
+});
+
+// ─── vercel.json wiring ────────────────────────────────────────────────
+
+describe('vercel.json crons (KAN-209)', () => {
+  const cfg = JSON.parse(fs.readFileSync(path.join(ROOT, 'vercel.json'), 'utf8'));
+
+  test('send-invites cron registered', () => {
+    const paths = (cfg.crons ?? []).map((c: { path: string }) => c.path);
+    expect(paths).toContain('/api/convene/cron/send-invites');
+  });
+
+  test('runs at sub-hourly cadence', () => {
+    const entry = (cfg.crons ?? []).find(
+      (c: { path: string }) => c.path === '/api/convene/cron/send-invites'
+    );
+    expect(entry).toBeDefined();
+    // Schedule should contain a "*/N" minute pattern OR be "* * * * *".
+    expect(entry.schedule).toMatch(/^(\*\/\d+|\*)\s/);
+  });
+
+  test('token-health cron preserved', () => {
+    const paths = (cfg.crons ?? []).map((c: { path: string }) => c.path);
+    expect(paths).toContain('/api/convene/cron/token-health');
+  });
+});

--- a/vercel.json
+++ b/vercel.json
@@ -6,6 +6,10 @@
     {
       "path": "/api/convene/cron/token-health",
       "schedule": "30 3 * * *"
+    },
+    {
+      "path": "/api/convene/cron/send-invites",
+      "schedule": "*/10 * * * *"
     }
   ]
 }


### PR DESCRIPTION
## Summary

The MCP-side `lyra_send_invite` tool queues rows in `gathering_invite_messages` with `delivery_status='queued'` but intentionally does NOT call Resend — that keeps the MCP server free of email credentials. This PR adds the lyra-side worker that drains the queue.

- **`src/lib/convene/invites/dispatch.ts`** — pure dispatcher. Reads queued rows, joins to invitee + contact + primary email + gathering + venue + host, renders templates, builds ICS, calls `sendInviteEmail` (which itself gates on `CONVENE_INVITE_ALLOWLIST`). Marks rows `sent` / `failed` and writes `gathering_events_log` entries on each path. Allowlist-blocked rows stay `queued` so they ship when the recipient is later allow-listed.
- **`src/app/api/convene/cron/send-invites/route.ts`** — Vercel Cron entry. Gated by `isConveneEnabled()` + `CRON_SECRET`, same shape as `token-health`.
- **`vercel.json`** — cron registered at `*/10 * * * *`.
- **`tests/unit/convene/dispatch.test.ts`** — 13 tests covering `buildSendInputs` transformation, cron route gating, vercel.json wiring.

## Test plan

- [x] `npx jest tests/unit/convene/dispatch.test.ts` — 13/13 pass
- [x] `npx jest` (full suite) — 1141/1141 unit tests pass
- [x] `npx tsc --noEmit` — clean
- [x] `npm run build` — `/api/convene/cron/send-invites` registered in route table
- [x] `npx eslint` on new files — clean
- [ ] On develop (CONVENE_ENABLED=true): manual MCP `lyra_send_invite` → wait 10 min → confirm row goes `queued → sent` and `gathering_invite_delivered` audit row exists
- [ ] Once shipped: verify staging/beta/prod still 404 on `/api/convene/cron/send-invites` (CONVENE_ENABLED unset on those scopes)

## Notes

- DB-touching paths (`loadContext`, `dispatchQueuedInvites`) are exercised by the smoke-test pattern (real MCP + Vercel cron firing) rather than mocked — the Supabase client surface is wide enough that mocking it would just be testing the mock.
- `CONVENE_INVITE_ALLOWLIST` must be set on develop's Vercel env before any send actually goes out. Without it, every recipient is blocked at the email-layer gate.
- `CONVENE_INVITE_FROM_EMAIL` is optional (defaults to `invites@checklyra.com`). Domain must be verified in Resend before non-allowlisted sends will succeed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)