### PR TITLE
feat(KAN-88) P2: Dynamic Client Registration (RFC 7591)

### DIFF
--- a/src/app/oauth/register/route.ts
+++ b/src/app/oauth/register/route.ts
@@ -1,0 +1,79 @@
+/**
+ * POST /oauth/register — Dynamic Client Registration (RFC 7591).
+ *
+ * Clients like claude.ai POST their metadata (client_name, redirect_uris)
+ * and receive a client_id (and optionally client_secret) to use in the
+ * OAuth flow.
+ *
+ * This endpoint is INTENTIONALLY UNAUTHENTICATED — that's how DCR works
+ * for public/dynamic clients. Rate limiting + the trust-on-first-use
+ * model is what protects us; we can't refuse to register clients we
+ * don't recognise because we *can't* recognise them yet.
+ *
+ * Mitigations against abuse:
+ *   - RFC 7591 only — no extension fields acted upon.
+ *   - HTTPS redirect URIs only (or http://localhost for native dev).
+ *   - Capped per-IP rate limit (configured at the edge / Vercel).
+ *   - Clients can be revoked by admin if abused.
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import {
+  validateRegisterInput,
+  createOauthClient,
+  type RegistrationError,
+} from '@/lib/oauth/clients';
+
+export async function POST(req: NextRequest) {
+  let body: unknown;
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json(
+      { error: 'invalid_client_metadata', error_description: 'request body must be JSON' },
+      { status: 400, headers: { 'Cache-Control': 'no-store', Pragma: 'no-cache' } }
+    );
+  }
+
+  const v = validateRegisterInput(body);
+  if (!v.ok) {
+    return errorResponse(v.error, 400);
+  }
+
+  let client;
+  try {
+    client = await createOauthClient(v.input);
+  } catch (e) {
+    return errorResponse(
+      { code: 'invalid_client_metadata', description: e instanceof Error ? e.message : 'registration failed' },
+      500
+    );
+  }
+
+  // RFC 7591 §3.2.1 — return the full registered metadata to the client.
+  return NextResponse.json(
+    {
+      client_id: client.client_id,
+      ...(client.client_secret ? { client_secret: client.client_secret } : {}),
+      client_id_issued_at: client.client_id_issued_at,
+      client_name: client.client_name,
+      redirect_uris: client.redirect_uris,
+      grant_types: client.grant_types,
+      response_types: client.response_types,
+      application_type: client.application_type,
+      token_endpoint_auth_method: client.token_endpoint_auth_method,
+      scope: client.scopes,
+    },
+    {
+      status: 201,
+      headers: { 'Cache-Control': 'no-store', Pragma: 'no-cache' },
+    }
+  );
+}
+
+function errorResponse(err: RegistrationError, status: number) {
+  return NextResponse.json(
+    { error: err.code, error_description: err.description },
+    { status, headers: { 'Cache-Control': 'no-store', Pragma: 'no-cache' } }
+  );
+}

--- a/src/lib/oauth/clients.ts
+++ b/src/lib/oauth/clients.ts
@@ -1,0 +1,253 @@
+/**
+ * OAuth client repository — KAN-88.
+ *
+ * CRUD operations on the `oauth_clients` table. Used by the registration
+ * endpoint (P2) and by the authorize/token endpoints (P3/P4) to look up
+ * the calling client.
+ *
+ * Service-role only — the lyra app holds SUPABASE_SERVICE_ROLE_KEY and is
+ * the single writer/reader for this table.
+ */
+
+import { createClient, type SupabaseClient } from '@supabase/supabase-js';
+import { env } from '@/lib/env';
+import { randomBytes, createHash } from 'crypto';
+
+function admin(): SupabaseClient {
+  return createClient(env.supabaseUrl(), env.supabaseServiceRoleKey(), {
+    auth: { persistSession: false },
+  });
+}
+
+export interface RegisterClientInput {
+  client_name: string;
+  redirect_uris: string[];
+  grant_types?: string[];
+  response_types?: string[];
+  application_type?: 'web' | 'native';
+  token_endpoint_auth_method?: 'none' | 'client_secret_basic' | 'client_secret_post';
+}
+
+export interface RegisteredClient {
+  client_id: string;
+  client_secret?: string;
+  client_name: string;
+  redirect_uris: string[];
+  grant_types: string[];
+  response_types: string[];
+  application_type: string;
+  token_endpoint_auth_method: string;
+  scopes: string;
+  client_id_issued_at: number;
+}
+
+export function generateClientId(): string {
+  // ~22 chars, base64url, 128 bits of entropy. RFC 6749 doesn't constrain
+  // the shape but we keep it human-copy-pasteable.
+  return `lyra_oauth_${randomBytes(16).toString('base64url')}`;
+}
+
+export function generateClientSecret(): string {
+  // 32 bytes = 43 base64url chars, 256 bits of entropy.
+  return randomBytes(32).toString('base64url');
+}
+
+export function hashClientSecret(secret: string): string {
+  return createHash('sha256').update(secret).digest('hex');
+}
+
+const VALID_GRANT_TYPES = ['authorization_code', 'refresh_token'] as const;
+const VALID_RESPONSE_TYPES = ['code'] as const;
+const VALID_AUTH_METHODS = ['none', 'client_secret_basic', 'client_secret_post'] as const;
+
+export type RegistrationError =
+  | { code: 'invalid_redirect_uri'; description: string }
+  | { code: 'invalid_client_metadata'; description: string };
+
+export function validateRegisterInput(
+  body: unknown
+): { ok: true; input: RegisterClientInput } | { ok: false; error: RegistrationError } {
+  if (!body || typeof body !== 'object') {
+    return { ok: false, error: { code: 'invalid_client_metadata', description: 'body must be an object' } };
+  }
+  const b = body as Record<string, unknown>;
+
+  const name = b.client_name;
+  if (typeof name !== 'string' || name.length === 0 || name.length > 200) {
+    return {
+      ok: false,
+      error: { code: 'invalid_client_metadata', description: 'client_name must be a non-empty string ≤200 chars' },
+    };
+  }
+
+  const redirectUris = b.redirect_uris;
+  if (!Array.isArray(redirectUris) || redirectUris.length === 0 || redirectUris.length > 10) {
+    return {
+      ok: false,
+      error: { code: 'invalid_redirect_uri', description: 'redirect_uris must be a non-empty array (≤10)' },
+    };
+  }
+  for (const uri of redirectUris) {
+    if (typeof uri !== 'string') {
+      return { ok: false, error: { code: 'invalid_redirect_uri', description: 'redirect_uris must be strings' } };
+    }
+    // Must be a valid absolute URL.
+    let parsed: URL;
+    try {
+      parsed = new URL(uri);
+    } catch {
+      return { ok: false, error: { code: 'invalid_redirect_uri', description: `invalid URL: ${uri.slice(0, 80)}` } };
+    }
+    // Reject non-https except for localhost — RFC 8252 carve-out for native dev.
+    const isLocalhost = parsed.hostname === 'localhost' || parsed.hostname === '127.0.0.1';
+    if (parsed.protocol !== 'https:' && !isLocalhost) {
+      return {
+        ok: false,
+        error: {
+          code: 'invalid_redirect_uri',
+          description: `redirect_uri must use https (or http://localhost): ${uri.slice(0, 80)}`,
+        },
+      };
+    }
+    // Reject URLs with fragments (RFC 6749 §3.1.2).
+    if (parsed.hash) {
+      return {
+        ok: false,
+        error: { code: 'invalid_redirect_uri', description: `redirect_uri must not contain a fragment: ${uri.slice(0, 80)}` },
+      };
+    }
+  }
+
+  // Grant types (default to ['authorization_code']).
+  let grantTypes = b.grant_types;
+  if (grantTypes === undefined) {
+    grantTypes = ['authorization_code'];
+  }
+  if (
+    !Array.isArray(grantTypes) ||
+    grantTypes.some(
+      (g) => typeof g !== 'string' || !VALID_GRANT_TYPES.includes(g as (typeof VALID_GRANT_TYPES)[number])
+    )
+  ) {
+    return {
+      ok: false,
+      error: {
+        code: 'invalid_client_metadata',
+        description: `grant_types must be a subset of [${VALID_GRANT_TYPES.join(', ')}]`,
+      },
+    };
+  }
+
+  // Response types — default ['code']. MVP only supports 'code'.
+  let responseTypes = b.response_types;
+  if (responseTypes === undefined) {
+    responseTypes = ['code'];
+  }
+  if (
+    !Array.isArray(responseTypes) ||
+    responseTypes.some(
+      (r) => typeof r !== 'string' || !VALID_RESPONSE_TYPES.includes(r as (typeof VALID_RESPONSE_TYPES)[number])
+    )
+  ) {
+    return {
+      ok: false,
+      error: { code: 'invalid_client_metadata', description: 'response_types must be ["code"]' },
+    };
+  }
+
+  // application_type — default 'web'.
+  let appType = b.application_type;
+  if (appType === undefined) appType = 'web';
+  if (appType !== 'web' && appType !== 'native') {
+    return {
+      ok: false,
+      error: { code: 'invalid_client_metadata', description: 'application_type must be "web" or "native"' },
+    };
+  }
+
+  // token_endpoint_auth_method — default 'none' (public client).
+  let authMethod = b.token_endpoint_auth_method;
+  if (authMethod === undefined) authMethod = 'none';
+  if (typeof authMethod !== 'string' || !VALID_AUTH_METHODS.includes(authMethod as (typeof VALID_AUTH_METHODS)[number])) {
+    return {
+      ok: false,
+      error: {
+        code: 'invalid_client_metadata',
+        description: `token_endpoint_auth_method must be one of [${VALID_AUTH_METHODS.join(', ')}]`,
+      },
+    };
+  }
+
+  return {
+    ok: true,
+    input: {
+      client_name: name,
+      redirect_uris: redirectUris as string[],
+      grant_types: grantTypes as string[],
+      response_types: responseTypes as string[],
+      application_type: appType as 'web' | 'native',
+      token_endpoint_auth_method: authMethod as 'none' | 'client_secret_basic' | 'client_secret_post',
+    },
+  };
+}
+
+export async function createOauthClient(input: RegisterClientInput): Promise<RegisteredClient> {
+  const sb = admin();
+  const clientId = generateClientId();
+  const isPublic = input.token_endpoint_auth_method === 'none';
+  const secret = isPublic ? undefined : generateClientSecret();
+  const secretHash = secret ? hashClientSecret(secret) : null;
+
+  // ownership-ok: service-role insert (KAN-88).
+  const { error } = await sb.from('oauth_clients').insert({
+    client_id: clientId,
+    client_secret_hash: secretHash,
+    client_name: input.client_name,
+    redirect_uris: input.redirect_uris,
+    grant_types: input.grant_types,
+    response_types: input.response_types,
+    application_type: input.application_type,
+    token_endpoint_auth_method: input.token_endpoint_auth_method,
+    scopes: 'lyra:full',
+  });
+
+  if (error) throw new Error(`client registration failed: ${error.message}`);
+
+  return {
+    client_id: clientId,
+    client_secret: secret,
+    client_name: input.client_name,
+    redirect_uris: input.redirect_uris,
+    grant_types: input.grant_types ?? ['authorization_code'],
+    response_types: input.response_types ?? ['code'],
+    application_type: input.application_type ?? 'web',
+    token_endpoint_auth_method: input.token_endpoint_auth_method ?? 'none',
+    scopes: 'lyra:full',
+    client_id_issued_at: Math.floor(Date.now() / 1000),
+  };
+}
+
+export interface ClientRecord {
+  client_id: string;
+  client_secret_hash: string | null;
+  client_name: string;
+  redirect_uris: string[];
+  grant_types: string[];
+  response_types: string[];
+  application_type: string;
+  token_endpoint_auth_method: string;
+  scopes: string;
+  revoked_at: string | null;
+}
+
+export async function getOauthClient(clientId: string): Promise<ClientRecord | null> {
+  const sb = admin();
+  const { data } = await sb
+    .from('oauth_clients')
+    .select(
+      'client_id, client_secret_hash, client_name, redirect_uris, grant_types, response_types, application_type, token_endpoint_auth_method, scopes, revoked_at'
+    )
+    .eq('client_id', clientId)
+    .maybeSingle();
+  return (data as ClientRecord | null) ?? null;
+}

--- a/tests/unit/oauth/clients.test.ts
+++ b/tests/unit/oauth/clients.test.ts
@@ -1,0 +1,147 @@
+/**
+ * KAN-88 P2 — Dynamic Client Registration validator tests.
+ *
+ * Pure validation logic, no DB. The DB-touching createOauthClient path
+ * is exercised by the integration smoke test once the endpoint is live.
+ */
+
+import {
+  validateRegisterInput,
+  generateClientId,
+  generateClientSecret,
+  hashClientSecret,
+} from '@/lib/oauth/clients';
+
+describe('validateRegisterInput (KAN-88 P2)', () => {
+  const minimal = {
+    client_name: 'Claude',
+    redirect_uris: ['https://claude.ai/api/mcp/auth_callback'],
+  };
+
+  test('accepts minimal valid input + defaults grant/response/auth method', () => {
+    const v = validateRegisterInput(minimal);
+    if (!v.ok) throw new Error(`expected ok, got ${v.error.code}`);
+    expect(v.input.client_name).toBe('Claude');
+    expect(v.input.grant_types).toEqual(['authorization_code']);
+    expect(v.input.response_types).toEqual(['code']);
+    expect(v.input.application_type).toBe('web');
+    expect(v.input.token_endpoint_auth_method).toBe('none');
+  });
+
+  test('rejects non-object body', () => {
+    const v = validateRegisterInput('string-body');
+    expect(v.ok).toBe(false);
+    if (v.ok) return;
+    expect(v.error.code).toBe('invalid_client_metadata');
+  });
+
+  test('rejects missing client_name', () => {
+    const v = validateRegisterInput({ redirect_uris: ['https://x.com/cb'] });
+    expect(v.ok).toBe(false);
+  });
+
+  test('rejects empty client_name', () => {
+    const v = validateRegisterInput({ ...minimal, client_name: '' });
+    expect(v.ok).toBe(false);
+  });
+
+  test('rejects >200 char client_name', () => {
+    const v = validateRegisterInput({ ...minimal, client_name: 'x'.repeat(201) });
+    expect(v.ok).toBe(false);
+  });
+
+  test('rejects missing/empty redirect_uris', () => {
+    expect(validateRegisterInput({ client_name: 'Claude' }).ok).toBe(false);
+    expect(validateRegisterInput({ client_name: 'Claude', redirect_uris: [] }).ok).toBe(false);
+  });
+
+  test('rejects >10 redirect_uris', () => {
+    const v = validateRegisterInput({
+      ...minimal,
+      redirect_uris: new Array(11).fill('https://x.com/cb'),
+    });
+    expect(v.ok).toBe(false);
+  });
+
+  test('rejects non-https redirect_uri (except localhost)', () => {
+    const v = validateRegisterInput({ ...minimal, redirect_uris: ['http://malicious.com/cb'] });
+    expect(v.ok).toBe(false);
+    if (v.ok) return;
+    expect(v.error.code).toBe('invalid_redirect_uri');
+  });
+
+  test('allows http://localhost for native dev (RFC 8252)', () => {
+    const v = validateRegisterInput({ ...minimal, redirect_uris: ['http://localhost:8080/cb'] });
+    expect(v.ok).toBe(true);
+    const v2 = validateRegisterInput({ ...minimal, redirect_uris: ['http://127.0.0.1:3000/cb'] });
+    expect(v2.ok).toBe(true);
+  });
+
+  test('rejects redirect_uri with fragment', () => {
+    const v = validateRegisterInput({ ...minimal, redirect_uris: ['https://x.com/cb#frag'] });
+    expect(v.ok).toBe(false);
+    if (v.ok) return;
+    expect(v.error.code).toBe('invalid_redirect_uri');
+  });
+
+  test('rejects unsupported grant_type', () => {
+    const v = validateRegisterInput({ ...minimal, grant_types: ['password'] });
+    expect(v.ok).toBe(false);
+  });
+
+  test('accepts subset of supported grant_types', () => {
+    expect(validateRegisterInput({ ...minimal, grant_types: ['authorization_code'] }).ok).toBe(true);
+    expect(
+      validateRegisterInput({ ...minimal, grant_types: ['authorization_code', 'refresh_token'] }).ok
+    ).toBe(true);
+  });
+
+  test('rejects non-code response_type', () => {
+    const v = validateRegisterInput({ ...minimal, response_types: ['token'] });
+    expect(v.ok).toBe(false);
+  });
+
+  test('rejects unknown application_type', () => {
+    const v = validateRegisterInput({ ...minimal, application_type: 'tv' });
+    expect(v.ok).toBe(false);
+  });
+
+  test('accepts native application_type', () => {
+    const v = validateRegisterInput({ ...minimal, application_type: 'native' });
+    expect(v.ok).toBe(true);
+  });
+
+  test('rejects unknown token_endpoint_auth_method', () => {
+    const v = validateRegisterInput({ ...minimal, token_endpoint_auth_method: 'private_key_jwt' });
+    expect(v.ok).toBe(false);
+  });
+});
+
+describe('client id / secret generators (KAN-88 P2)', () => {
+  test('client_id has lyra_oauth_ prefix and is URL-safe', () => {
+    const id = generateClientId();
+    expect(id).toMatch(/^lyra_oauth_[A-Za-z0-9_-]+$/);
+    expect(id.length).toBeGreaterThan(20);
+  });
+
+  test('100 client_ids are all unique (entropy check)', () => {
+    const ids = new Set<string>();
+    for (let i = 0; i < 100; i++) ids.add(generateClientId());
+    expect(ids.size).toBe(100);
+  });
+
+  test('client_secret is high-entropy URL-safe', () => {
+    const s = generateClientSecret();
+    expect(s).toMatch(/^[A-Za-z0-9_-]+$/);
+    expect(s.length).toBeGreaterThan(40);
+  });
+
+  test('hashClientSecret returns 64-char hex (sha256)', () => {
+    const h = hashClientSecret('test-secret');
+    expect(h).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  test('hashClientSecret is deterministic for same input', () => {
+    expect(hashClientSecret('abc')).toBe(hashClientSecret('abc'));
+  });
+});

--- a/tests/unit/oauth/register-route.test.ts
+++ b/tests/unit/oauth/register-route.test.ts
@@ -1,0 +1,72 @@
+/**
+ * KAN-88 P2 — POST /oauth/register structural + error-path tests.
+ *
+ * Doesn't hit Supabase — that's covered by the live smoke test after
+ * deploy. These tests verify the wire shape (status codes, headers,
+ * error format) is RFC 7591 compliant.
+ */
+
+import { POST } from '@/app/oauth/register/route';
+
+function fakePost(body: unknown): Request {
+  return new Request('https://dev.checklyra.com/oauth/register', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: typeof body === 'string' ? body : JSON.stringify(body),
+  });
+}
+
+describe('POST /oauth/register (KAN-88 P2)', () => {
+  test('returns 400 + invalid_client_metadata for non-JSON body', async () => {
+    const req = new Request('https://dev.checklyra.com/oauth/register', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: 'not json',
+    });
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const res = await POST(req as any);
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe('invalid_client_metadata');
+  });
+
+  test('returns 400 + invalid_redirect_uri for non-https redirect', async () => {
+    const req = fakePost({
+      client_name: 'Bad',
+      redirect_uris: ['http://evil.com/cb'],
+    });
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const res = await POST(req as any);
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe('invalid_redirect_uri');
+    expect(body.error_description).toMatch(/https/);
+  });
+
+  test('returns 400 for missing client_name', async () => {
+    const req = fakePost({ redirect_uris: ['https://x.com/cb'] });
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const res = await POST(req as any);
+    expect(res.status).toBe(400);
+  });
+
+  test('error responses set Cache-Control: no-store', async () => {
+    const req = fakePost({ client_name: '', redirect_uris: ['https://x.com/cb'] });
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const res = await POST(req as any);
+    expect(res.headers.get('cache-control')).toMatch(/no-store/);
+  });
+
+  test('rejects redirect_uri with fragment per RFC 6749 §3.1.2', async () => {
+    const req = fakePost({
+      client_name: 'X',
+      redirect_uris: ['https://x.com/cb#frag'],
+    });
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const res = await POST(req as any);
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe('invalid_redirect_uri');
+    expect(body.error_description).toMatch(/fragment/);
+  });
+});


### PR DESCRIPTION
## Summary

**Phase 2 of 6**. Adds \`/oauth/register\` — the endpoint claude.ai (and other MCP clients) call to obtain a \`client_id\` before starting the OAuth flow. RFC 7591.

DCR is **intentionally unauthenticated** — that's how RFC 7591 works for dynamic clients. Mitigations baked in:

- HTTPS-only redirect URIs (except \`http://localhost\` per RFC 8252 for native dev)
- Reject redirect URIs with fragments (RFC 6749 §3.1.2)
- Cap redirect_uris ≤10, client_name ≤200 chars
- \`Cache-Control: no-store\` + \`Pragma: no-cache\` on every response
- Admin can revoke misbehaving clients via \`oauth_clients.revoked_at\`

### Files

- \`src/lib/oauth/clients.ts\` — repository + validator. Generates \`lyra_oauth_<base64url>\` client IDs (128 bits entropy) and (for confidential clients) base64url client secrets (256 bits). \`hashClientSecret\` uses sha256.
- \`src/app/oauth/register/route.ts\` — POST handler. Returns 201 + RFC 7591 §3.2.1 client info on success; 400 + RFC 7591 error response on invalid input.

### Tests

- \`tests/unit/oauth/clients.test.ts\` — 21 tests: input validation (URI scheme, fragments, count caps), grant/response type whitelisting, application_type validation, auth method validation, entropy checks on ID/secret generators.
- \`tests/unit/oauth/register-route.test.ts\` — 5 tests: wire shape (status codes, error format, no-store cache).

### Test plan

- [x] \`npx jest tests/unit/oauth/\` — 26/26 pass
- [x] \`npx tsc --noEmit\` — clean
- [x] \`npm run build\` — \`/oauth/register\` registered
- [ ] After deploy: \`curl -X POST -H 'Content-Type: application/json' -d '{\"client_name\":\"smoke test\",\"redirect_uris\":[\"https://example.com/cb\"]}' https://dev.checklyra.com/oauth/register\` should return 201 with client_id

### Roadmap

| Phase | Status |
|---|---|
| P1 | Merged ([#258](https://github.com/luisa-sys/lyra/pull/258)) |
| **P2** | **this PR** |
| P3 | next — /oauth/authorize + consent |
| P4 | /oauth/token (code→JWT + refresh) |
| P5 | JWT validator on MCP middleware |
| P6 | WWW-Authenticate 401 + /oauth/revoke |

🤖 Generated with [Claude Code](https://claude.com/claude-code)