### PR TITLE
fix(KAN-104): build with --webpack so Sentry client SDK ships

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
-    "build": "next build",
+    "build": "next build --webpack",
     "start": "next start",
     "lint": "eslint",
     "type-check": "tsc --noEmit",


### PR DESCRIPTION
## Summary

Definitive fix for KAN-104. Diagnosed via PR #251 + #253: every input was correct (env vars on all 6 Vercel scopes, `vercel pull` retrieving them, `next build` processing them, Sentry post-compile hook firing), but the **client bundle in the browser had no DSN and no `window.Sentry`**.

Cause: Next.js 16.2.6 uses Turbopack by default for production builds. `@sentry/nextjs@10.53.1`'s `withSentryConfig` wrapper handles server-side instrumentation under Turbopack but **doesn't thread `instrumentation-client.ts` into the client bundle**. Webpack works correctly.

Fix: one-line build-script change — `next build` → `next build --webpack`.

## Local verification (before push)

Built locally with `NEXT_PUBLIC_SENTRY_DSN` and `IS_SENTRY_ENABLED=true` in env:

```
$ grep -lr "o4511340602523648" .next/static/
.next/static/chunks/main-f0bbc02d04292dcb.js
.next/static/chunks/main-app-2ba13cb1350d9d48.js

$ grep -lr "@sentry/nextjs" .next/static/chunks/
.next/static/chunks/8804-0a693d37fa2e898f.js
.next/static/chunks/main-f0bbc02d04292dcb.js
```

DSN string + Sentry init code both reach the **client static chunks**. Under Turbopack, neither did.

## Trade-off

`--webpack` builds are slower than Turbopack (Next.js's release notes claim Turbopack is ~2-5x faster for production builds — we haven't benchmarked our specific setup yet). Worth accepting for working Sentry on day one.

**Revisit when `@sentry/nextjs` ships a Turbopack-complete release.** Reasonable cadence: check quarterly.

## Test plan

- [x] `npm run build` locally with `--webpack` and Sentry env vars set → DSN string + init code in `.next/static/chunks/main-*.js`
- [x] No new test failures (build script change only, no source changes)
- [ ] After merge: dev.checklyra.com loads, `window.Sentry` defined, DSN in network requests to `*.ingest.de.sentry.io`

## What's NOT in this PR

- Cherry-picking the same flag onto deploy-staging / deploy-beta / deploy-prod workflows. Not needed — they all invoke `npm run build` (or equivalent), so the package.json change covers every env on the next promotion cycle.
- A KAN-104 follow-up to bump `@sentry/nextjs` when v11+ ships Turbopack-complete. Filing separately if you want it tracked.

## References

- [#247](https://github.com/luisa-sys/lyra/pull/247) — activate-sentry env-var fix (kept)
- [#251](https://github.com/luisa-sys/lyra/pull/251) — diagnostic that proved the build was correct (reverted in #253)
- [#253](https://github.com/luisa-sys/lyra/pull/253) — revert of diagnostic, kept `--git-branch=develop` improvement
- This PR — the actual fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)