### PR TITLE
revert(KAN-104): remove deploy-dev diagnostic steps (keep --git-branch)

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -53,48 +53,14 @@ jobs:
       - name: Install Vercel CLI
         run: npm install -g vercel@latest
       - name: Pull Vercel environment
-        # KAN-104 diagnostic: also pass --git-branch=develop so branch-scoped
-        # vars (if Vercel's CLI requires explicit branch context to pick them
-        # up) are guaranteed to be included alongside the unscoped preview
-        # vars. Revert once we know which Vercel CLI behaviour applies.
+        # KAN-104: --git-branch=develop kept after diagnostic — guarantees
+        # branch-scoped vars are pulled even if Vercel CLI on detached-HEAD
+        # CI checkouts doesn't auto-infer the branch context. With PR #247
+        # also placing the vars on the unscoped Preview target, this is
+        # belt-and-braces.
         run: vercel pull --yes --environment=preview --git-branch=develop --token=${{ secrets.VERCEL_TOKEN }}
-      - name: DIAG (KAN-104) — inspect pulled env files for Sentry vars
-        # Diagnostic only — prints which files vercel pull produced and
-        # whether SENTRY-prefixed keys are present (values masked).
-        # Remove this step once Sentry is confirmed loading on dev.
-        run: |
-          set -euo pipefail
-          echo "::group::.vercel/ listing"
-          ls -la .vercel/ || echo "(no .vercel directory)"
-          echo "::endgroup::"
-          echo "::group::SENTRY keys in pulled env files (values masked)"
-          for f in .vercel/.env*.local .vercel/.env*; do
-            [ -f "$f" ] || continue
-            echo "--- $f ---"
-            grep -i "SENTRY\|IS_SENTRY" "$f" | sed 's/=.*$/=<value-redacted>/' || echo "(no SENTRY keys present)"
-          done
-          echo "::endgroup::"
       - name: Build project
         run: vercel build --token=${{ secrets.VERCEL_TOKEN }}
-      - name: DIAG (KAN-104) — inspect built bundle for the DSN string
-        # If the pulled env had the DSN but the built bundle doesn't,
-        # vercel build / next build is dropping it (Hypothesis B or C).
-        # If the pulled env didn't have it, vercel pull is the culprit.
-        run: |
-          set -euo pipefail
-          echo "::group::Search build output for DSN domain marker"
-          # The DSN ingestion host: o4511340602523648.ingest.de.sentry.io
-          # The leading numeric host segment is a stable fingerprint —
-          # if it's in the bundle, init code is wired up.
-          if grep -r "o4511340602523648" .vercel/output/ >/dev/null 2>&1; then
-            echo "✅ DSN marker found in built bundle"
-          else
-            echo "❌ DSN marker NOT in built bundle"
-            echo ""
-            echo "Top-level bundle structure (for context):"
-            ls -la .vercel/output/ 2>/dev/null || echo "(no .vercel/output)"
-          fi
-          echo "::endgroup::"
       - name: Deploy to Vercel
         id: deploy
         run: |


### PR DESCRIPTION
## Summary

The diagnostic instrumentation from PR #251 did its job — confirmed:

- ✅ `vercel pull` correctly retrieves `NEXT_PUBLIC_SENTRY_DSN` + `IS_SENTRY_ENABLED` into `.vercel/.env.preview.local`
- ✅ `vercel build` / `next build` processes them (Sentry's "After Production Compile" hook fires)
- ✅ DSN string IS present somewhere in `.vercel/output/`

Yet the browser shows no Sentry SDK init, no DSN in served HTML, no `window.Sentry`. Strongly points to **Turbopack-vs-`instrumentation-client.ts` handling** in this version of `@sentry/nextjs` — Next.js 16.2.6 default-builds with Turbopack, and `@sentry/nextjs@10.53.1` may not fully wire the client-side init through Turbopack the way it does through Webpack.

This PR reverts the two diagnostic steps from #251. Keeps `--git-branch=develop` on the pull (real improvement — removes one variable from the equation for future debugging).

The deeper Turbopack issue is documented as a follow-up note on KAN-104 with the suggested next steps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)