### PR TITLE
feat(KAN-209): admin drain-queue accepts api_key body fallback (Bearer symmetry)

### DIFF
--- a/src/app/api/convene/admin/drain-queue/route.ts
+++ b/src/app/api/convene/admin/drain-queue/route.ts
@@ -7,26 +7,59 @@
  * this route lets the lyra_drain_invite_queue MCP tool call it on
  * behalf of an authenticated user.
  *
- * Auth: `Authorization: Bearer lyra_…` (a user-owned API key, same
- * format as every other MCP-callable). The drain is filtered to that
- * user's gatherings only — one user cannot drain another's queue.
+ * Auth accepts two equivalent forms (KAN-240 symmetry with the MCP
+ * server's middleware):
+ *
+ *   1. `Authorization: Bearer lyra_…` header — preferred.
+ *   2. `{ "api_key": "lyra_…" }` in the JSON body — fallback for clients
+ *      that cannot set custom headers (form posts, simple curl, etc).
+ *
+ * The drain is filtered to the calling user's gatherings only — one
+ * user cannot drain another's queue.
  *
  * Gate: `CONVENE_ENABLED` must be 'true' or the route 404s.
  */
 
 import { NextRequest, NextResponse } from 'next/server';
 import { isConveneEnabled } from '@/lib/convene/flags';
-import { authenticateBearerApiKey } from '@/lib/convene/auth-bearer';
+import {
+  authenticateBearerApiKey,
+  type BearerAuthResult,
+  type BearerAuthError,
+} from '@/lib/convene/auth-bearer';
 import { dispatchQueuedInvites } from '@/lib/convene/invites/dispatch';
 
 export const maxDuration = 60;
+
+async function resolveAuth(
+  req: NextRequest
+): Promise<BearerAuthResult | BearerAuthError> {
+  // Header path — preferred (matches MCP-server middleware).
+  const headerAuth = await authenticateBearerApiKey(req.headers.get('authorization'));
+  if (headerAuth.ok) return headerAuth;
+
+  // Body fallback — for clients that can't set headers. Reading the
+  // body here consumes the stream, but the route doesn't read the body
+  // elsewhere, so this is safe.
+  let body: unknown;
+  try {
+    body = await req.json();
+  } catch {
+    return headerAuth;
+  }
+  const apiKey = (body as { api_key?: unknown } | null)?.api_key;
+  if (typeof apiKey === 'string' && apiKey.length > 0) {
+    return authenticateBearerApiKey(`Bearer ${apiKey}`);
+  }
+  return headerAuth;
+}
 
 export async function POST(req: NextRequest) {
   if (!isConveneEnabled()) {
     return NextResponse.json({ ok: false, error: 'convene_disabled' }, { status: 404 });
   }
 
-  const auth = await authenticateBearerApiKey(req.headers.get('authorization'));
+  const auth = await resolveAuth(req);
   if (!auth.ok) {
     return NextResponse.json({ ok: false, error: auth.error }, { status: auth.status });
   }

--- a/tests/unit/convene/drain-route.test.ts
+++ b/tests/unit/convene/drain-route.test.ts
@@ -34,6 +34,34 @@ describe('admin drain-queue route (KAN-209)', () => {
     expect(src).not.toMatch(/export async function GET/);
   });
 
+  test('accepts api_key in JSON body as fallback when Authorization header absent (KAN-240 symmetry)', () => {
+    const src = fs.readFileSync(routePath, 'utf8');
+    // Body parse + api_key extraction.
+    expect(src).toMatch(/await req\.json\(\)/);
+    expect(src).toMatch(/api_key\?:\s*unknown/);
+    expect(src).toMatch(/typeof apiKey === ['"]string['"] && apiKey\.length > 0/);
+    // The fallback re-runs Bearer auth with the body value wrapped as a Bearer.
+    expect(src).toMatch(/authenticateBearerApiKey\(`Bearer \$\{apiKey\}`\)/);
+  });
+
+  test('header path is preferred over body — header is tried first', () => {
+    const src = fs.readFileSync(routePath, 'utf8');
+    // Implementation order matters: header path runs before body path.
+    const headerIdx = src.indexOf("req.headers.get('authorization')");
+    const bodyIdx = src.indexOf('await req.json()');
+    expect(headerIdx).toBeGreaterThan(-1);
+    expect(bodyIdx).toBeGreaterThan(-1);
+    expect(headerIdx).toBeLessThan(bodyIdx);
+  });
+
+  test('body-parse errors do not crash the route', () => {
+    const src = fs.readFileSync(routePath, 'utf8');
+    // try/catch around req.json() so non-JSON bodies just fall through
+    // to the header-auth error.
+    expect(src).toMatch(/try\s*\{\s*body\s*=\s*await req\.json\(\)/);
+    expect(src).toMatch(/\}\s*catch\b/);
+  });
+
   test('dispatcher is called with hostUserId filter (per-user scoping)', () => {
     const src = fs.readFileSync(routePath, 'utf8');
     expect(src).toMatch(/dispatchQueuedInvites\(\s*\{\s*hostUserId:\s*auth\.userId\s*\}/);


### PR DESCRIPTION
Mirrors KAN-240's dual-mode auth surface onto the lyra-side admin route. Both `Authorization: Bearer` (preferred) and `{ "api_key": ... }` body field now work.

Header path runs first; body fallback only when header auth fails. Body-parse errors fall through gracefully.

The dispatcher continues to scope strictly to the authenticated user's gatherings — symmetry is on the auth **input** surface only, not on the authorization model.

## Test plan

- [x] `npx jest tests/unit/convene/drain-route.test.ts` — 14/14 pass
- [x] `npx tsc --noEmit` — clean
- [x] `npm run build` — route registered
- [ ] After merge + dev deploy: curl with Bearer header, then curl with api_key body, both should return 200 + summary

## Context

claude.ai's hosted-connector UI requires OAuth ([KAN-88](https://checklyra.atlassian.net/browse/KAN-88) — separate ticket, just commented). Other clients (Claude Code, curl, MCP Inspector, future admin UI) get a clean dual-mode option here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[KAN-88]: https://checklyra.atlassian.net/browse/KAN-88?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ