### PR TITLE
feat(KAN-237): auto-delete Vercel preview deployments on PR close

### DIFF
--- a/.github/workflows/cleanup-preview-deployments.yml
+++ b/.github/workflows/cleanup-preview-deployments.yml
@@ -1,0 +1,178 @@
+# KAN-237 — Auto-delete Vercel preview deployments when a PR closes.
+#
+# Why this exists:
+#   After KAN-82/KAN-85 closed out, Vercel Authentication was disabled
+#   project-wide so that Cloudflare Access could be the sole gate on
+#   stage.checklyra.com and beta.checklyra.com. Side effect: every PR
+#   preview URL Vercel generates is now publicly viewable to anyone
+#   holding the link, and Vercel keeps every SHA-pinned deployment URL
+#   live indefinitely on the Pro plan. This workflow deletes both the
+#   branch-alias and SHA-pinned URLs as soon as the PR closes (merged
+#   or abandoned), closing the long-tail exposure.
+#
+# Residual risk for OPEN PRs is tracked under BUGS-22.
+#
+# Required secrets (already present in luisa-sys/lyra):
+#   - VERCEL_TOKEN      (scope: luisa-sys team only; rotate every 90 days)
+#   - VERCEL_ORG_ID     (= team ID)
+#   - VERCEL_PROJECT_ID
+#
+# Behavior:
+#   - On pull_request: closed (any close, including merge), look up
+#     every Vercel deployment for the PR's head branch and DELETE it.
+#   - If zero deployments are found, log a GitHub ::warning:: and exit 0
+#     (this is fine — not every PR generates a Vercel preview).
+#   - If the Vercel API errors, fail loud with a ::error:: annotation.
+#   - Branch names are validated against ^[A-Za-z0-9._/-]+$ before being
+#     sent to the Vercel API, defense against odd branch names.
+
+name: Cleanup preview deployments
+
+on:
+  pull_request:
+    types: [closed]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Validate branch name
+        id: branch
+        env:
+          PR_BRANCH: ${{ github.event.pull_request.head.ref }}
+        run: |
+          set -euo pipefail
+          if [[ -z "${PR_BRANCH}" ]]; then
+            echo "::error::PR head ref is empty — refusing to proceed"
+            exit 1
+          fi
+          # Only allow GitHub-permitted branch-name chars. Defense
+          # against shell-injection via odd branch names.
+          if ! [[ "${PR_BRANCH}" =~ ^[A-Za-z0-9._/-]+$ ]]; then
+            echo "::error::PR head ref contains disallowed characters: ${PR_BRANCH}"
+            exit 1
+          fi
+          echo "branch=${PR_BRANCH}" >> "$GITHUB_OUTPUT"
+          echo "Will clean up deployments for branch: ${PR_BRANCH}"
+
+      - name: Delete Vercel preview deployments for branch
+        env:
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+          PR_BRANCH: ${{ steps.branch.outputs.branch }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_MERGED: ${{ github.event.pull_request.merged }}
+        run: |
+          set -euo pipefail
+
+          if [[ -z "${VERCEL_TOKEN}" || -z "${VERCEL_ORG_ID}" || -z "${VERCEL_PROJECT_ID}" ]]; then
+            echo "::error::One or more Vercel secrets (VERCEL_TOKEN/VERCEL_ORG_ID/VERCEL_PROJECT_ID) are missing"
+            exit 1
+          fi
+
+          echo "PR #${PR_NUMBER} closed (merged=${PR_MERGED}). Looking up Vercel deployments for branch '${PR_BRANCH}'..."
+
+          # Paginate through deployments and collect IDs whose
+          # meta.githubCommitRef matches the PR branch. Vercel returns
+          # at most 100 per page; we use the documented `until` cursor
+          # (millisecond epoch) to walk older pages. Cap at 10 pages =
+          # 1000 deployments — any branch with more than that has
+          # bigger problems than cleanup latency.
+          IDS=()
+          UNTIL=""
+          PAGE=0
+          MAX_PAGES=10
+          while [[ "${PAGE}" -lt "${MAX_PAGES}" ]]; do
+            PAGE=$((PAGE + 1))
+            URL="https://api.vercel.com/v6/deployments?projectId=${VERCEL_PROJECT_ID}&teamId=${VERCEL_ORG_ID}&limit=100"
+            if [[ -n "${UNTIL}" ]]; then
+              URL="${URL}&until=${UNTIL}"
+            fi
+
+            RESPONSE=$(curl -sf \
+              -H "Authorization: Bearer ${VERCEL_TOKEN}" \
+              "${URL}") || {
+                echo "::error::Vercel API list call failed (page ${PAGE}). URL: ${URL}"
+                exit 1
+              }
+
+            # Extract deployment IDs whose meta.githubCommitRef matches.
+            # Also extract the oldest 'createdAt' on this page for the
+            # next pagination cursor.
+            PAGE_IDS=$(echo "${RESPONSE}" | python3 -c "
+          import json, sys
+          want = '${PR_BRANCH}'
+          data = json.load(sys.stdin)
+          for d in data.get('deployments', []):
+              meta = d.get('meta', {}) or {}
+              if meta.get('githubCommitRef') == want:
+                  print(d['uid'])
+          ")
+            if [[ -n "${PAGE_IDS}" ]]; then
+              while IFS= read -r id; do
+                IDS+=("${id}")
+              done <<< "${PAGE_IDS}"
+            fi
+
+            # Compute next cursor = oldest createdAt on this page minus 1ms.
+            NEXT_UNTIL=$(echo "${RESPONSE}" | python3 -c "
+          import json, sys
+          data = json.load(sys.stdin)
+          deps = data.get('deployments', [])
+          if not deps:
+              print('')
+          else:
+              ts = min(int(d.get('createdAt', 0)) for d in deps)
+              print(ts - 1 if ts else '')
+          ")
+            COUNT=$(echo "${RESPONSE}" | python3 -c "
+          import json, sys
+          print(len(json.load(sys.stdin).get('deployments', [])))
+          ")
+
+            if [[ "${COUNT}" -lt 100 || -z "${NEXT_UNTIL}" ]]; then
+              # Fewer than a full page = exhausted.
+              break
+            fi
+            UNTIL="${NEXT_UNTIL}"
+          done
+
+          TOTAL=${#IDS[@]}
+          echo "Found ${TOTAL} deployment(s) for branch '${PR_BRANCH}'."
+
+          if [[ "${TOTAL}" -eq 0 ]]; then
+            echo "::warning::No Vercel deployments found for branch '${PR_BRANCH}'. Either this PR never produced a preview, or they were already deleted. Nothing to do."
+            exit 0
+          fi
+
+          DELETED=0
+          FAILED=0
+          for ID in "${IDS[@]}"; do
+            # v13 is the documented DELETE endpoint as of 2026.
+            HTTP=$(curl -s -o /tmp/vercel_del_response -w '%{http_code}' \
+              -X DELETE \
+              -H "Authorization: Bearer ${VERCEL_TOKEN}" \
+              "https://api.vercel.com/v13/deployments/${ID}?teamId=${VERCEL_ORG_ID}") || HTTP="000"
+
+            if [[ "${HTTP}" == "200" || "${HTTP}" == "202" || "${HTTP}" == "204" ]]; then
+              echo "  ✓ deleted ${ID}"
+              DELETED=$((DELETED + 1))
+            else
+              echo "::error::Failed to delete ${ID} (HTTP ${HTTP}): $(cat /tmp/vercel_del_response 2>/dev/null || echo '<no body>')"
+              FAILED=$((FAILED + 1))
+            fi
+          done
+
+          echo ""
+          echo "Cleanup summary for branch '${PR_BRANCH}': ${DELETED} deleted, ${FAILED} failed (total ${TOTAL})."
+
+          if [[ "${FAILED}" -gt 0 ]]; then
+            echo "::error::${FAILED} deployment(s) failed to delete — see log above."
+            exit 1
+          fi

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -228,6 +228,15 @@ The pipeline is: **develop → staging → beta → main** (promotion-based, fou
 - Commit and push only after verifying code compiles and tests pass
 - Cadence: at least one release/week to flush the chain (see `docs/RELEASE_POLICY.md`)
 
+### PR preview deployment lifecycle (KAN-237)
+
+- Every push to a PR branch generates a Vercel preview deployment with two URLs:
+  - A branch-alias URL (`lyra-git-<branch>-luisa-sys-projects.vercel.app`), which is repointed on each push.
+  - A SHA-pinned URL (`lyra-<deployhash>-luisa-sys-projects.vercel.app`), which is immutable.
+- Since the KAN-82/KAN-85 closeout (Vercel Authentication globally disabled in favour of Cloudflare Access on stage/beta), these preview URLs are **publicly viewable to anyone holding the link**. They are unguessable hashes but not gated.
+- The `.github/workflows/cleanup-preview-deployments.yml` workflow runs on every `pull_request: closed` event and deletes every Vercel deployment whose `meta.githubCommitRef` matches the PR's head branch — both URL types. Deletion is permanent; you cannot recover a preview after a PR closes.
+- Open-PR window risk (someone capturing a preview URL while the PR is still open) is tracked under BUGS-22; see that ticket for the residual risk model and Option A/B/C decision.
+
 ## Testing Requirements
 
 - All deployments to dev must pass unit and build tests


### PR DESCRIPTION
## Summary

- New GitHub Actions workflow `cleanup-preview-deployments.yml` that fires on every `pull_request: closed` event (merged OR abandoned) and deletes every Vercel deployment whose `meta.githubCommitRef` matches the closed PR's head branch.
- Closes the **long-tail** of the Vercel preview-URL exposure introduced by KAN-82/KAN-85 (Vercel Auth disabled globally so CF Access can be the sole gate on stage/beta). Both branch-alias and SHA-pinned URLs go away as soon as the PR closes.
- Open-PR window residual risk (someone capturing a preview URL while the PR is still open) is tracked under **BUGS-22** and explicitly out of scope here.
- Updates `CLAUDE.md` Deployment Pipeline section to document the new PR-close lifecycle and link to BUGS-22.

## Implementation notes

- Uses Vercel's REST API directly (`v6/deployments` for list, `v13/deployments/{id}` for DELETE) — no CLI install step needed.
- Paginates via the `until` cursor; capped at 10 × 100 = 1000 deployments per branch.
- All multi-line shell blocks start with `set -euo pipefail`. GitHub `::error::` / `::warning::` annotations on every failure or empty-list case.
- Branch name validated against `^[A-Za-z0-9._/-]+$` before being interpolated anywhere — defends against odd branch names breaking the shell.
- Workflow `permissions:` block scoped to `contents: read` + `pull-requests: read`; deletion is via the Vercel token, not GH credentials.
- Pre-merge grep checks for the forbidden patterns (silent-skip / lossy-fallback / `continue-on-error: true`) all return clean.

## Test plan

- [ ] After merge to develop and through to main, open a throwaway PR with two pushes (= two preview deployments), close the PR, watch the workflow run.
- [ ] Confirm both URLs return 404 within ~5 min (`curl -sI <preview-url>`).
- [ ] Test the empty-list path by closing a PR that never produced a preview (e.g. docs-only PR if Vercel skips it) — should emit a `::warning::` and exit 0.
- [ ] Verify no regression in existing workflows (no other workflow listens on `pull_request: closed`).

## Acceptance criteria status

From KAN-237:

- [x] Workflow file present and runs on `pull_request: closed` in lyra. **(lyra-mcp-server scoped out — deploys to Railway, not Vercel; will note this in the KAN-237 ticket.)**
- [ ] On a throwaway PR with two preview deployments: closing the PR results in both URLs returning 404 within 5 minutes. **(Will validate post-merge.)**
- [x] Workflow includes `set -euo pipefail`, error annotations, and branch-name validation.
- [x] Documented in `CLAUDE.md`. (Lyra core reference memory will be updated in the KAN-237 closeout commentary.)
- [x] BUGS-22 linked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)