### PR TITLE
fix(KAN-104): activate-sentry sets vars on unscoped preview (was only branch-scoped)

### DIFF
--- a/.github/workflows/activate-sentry.yml
+++ b/.github/workflows/activate-sentry.yml
@@ -69,7 +69,18 @@ jobs:
             # API rejects an empty `target`, so unbranched scopes need
             # the label and target equal (development:development:,
             # production:production:). gitBranch is empty for those.
-            echo "list=development:development:,preview:preview:develop,preview:preview:staging,preview:preview:beta,production:production:" >> "$GITHUB_OUTPUT"
+            #
+            # KAN-104 follow-up (2026-05-17 verification pass): the
+            # branch-scoped preview entries (preview:preview:develop|
+            # staging|beta) get IGNORED by the deploy-dev/staging/beta
+            # workflows because those call `vercel pull --environment=preview`
+            # WITHOUT a `--git-branch` flag, so they only see vars set on
+            # the un-scoped preview target. Adding a plain `preview:preview:`
+            # entry ensures the SDK env vars actually reach the build for
+            # all preview deploys, regardless of branch. The branch-scoped
+            # entries remain so a future deploy workflow that DOES pass
+            # `--git-branch` would still find them.
+            echo "list=development:development:,preview:preview:,preview:preview:develop,preview:preview:staging,preview:preview:beta,production:production:" >> "$GITHUB_OUTPUT"
           else
             echo "list=$requested" >> "$GITHUB_OUTPUT"
           fi


### PR DESCRIPTION
## Summary

The `activate-sentry.yml --scopes=all` flow only set `NEXT_PUBLIC_SENTRY_DSN` + `IS_SENTRY_ENABLED` on **branch-scoped** preview targets (`preview/develop`, `preview/staging`, `preview/beta`). But the deploy-dev/staging/beta workflows do `vercel pull --environment=preview` **without** `--git-branch=…`, so they only see the *unscoped* preview vars — which had no Sentry DSN.

Net effect: Sentry stayed inert on dev/staging/beta even though the workflow reported success. Confirmed by inspecting the dev bundle — DSN string nowhere in the JS, no Sentry SDK initialised at runtime.

Discovered during the KAN-104 closure pass this morning, after a fresh deploy-dev with the (supposedly) populated env vars still produced an inert SDK.

## Fix

One-line scope-list change in `activate-sentry.yml`. Prepend an unscoped `preview:preview:` entry so the next run upserts on the target that deploy-dev/staging/beta actually pull from. Existing branch-scoped entries are retained so a future deploy workflow that DOES pass `--git-branch` keeps finding them.

Production scope was unaffected (`production:production:` matches deploy-production's `vercel pull --environment=production`).

## Test plan

- [x] YAML still parses (no syntax change beyond comma-separated list extension)
- [ ] After merge: re-run `activate-sentry.yml --scopes=all`, then push a no-op commit to develop. Inspect the new dev bundle for the DSN string. Confirm a thrown error reaches Sentry.

## Why no unit test

The workflow is config-only — the testable change is the value of one string in a shell echo. Verifying it via test would mean parsing the YAML and re-implementing the workflow's runtime semantics, which is brittle. The real test is the rerun + bundle inspection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)