### PR TITLE
feat(KAN-88) P3: /oauth/authorize + consent screen

### DIFF
--- a/src/app/oauth/authorize/actions.ts
+++ b/src/app/oauth/authorize/actions.ts
@@ -1,0 +1,85 @@
+'use server';
+
+/**
+ * /oauth/authorize server actions — KAN-88 P3.
+ *
+ * Server actions invoked from the consent screen's <form>. Only async
+ * functions can be exported from a 'use server' file (BUGS-12 gotcha
+ * from CLAUDE.md).
+ *
+ * The action does the final issue-and-redirect step after the user
+ * clicks Allow or Deny:
+ *   - Allow → record consent (if not already), issue auth code,
+ *     redirect to client redirect_uri with ?code=…&state=…
+ *   - Deny  → redirect with ?error=access_denied&state=…
+ */
+
+import { redirect } from 'next/navigation';
+import { createClient as createSupabaseServer } from '@/lib/supabase-server';
+import { issueAuthCode } from '@/lib/oauth/codes';
+import { recordConsent } from '@/lib/oauth/consents';
+import { getOauthClient } from '@/lib/oauth/clients';
+import { buildSuccessRedirect, buildErrorRedirect } from '@/lib/oauth/authorize';
+
+export interface DecideInput {
+  client_id: string;
+  redirect_uri: string;
+  scope: string;
+  state: string;
+  code_challenge: string;
+  code_challenge_method: string;
+  decision: 'allow' | 'deny';
+}
+
+export async function submitConsent(input: DecideInput): Promise<void> {
+  // Re-validate the client + redirect URI on the action side. A
+  // malicious caller might POST directly to the action with crafted
+  // params — we cannot trust the form payload.
+  const client = await getOauthClient(input.client_id);
+  if (!client || client.revoked_at) {
+    redirect('/oauth/error?reason=invalid_client');
+  }
+  if (!client!.redirect_uris.includes(input.redirect_uri)) {
+    redirect('/oauth/error?reason=invalid_redirect_uri');
+  }
+  if (input.code_challenge_method !== 'S256' || !input.code_challenge) {
+    redirect(buildErrorRedirect(input.redirect_uri, 'invalid_request', 'pkce required', input.state || undefined));
+  }
+
+  const sb = await createSupabaseServer();
+  const {
+    data: { user },
+  } = await sb.auth.getUser();
+  if (!user) {
+    // Session expired between page render and form submit. Bounce
+    // back to login; preserve the original authorize URL.
+    const next = new URL('/oauth/authorize', 'https://placeholder');
+    next.searchParams.set('client_id', input.client_id);
+    next.searchParams.set('redirect_uri', input.redirect_uri);
+    next.searchParams.set('response_type', 'code');
+    next.searchParams.set('scope', input.scope);
+    if (input.state) next.searchParams.set('state', input.state);
+    next.searchParams.set('code_challenge', input.code_challenge);
+    next.searchParams.set('code_challenge_method', input.code_challenge_method);
+    redirect(`/login?next=${encodeURIComponent(next.pathname + next.search)}`);
+  }
+
+  const state = input.state || undefined;
+
+  if (input.decision === 'deny') {
+    redirect(buildErrorRedirect(input.redirect_uri, 'access_denied', 'user denied authorization', state));
+  }
+
+  // Allow path — record consent + issue code + redirect.
+  await recordConsent(user!.id, input.client_id, input.scope);
+  const { code } = await issueAuthCode({
+    clientId: input.client_id,
+    userId: user!.id,
+    redirectUri: input.redirect_uri,
+    scope: input.scope,
+    codeChallenge: input.code_challenge,
+    codeChallengeMethod: 'S256',
+  });
+
+  redirect(buildSuccessRedirect(input.redirect_uri, code, state));
+}

--- a/src/app/oauth/authorize/actions.ts
+++ b/src/app/oauth/authorize/actions.ts
@@ -20,16 +20,7 @@ import { issueAuthCode } from '@/lib/oauth/codes';
 import { recordConsent } from '@/lib/oauth/consents';
 import { getOauthClient } from '@/lib/oauth/clients';
 import { buildSuccessRedirect, buildErrorRedirect } from '@/lib/oauth/authorize';
-
-export interface DecideInput {
-  client_id: string;
-  redirect_uri: string;
-  scope: string;
-  state: string;
-  code_challenge: string;
-  code_challenge_method: string;
-  decision: 'allow' | 'deny';
-}
+import type { DecideInput } from './types';
 
 export async function submitConsent(input: DecideInput): Promise<void> {
   // Re-validate the client + redirect URI on the action side. A

--- a/src/app/oauth/authorize/page.tsx
+++ b/src/app/oauth/authorize/page.tsx
@@ -1,0 +1,199 @@
+/**
+ * /oauth/authorize — KAN-88 P3 consent screen.
+ *
+ * Entry point of the OAuth Authorization Code + PKCE flow. Validates
+ * the inbound request, requires the user to be signed in, and shows
+ * the consent screen so they can Allow or Deny the request.
+ *
+ * Auto-skips the consent screen if the user has previously consented
+ * to this client and the requested scopes match the previous grant.
+ */
+
+import { redirect } from 'next/navigation';
+import { createClient as createSupabaseServer } from '@/lib/supabase-server';
+import { validateAuthorizeRequest, buildErrorRedirect, buildSuccessRedirect } from '@/lib/oauth/authorize';
+import { issueAuthCode } from '@/lib/oauth/codes';
+import { getConsent, recordConsent } from '@/lib/oauth/consents';
+import { submitConsent } from './actions';
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'Authorize access — Lyra',
+  robots: { index: false, follow: false },
+};
+
+interface PageProps {
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
+}
+
+export default async function AuthorizePage({ searchParams }: PageProps) {
+  const params = await searchParams;
+
+  // Coerce searchParams shape — Next gives us strings or arrays.
+  const pick = (k: string): string | undefined => {
+    const v = params[k];
+    if (Array.isArray(v)) return v[0];
+    return v;
+  };
+
+  const validation = await validateAuthorizeRequest({
+    response_type: pick('response_type'),
+    client_id: pick('client_id'),
+    redirect_uri: pick('redirect_uri'),
+    scope: pick('scope'),
+    state: pick('state'),
+    code_challenge: pick('code_challenge'),
+    code_challenge_method: pick('code_challenge_method'),
+  });
+
+  if (!validation.ok) {
+    if (validation.error.kind === 'fatal') {
+      // Cannot trust the redirect URI — render an in-page error.
+      return <FatalError code={validation.error.code} description={validation.error.description} />;
+    }
+    // Protocol error — redirect back to the client with ?error=…
+    redirect(
+      buildErrorRedirect(
+        validation.error.redirectUri,
+        validation.error.code,
+        validation.error.description,
+        validation.error.state
+      )
+    );
+  }
+
+  const req = validation.req;
+
+  // Require a signed-in user. If not, send to /login with `next` so they
+  // come back here after authenticating.
+  const sb = await createSupabaseServer();
+  const {
+    data: { user },
+  } = await sb.auth.getUser();
+
+  if (!user) {
+    const next = new URL('/oauth/authorize', 'https://placeholder');
+    next.searchParams.set('client_id', req.client.client_id);
+    next.searchParams.set('redirect_uri', req.redirectUri);
+    next.searchParams.set('response_type', 'code');
+    next.searchParams.set('scope', req.scope);
+    if (req.state) next.searchParams.set('state', req.state);
+    next.searchParams.set('code_challenge', req.codeChallenge);
+    next.searchParams.set('code_challenge_method', req.codeChallengeMethod);
+    redirect(`/login?next=${encodeURIComponent(next.pathname + next.search)}`);
+  }
+
+  // Auto-skip consent if user has already granted the same (or wider)
+  // scopes to this client. Reconsent only fires for new scopes.
+  const existing = await getConsent(user!.id, req.client.client_id);
+  if (existing && !existing.revoked_at && existing.scopes === req.scope) {
+    // Touch the consent (refresh granted_at) and issue the code.
+    await recordConsent(user!.id, req.client.client_id, req.scope);
+    const { code } = await issueAuthCode({
+      clientId: req.client.client_id,
+      userId: user!.id,
+      redirectUri: req.redirectUri,
+      scope: req.scope,
+      codeChallenge: req.codeChallenge,
+      codeChallengeMethod: 'S256',
+    });
+    redirect(buildSuccessRedirect(req.redirectUri, code, req.state));
+  }
+
+  // Otherwise — show the consent screen.
+  return (
+    <main style={{ maxWidth: 560, margin: '64px auto', padding: '0 24px', fontFamily: 'system-ui' }}>
+      <h1 style={{ fontSize: 24, marginBottom: 8 }}>Authorize access</h1>
+      <p style={{ color: '#555' }}>
+        <strong>{req.client.client_name}</strong> wants access to your Lyra account.
+      </p>
+
+      <div style={{ background: '#f5f4ef', padding: 16, borderRadius: 8, margin: '24px 0' }}>
+        <p style={{ margin: 0, fontWeight: 600 }}>This will let it:</p>
+        <ul style={{ marginTop: 8, marginBottom: 0 }}>
+          {req.scope.split(/\s+/).map((s) => (
+            <li key={s}>{scopeDescription(s)}</li>
+          ))}
+        </ul>
+      </div>
+
+      <p style={{ fontSize: 14, color: '#777' }}>
+        Signed in as <strong>{user!.email}</strong>. You can revoke this access anytime from your
+        Lyra settings.
+      </p>
+
+      <form
+        action={async (formData: FormData) => {
+          'use server';
+          const decision = formData.get('decision') === 'allow' ? 'allow' : 'deny';
+          await submitConsent({
+            client_id: req.client.client_id,
+            redirect_uri: req.redirectUri,
+            scope: req.scope,
+            state: req.state ?? '',
+            code_challenge: req.codeChallenge,
+            code_challenge_method: req.codeChallengeMethod,
+            decision,
+          });
+        }}
+        style={{ display: 'flex', gap: 12, marginTop: 24 }}
+      >
+        <button
+          type="submit"
+          name="decision"
+          value="deny"
+          style={{
+            background: '#fff',
+            border: '1px solid #ccc',
+            padding: '10px 20px',
+            borderRadius: 8,
+            cursor: 'pointer',
+          }}
+        >
+          Deny
+        </button>
+        <button
+          type="submit"
+          name="decision"
+          value="allow"
+          style={{
+            background: '#6b8e6f',
+            color: '#fff',
+            border: 'none',
+            padding: '10px 20px',
+            borderRadius: 8,
+            cursor: 'pointer',
+            fontWeight: 600,
+          }}
+        >
+          Allow
+        </button>
+      </form>
+    </main>
+  );
+}
+
+function scopeDescription(scope: string): string {
+  switch (scope) {
+    case 'lyra:full':
+      return 'Read and edit your Lyra profile, gatherings, contacts, and calendar connections';
+    default:
+      return scope;
+  }
+}
+
+function FatalError({ code, description }: { code: string; description: string }) {
+  return (
+    <main style={{ maxWidth: 560, margin: '96px auto', padding: '0 24px', fontFamily: 'system-ui' }}>
+      <h1 style={{ fontSize: 24, marginBottom: 8 }}>Authorization request rejected</h1>
+      <p style={{ color: '#a32' }}>
+        <strong>Error:</strong> {code}
+      </p>
+      <p style={{ color: '#555' }}>{description}</p>
+      <p style={{ color: '#888', fontSize: 14, marginTop: 32 }}>
+        This usually means the app sending you here misconfigured its OAuth client. There's nothing
+        wrong with your Lyra account — just close this tab.
+      </p>
+    </main>
+  );
+}

--- a/src/app/oauth/authorize/page.tsx
+++ b/src/app/oauth/authorize/page.tsx
@@ -191,8 +191,8 @@ function FatalError({ code, description }: { code: string; description: string }
       </p>
       <p style={{ color: '#555' }}>{description}</p>
       <p style={{ color: '#888', fontSize: 14, marginTop: 32 }}>
-        This usually means the app sending you here misconfigured its OAuth client. There's nothing
-        wrong with your Lyra account — just close this tab.
+        This usually means the app sending you here misconfigured its OAuth client. There&apos;s
+        nothing wrong with your Lyra account — just close this tab.
       </p>
     </main>
   );

--- a/src/app/oauth/authorize/types.ts
+++ b/src/app/oauth/authorize/types.ts
@@ -1,0 +1,17 @@
+/**
+ * Type-only sibling module for the authorize server action — KAN-88 P3.
+ *
+ * BUGS-12 / CLAUDE.md gotcha #18: a 'use server' file can only export
+ * async functions. The DecideInput interface lives here so actions.ts
+ * stays pure.
+ */
+
+export interface DecideInput {
+  client_id: string;
+  redirect_uri: string;
+  scope: string;
+  state: string;
+  code_challenge: string;
+  code_challenge_method: string;
+  decision: 'allow' | 'deny';
+}

--- a/src/lib/oauth/authorize.ts
+++ b/src/lib/oauth/authorize.ts
@@ -1,0 +1,181 @@
+/**
+ * /oauth/authorize request validation — KAN-88 P3.
+ *
+ * Splits errors into two categories per OAuth 2.1 §4.1.2.1:
+ *
+ *   FATAL (display error page directly, never redirect):
+ *     - invalid/unknown client_id
+ *     - invalid/unregistered redirect_uri
+ *   These errors must NOT redirect because we cannot trust the
+ *   redirect_uri the client supplied.
+ *
+ *   REDIRECT (return to client's redirect_uri with ?error=…):
+ *     - unsupported_response_type
+ *     - invalid_request (missing PKCE, wrong method, etc.)
+ *     - invalid_scope
+ *     - access_denied (user clicked Deny)
+ */
+
+import { getOauthClient, type ClientRecord } from './clients';
+
+export interface AuthorizeRequest {
+  response_type?: string;
+  client_id?: string;
+  redirect_uri?: string;
+  scope?: string;
+  state?: string;
+  code_challenge?: string;
+  code_challenge_method?: string;
+}
+
+export type AuthorizeError =
+  | {
+      kind: 'fatal';
+      // Show on the in-page error screen — no redirect.
+      code: 'invalid_client' | 'invalid_redirect_uri';
+      description: string;
+    }
+  | {
+      kind: 'redirect';
+      // Return to the client's redirect_uri with these query params.
+      redirectUri: string;
+      state: string | undefined;
+      code: 'invalid_request' | 'unsupported_response_type' | 'invalid_scope' | 'access_denied' | 'server_error';
+      description: string;
+    };
+
+export interface ValidatedAuthorizeRequest {
+  client: ClientRecord;
+  redirectUri: string;
+  scope: string;
+  state: string | undefined;
+  codeChallenge: string;
+  codeChallengeMethod: 'S256';
+}
+
+export async function validateAuthorizeRequest(
+  raw: AuthorizeRequest
+): Promise<{ ok: true; req: ValidatedAuthorizeRequest } | { ok: false; error: AuthorizeError }> {
+  // 1. client_id — fatal if missing/unknown.
+  if (!raw.client_id || typeof raw.client_id !== 'string') {
+    return { ok: false, error: { kind: 'fatal', code: 'invalid_client', description: 'client_id is required' } };
+  }
+  const client = await getOauthClient(raw.client_id);
+  if (!client) {
+    return { ok: false, error: { kind: 'fatal', code: 'invalid_client', description: 'unknown client_id' } };
+  }
+  if (client.revoked_at) {
+    return { ok: false, error: { kind: 'fatal', code: 'invalid_client', description: 'client revoked' } };
+  }
+
+  // 2. redirect_uri — fatal if missing/unregistered.
+  // Exact match (no scheme/host/path normalisation per OAuth 2.1).
+  if (!raw.redirect_uri || typeof raw.redirect_uri !== 'string') {
+    return {
+      ok: false,
+      error: { kind: 'fatal', code: 'invalid_redirect_uri', description: 'redirect_uri is required' },
+    };
+  }
+  if (!client.redirect_uris.includes(raw.redirect_uri)) {
+    return {
+      ok: false,
+      error: { kind: 'fatal', code: 'invalid_redirect_uri', description: 'redirect_uri not registered for this client' },
+    };
+  }
+
+  // From here on, errors can redirect back to the (now-validated) URI.
+  const state = typeof raw.state === 'string' ? raw.state : undefined;
+  const redirectUri = raw.redirect_uri;
+
+  // 3. response_type — must be 'code'.
+  if (raw.response_type !== 'code') {
+    return {
+      ok: false,
+      error: {
+        kind: 'redirect',
+        redirectUri,
+        state,
+        code: 'unsupported_response_type',
+        description: 'response_type must be "code"',
+      },
+    };
+  }
+
+  // 4. PKCE — required in OAuth 2.1.
+  if (!raw.code_challenge || typeof raw.code_challenge !== 'string') {
+    return {
+      ok: false,
+      error: { kind: 'redirect', redirectUri, state, code: 'invalid_request', description: 'code_challenge is required' },
+    };
+  }
+  if (raw.code_challenge_method !== 'S256') {
+    return {
+      ok: false,
+      error: {
+        kind: 'redirect',
+        redirectUri,
+        state,
+        code: 'invalid_request',
+        description: 'code_challenge_method must be "S256"',
+      },
+    };
+  }
+
+  // 5. Scope — default to client's allowed scope if not provided.
+  const requested = typeof raw.scope === 'string' && raw.scope.length > 0 ? raw.scope : client.scopes;
+  // For MVP we only accept lyra:full. Any other scope is invalid_scope.
+  const requestedScopes = requested.split(/\s+/).filter(Boolean);
+  for (const s of requestedScopes) {
+    if (s !== 'lyra:full') {
+      return {
+        ok: false,
+        error: {
+          kind: 'redirect',
+          redirectUri,
+          state,
+          code: 'invalid_scope',
+          description: `unknown scope: ${s.slice(0, 80)}`,
+        },
+      };
+    }
+  }
+
+  return {
+    ok: true,
+    req: {
+      client,
+      redirectUri,
+      scope: requested,
+      state,
+      codeChallenge: raw.code_challenge,
+      codeChallengeMethod: 'S256',
+    },
+  };
+}
+
+/**
+ * Build a redirect URL back to the client with error params.
+ * Used both for protocol-level errors and user-denies.
+ */
+export function buildErrorRedirect(
+  redirectUri: string,
+  code: string,
+  description: string,
+  state: string | undefined
+): string {
+  const url = new URL(redirectUri);
+  url.searchParams.set('error', code);
+  url.searchParams.set('error_description', description);
+  if (state) url.searchParams.set('state', state);
+  return url.toString();
+}
+
+/**
+ * Build a redirect URL back to the client with the successful auth code.
+ */
+export function buildSuccessRedirect(redirectUri: string, code: string, state: string | undefined): string {
+  const url = new URL(redirectUri);
+  url.searchParams.set('code', code);
+  if (state) url.searchParams.set('state', state);
+  return url.toString();
+}

--- a/src/lib/oauth/codes.ts
+++ b/src/lib/oauth/codes.ts
@@ -1,0 +1,93 @@
+/**
+ * OAuth authorization code repository — KAN-88 P3.
+ *
+ * Manages oauth_authorization_codes rows. Codes are:
+ *   - 32 random bytes, base64url-encoded
+ *   - bound to (client_id, user_id, redirect_uri, code_challenge)
+ *   - one-time-use (used_at gates redemption)
+ *   - short-lived (10min default per oauth config)
+ */
+
+import { createClient, type SupabaseClient } from '@supabase/supabase-js';
+import { env } from '@/lib/env';
+import { randomBytes } from 'crypto';
+import { oauthConfig } from './config';
+
+function admin(): SupabaseClient {
+  return createClient(env.supabaseUrl(), env.supabaseServiceRoleKey(), {
+    auth: { persistSession: false },
+  });
+}
+
+export function generateAuthCode(): string {
+  return randomBytes(32).toString('base64url');
+}
+
+export interface IssueCodeInput {
+  clientId: string;
+  userId: string;
+  redirectUri: string;
+  scope: string;
+  codeChallenge: string;
+  codeChallengeMethod: 'S256';
+}
+
+export async function issueAuthCode(input: IssueCodeInput): Promise<{ code: string; expiresAt: Date }> {
+  const sb = admin();
+  const code = generateAuthCode();
+  const expiresAt = new Date(Date.now() + oauthConfig.authorizationCodeTtlSeconds * 1000);
+
+  // ownership-ok: service-role insert, scoped to the authenticated user (KAN-88).
+  const { error } = await sb.from('oauth_authorization_codes').insert({
+    code,
+    client_id: input.clientId,
+    user_id: input.userId,
+    redirect_uri: input.redirectUri,
+    scope: input.scope,
+    code_challenge: input.codeChallenge,
+    code_challenge_method: input.codeChallengeMethod,
+    expires_at: expiresAt.toISOString(),
+  });
+  if (error) throw new Error(`code issue failed: ${error.message}`);
+  return { code, expiresAt };
+}
+
+export interface CodeRecord {
+  code: string;
+  client_id: string;
+  user_id: string;
+  redirect_uri: string;
+  scope: string;
+  code_challenge: string;
+  code_challenge_method: string;
+  expires_at: string;
+  used_at: string | null;
+}
+
+export async function getAuthCode(code: string): Promise<CodeRecord | null> {
+  const sb = admin();
+  const { data } = await sb
+    .from('oauth_authorization_codes')
+    .select('*')
+    .eq('code', code)
+    .maybeSingle();
+  return (data as CodeRecord | null) ?? null;
+}
+
+/**
+ * Mark a code as used. Returns false if the code is already used —
+ * the caller should treat this as code-reuse-attack and reject the
+ * exchange. (P4 uses this in the token exchange path.)
+ */
+export async function markCodeUsed(code: string): Promise<boolean> {
+  const sb = admin();
+  const { data, error } = await sb
+    .from('oauth_authorization_codes')
+    .update({ used_at: new Date().toISOString() })
+    .eq('code', code)
+    .is('used_at', null)
+    .select('code')
+    .maybeSingle();
+  if (error) throw new Error(`code mark-used failed: ${error.message}`);
+  return data !== null;
+}

--- a/src/lib/oauth/consents.ts
+++ b/src/lib/oauth/consents.ts
@@ -1,0 +1,60 @@
+/**
+ * OAuth consent repository — KAN-88 P3.
+ *
+ * Records each user-client consent grant. Used to skip the consent
+ * screen for clients the user has previously authorised (re-auth flow
+ * within a session goes straight through).
+ *
+ * Users can revoke consents from /dashboard/settings (P6 dashboard
+ * surface). Revoking a consent does NOT invalidate already-issued
+ * tokens — that's done separately via /oauth/revoke.
+ */
+
+import { createClient, type SupabaseClient } from '@supabase/supabase-js';
+import { env } from '@/lib/env';
+
+function admin(): SupabaseClient {
+  return createClient(env.supabaseUrl(), env.supabaseServiceRoleKey(), {
+    auth: { persistSession: false },
+  });
+}
+
+export interface ConsentRecord {
+  user_id: string;
+  client_id: string;
+  scopes: string;
+  granted_at: string;
+  revoked_at: string | null;
+}
+
+export async function getConsent(userId: string, clientId: string): Promise<ConsentRecord | null> {
+  const sb = admin();
+  const { data } = await sb
+    .from('oauth_consents')
+    .select('user_id, client_id, scopes, granted_at, revoked_at')
+    .eq('user_id', userId)
+    .eq('client_id', clientId)
+    .maybeSingle();
+  return (data as ConsentRecord | null) ?? null;
+}
+
+export async function recordConsent(userId: string, clientId: string, scopes: string): Promise<void> {
+  const sb = admin();
+  // Upsert — re-consenting replaces the previous grant timestamp and clears
+  // any revoked_at.
+  // ownership-ok: service-role write, the route already verified userId via
+  // the Supabase session cookie (KAN-88).
+  const { error } = await sb
+    .from('oauth_consents')
+    .upsert(
+      {
+        user_id: userId,
+        client_id: clientId,
+        scopes,
+        granted_at: new Date().toISOString(),
+        revoked_at: null,
+      },
+      { onConflict: 'user_id,client_id' }
+    );
+  if (error) throw new Error(`consent persist failed: ${error.message}`);
+}

--- a/tests/unit/oauth/authorize.test.ts
+++ b/tests/unit/oauth/authorize.test.ts
@@ -1,0 +1,186 @@
+/**
+ * KAN-88 P3 — /oauth/authorize request validator tests.
+ *
+ * Mocks the client lookup so we exercise the validation logic in
+ * isolation. The DB-touching path (issueAuthCode + getConsent) is
+ * covered by the live smoke test after deploy.
+ */
+
+import {
+  buildErrorRedirect,
+  buildSuccessRedirect,
+  validateAuthorizeRequest,
+} from '@/lib/oauth/authorize';
+
+jest.mock('@/lib/oauth/clients', () => {
+  return {
+    getOauthClient: jest.fn(async (clientId: string) => {
+      if (clientId === 'lyra_oauth_known') {
+        return {
+          client_id: 'lyra_oauth_known',
+          client_secret_hash: null,
+          client_name: 'Test Client',
+          redirect_uris: ['https://example.com/cb', 'https://example.com/cb2'],
+          grant_types: ['authorization_code', 'refresh_token'],
+          response_types: ['code'],
+          application_type: 'web',
+          token_endpoint_auth_method: 'none',
+          scopes: 'lyra:full',
+          revoked_at: null,
+        };
+      }
+      if (clientId === 'lyra_oauth_revoked') {
+        return {
+          client_id: 'lyra_oauth_revoked',
+          client_secret_hash: null,
+          client_name: 'Revoked',
+          redirect_uris: ['https://example.com/cb'],
+          grant_types: ['authorization_code'],
+          response_types: ['code'],
+          application_type: 'web',
+          token_endpoint_auth_method: 'none',
+          scopes: 'lyra:full',
+          revoked_at: '2026-05-01T00:00:00Z',
+        };
+      }
+      return null;
+    }),
+  };
+});
+
+describe('validateAuthorizeRequest (KAN-88 P3)', () => {
+  const validParams = {
+    response_type: 'code' as const,
+    client_id: 'lyra_oauth_known',
+    redirect_uri: 'https://example.com/cb',
+    code_challenge: 'E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM',
+    code_challenge_method: 'S256',
+    state: 'random123',
+    scope: 'lyra:full',
+  };
+
+  test('accepts a minimal valid request', async () => {
+    const v = await validateAuthorizeRequest(validParams);
+    if (!v.ok) throw new Error(`expected ok, got ${JSON.stringify(v.error)}`);
+    expect(v.req.client.client_id).toBe('lyra_oauth_known');
+    expect(v.req.scope).toBe('lyra:full');
+    expect(v.req.state).toBe('random123');
+  });
+
+  test('FATAL: unknown client_id returns invalid_client, no redirect', async () => {
+    const v = await validateAuthorizeRequest({ ...validParams, client_id: 'lyra_oauth_nope' });
+    expect(v.ok).toBe(false);
+    if (v.ok) return;
+    expect(v.error.kind).toBe('fatal');
+    expect(v.error.code).toBe('invalid_client');
+  });
+
+  test('FATAL: missing client_id is invalid_client', async () => {
+    const v = await validateAuthorizeRequest({ ...validParams, client_id: undefined });
+    expect(v.ok).toBe(false);
+    if (v.ok) return;
+    expect(v.error.kind).toBe('fatal');
+    expect(v.error.code).toBe('invalid_client');
+  });
+
+  test('FATAL: revoked client is invalid_client', async () => {
+    const v = await validateAuthorizeRequest({ ...validParams, client_id: 'lyra_oauth_revoked' });
+    expect(v.ok).toBe(false);
+    if (v.ok) return;
+    expect(v.error.kind).toBe('fatal');
+    expect(v.error.description).toMatch(/revoked/);
+  });
+
+  test('FATAL: unregistered redirect_uri', async () => {
+    const v = await validateAuthorizeRequest({ ...validParams, redirect_uri: 'https://evil.com/cb' });
+    expect(v.ok).toBe(false);
+    if (v.ok) return;
+    expect(v.error.kind).toBe('fatal');
+    expect(v.error.code).toBe('invalid_redirect_uri');
+  });
+
+  test('FATAL: redirect_uri must be exact match (one of the registered ones)', async () => {
+    const v = await validateAuthorizeRequest({ ...validParams, redirect_uri: 'https://example.com/cb/' });
+    expect(v.ok).toBe(false);
+    if (v.ok) return;
+    expect(v.error.kind).toBe('fatal');
+  });
+
+  test('REDIRECT: unsupported response_type', async () => {
+    const v = await validateAuthorizeRequest({ ...validParams, response_type: 'token' });
+    expect(v.ok).toBe(false);
+    if (v.ok) return;
+    expect(v.error.kind).toBe('redirect');
+    if (v.error.kind !== 'redirect') return;
+    expect(v.error.code).toBe('unsupported_response_type');
+    expect(v.error.redirectUri).toBe('https://example.com/cb');
+    expect(v.error.state).toBe('random123');
+  });
+
+  test('REDIRECT: missing code_challenge', async () => {
+    const v = await validateAuthorizeRequest({ ...validParams, code_challenge: undefined });
+    expect(v.ok).toBe(false);
+    if (v.ok) return;
+    if (v.error.kind !== 'redirect') throw new Error('expected redirect');
+    expect(v.error.code).toBe('invalid_request');
+    expect(v.error.description).toMatch(/code_challenge/);
+  });
+
+  test('REDIRECT: code_challenge_method must be S256 (not plain)', async () => {
+    const v = await validateAuthorizeRequest({ ...validParams, code_challenge_method: 'plain' });
+    expect(v.ok).toBe(false);
+    if (v.ok) return;
+    if (v.error.kind !== 'redirect') throw new Error('expected redirect');
+    expect(v.error.code).toBe('invalid_request');
+    expect(v.error.description).toMatch(/S256/);
+  });
+
+  test('REDIRECT: unknown scope is invalid_scope', async () => {
+    const v = await validateAuthorizeRequest({ ...validParams, scope: 'admin' });
+    expect(v.ok).toBe(false);
+    if (v.ok) return;
+    if (v.error.kind !== 'redirect') throw new Error('expected redirect');
+    expect(v.error.code).toBe('invalid_scope');
+  });
+
+  test('defaults scope to client.scopes when not provided', async () => {
+    const v = await validateAuthorizeRequest({ ...validParams, scope: undefined });
+    expect(v.ok).toBe(true);
+    if (!v.ok) return;
+    expect(v.req.scope).toBe('lyra:full');
+  });
+
+  test('state is optional', async () => {
+    const v = await validateAuthorizeRequest({ ...validParams, state: undefined });
+    expect(v.ok).toBe(true);
+    if (!v.ok) return;
+    expect(v.req.state).toBeUndefined();
+  });
+});
+
+describe('buildErrorRedirect / buildSuccessRedirect (KAN-88 P3)', () => {
+  test('error redirect includes error, error_description, state', () => {
+    const url = buildErrorRedirect('https://example.com/cb', 'access_denied', 'user said no', 'abc');
+    expect(url).toContain('error=access_denied');
+    expect(url).toContain('error_description=user+said+no');
+    expect(url).toContain('state=abc');
+  });
+
+  test('error redirect without state omits the state param', () => {
+    const url = buildErrorRedirect('https://example.com/cb', 'invalid_request', 'missing', undefined);
+    expect(url).not.toMatch(/[?&]state=/);
+  });
+
+  test('preserves existing query params on redirect_uri', () => {
+    const url = buildErrorRedirect('https://example.com/cb?extant=1', 'access_denied', 'no', 's');
+    expect(url).toContain('extant=1');
+    expect(url).toContain('error=access_denied');
+  });
+
+  test('success redirect includes code + state, no error', () => {
+    const url = buildSuccessRedirect('https://example.com/cb', 'authcode_xyz', 'abc');
+    expect(url).toContain('code=authcode_xyz');
+    expect(url).toContain('state=abc');
+    expect(url).not.toContain('error=');
+  });
+});


### PR DESCRIPTION
## Summary

**Phase 3 of 6**. The user-facing entry point of the OAuth flow.

\`GET /oauth/authorize?response_type=code&client_id=…&redirect_uri=…&code_challenge=…&code_challenge_method=S256&state=…&scope=lyra:full\` →

1. Validate (RFC 6749 §4.1.2.1 error split: fatal errors stay on page; protocol errors redirect to client with \`?error=…\`).
2. Require Supabase session, bounce to \`/login?next=…\` if missing.
3. Auto-skip consent if previously granted with the same scopes.
4. Otherwise render Allow/Deny screen.

On Allow → record consent, issue one-time auth code (10min TTL), redirect to client.
On Deny → redirect with \`?error=access_denied\`.

### Files

- \`src/lib/oauth/authorize.ts\` — \`validateAuthorizeRequest\` + redirect URL builders. Strict redirect_uri equality (no normalisation).
- \`src/lib/oauth/codes.ts\` — \`issueAuthCode\` / \`getAuthCode\` / \`markCodeUsed\` for \`oauth_authorization_codes\`.
- \`src/lib/oauth/consents.ts\` — \`getConsent\` / \`recordConsent\` with upsert on (user_id, client_id).
- \`src/app/oauth/authorize/page.tsx\` — server component, inline \`'use server'\` form action.
- \`src/app/oauth/authorize/actions.ts\` — \`submitConsent\` (re-validates everything; form payload is untrusted).

### Test plan

- [x] \`npx jest tests/unit/oauth/\` — 52/52 across 4 OAuth suites
- [x] \`npx tsc --noEmit\` — clean
- [x] \`npm run build\` — \`/oauth/authorize\` registered
- [ ] After deploy: smoke-test the full flow with a real registered client (P2 + this PR) to confirm the consent screen renders + Allow redirects with code

### Roadmap

| Phase | Status |
|---|---|
| P1 + P2 | Merged ([#258](https://github.com/luisa-sys/lyra/pull/258), [#259](https://github.com/luisa-sys/lyra/pull/259)) |
| **P3** | **this PR** |
| P4 | next — /oauth/token (code→JWT + refresh) |
| P5 | JWT validator on MCP middleware |
| P6 | WWW-Authenticate 401 + /oauth/revoke |
| P7 | claude.ai E2E |

🤖 Generated with [Claude Code](https://claude.com/claude-code)