### PR TITLE
fix(KAN-104): drop non-NEXT_PUBLIC gate from client Sentry init

### DIFF
--- a/docs/SENTRY_SETUP.md
+++ b/docs/SENTRY_SETUP.md
@@ -1,16 +1,25 @@
 # Sentry Setup (KAN-104)
 
-> The SDK is scaffolded behind a two-flag gate. This doc walks through activating it on each environment.
+> The SDK is scaffolded behind a flag-based gate, asymmetric between server and browser by Next.js's `NEXT_PUBLIC_` env-var rules. This doc walks through activating it on each environment.
 
 ## What's already shipped (PR #136)
 
 - `@sentry/nextjs` installed
 - `instrumentation.ts` — server + edge runtime init, gated on `NEXT_PUBLIC_SENTRY_DSN` AND `IS_SENTRY_ENABLED='true'`
-- `instrumentation-client.ts` — browser init, same gate
+- `instrumentation-client.ts` — browser init, gated on `NEXT_PUBLIC_SENTRY_DSN` presence only (see "Why the gate asymmetry" below — KAN-104 follow-up 2026-05-17)
 - `next.config.ts` wrapped with `withSentryConfig` (source-map upload + tunnel-route off + DE-region CSP)
-- 8 unit tests guarding the gate + CSP + auth-token-never-NEXT_PUBLIC
+- Build uses Webpack (`next build --webpack`) because Sentry's plugin doesn't fully thread `instrumentation-client.ts` through Turbopack in `@sentry/nextjs@10.x` (revisit when v11 ships Turbopack-complete)
+- 8 unit tests guarding the gates + CSP + auth-token-never-NEXT_PUBLIC
 
-Until both env vars are populated, the SDK is **completely inert** — no network calls, no event capture, no overhead.
+Until the env vars are populated, the SDK is **completely inert** — no network calls, no event capture, no overhead.
+
+## Why the gate asymmetry (KAN-104 follow-up, 2026-05-17)
+
+The original design used `NEXT_PUBLIC_SENTRY_DSN` AND `IS_SENTRY_ENABLED='true'` for both server and browser. **The two-flag gate doesn't work in the browser** because Webpack/Next.js only inlines `process.env.NEXT_PUBLIC_*` env vars into client bundles. `IS_SENTRY_ENABLED` (no `NEXT_PUBLIC_` prefix) resolves to `undefined` at browser runtime, which means `"true" === undefined` was always false and Sentry never initialised in the browser regardless of what was set in Vercel.
+
+Fix: the browser gate now checks DSN presence only. Set the DSN var to empty (or unset it) to disable Sentry in the browser. Equivalent safety to the original design, just expressed through one visible env var instead of two.
+
+The server-side gate retains the two-flag combo because Node has access to all env vars at runtime.
 
 ## Account snapshot (filled in on first activation)
 
@@ -42,7 +51,7 @@ Vercel → `lyra` project → Settings → Environment Variables. Add the follow
 | Variable | Value | Sensitive? | Purpose |
 |---|---|---|---|
 | `NEXT_PUBLIC_SENTRY_DSN` | `https://1d003e90bf6a072f57d3a7765f124a70@o4511340602523648.ingest.de.sentry.io/4511340621594704` | No | Where the SDK sends events. The `NEXT_PUBLIC_` prefix exposes it to the browser, which is correct — DSN is public-by-design. |
-| `IS_SENTRY_ENABLED` | `true` | No | The kill switch. Setting to `false` (or removing) disables Sentry entirely on that env without touching code. |
+| `IS_SENTRY_ENABLED` | `true` | No | **Server kill switch only.** Setting to `false` (or removing) disables Sentry on the server runtime. Browser is gated on `NEXT_PUBLIC_SENTRY_DSN` presence — see "Why the gate asymmetry" above. To kill Sentry in the browser, clear `NEXT_PUBLIC_SENTRY_DSN` instead. |
 
 After saving, redeploy that environment (push a commit or manually trigger via Vercel UI) so the new vars reach the build.
 

--- a/instrumentation-client.ts
+++ b/instrumentation-client.ts
@@ -2,14 +2,32 @@
  * KAN-104: Sentry client (browser) initialization.
  *
  * Next.js 16 imports this file on the client; it pairs with the server +
- * edge `register()` in `instrumentation.ts`. Same env-flag gate.
+ * edge `register()` in `instrumentation.ts`.
+ *
+ * Gate is DSN-presence only, NOT the two-flag combo that
+ * `instrumentation.ts` uses. Why the asymmetry: Webpack/Next.js only
+ * inlines `process.env.NEXT_PUBLIC_*` env vars into client bundles. The
+ * server kill-switch `IS_SENTRY_ENABLED` (no `NEXT_PUBLIC_` prefix)
+ * resolves to `undefined` at browser runtime, which means
+ * `"true" === undefined` was always false and Sentry never initialised
+ * in the browser regardless of what was set in Vercel. This was the
+ * root cause of KAN-104 not "lighting up" after the env vars were
+ * configured — diagnosed 2026-05-17.
+ *
+ * The kill switch for the client is therefore: clear or unset
+ * `NEXT_PUBLIC_SENTRY_DSN`. If the DSN env var is empty, no SDK
+ * initialises and no events ship. Equivalent safety to the previous
+ * design, just expressed through a single visible env var.
+ *
+ * The server-side `instrumentation.ts` retains its two-flag gate
+ * because Node has access to all env vars at runtime, including the
+ * non-prefixed `IS_SENTRY_ENABLED`.
  */
 import * as Sentry from '@sentry/nextjs';
 
 const dsn = process.env.NEXT_PUBLIC_SENTRY_DSN;
-const enabled = process.env.IS_SENTRY_ENABLED === 'true';
 
-if (dsn && enabled) {
+if (dsn) {
   Sentry.init({
     dsn,
     environment: process.env.NEXT_PUBLIC_VERCEL_ENV || 'development',
@@ -26,6 +44,6 @@ if (dsn && enabled) {
 }
 
 // Required for Next.js navigation tracing (App Router).
-export const onRouterTransitionStart = dsn && enabled
+export const onRouterTransitionStart = dsn
   ? Sentry.captureRouterTransitionStart
   : () => {};

--- a/tests/unit/sentry-scaffold.test.ts
+++ b/tests/unit/sentry-scaffold.test.ts
@@ -54,10 +54,20 @@ describe('KAN-104 Sentry scaffold', () => {
     expect(src).toContain('Sentry.captureRequestError');
   });
 
-  test('client instrumentation gates on both env flags + has reasonable defaults', () => {
+  test('client instrumentation gates on DSN presence + has reasonable defaults', () => {
+    // KAN-104 follow-up (2026-05-17): the client gate dropped the
+    // `IS_SENTRY_ENABLED === 'true'` check because Webpack/Next.js only
+    // inlines `NEXT_PUBLIC_*` env vars into browser bundles — the
+    // non-prefixed flag always resolved to `undefined` at runtime,
+    // making the gate a no-op-that-always-failed. DSN presence is now
+    // the single source of truth for "Sentry on/off in the browser";
+    // set the DSN var to empty to disable.
+    //
+    // The server-side gate stays two-flag (asserted in the
+    // `server instrumentation gates on both env flags` test above).
     const src = readFileSync(resolve(ROOT, 'instrumentation-client.ts'), 'utf-8');
     expect(src).toContain('NEXT_PUBLIC_SENTRY_DSN');
-    expect(src).toContain("IS_SENTRY_ENABLED === 'true'");
+    expect(src).toMatch(/if \(dsn\)/);
     expect(src).toContain('replaysSessionSampleRate: 0');
     expect(src).toContain('sendDefaultPii: false');
   });


### PR DESCRIPTION
## Summary

Final fix for KAN-104. After PR #255 made the build use Webpack (proving the build pipeline produces correct artifacts), Sentry SDK STILL didn't initialise in the browser. Bundle forensics revealed the actual root cause: the gate in `instrumentation-client.ts` checks `process.env.IS_SENTRY_ENABLED === 'true'`, but **Webpack only inlines `NEXT_PUBLIC_*` env vars into client bundles**. `IS_SENTRY_ENABLED` (no `NEXT_PUBLIC_` prefix) resolves to `undefined` at browser runtime, making the gate always false.

The minified bundle confirms it explicitly:
```js
let n="https://1d003e90...sentry.io/...",
    o="true"===i.env.IS_SENTRY_ENABLED;  // ← always false in browser
n&&o&&t.init(...)                          // ← never runs
```

So Sentry has NEVER worked in the browser since the SDK was scaffolded, regardless of any Vercel env var configuration.

## The fix

Client gate becomes DSN-presence only. Set `NEXT_PUBLIC_SENTRY_DSN` to empty to disable Sentry in the browser. Equivalent safety, expressed through one visible env var.

Server-side `instrumentation.ts` is unchanged — Node has access to all env vars at runtime, so the two-flag gate works fine on the server.

## Test Integrity Policy — sign-off received in chat transcript

One assertion in `tests/unit/sentry-scaffold.test.ts:60` updated:

| | Old | New |
|---|---|---|
| **Assertion** | `expect(src).toContain("IS_SENTRY_ENABLED === 'true'")` | `expect(src).toMatch(/if \(dsn\)/)` |
| **What it guards** | A pattern that did nothing at runtime | The actual working pattern |
| **Security model** | Two-flag gate (broken) | DSN-presence gate (works) |

The server-side gate test (line 38) is unchanged — server still uses both flags.

## Test plan

- [x] `npx jest tests/unit/sentry-scaffold.test.ts` — 9/9 pass
- [x] Full suite — **1155 tests pass**
- [ ] After merge: dev.checklyra.com loads, `window.Sentry` defined, browser sends to `*.ingest.de.sentry.io`

## References

- [#247](https://github.com/luisa-sys/lyra/pull/247) — env vars on unscoped preview
- [#251](https://github.com/luisa-sys/lyra/pull/251) — diagnostic
- [#253](https://github.com/luisa-sys/lyra/pull/253) — diagnostic revert + `--git-branch`
- [#255](https://github.com/luisa-sys/lyra/pull/255) — switched build to Webpack
- This PR — the actual functional fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)