### PR TITLE
feat(KAN-209): admin drain-queue route + per-user dispatcher filter

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -428,6 +428,56 @@ These have caused real bugs. Read before making related changes:
 
 See `docs/ARCHITECTURE.md` for the full environment table. Three environments: dev, staging, production — each with independent Supabase projects, Vercel deployments, and DNS entries.
 
+## Smoke-testing MCP tools end-to-end
+
+Convene write-tools (and any future MCP tool) can be smoke-tested without leaving Claude Code, by combining three pieces:
+
+1. **The Claude Code MCP connector** (`mcp__9f554c80-…__lyra_*` namespace) — fast, type-safe, but the tool list is fetched at connector-start and **cached**. Newly-shipped tools (e.g. `lyra_send_invite`, `lyra_record_rsvp`) won't appear in this list until the connector is reconnected. Use this for tools that *are* in the cache: `lyra_list_my_gatherings`, `lyra_list_my_contacts`, `lyra_create_gathering`, `lyra_finalise_gathering`, `lyra_get_gathering`, etc.
+2. **Direct JSON-RPC POST to the MCP server** — bypasses the cached tool list. Works against `mcp-dev.checklyra.com` (dev MCP, dev Supabase project) or `mcp.checklyra.com` (prod), using the same Bearer API key auth. Use this for tools that were added since the connector last reconnected.
+3. **The Supabase MCP** (`mcp__0ad2c807-…__execute_sql`) — for direct DB reads (verifying a row updated, looking up auth.users IDs) and for seeding test data that has no MCP tool yet (e.g. inserting a contact + contact_methods row, since there is currently no `lyra_add_contact` tool).
+
+**The direct JSON-RPC call shape:**
+
+```bash
+curl -sS -N --max-time 30 \
+  -X POST https://mcp-dev.checklyra.com/mcp \
+  -H 'Content-Type: application/json' \
+  -H 'Accept: application/json, text/event-stream' \
+  -d '{
+    "jsonrpc": "2.0",
+    "id": 1,
+    "method": "tools/call",
+    "params": {
+      "name": "lyra_send_invite",
+      "arguments": { "api_key": "lyra_…", "gathering_id": "…", "invitee_id": "…", "channel": "email" }
+    }
+  }'
+```
+
+The response is a single SSE `event: message` line whose `data:` is the same JSON-RPC envelope the connector returns. Parse the `result.content[0].text` to get the tool's payload.
+
+**Worked example — P5 invite send (2026-05-17):**
+
+1. `lyra_list_my_gatherings` (via connector) → confirms env + finds `0f4f8220-9cb6-…` (status=`live`, 0 invitees).
+2. Seed contact + email + invitee via Supabase MCP `execute_sql` (allowlisted email so the send-worker won't block it).
+3. `lyra_send_invite` via direct JSON-RPC (tool not in connector cache) → returns `message_id` + `rsvp_url`, row in `gathering_invite_messages` with `delivery_status=queued`.
+4. Wait for next `*/10` cron fire (Vercel `/api/convene/cron/send-invites` on develop).
+5. Re-query `gathering_invite_messages` via Supabase MCP → confirm `delivery_status=sent` + `external_message_id` populated; `gathering_events_log` shows a `gathering_invite_delivered` row.
+
+**Pre-requisites for a successful end-to-end:**
+
+- `CONVENE_ENABLED=true` on develop Vercel scope (the cron 404s otherwise).
+- `CONVENE_INVITE_ALLOWLIST` set on develop Vercel scope with the recipient address (or `*`). Missing/empty → every send blocked at the email-layer gate.
+- The sender domain on `CONVENE_INVITE_FROM_EMAIL` (default `invites@checklyra.com`) must be **verified in Resend** — otherwise Resend's API returns 422 and the row goes to `failed`.
+- Dev MCP API key (`lyra_…`) issued from `dev.checklyra.com/dashboard/settings`. Keys are env-scoped (BUGS-1 / Gotcha #19): a key from dev cannot auth against the prod MCP server and vice versa. Read-tools accept any key (no auth on read); write-tools enforce.
+
+**Vercel Cron does NOT fire on develop (or any Preview branch).** Cron jobs are scheduled only against Production deployments — by default that's `main`. So the cron at `/api/convene/cron/send-invites` will never invoke automatically on `develop`. To drive the dispatcher on dev there are two paths:
+
+1. **`lyra_drain_invite_queue` MCP tool** (preferred). Authenticated by the same API key as every other write tool; only drains the calling user's own gatherings. Calls `POST /api/convene/admin/drain-queue` on lyra under the hood. Use this for any manual smoke test — it works on dev without a Vercel cron, and on prod once Convene ships there.
+2. **Manual `curl` to `/api/convene/cron/send-invites`** with `Authorization: Bearer ${CRON_SECRET}`. Requires `CRON_SECRET` to be set on the relevant Vercel scope. Fine for one-off ops debugging; not the everyday tool.
+
+The cron route is still wired in `vercel.json` because Production (once Convene flips on) WILL want a periodic background drain — it's just inert on Preview, which is expected.
+
 ## Scheduled Workflows
 
 See `docs/RUNBOOK.md` for the full schedule. Key times (UTC):

--- a/src/app/api/convene/admin/drain-queue/route.ts
+++ b/src/app/api/convene/admin/drain-queue/route.ts
@@ -1,0 +1,41 @@
+/**
+ * /api/convene/admin/drain-queue — KAN-209 P5 part 2 follow-up.
+ *
+ * Manual, user-scoped drain trigger. The Vercel cron at
+ * /api/convene/cron/send-invites only fires on production deployments —
+ * to drive the dispatcher on dev (or to manually flush after queueing),
+ * this route lets the lyra_drain_invite_queue MCP tool call it on
+ * behalf of an authenticated user.
+ *
+ * Auth: `Authorization: Bearer lyra_…` (a user-owned API key, same
+ * format as every other MCP-callable). The drain is filtered to that
+ * user's gatherings only — one user cannot drain another's queue.
+ *
+ * Gate: `CONVENE_ENABLED` must be 'true' or the route 404s.
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { isConveneEnabled } from '@/lib/convene/flags';
+import { authenticateBearerApiKey } from '@/lib/convene/auth-bearer';
+import { dispatchQueuedInvites } from '@/lib/convene/invites/dispatch';
+
+export const maxDuration = 60;
+
+export async function POST(req: NextRequest) {
+  if (!isConveneEnabled()) {
+    return NextResponse.json({ ok: false, error: 'convene_disabled' }, { status: 404 });
+  }
+
+  const auth = await authenticateBearerApiKey(req.headers.get('authorization'));
+  if (!auth.ok) {
+    return NextResponse.json({ ok: false, error: auth.error }, { status: auth.status });
+  }
+
+  try {
+    const summary = await dispatchQueuedInvites({ hostUserId: auth.userId });
+    return NextResponse.json({ ok: true, summary });
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : 'unknown';
+    return NextResponse.json({ ok: false, error: msg }, { status: 500 });
+  }
+}

--- a/src/lib/convene/auth-bearer.ts
+++ b/src/lib/convene/auth-bearer.ts
@@ -1,0 +1,57 @@
+/**
+ * Bearer-token API-key authentication for Convene admin endpoints.
+ *
+ * Mirrors the MCP server's authentication path: take an opaque
+ * `lyra_<base64url>` API key from `Authorization: Bearer …`, sha256-hash
+ * it, look up the row in api_keys, return the owning user_id.
+ *
+ * Used by /api/convene/admin/* routes that need server-to-server (no
+ * cookie session) auth — currently just the queue-drain endpoint, but
+ * we'll grow more admin tools later (resend-failed-invites, etc.).
+ */
+import { createClient } from '@supabase/supabase-js';
+import { createHash } from 'crypto';
+import { env } from '@/lib/env';
+
+export interface BearerAuthResult {
+  ok: true;
+  userId: string;
+  keyId: string;
+}
+export interface BearerAuthError {
+  ok: false;
+  status: 401;
+  error: string;
+}
+
+function admin() {
+  return createClient(env.supabaseUrl(), env.supabaseServiceRoleKey(), {
+    auth: { persistSession: false },
+  });
+}
+
+export async function authenticateBearerApiKey(
+  authHeader: string | null
+): Promise<BearerAuthResult | BearerAuthError> {
+  if (!authHeader) return { ok: false, status: 401, error: 'missing_bearer' };
+  const m = authHeader.match(/^Bearer\s+(\S+)$/);
+  if (!m) return { ok: false, status: 401, error: 'malformed_bearer' };
+  const raw = m[1];
+  if (!raw.startsWith('lyra_')) return { ok: false, status: 401, error: 'bad_prefix' };
+
+  const keyHash = createHash('sha256').update(raw).digest('hex');
+  const sb = admin();
+  const { data, error } = await sb
+    .from('api_keys')
+    .select('id, user_id, revoked_at')
+    .eq('key_hash', keyHash)
+    .maybeSingle();
+  if (error || !data) return { ok: false, status: 401, error: 'invalid_key' };
+  const row = data as { id: string; user_id: string; revoked_at: string | null };
+  if (row.revoked_at) return { ok: false, status: 401, error: 'revoked_key' };
+
+  // touch last_used_at, best effort
+  void sb.from('api_keys').update({ last_used_at: new Date().toISOString() }).eq('id', row.id);
+
+  return { ok: true, userId: row.user_id, keyId: row.id };
+}

--- a/src/lib/convene/invites/dispatch.ts
+++ b/src/lib/convene/invites/dispatch.ts
@@ -279,7 +279,7 @@ async function processOne(
 }
 
 export async function dispatchQueuedInvites(
-  opts: { batchSize?: number; concurrency?: number } = {}
+  opts: { batchSize?: number; concurrency?: number; hostUserId?: string } = {}
 ): Promise<DispatchSummary> {
   const sb = admin();
   const batchSize = opts.batchSize ?? DEFAULT_BATCH_SIZE;
@@ -294,15 +294,40 @@ export async function dispatchQueuedInvites(
     errors: [],
   };
 
-  const { data: rows, error } = await sb
-    .from('gathering_invite_messages')
-    .select('id, gathering_id, invitee_id, channel, template_name')
-    .eq('delivery_status', 'queued')
-    .eq('channel', 'email')
-    .order('created_at', { ascending: true })
-    .limit(batchSize);
-  if (error) throw new Error(`queue scan failed: ${error.message}`);
-  const queue = [...((rows as QueuedRow[]) ?? [])];
+  // When hostUserId is given, narrow to that user's gatherings only.
+  // The MCP admin tool relies on this so one user can't drain another's queue.
+  let queuedRows: QueuedRow[];
+  if (opts.hostUserId) {
+    const { data: gatherings, error: gErr } = await sb
+      .from('gatherings')
+      .select('id')
+      .eq('host_user_id', opts.hostUserId)
+      .is('deleted_at', null);
+    if (gErr) throw new Error(`gathering scan failed: ${gErr.message}`);
+    const gatheringIds = (gatherings ?? []).map((g: { id: string }) => g.id);
+    if (gatheringIds.length === 0) return summary;
+    const { data, error } = await sb
+      .from('gathering_invite_messages')
+      .select('id, gathering_id, invitee_id, channel, template_name')
+      .eq('delivery_status', 'queued')
+      .eq('channel', 'email')
+      .in('gathering_id', gatheringIds)
+      .order('created_at', { ascending: true })
+      .limit(batchSize);
+    if (error) throw new Error(`queue scan failed: ${error.message}`);
+    queuedRows = (data as QueuedRow[]) ?? [];
+  } else {
+    const { data, error } = await sb
+      .from('gathering_invite_messages')
+      .select('id, gathering_id, invitee_id, channel, template_name')
+      .eq('delivery_status', 'queued')
+      .eq('channel', 'email')
+      .order('created_at', { ascending: true })
+      .limit(batchSize);
+    if (error) throw new Error(`queue scan failed: ${error.message}`);
+    queuedRows = (data as QueuedRow[]) ?? [];
+  }
+  const queue = [...queuedRows];
   summary.scanned = queue.length;
 
   const workers: Promise<void>[] = [];

--- a/tests/unit/convene/drain-route.test.ts
+++ b/tests/unit/convene/drain-route.test.ts
@@ -1,0 +1,76 @@
+/**
+ * KAN-209 admin drain-queue route — structural tests.
+ *
+ * DB-touching paths are exercised by the smoke-test (real MCP +
+ * route call) rather than mocked here.
+ */
+
+import fs from 'fs';
+import path from 'path';
+
+const ROOT = path.join(__dirname, '..', '..', '..');
+
+describe('admin drain-queue route (KAN-209)', () => {
+  const routePath = path.join(ROOT, 'src/app/api/convene/admin/drain-queue/route.ts');
+  const authPath = path.join(ROOT, 'src/lib/convene/auth-bearer.ts');
+
+  test('route file exists', () => {
+    expect(fs.existsSync(routePath)).toBe(true);
+  });
+
+  test('auth helper file exists', () => {
+    expect(fs.existsSync(authPath)).toBe(true);
+  });
+
+  test('route gates on isConveneEnabled + authenticateBearerApiKey', () => {
+    const src = fs.readFileSync(routePath, 'utf8');
+    expect(src).toMatch(/isConveneEnabled\(\)/);
+    expect(src).toMatch(/authenticateBearerApiKey/);
+  });
+
+  test('route uses POST not GET (so a stray browser cannot accidentally fire it)', () => {
+    const src = fs.readFileSync(routePath, 'utf8');
+    expect(src).toMatch(/export async function POST/);
+    expect(src).not.toMatch(/export async function GET/);
+  });
+
+  test('dispatcher is called with hostUserId filter (per-user scoping)', () => {
+    const src = fs.readFileSync(routePath, 'utf8');
+    expect(src).toMatch(/dispatchQueuedInvites\(\s*\{\s*hostUserId:\s*auth\.userId\s*\}/);
+  });
+
+  test('auth helper hashes the key with sha256 (matches generateApiKey storage)', () => {
+    const src = fs.readFileSync(authPath, 'utf8');
+    expect(src).toMatch(/createHash\(['"]sha256['"]\)/);
+  });
+
+  test('auth helper rejects keys without lyra_ prefix', () => {
+    const src = fs.readFileSync(authPath, 'utf8');
+    expect(src).toMatch(/startsWith\(['"]lyra_['"]\)/);
+  });
+
+  test('auth helper rejects revoked keys', () => {
+    const src = fs.readFileSync(authPath, 'utf8');
+    expect(src).toMatch(/revoked_at/);
+    expect(src).toMatch(/revoked_key/);
+  });
+});
+
+describe('dispatchQueuedInvites — hostUserId filter (KAN-209)', () => {
+  const dispatchPath = path.join(ROOT, 'src/lib/convene/invites/dispatch.ts');
+
+  test('accepts optional hostUserId option', () => {
+    const src = fs.readFileSync(dispatchPath, 'utf8');
+    expect(src).toMatch(/hostUserId\?:\s*string/);
+  });
+
+  test('narrows to host_user_id when set', () => {
+    const src = fs.readFileSync(dispatchPath, 'utf8');
+    expect(src).toMatch(/eq\(['"]host_user_id['"],\s*opts\.hostUserId\)/);
+  });
+
+  test('uses .in("gathering_id", …) for the narrowed query', () => {
+    const src = fs.readFileSync(dispatchPath, 'utf8');
+    expect(src).toMatch(/\.in\(['"]gathering_id['"]/);
+  });
+});


### PR DESCRIPTION
## Summary

Vercel Cron only schedules Production deployments — `develop` is a Preview branch, so `/api/convene/cron/send-invites` never fires automatically on dev. This adds a manual path the `lyra_drain_invite_queue` MCP tool can call.

- **`src/lib/convene/auth-bearer.ts`** — Bearer API-key auth helper (sha256 + `api_keys` lookup, matches the MCP server's auth pattern).
- **`src/app/api/convene/admin/drain-queue/route.ts`** — POST endpoint, authenticates via the user's `lyra_…` API key, drains ONLY that user's gatherings.
- **`src/lib/convene/invites/dispatch.ts`** — adds optional `hostUserId` filter to `dispatchQueuedInvites`. When set, narrows the queue scan to that user's gatherings via an `IN (...)` clause.
- **`tests/unit/convene/drain-route.test.ts`** — 10 structural tests.
- **`CLAUDE.md`** — extends the smoke-test note with the cron-on-preview caveat + how to drive the dispatcher manually.

The matching MCP tool lands in a separate PR on `lyra-mcp-server-p5` per the KAN-222 lockstep policy.

## Test plan

- [x] `npx jest tests/unit/convene/drain-route.test.ts tests/unit/convene/dispatch.test.ts` — 24/24 pass
- [x] `npx tsc --noEmit` — clean
- [x] `npm run build` — `/api/convene/admin/drain-queue` registered
- [ ] After deploy + MCP tool PR merge: call `lyra_drain_invite_queue` against the existing queued `223e5b46-…` row; verify it flips `queued → sent` (or `failed` with a real Resend error if the sender domain isn't verified)

🤖 Generated with [Claude Code](https://claude.com/claude-code)