### PR TITLE
feat(KAN-241): wire content-moderation into profile-write server actions

### DIFF
--- a/src/app/dashboard/profile/actions.ts
+++ b/src/app/dashboard/profile/actions.ts
@@ -3,6 +3,7 @@
 import { createClient } from '@/lib/supabase-server';
 import { revalidatePath } from 'next/cache';
 import { sanitiseText, sanitiseUrl, type ActionResult } from '@/lib/sanitise';
+import { checkModeration } from '@/lib/moderation-policy';
 import { isAllowedProfileField } from './profile-fields';
 import { coerceVisibility } from './visibility';
 import { coerceAffiliationType } from './affiliation-fields';
@@ -66,6 +67,19 @@ export async function updateProfileFields(data: Record<string, string | boolean 
     };
   }
 
+  // KAN-241 — content moderation. Runs AFTER sanitiseText so the moderator
+  // sees the post-strip text (a profanity inside <script>profanity</script>
+  // gets stripped to plain `profanity` first, then caught). Public field
+  // type for everything in `profiles` (display_name, bio_short, etc all
+  // appear on the public profile page).
+  for (const [key, val] of Object.entries(sanitised)) {
+    if (typeof val !== 'string') continue;
+    const mod = checkModeration(val, 'public', `profiles.${key}`);
+    if (!mod.ok) {
+      return { success: false, error: mod.error };
+    }
+  }
+
   // If after filtering there's nothing to write, treat as a no-op success
   // rather than firing a meaningless UPDATE with empty SET.
   if (Object.keys(sanitised).length === 0) {
@@ -116,13 +130,27 @@ export async function addProfileItem(data: {
     ? coerceVisibility(data.visibility)
     : null;
 
+  // KAN-241 — content moderation on profile-item text fields. Sanitise
+  // first, then moderate the cleaned text. Profile items render on the
+  // public profile, so 'public' fieldType applies.
+  const sanitisedTitle = sanitiseText(data.title, 200);
+  const sanitisedDesc = data.description
+    ? sanitiseText(data.description, 1000)
+    : null;
+  const titleMod = checkModeration(sanitisedTitle, 'public', 'profile_items.title');
+  if (!titleMod.ok) return { success: false, error: titleMod.error };
+  if (sanitisedDesc) {
+    const descMod = checkModeration(sanitisedDesc, 'public', 'profile_items.description');
+    if (!descMod.ok) return { success: false, error: descMod.error };
+  }
+
   const { error } = await supabase
     .from('profile_items')
     .insert({
       profile_id: profile.id,
       category: sanitiseText(data.category, 50),
-      title: sanitiseText(data.title, 200),
-      description: data.description ? sanitiseText(data.description, 1000) : null,
+      title: sanitisedTitle,
+      description: sanitisedDesc,
       url: sanitisedUrl,
       visibility,
     });
@@ -188,12 +216,24 @@ export async function addSchoolAffiliation(data: {
   const profile = await getUserProfile(supabase, user!.id);
   if (!profile) return { success: false, error: 'Profile not found' };
 
+  // KAN-241 — content moderation. Affiliations show on the public profile.
+  const sanitisedName = sanitiseText(data.school_name, 200);
+  const sanitisedLoc = data.school_location
+    ? sanitiseText(data.school_location, 200)
+    : null;
+  const nameMod = checkModeration(sanitisedName, 'public', 'school_affiliations.school_name');
+  if (!nameMod.ok) return { success: false, error: nameMod.error };
+  if (sanitisedLoc) {
+    const locMod = checkModeration(sanitisedLoc, 'public', 'school_affiliations.school_location');
+    if (!locMod.ok) return { success: false, error: locMod.error };
+  }
+
   const { error } = await supabase
     .from('school_affiliations')
     .insert({
       profile_id: profile.id,
-      school_name: sanitiseText(data.school_name, 200),
-      school_location: data.school_location ? sanitiseText(data.school_location, 200) : null,
+      school_name: sanitisedName,
+      school_location: sanitisedLoc,
       relationship: data.relationship || 'parent',
       affiliation_type: coerceAffiliationType(data.affiliation_type),
     });
@@ -231,11 +271,18 @@ export async function addExternalLink(data: {
   const sanitisedUrl = sanitiseUrl(data.url);
   if (!sanitisedUrl) return { success: false, error: 'Invalid URL — must start with http:// or https://' };
 
+  // KAN-241 — content moderation on link title (link itself is already
+  // sanitiseUrl-restricted to http(s); only the user-visible title text
+  // needs the wordlist + PII pass).
+  const sanitisedLinkTitle = sanitiseText(data.title, 200);
+  const linkTitleMod = checkModeration(sanitisedLinkTitle, 'public', 'external_links.title');
+  if (!linkTitleMod.ok) return { success: false, error: linkTitleMod.error };
+
   const { error } = await supabase
     .from('external_links')
     .insert({
       profile_id: profile.id,
-      title: sanitiseText(data.title, 200),
+      title: sanitisedLinkTitle,
       url: sanitisedUrl,
       link_type: data.link_type || 'general',
     });

--- a/src/app/dashboard/profile/conversation-starters-actions.ts
+++ b/src/app/dashboard/profile/conversation-starters-actions.ts
@@ -3,6 +3,7 @@
 import { createClient } from '@/lib/supabase-server';
 import { revalidatePath } from 'next/cache';
 import { sanitiseText, type ActionResult } from '@/lib/sanitise';
+import { checkModeration } from '@/lib/moderation-policy';
 
 /**
  * KAN-181: server actions for `profile_conversation_starters`.
@@ -60,6 +61,10 @@ export async function addConversationStarter(input: {
     return { success: false, error: 'Answer cannot be empty' };
   }
 
+  // KAN-241 — content moderation. Answers render on the public profile.
+  const mod = checkModeration(cleaned, 'public', 'profile_conversation_starters.answer');
+  if (!mod.ok) return { success: false, error: mod.error };
+
   const { error } = await supabase
     .from('profile_conversation_starters')
     .insert({
@@ -97,6 +102,10 @@ export async function updateConversationStarter(
   if (cleaned.trim().length === 0) {
     return { success: false, error: 'Answer cannot be empty' };
   }
+
+  // KAN-241 — content moderation, same as the add path.
+  const mod = checkModeration(cleaned, 'public', 'profile_conversation_starters.answer');
+  if (!mod.ok) return { success: false, error: mod.error };
 
   const { error } = await supabase
     .from('profile_conversation_starters')

--- a/src/app/dashboard/profile/manual-of-me-actions.ts
+++ b/src/app/dashboard/profile/manual-of-me-actions.ts
@@ -20,6 +20,7 @@
 import { createClient } from '@/lib/supabase-server';
 import { revalidatePath } from 'next/cache';
 import { sanitiseText, type ActionResult } from '@/lib/sanitise';
+import { checkModeration } from '@/lib/moderation-policy';
 import {
   MANUAL_OF_ME_FIELDS,
   MANUAL_OF_ME_MAX_LENGTHS,
@@ -70,6 +71,18 @@ export async function updateManualOfMe(
       success: false,
       error: `Field(s) not permitted: ${rejected.join(', ')}`,
     };
+  }
+
+  // 1b. KAN-241 — content moderation. Manual of Me fields appear on the
+  // public profile via [slug]/page.tsx, so 'public' fieldType applies.
+  // Moderate the sanitised text (post-strip, post-trim) so HTML wrappers
+  // can't hide profanity from the word-boundary matcher.
+  for (const [key, val] of Object.entries(sanitised)) {
+    if (!val) continue;
+    const mod = checkModeration(val, 'public', `profile_manual_of_me.${key}`);
+    if (!mod.ok) {
+      return { success: false, error: mod.error };
+    }
   }
 
   // 2. Resolve the owning profile (server-side, not client-supplied).

--- a/src/lib/moderation-policy.ts
+++ b/src/lib/moderation-policy.ts
@@ -1,0 +1,96 @@
+/**
+ * KAN-241 (part of KAN-63 Tier 2): policy wrapper around `content-moderation`.
+ *
+ * The library exposes `moderateContent(text, fieldType)` which returns
+ * structured flags + a severity grade. This wrapper consumes that result
+ * and turns it into the action-decision the server actions need:
+ *
+ *   - severity 'block' → return a user-friendly error string; caller
+ *     bails out without writing to the DB.
+ *   - severity 'warn'  → return ok=true but log to console so admin
+ *     monitoring picks it up. Future iteration replaces the console
+ *     log with a `moderation_events` table insert.
+ *   - severity 'none'  → return ok=true silently.
+ *
+ * The error string deliberately reports only category-level flags
+ * ('profanity', 'pii', 'spam') and NOT the specific matched word.
+ * Surfacing the exact match would let an attacker binary-search the
+ * profanity wordlist by feeding inputs and reading rejection details.
+ *
+ * Lives in `src/lib/` (not in any `'use server'` file) per BUGS-12 —
+ * non-async-function exports must stay outside server-action modules.
+ */
+
+import { moderateContent, type FieldType } from './content-moderation';
+
+export type CheckResult =
+  | { ok: true }
+  | { ok: false; error: string; flags: string[] };
+
+/**
+ * Run text through the moderation library, apply the policy decision.
+ *
+ * @param text       The text to check. NULL/undefined/empty → pass.
+ * @param fieldType  'public' (default) for fields that appear on the
+ *                   public profile (item titles, bios, etc.). 'private'
+ *                   for owner-only fields — currently none on Lyra; the
+ *                   parameter exists so future private-field flows are
+ *                   easy to wire.
+ * @param fieldName  Optional — included in the warn-log so admin sees
+ *                   which field triggered. Not surfaced in the error
+ *                   string (keeps category-only error policy).
+ */
+export function checkModeration(
+  text: string | null | undefined,
+  fieldType: FieldType = 'public',
+  fieldName?: string,
+): CheckResult {
+  if (!text) return { ok: true };
+
+  const result = moderateContent(text, fieldType);
+
+  if (result.severity === 'block') {
+    return {
+      ok: false,
+      error: buildErrorMessage(result.flags),
+      flags: result.flags,
+    };
+  }
+
+  if (result.severity === 'warn') {
+    // Console.warn lands in Vercel function logs + (after KAN-104)
+    // Sentry breadcrumbs. Replace with a moderation_events table insert
+    // when admin review surface lands.
+    console.warn('[moderation] warn-level flag', {
+      field: fieldName ?? '(unspecified)',
+      flags: result.flags,
+      preview: text.slice(0, 80),
+    });
+  }
+
+  return { ok: true };
+}
+
+/**
+ * Category-only error message. Never includes the exact match — that
+ * would expose the wordlist by trial and error.
+ */
+function buildErrorMessage(flags: string[]): string {
+  // flags look like 'profanity:fuck', 'pii:email', 'spam:repeated_chars'.
+  // Keep only the category before the colon, dedupe.
+  const categories = Array.from(
+    new Set(flags.map((f) => f.split(':')[0]).filter(Boolean)),
+  );
+  const friendly = categories
+    .map((c) =>
+      c === 'profanity'
+        ? 'inappropriate language'
+        : c === 'pii'
+          ? 'personal information that should not be in public fields (e.g. phone, email)'
+          : c === 'spam'
+            ? 'spam-like patterns'
+            : c,
+    )
+    .join(', ');
+  return `Content rejected: ${friendly}. Please edit and try again.`;
+}

--- a/tests/unit/moderation-actions.test.ts
+++ b/tests/unit/moderation-actions.test.ts
@@ -1,0 +1,311 @@
+/**
+ * KAN-241 — moderation integration into profile-write server actions.
+ *
+ * Per action, two behavioural tests:
+ *   - Clean input → write fires (proves moderation doesn't false-positive)
+ *   - Profanity input → action returns success: false with the moderation
+ *     error, NO write fires (proves moderation gates correctly)
+ *
+ * Plus static-grep regression guards that each action file imports +
+ * calls `checkModeration`.
+ */
+
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const ROOT = resolve(__dirname, '../..');
+
+// ───────────── Mocks ─────────────
+
+const mockInsertCapture = jest.fn();
+const mockUpdateCapture = jest.fn();
+const mockUpsertCapture = jest.fn();
+const mockRevalidatePath = jest.fn();
+
+jest.mock('next/cache', () => ({
+  revalidatePath: (...args: unknown[]) => mockRevalidatePath(...args),
+}));
+
+jest.mock('@/lib/supabase-server', () => ({
+  createClient: jest.fn().mockResolvedValue({
+    auth: {
+      getUser: jest.fn().mockResolvedValue({
+        data: { user: { id: 'test-user-id' } },
+      }),
+    },
+    from: jest.fn().mockImplementation((tableName: string) => {
+      if (tableName === 'profiles') {
+        return {
+          select: () => ({
+            eq: () => ({
+              single: () => Promise.resolve({ data: { id: 'test-profile-id' } }),
+            }),
+          }),
+          update: (data: unknown) => {
+            mockUpdateCapture('profiles', data);
+            return { eq: () => Promise.resolve({ error: null }) };
+          },
+        };
+      }
+      // All write tables: capture inserts + upserts + updates
+      return {
+        insert: (data: unknown) => {
+          mockInsertCapture(tableName, data);
+          return Promise.resolve({ error: null });
+        },
+        upsert: (data: unknown) => {
+          mockUpsertCapture(tableName, data);
+          return Promise.resolve({ error: null });
+        },
+        update: (data: unknown) => {
+          mockUpdateCapture(tableName, data);
+          return {
+            eq: () => ({
+              eq: () => Promise.resolve({ error: null }),
+            }),
+          };
+        },
+      };
+    }),
+  }),
+}));
+
+import {
+  addProfileItem,
+  addSchoolAffiliation,
+  addExternalLink,
+  updateProfileFields,
+} from '@/app/dashboard/profile/actions';
+import { updateManualOfMe } from '@/app/dashboard/profile/manual-of-me-actions';
+import { addConversationStarter, updateConversationStarter } from '@/app/dashboard/profile/conversation-starters-actions';
+
+beforeEach(() => {
+  mockInsertCapture.mockClear();
+  mockUpdateCapture.mockClear();
+  mockUpsertCapture.mockClear();
+  mockRevalidatePath.mockClear();
+});
+
+// ───────────── addProfileItem ─────────────
+
+describe('KAN-241: addProfileItem moderation', () => {
+  test('clean title + description → write succeeds', async () => {
+    const result = await addProfileItem({
+      category: 'likes',
+      title: 'Coffee',
+      description: 'Single origin, light roast',
+    });
+    expect(result).toEqual({ success: true });
+    expect(mockInsertCapture).toHaveBeenCalledWith('profile_items', expect.objectContaining({
+      title: 'Coffee',
+      description: 'Single origin, light roast',
+    }));
+  });
+
+  test('profane title → blocked, no DB write', async () => {
+    const result = await addProfileItem({
+      category: 'likes',
+      title: 'fuck this',
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error).toMatch(/inappropriate language/i);
+    }
+    expect(mockInsertCapture).not.toHaveBeenCalled();
+  });
+
+  test('profane description → blocked, no DB write', async () => {
+    const result = await addProfileItem({
+      category: 'likes',
+      title: 'Coffee',
+      description: 'this fuck is great',
+    });
+    expect(result.success).toBe(false);
+    expect(mockInsertCapture).not.toHaveBeenCalled();
+  });
+
+  test('PII in description (international phone) → blocked', async () => {
+    const result = await addProfileItem({
+      category: 'gift_ideas',
+      title: 'Bluetooth headphones',
+      description: 'Call me on +44 7700 900123 for size',
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error).toMatch(/personal information/i);
+    }
+    expect(mockInsertCapture).not.toHaveBeenCalled();
+  });
+});
+
+// ───────────── updateProfileFields ─────────────
+
+describe('KAN-241: updateProfileFields moderation', () => {
+  test('clean fields → update succeeds', async () => {
+    const result = await updateProfileFields({
+      display_name: 'Sarah Patel',
+      headline: 'Primary school teacher in London',
+      bio_short: 'I love books, coffee and long walks.',
+    });
+    expect(result).toEqual({ success: true });
+    expect(mockUpdateCapture).toHaveBeenCalledWith('profiles', expect.objectContaining({
+      display_name: 'Sarah Patel',
+    }));
+  });
+
+  test('profane bio → blocked, no DB write', async () => {
+    const result = await updateProfileFields({
+      bio_short: 'I love fuck and other things',
+    });
+    expect(result.success).toBe(false);
+    expect(mockUpdateCapture).not.toHaveBeenCalled();
+  });
+
+  test('PII in display_name (email) → blocked', async () => {
+    const result = await updateProfileFields({
+      display_name: 'Contact me at sarah@example.com',
+    });
+    expect(result.success).toBe(false);
+    expect(mockUpdateCapture).not.toHaveBeenCalled();
+  });
+});
+
+// ───────────── addSchoolAffiliation ─────────────
+
+describe('KAN-241: addSchoolAffiliation moderation', () => {
+  test('clean school name → write succeeds', async () => {
+    const result = await addSchoolAffiliation({
+      school_name: 'Greenfield Primary',
+      school_location: 'London',
+    });
+    expect(result).toEqual({ success: true });
+    expect(mockInsertCapture).toHaveBeenCalledWith('school_affiliations', expect.objectContaining({
+      school_name: 'Greenfield Primary',
+    }));
+  });
+
+  test('profane school name → blocked', async () => {
+    const result = await addSchoolAffiliation({
+      school_name: 'fuck primary school',
+    });
+    expect(result.success).toBe(false);
+    expect(mockInsertCapture).not.toHaveBeenCalled();
+  });
+});
+
+// ───────────── addExternalLink ─────────────
+
+describe('KAN-241: addExternalLink moderation', () => {
+  test('clean link title → write succeeds', async () => {
+    const result = await addExternalLink({
+      title: 'My favourite recipe blog',
+      url: 'https://example.com/recipes',
+    });
+    expect(result).toEqual({ success: true });
+    expect(mockInsertCapture).toHaveBeenCalledWith('external_links', expect.objectContaining({
+      title: 'My favourite recipe blog',
+    }));
+  });
+
+  test('profane link title → blocked', async () => {
+    const result = await addExternalLink({
+      title: 'fuck this is my blog',
+      url: 'https://example.com/blog',
+    });
+    expect(result.success).toBe(false);
+    expect(mockInsertCapture).not.toHaveBeenCalled();
+  });
+});
+
+// ───────────── updateManualOfMe ─────────────
+
+describe('KAN-241: updateManualOfMe moderation', () => {
+  test('clean Manual of Me fields → upsert succeeds', async () => {
+    const result = await updateManualOfMe({
+      communication_style: 'I prefer email over calls.',
+      working_preferences: 'Early mornings are my deep-work time.',
+    });
+    expect(result).toEqual({ success: true });
+    expect(mockUpsertCapture).toHaveBeenCalledWith('profile_manual_of_me', expect.objectContaining({
+      communication_style: 'I prefer email over calls.',
+    }));
+  });
+
+  test('profane communication_style → blocked', async () => {
+    const result = await updateManualOfMe({
+      communication_style: 'fuck calls, only email',
+    });
+    expect(result.success).toBe(false);
+    expect(mockUpsertCapture).not.toHaveBeenCalled();
+  });
+});
+
+// ───────────── addConversationStarter / updateConversationStarter ─────────────
+
+describe('KAN-241: conversation starter moderation', () => {
+  const VALID_PROMPT_ID = '11111111-2222-3333-4444-555555555555';
+
+  test('clean answer → add succeeds', async () => {
+    const result = await addConversationStarter({
+      promptId: VALID_PROMPT_ID,
+      answer: 'I would take a Kindle to a desert island.',
+    });
+    expect(result).toEqual({ success: true });
+    expect(mockInsertCapture).toHaveBeenCalledWith('profile_conversation_starters', expect.objectContaining({
+      answer: 'I would take a Kindle to a desert island.',
+    }));
+  });
+
+  test('profane answer → blocked on add', async () => {
+    const result = await addConversationStarter({
+      promptId: VALID_PROMPT_ID,
+      answer: 'fuck this question',
+    });
+    expect(result.success).toBe(false);
+    expect(mockInsertCapture).not.toHaveBeenCalled();
+  });
+
+  test('profane answer → blocked on update too', async () => {
+    const result = await updateConversationStarter('item-id', 'fuck this');
+    expect(result.success).toBe(false);
+    expect(mockUpdateCapture).not.toHaveBeenCalled();
+  });
+});
+
+// ───────────── Static regression guards ─────────────
+
+describe('KAN-241: surface-area regression guards', () => {
+  test('moderation-policy module exists with checkModeration export', () => {
+    const src = readFileSync(resolve(ROOT, 'src/lib/moderation-policy.ts'), 'utf-8');
+    expect(src).toMatch(/export function checkModeration/);
+    expect(src).toMatch(/moderateContent/); // pulls from content-moderation
+  });
+
+  test('actions.ts imports + calls checkModeration', () => {
+    const src = readFileSync(resolve(ROOT, 'src/app/dashboard/profile/actions.ts'), 'utf-8');
+    expect(src).toMatch(/import\s*\{\s*checkModeration\s*\}\s*from\s*['"]@\/lib\/moderation-policy['"]/);
+    // Used in at least 4 places (updateProfileFields, addProfileItem,
+    // addSchoolAffiliation, addExternalLink)
+    const callCount = (src.match(/checkModeration\(/g) || []).length;
+    expect(callCount).toBeGreaterThanOrEqual(4);
+  });
+
+  test('manual-of-me-actions.ts imports + calls checkModeration', () => {
+    const src = readFileSync(resolve(ROOT, 'src/app/dashboard/profile/manual-of-me-actions.ts'), 'utf-8');
+    expect(src).toMatch(/import\s*\{\s*checkModeration\s*\}\s*from\s*['"]@\/lib\/moderation-policy['"]/);
+    expect(src).toMatch(/checkModeration\(/);
+  });
+
+  test('conversation-starters-actions.ts imports + calls checkModeration in both add + update', () => {
+    const src = readFileSync(resolve(ROOT, 'src/app/dashboard/profile/conversation-starters-actions.ts'), 'utf-8');
+    expect(src).toMatch(/import\s*\{\s*checkModeration\s*\}\s*from\s*['"]@\/lib\/moderation-policy['"]/);
+    // One call in add path, one in update path
+    const callCount = (src.match(/checkModeration\(/g) || []).length;
+    expect(callCount).toBeGreaterThanOrEqual(2);
+  });
+
+  test('moderation-policy.ts is NOT a use-server file (BUGS-12 safe)', () => {
+    const src = readFileSync(resolve(ROOT, 'src/lib/moderation-policy.ts'), 'utf-8');
+    expect(src).not.toMatch(/^['"]use server['"]/m);
+  });
+});

--- a/tests/unit/moderation-policy.test.ts
+++ b/tests/unit/moderation-policy.test.ts
@@ -1,0 +1,124 @@
+/**
+ * KAN-241 — moderation policy wrapper tests.
+ *
+ * The underlying `content-moderation` library has its own tests
+ * (`tests/unit/content-moderation.test.ts`). This file just tests the
+ * decision logic that turns the library's structured output into the
+ * action-level OK/error result.
+ */
+
+import { checkModeration } from '@/lib/moderation-policy';
+
+describe('KAN-241: checkModeration policy wrapper', () => {
+  // ───────────── Pass-through cases ─────────────
+
+  test.each([null, undefined, ''])('returns ok=true for empty/null/undefined: %p', (input) => {
+    const result = checkModeration(input);
+    expect(result).toEqual({ ok: true });
+  });
+
+  test('clean public text passes', () => {
+    expect(checkModeration('Hello world, I love cycling.')).toEqual({ ok: true });
+  });
+
+  test('clean private text passes', () => {
+    expect(checkModeration('Personal notes about my hobbies.', 'private')).toEqual({ ok: true });
+  });
+
+  // ───────────── Block cases (severity=block on public) ─────────────
+
+  test('public profanity blocks with category-only error', () => {
+    const result = checkModeration('fuck this', 'public');
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toMatch(/inappropriate language/i);
+      // Critical: does NOT include the specific match — prevents wordlist enumeration
+      expect(result.error).not.toMatch(/fuck/);
+      expect(result.flags.some((f) => f.startsWith('profanity:'))).toBe(true);
+    }
+  });
+
+  test('public PII (international phone) blocks', () => {
+    // The PII detector requires either international (+CC) format, a
+    // 3-part separated format, or a 10-15 digit run. Use +44 to hit the
+    // international branch.
+    const result = checkModeration('Call me on +44 7700 900123', 'public');
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toMatch(/personal information/i);
+    }
+  });
+
+  test('public PII (email) blocks', () => {
+    const result = checkModeration('Email me at user@example.com', 'public');
+    expect(result.ok).toBe(false);
+  });
+
+  test('combined profanity + PII reports both categories (deduped)', () => {
+    const result = checkModeration('fuck call me +44 7700 900123 fuck', 'public');
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      // Both category names appear, neither appears twice
+      const msg = result.error.toLowerCase();
+      expect(msg).toContain('inappropriate language');
+      expect(msg).toContain('personal information');
+    }
+  });
+
+  // ───────────── Warn cases (severity=warn) ─────────────
+
+  test('private profanity is warn-level (not block) — returns ok=true', () => {
+    // Spy on console.warn to confirm the warn was logged but the action passes
+    const spy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      const result = checkModeration('fuck this', 'private');
+      expect(result).toEqual({ ok: true });
+      expect(spy).toHaveBeenCalled();
+      const callArgs = spy.mock.calls[0];
+      expect(callArgs[0]).toMatch(/\[moderation\]/);
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  test('warn-log includes field name when provided', () => {
+    const spy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      checkModeration('fuck this', 'private', 'manual_of_me.energises_me');
+      const meta = spy.mock.calls[0][1] as { field: string };
+      expect(meta.field).toBe('manual_of_me.energises_me');
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  // ───────────── Defence-in-depth ─────────────
+
+  test('does NOT leak the specific profanity match in error', () => {
+    // Try several profane inputs; ensure error never contains them.
+    for (const bad of ['fuck this', 'you bitch', 'wanker behaviour']) {
+      const result = checkModeration(bad, 'public');
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        // The error must not include the word itself, only the category.
+        const exactWords = bad.toLowerCase().split(/\s+/);
+        for (const word of exactWords) {
+          if (word.length > 3) {
+            // Allow only the category label substrings
+            // (e.g. 'inappropriate' doesn't contain the profanity)
+            expect(result.error.toLowerCase()).not.toContain(word);
+          }
+        }
+      }
+    }
+  });
+
+  test('flags array IS returned for caller-side logging even though error string is sanitised', () => {
+    const result = checkModeration('fuck this', 'public');
+    if (!result.ok) {
+      // Flags include the specific match — caller can log internally, just
+      // shouldn't surface to the user.
+      expect(result.flags.some((f) => f === 'profanity:fuck')).toBe(true);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

[KAN-241](https://checklyra.atlassian.net/browse/KAN-241) — direct continuation of [KAN-63 Tier 2](https://checklyra.atlassian.net/browse/KAN-63). [KAN-224](https://checklyra.atlassian.net/browse/KAN-224) (PR #230) shipped `src/lib/content-moderation.ts` but explicitly deferred integration into write paths. This PR is that follow-up — the library now actually does something at runtime instead of being unused dead code.

After this lands, profanity + PII + spam-pattern detection runs on every user text-input field before it hits the database. Bad content is rejected with a user-friendly error; clean content passes through untouched.

## Architecture

| Layer | What |
|---|---|
| `src/lib/content-moderation.ts` (KAN-224, shipped) | Pure detection: `containsProfanity`, `containsPII`, `detectSpam`, `moderateContent` |
| `src/lib/moderation-policy.ts` (this PR) | Wraps `moderateContent`. Block → user-friendly error. Warn → `console.warn`. None → no-op. Category-only error message (no wordlist enumeration). |
| Server actions (this PR) | Call `checkModeration` after `sanitiseText` but before insert/update |

## Wired into (6 server actions)

| File | Action | Fields moderated |
|---|---|---|
| `actions.ts` | `updateProfileFields` | every string field that's allowlisted (display_name, bio_short, etc.) |
| `actions.ts` | `addProfileItem` | title, description |
| `actions.ts` | `addSchoolAffiliation` | school_name, school_location |
| `actions.ts` | `addExternalLink` | title |
| `manual-of-me-actions.ts` | `updateManualOfMe` | all 4 fields |
| `conversation-starters-actions.ts` | `addConversationStarter` + `updateConversationStarter` | answer |

All fields treated as `'public'` — they render on the public profile via `[slug]/page.tsx`.

## Security model

- **Order: sanitise then moderate.** `sanitiseText` runs FIRST (HTML-strip + whitespace-normalize), then moderation runs on the cleaned text. This prevents `<script>fuck</script>` from hiding profanity behind tags.
- **Error reveals category only.** `Content rejected: inappropriate language, personal information. Please edit and try again.` — never the specific matched word. Attackers can't binary-search the wordlist by reading rejection details. The internal `flags` array (which DOES include specific matches) is returned to callers for logging but never reaches the user.
- **Warn-level events log to console only.** PII isn't written to a DB row (future iteration will use a `moderation_events` table with strict RLS).

## Test plan

- [x] `tests/unit/moderation-policy.test.ts` — 13 tests covering pass / block / warn paths, dedup, no-leak guarantee, field-name in warn log
- [x] `tests/unit/moderation-actions.test.ts` — 21 tests covering clean + profane + PII inputs across all 6 actions + 5 static-grep regression guards
- [x] Full unit suite: **1225 tests passing** (was 1191; +34 net)
- [x] No existing test broken — all KAN-219, KAN-220, KAN-234 etc. tests still pass because their inputs are clean

After merge, manual on dev.checklyra.com:
- [ ] Add a profile item titled "fuck this" → should see a friendly error, item not saved
- [ ] Add a profile item with a phone number in the description → blocked
- [ ] Add a profile item with normal content → saves fine
- [ ] Try the same on Manual of Me, Schools, External Links — all should reject

## MCP coverage: deferred — see follow-up

Per CLAUDE.md MCP-main lockstep policy: this PR only covers the web app's server actions. The `lyra-mcp-server` write tools (`lyra_add_item`, `lyra_update_profile`, etc.) bypass these actions and call Supabase directly. Same gap as today's pre-PR state — formally documented now. I'll file a follow-up ticket once this lands so the same policy ships in the MCP repo too.

## Where this fits

| Ticket | Status |
|---|---|
| [KAN-63](https://checklyra.atlassian.net/browse/KAN-63) (parent epic) | In progress; this PR closes the "Profile content scanning on save" sub-feature in Tier 2 |
| [KAN-224](https://checklyra.atlassian.net/browse/KAN-224) (library) | ✅ Done (PR #230) |
| **[KAN-241](https://checklyra.atlassian.net/browse/KAN-241) (this PR)** | **In progress** |
| MCP coverage follow-up | not yet filed; will create after merge |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[KAN-241]: https://checklyra.atlassian.net/browse/KAN-241?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[KAN-224]: https://checklyra.atlassian.net/browse/KAN-224?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[KAN-63]: https://checklyra.atlassian.net/browse/KAN-63?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ