### PR TITLE
feat(KAN-88) P1: OAuth 2.1 schema + AS metadata endpoint

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -2,6 +2,17 @@ import type { NextConfig } from "next";
 import { withSentryConfig } from "@sentry/nextjs";
 
 const nextConfig: NextConfig = {
+  // KAN-88: OAuth 2.1 well-known discovery endpoints. Next.js doesn't route
+  // folder names starting with '.' reliably, so we serve the canonical
+  // /.well-known/* paths via internal /api/well-known/* routes.
+  async rewrites() {
+    return [
+      {
+        source: '/.well-known/oauth-authorization-server',
+        destination: '/api/well-known/oauth-authorization-server',
+      },
+    ];
+  },
   async headers() {
     return [
       {

--- a/src/app/api/well-known/oauth-authorization-server/route.ts
+++ b/src/app/api/well-known/oauth-authorization-server/route.ts
@@ -1,0 +1,48 @@
+/**
+ * /.well-known/oauth-authorization-server — KAN-88 OAuth AS metadata.
+ *
+ * RFC 8414. Returned by GET as application/json. Clients (claude.ai,
+ * Claude Desktop, MCP Inspector) fetch this to discover where to
+ * authorize, exchange tokens, register, and revoke.
+ *
+ * This endpoint is public — no auth needed. It's effectively a
+ * configuration document.
+ */
+
+import { NextResponse } from 'next/server';
+import { oauthConfig } from '@/lib/oauth/config';
+
+export const dynamic = 'force-dynamic'; // env-driven URLs — never cache
+
+export async function GET() {
+  return NextResponse.json(
+    {
+      issuer: oauthConfig.issuer(),
+      authorization_endpoint: oauthConfig.authorizationEndpoint(),
+      token_endpoint: oauthConfig.tokenEndpoint(),
+      registration_endpoint: oauthConfig.registrationEndpoint(),
+      revocation_endpoint: oauthConfig.revocationEndpoint(),
+      response_types_supported: ['code'],
+      response_modes_supported: ['query'],
+      grant_types_supported: ['authorization_code', 'refresh_token'],
+      // PKCE is mandatory in OAuth 2.1; we accept S256 only (not 'plain').
+      code_challenge_methods_supported: ['S256'],
+      // Public clients only for MVP — claude.ai is a confidential client
+      // in practice but PKCE protects it adequately.
+      token_endpoint_auth_methods_supported: ['none'],
+      scopes_supported: oauthConfig.supportedScopes,
+      // RFC 8628 device flow not supported.
+      // RFC 7592 client config endpoint not supported (clients can't update
+      // themselves post-registration in MVP).
+      service_documentation: `${oauthConfig.issuer()}/docs/mcp-oauth`,
+      ui_locales_supported: ['en-GB'],
+    },
+    {
+      headers: {
+        // Allow MCP clients to discover us cross-origin.
+        'Access-Control-Allow-Origin': '*',
+        'Cache-Control': 'public, max-age=300',
+      },
+    }
+  );
+}

--- a/src/lib/oauth/config.ts
+++ b/src/lib/oauth/config.ts
@@ -1,0 +1,52 @@
+/**
+ * OAuth 2.1 server configuration — KAN-88.
+ *
+ * Single source of truth for issuer URL, supported scopes, TTLs, and
+ * endpoint paths. Everything is environment-driven so dev/staging/prod
+ * advertise the right URLs in their well-known metadata.
+ */
+
+function siteUrl(): string {
+  // Production deploy: NEXT_PUBLIC_SITE_URL is set by the deploy workflow.
+  // Preview / dev: fall back to VERCEL_URL if NEXT_PUBLIC_SITE_URL isn't set
+  // (Vercel injects VERCEL_URL automatically on every deploy).
+  const url = process.env.NEXT_PUBLIC_SITE_URL || process.env.LYRA_SITE_URL;
+  if (url) return url.replace(/\/$/, '');
+  const vercel = process.env.VERCEL_URL;
+  if (vercel) return `https://${vercel}`;
+  return 'https://checklyra.com';
+}
+
+export const oauthConfig = {
+  issuer: () => siteUrl(),
+  authorizationEndpoint: () => `${siteUrl()}/oauth/authorize`,
+  tokenEndpoint: () => `${siteUrl()}/oauth/token`,
+  registrationEndpoint: () => `${siteUrl()}/oauth/register`,
+  revocationEndpoint: () => `${siteUrl()}/oauth/revoke`,
+  // For MVP we don't expose JWKS — HS256 with shared secret. RS256 + JWKS
+  // is a follow-up. The AS metadata still has to omit the jwks_uri field
+  // gracefully so claude.ai doesn't reject us.
+
+  // Scope catalogue. MVP = single 'lyra:full' scope. Granular scopes
+  // (lyra:profile:read, lyra:convene:write, etc.) come later.
+  supportedScopes: ['lyra:full'] as const,
+
+  // Code lifetime — short per OAuth 2.1 (codes must be ≤ 10min).
+  authorizationCodeTtlSeconds: 10 * 60,
+  // Access token lifetime — 1h industry standard.
+  accessTokenTtlSeconds: 60 * 60,
+  // Refresh token lifetime — 30d.
+  refreshTokenTtlSeconds: 30 * 24 * 60 * 60,
+};
+
+/**
+ * Bearer-realm string used in WWW-Authenticate headers when auth fails.
+ * Per RFC 6750 + the MCP authorization spec, this points the client at
+ * the AS so it can discover the OAuth flow.
+ */
+export function wwwAuthenticateHeader(opts: { error?: string; errorDescription?: string } = {}): string {
+  const parts = [`Bearer realm="${oauthConfig.issuer()}"`];
+  if (opts.error) parts.push(`error="${opts.error}"`);
+  if (opts.errorDescription) parts.push(`error_description="${opts.errorDescription}"`);
+  return parts.join(', ');
+}

--- a/supabase/migrations/20260517100000_oauth_2_1_server.sql
+++ b/supabase/migrations/20260517100000_oauth_2_1_server.sql
@@ -1,0 +1,167 @@
+-- KAN-88 — OAuth 2.1 authorization server schema.
+--
+-- Lyra acts as an OAuth 2.1 Authorization Server, issuing access + refresh
+-- tokens to MCP clients (claude.ai, Claude Desktop, etc). Clients register
+-- via Dynamic Client Registration (RFC 7591) and use Authorization Code +
+-- PKCE (S256) to obtain access tokens.
+--
+-- Tables:
+--   oauth_clients              — registered OAuth clients (one row per
+--                                claude.ai install + any other clients).
+--                                Dynamically registered via /oauth/register.
+--   oauth_authorization_codes  — short-lived (≤10 min), one-time codes
+--                                exchanged for tokens at /oauth/token.
+--   oauth_access_tokens        — issued JWTs, recorded by `jti` for
+--                                revocation tracking. JWT validation does
+--                                not strictly require this table (HS256
+--                                self-validating) but revocation does.
+--   oauth_refresh_tokens       — opaque refresh tokens (30-day TTL),
+--                                rotated on every use.
+--   oauth_consents             — record of each user-client consent grant,
+--                                so we can show "you previously authorised
+--                                X — confirm?" rather than always re-asking.
+--
+-- All tables are write-only by the service role; users never directly read
+-- or write them. RLS is enabled and denies all by default; the lyra app
+-- uses SUPABASE_SERVICE_ROLE_KEY to bypass.
+
+-- ─── oauth_clients ────────────────────────────────────────────────────────
+
+create table public.oauth_clients (
+  id uuid primary key default gen_random_uuid(),
+  -- The public-facing client_id we hand out. Random base64url, ~22 chars.
+  client_id text unique not null,
+  -- For confidential clients only. Public clients (PKCE-only) have NULL.
+  client_secret_hash text,
+  -- Registration metadata (RFC 7591). Free-form within the schema.
+  client_name text not null,
+  redirect_uris text[] not null,
+  -- Comma-separated grant types. For us: 'authorization_code', 'refresh_token'.
+  grant_types text[] not null default array['authorization_code', 'refresh_token'],
+  response_types text[] not null default array['code'],
+  -- Application type per RFC 7591. Most MCP clients are 'web'.
+  application_type text not null default 'web' check (application_type in ('web', 'native')),
+  -- Token endpoint auth method. Public clients use 'none' (PKCE only).
+  token_endpoint_auth_method text not null default 'none' check (
+    token_endpoint_auth_method in ('none', 'client_secret_basic', 'client_secret_post')
+  ),
+  -- Scope this client is allowed to request. For MVP all clients get 'lyra:full'.
+  scopes text not null default 'lyra:full',
+  -- Soft-state — admin can revoke a misbehaving client without dropping rows.
+  revoked_at timestamptz,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create index oauth_clients_client_id_idx on public.oauth_clients (client_id);
+alter table public.oauth_clients enable row level security;
+-- Service-role only. No user policy.
+
+comment on table public.oauth_clients is 'KAN-88 — OAuth 2.1 registered clients. Service-role writes only.';
+
+-- ─── oauth_authorization_codes ────────────────────────────────────────────
+
+create table public.oauth_authorization_codes (
+  code text primary key,                                -- random 32-byte token, base64url
+  client_id text not null references public.oauth_clients(client_id) on delete cascade,
+  user_id uuid not null references auth.users(id) on delete cascade,
+  redirect_uri text not null,
+  scope text not null,
+  -- PKCE — S256 only per OAuth 2.1.
+  code_challenge text not null,
+  code_challenge_method text not null check (code_challenge_method = 'S256'),
+  expires_at timestamptz not null,
+  -- Set when redeemed to enforce one-time use.
+  used_at timestamptz,
+  created_at timestamptz not null default now()
+);
+
+create index oauth_authz_codes_client_idx on public.oauth_authorization_codes (client_id);
+create index oauth_authz_codes_expires_idx on public.oauth_authorization_codes (expires_at);
+alter table public.oauth_authorization_codes enable row level security;
+
+comment on table public.oauth_authorization_codes is 'KAN-88 — One-time, short-lived (≤10 min) authorization codes exchanged at /oauth/token.';
+
+-- ─── oauth_access_tokens ──────────────────────────────────────────────────
+-- We only record the JWT's `jti` claim + metadata. The token itself is the
+-- signed JWT (HS256 with OAUTH_JWT_SIGNING_SECRET) and is self-validating.
+-- This table exists so we can revoke specific tokens before they expire.
+
+create table public.oauth_access_tokens (
+  jti uuid primary key default gen_random_uuid(),
+  client_id text not null references public.oauth_clients(client_id) on delete cascade,
+  user_id uuid not null references auth.users(id) on delete cascade,
+  scope text not null,
+  expires_at timestamptz not null,
+  revoked_at timestamptz,
+  issued_at timestamptz not null default now()
+);
+
+create index oauth_access_tokens_user_idx on public.oauth_access_tokens (user_id);
+create index oauth_access_tokens_expires_idx on public.oauth_access_tokens (expires_at);
+alter table public.oauth_access_tokens enable row level security;
+
+comment on table public.oauth_access_tokens is 'KAN-88 — Issued JWT registry (jti only — not the signed token). Used for revocation lookups.';
+
+-- ─── oauth_refresh_tokens ─────────────────────────────────────────────────
+
+create table public.oauth_refresh_tokens (
+  -- Random opaque token; we store the sha256 hash, never the raw value.
+  token_hash text primary key,
+  client_id text not null references public.oauth_clients(client_id) on delete cascade,
+  user_id uuid not null references auth.users(id) on delete cascade,
+  scope text not null,
+  expires_at timestamptz not null,
+  -- Refresh-token rotation: when the holder exchanges this token for a new
+  -- access token + new refresh token, we mark the old one used. Subsequent
+  -- presentation of the same token => treat as compromised, revoke the chain.
+  used_at timestamptz,
+  -- Allows revoking the whole chain when a leak is detected.
+  family_id uuid not null,
+  issued_at timestamptz not null default now()
+);
+
+create index oauth_refresh_tokens_user_idx on public.oauth_refresh_tokens (user_id);
+create index oauth_refresh_tokens_family_idx on public.oauth_refresh_tokens (family_id);
+create index oauth_refresh_tokens_expires_idx on public.oauth_refresh_tokens (expires_at);
+alter table public.oauth_refresh_tokens enable row level security;
+
+comment on table public.oauth_refresh_tokens is 'KAN-88 — Rotating refresh tokens with family chain for compromise detection.';
+
+-- ─── oauth_consents ───────────────────────────────────────────────────────
+
+create table public.oauth_consents (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid not null references auth.users(id) on delete cascade,
+  client_id text not null references public.oauth_clients(client_id) on delete cascade,
+  scopes text not null,                                 -- space-separated, e.g. 'lyra:full'
+  granted_at timestamptz not null default now(),
+  revoked_at timestamptz,
+  unique (user_id, client_id)
+);
+
+create index oauth_consents_user_idx on public.oauth_consents (user_id);
+alter table public.oauth_consents enable row level security;
+-- Users CAN read + revoke their own consents from a future dashboard page.
+create policy oauth_consents_own_select on public.oauth_consents
+  for select using (auth.uid() = user_id);
+create policy oauth_consents_own_update on public.oauth_consents
+  for update using (auth.uid() = user_id);
+
+comment on table public.oauth_consents is 'KAN-88 — Per-user-per-client consent grants. Users see their own row in /dashboard/settings.';
+
+-- ─── Trigger: updated_at on oauth_clients ────────────────────────────────
+
+create or replace function public.oauth_clients_set_updated_at()
+returns trigger
+language plpgsql
+as $$
+begin
+  new.updated_at = now();
+  return new;
+end;
+$$;
+
+create trigger oauth_clients_updated_at
+  before update on public.oauth_clients
+  for each row execute function public.oauth_clients_set_updated_at();

--- a/tests/unit/oauth/metadata.test.ts
+++ b/tests/unit/oauth/metadata.test.ts
@@ -1,0 +1,108 @@
+/**
+ * KAN-88 — OAuth AS metadata endpoint tests.
+ *
+ * The route is exposed at /.well-known/oauth-authorization-server via
+ * a next.config rewrite, and the handler lives at
+ * /api/well-known/oauth-authorization-server/route.ts. We test the
+ * handler directly here; the rewrite is covered by a structural
+ * test on next.config.ts.
+ */
+
+import fs from 'fs';
+import path from 'path';
+
+const ROOT = path.join(__dirname, '..', '..', '..');
+
+// Handler import — under jest.config the @ alias resolves into src/.
+import { GET } from '@/app/api/well-known/oauth-authorization-server/route';
+
+describe('GET /.well-known/oauth-authorization-server (KAN-88)', () => {
+  const ORIGINAL_URL = process.env.NEXT_PUBLIC_SITE_URL;
+  const ORIGINAL_VERCEL = process.env.VERCEL_URL;
+  beforeEach(() => {
+    delete process.env.NEXT_PUBLIC_SITE_URL;
+    delete process.env.VERCEL_URL;
+  });
+  afterAll(() => {
+    if (ORIGINAL_URL !== undefined) process.env.NEXT_PUBLIC_SITE_URL = ORIGINAL_URL;
+    if (ORIGINAL_VERCEL !== undefined) process.env.VERCEL_URL = ORIGINAL_VERCEL;
+  });
+
+  test('returns 200 with application/json', async () => {
+    const res = await GET();
+    expect(res.status).toBe(200);
+    expect(res.headers.get('content-type')).toMatch(/application\/json/);
+  });
+
+  test('contains required RFC 8414 fields', async () => {
+    process.env.NEXT_PUBLIC_SITE_URL = 'https://dev.checklyra.com';
+    const res = await GET();
+    const body = await res.json();
+    expect(body.issuer).toBe('https://dev.checklyra.com');
+    expect(body.authorization_endpoint).toBe('https://dev.checklyra.com/oauth/authorize');
+    expect(body.token_endpoint).toBe('https://dev.checklyra.com/oauth/token');
+    expect(body.registration_endpoint).toBe('https://dev.checklyra.com/oauth/register');
+    expect(body.revocation_endpoint).toBe('https://dev.checklyra.com/oauth/revoke');
+    expect(body.response_types_supported).toEqual(['code']);
+    expect(body.grant_types_supported).toEqual(expect.arrayContaining(['authorization_code', 'refresh_token']));
+  });
+
+  test('advertises PKCE S256 (not plain)', async () => {
+    const res = await GET();
+    const body = await res.json();
+    expect(body.code_challenge_methods_supported).toEqual(['S256']);
+  });
+
+  test('advertises public-client (token_endpoint_auth_methods = none)', async () => {
+    const res = await GET();
+    const body = await res.json();
+    expect(body.token_endpoint_auth_methods_supported).toEqual(['none']);
+  });
+
+  test('advertises lyra:full scope', async () => {
+    const res = await GET();
+    const body = await res.json();
+    expect(body.scopes_supported).toContain('lyra:full');
+  });
+
+  test('uses VERCEL_URL fallback when NEXT_PUBLIC_SITE_URL absent', async () => {
+    process.env.VERCEL_URL = 'lyra-abc123.vercel.app';
+    const res = await GET();
+    const body = await res.json();
+    expect(body.issuer).toBe('https://lyra-abc123.vercel.app');
+  });
+
+  test('sets CORS open + short cache so clients can discover us', async () => {
+    const res = await GET();
+    expect(res.headers.get('access-control-allow-origin')).toBe('*');
+    expect(res.headers.get('cache-control')).toMatch(/max-age=\d+/);
+  });
+});
+
+describe('next.config.ts rewrite for /.well-known/oauth-authorization-server (KAN-88)', () => {
+  test('rewrite is configured', () => {
+    const src = fs.readFileSync(path.join(ROOT, 'next.config.ts'), 'utf8');
+    expect(src).toMatch(/source:\s*['"]\/\.well-known\/oauth-authorization-server['"]/);
+    expect(src).toMatch(/destination:\s*['"]\/api\/well-known\/oauth-authorization-server['"]/);
+  });
+});
+
+describe('oauth config (KAN-88)', () => {
+  test('TTLs match documented values', async () => {
+    const { oauthConfig } = await import('@/lib/oauth/config');
+    expect(oauthConfig.authorizationCodeTtlSeconds).toBe(600); // 10 min
+    expect(oauthConfig.accessTokenTtlSeconds).toBe(3600); // 1h
+    expect(oauthConfig.refreshTokenTtlSeconds).toBe(30 * 24 * 60 * 60); // 30d
+  });
+
+  test('wwwAuthenticateHeader builds the right shape', async () => {
+    const { wwwAuthenticateHeader, oauthConfig } = await import('@/lib/oauth/config');
+    const plain = wwwAuthenticateHeader();
+    expect(plain).toMatch(/^Bearer realm="/);
+    expect(plain).toContain(oauthConfig.issuer());
+
+    const withErr = wwwAuthenticateHeader({ error: 'invalid_token', errorDescription: 'expired' });
+    expect(withErr).toContain('error="invalid_token"');
+    expect(withErr).toContain('error_description="expired"');
+  });
+});


### PR DESCRIPTION
## Summary

**Phase 1 of 6** toward full MCP OAuth 2.1 authorization. Just the foundation: DB schema and the AS discovery document. No flow endpoints yet — those land in P2-P4.

### Database

Migration `20260517100000_oauth_2_1_server` adds:
- `oauth_clients` — registered OAuth clients (DCR target in P2)
- `oauth_authorization_codes` — one-time codes, ≤10min TTL
- `oauth_access_tokens` — JWT `jti` registry for revocation lookups
- `oauth_refresh_tokens` — rotating refresh tokens with family chain for compromise detection
- `oauth_consents` — per-user-per-client consent grants. Users can read + revoke their own rows; everything else is service-role.

Already applied on dev Supabase.

### Discovery

- `src/lib/oauth/config.ts` — env-driven URLs + TTL constants + `wwwAuthenticateHeader` helper (used in P6)
- `src/app/api/well-known/oauth-authorization-server/route.ts` — RFC 8414 metadata. Advertises PKCE S256 only, public-client auth (`none`), single `lyra:full` scope. CORS open + 5min cache.
- `next.config.ts` rewrite from `/.well-known/oauth-authorization-server` → `/api/well-known/oauth-authorization-server` (Next.js doesn't route dot-prefixed folders reliably).

### Test plan

- [x] `npx jest tests/unit/oauth/metadata.test.ts` — 10/10 pass
- [x] `npx tsc --noEmit` — clean
- [x] `npm run build` — route registered as `/api/well-known/oauth-authorization-server`
- [ ] After deploy: `curl https://dev.checklyra.com/.well-known/oauth-authorization-server | jq` should return the RFC 8414 document

### Roadmap

| Phase | Scope | Status |
|---|---|---|
| **P1** | Schema + AS metadata | **this PR** |
| P2 | Dynamic Client Registration | next |
| P3 | /oauth/authorize + consent | … |
| P4 | /oauth/token (code→JWT + refresh) | … |
| P5 | JWT validator on MCP middleware | … |
| P6 | WWW-Authenticate 401 + /oauth/revoke | … |
| P7 | claude.ai E2E test | … |

Companion MCP PR: [lyra-mcp-server#43](https://github.com/luisa-sys/lyra-mcp-server/pull/43) for the matching PRM endpoint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)