### PR TITLE
fix(KAN-238): pagination JSON-into-heredoc breakage

### DIFF
--- a/.github/workflows/cleanup-stale-branch-deploys.yml
+++ b/.github/workflows/cleanup-stale-branch-deploys.yml
@@ -96,7 +96,17 @@ jobs:
 
           # Paginate through every deployment. Cap at 100 pages to prevent
           # runaway in pathological cases — 100 × 100 = 10 000 deploys.
+          #
+          # Implementation note: curl writes each page directly to a temp
+          # file and python reads it from disk. Earlier attempts that
+          # captured the response into a shell variable and interpolated
+          # it into a python heredoc broke when commit messages contained
+          # characters that conflicted with heredoc string-quoting (e.g.
+          # apostrophes inside ${RESP}). Files-on-disk avoid every
+          # quoting hazard.
           ALL_PATH=/tmp/vercel-deploys-all.json
+          PAGES_DIR=/tmp/vercel-pages
+          mkdir -p "${PAGES_DIR}"
           echo '[]' > "${ALL_PATH}"
           UNTIL=""
           PAGE=0
@@ -107,37 +117,44 @@ jobs:
             if [[ -n "${UNTIL}" ]]; then
               URL="${URL}&until=${UNTIL}"
             fi
-            RESP=$(curl -sf -H "Authorization: Bearer ${VERCEL_TOKEN}" "${URL}") || {
-              echo "::error::Vercel API list failed on page ${PAGE}"
+            PAGE_FILE="${PAGES_DIR}/page-${PAGE}.json"
+            HTTP=$(curl -s -o "${PAGE_FILE}" -w '%{http_code}' \
+              -H "Authorization: Bearer ${VERCEL_TOKEN}" "${URL}") || HTTP="000"
+            if [[ "${HTTP}" != "200" ]]; then
+              echo "::error::Vercel API list failed on page ${PAGE} (HTTP ${HTTP})"
               exit 1
-            }
-            # Append this page's deploys to the running array.
-            python3 - <<PY
-          import json
-          with open("${ALL_PATH}") as f:
+            fi
+            # Merge this page into the running list + extract the page count
+            # and next cursor in one python pass, never via shell interpolation.
+            ALL_PATH="${ALL_PATH}" PAGE_FILE="${PAGE_FILE}" \
+              python3 <<'PY' > /tmp/page-meta
+          import json, os
+          all_path = os.environ["ALL_PATH"]
+          page_path = os.environ["PAGE_FILE"]
+          with open(all_path) as f:
               acc = json.load(f)
-          page = json.loads('''${RESP}''').get("deployments", [])
+          with open(page_path) as f:
+              page = json.load(f).get("deployments", []) or []
           acc.extend(page)
-          with open("${ALL_PATH}", "w") as f:
+          with open(all_path, "w") as f:
               json.dump(acc, f)
+          count = len(page)
+          oldest = min((int(d.get("createdAt", 0)) for d in page), default=0)
+          next_until = oldest - 1 if (count and oldest) else ""
+          print(f"{count}|{next_until}")
           PY
-            COUNT=$(echo "${RESP}" | python3 -c "import json,sys; print(len(json.load(sys.stdin).get('deployments', [])))")
+            META=$(cat /tmp/page-meta)
+            COUNT="${META%%|*}"
+            NEXT_UNTIL="${META##*|}"
             if [[ "${COUNT}" -lt 100 ]]; then
               break
             fi
-            NEXT_UNTIL=$(echo "${RESP}" | python3 -c "
-          import json, sys
-          data = json.load(sys.stdin)
-          deps = data.get('deployments', [])
-          ts = min(int(d.get('createdAt', 0)) for d in deps) if deps else 0
-          print(ts - 1 if ts else '')
-          ")
             if [[ -z "${NEXT_UNTIL}" ]]; then
               break
             fi
             UNTIL="${NEXT_UNTIL}"
           done
-          TOTAL=$(python3 -c "import json; print(len(json.load(open('${ALL_PATH}'))))")
+          TOTAL=$(ALL_PATH="${ALL_PATH}" python3 -c "import json,os; print(len(json.load(open(os.environ['ALL_PATH']))))")
           echo "Total deployments scanned: ${TOTAL}"
 
           # Compute the deletion decision per deploy. Emits JSON lines:


### PR DESCRIPTION
## Summary

First post-merge dispatch of KAN-238 (`cleanup-stale-branch-deploys.yml`) failed at the pagination step with `json.decoder.JSONDecodeError: Expecting ',' delimiter: line 1 column 1062 (char 1061)`.

Root cause: the original implementation captured each Vercel API response into shell var `RESP` and interpolated it into a python heredoc as `'''${RESP}'''`. That triple-quote trick breaks when the JSON body contains text conflicting with python's string-quoting rules — e.g. apostrophes inside a `githubCommitMessage` like `"PR's tests"`. Page 1 of the deployment list was unparseable.

## Fix

curl now writes each page directly to a temp file (`/tmp/vercel-pages/page-N.json`) and python reads from disk via env vars. No JSON ever touches a shell-quoted heredoc. Same pattern that `diagnose-vercel-env.yml` already uses for the project env list.

The other two python heredocs in the workflow (decision-logic + summary) only interpolate numbers and file paths, not JSON — those are safe as-is. Comment added explaining the constraint so future edits don't reintroduce the bug.

## Test plan

- [x] YAML valid (`python3 -c "import yaml; yaml.safe_load(...)"`).
- [x] Pre-merge grep checks (silent-skip / lossy-fallback / continue-on-error) clean.
- [ ] After this lands on main, re-dispatch with `dry_run=true` — expected: completes successfully, summary table shows 0 "delete" decisions (project too young; the bug fix is what's being validated, not the deletion logic).

🤖 Generated with [Claude Code](https://claude.com/claude-code)