### PR TITLE
feat(KAN-240): detect Vercel 429 and back off in cleanup workflows

### DIFF
--- a/.github/workflows/cleanup-preview-deployments.yml
+++ b/.github/workflows/cleanup-preview-deployments.yml
@@ -151,26 +151,78 @@ jobs:
             exit 0
           fi
 
+          # Vercel's DELETE endpoint enforces a "now-rm" rate limit of 200
+          # per 10 minutes. PR-close cleanup rarely hits 200 (one PR's
+          # worth of previews is usually <50), but we add the same backoff
+          # as the daily cron for consistency. Tracked under KAN-240.
+
+          # Helper: parse rate-limit reset epoch from response body on stdin,
+          # write wait seconds to stdout (capped at 900s).
+          cat > /tmp/wait_seconds.py <<'WS_PY'
+          import json, sys, time, math
+          try:
+              body = json.load(sys.stdin)
+              reset_ms = (body.get("error") or {}).get("limit", {}).get("reset", 0)
+              if not reset_ms:
+                  print(60)
+              else:
+                  now_ms = int(time.time() * 1000)
+                  delta_s = math.ceil((reset_ms - now_ms) / 1000.0) + 5
+                  print(min(max(delta_s, 5), 900))
+          except Exception:
+              print(60)
+          WS_PY
+
           DELETED=0
           FAILED=0
-          for ID in "${IDS[@]}"; do
-            # v13 is the documented DELETE endpoint as of 2026.
-            HTTP=$(curl -s -o /tmp/vercel_del_response -w '%{http_code}' \
+          RATE_LIMITED=0
+          RETRY_SUCCEEDED=0
+          RETRY_FAILED=0
+
+          do_delete() {
+            local id="$1"
+            local http
+            http=$(curl -s -o /tmp/vercel_del_response -w '%{http_code}' \
               -X DELETE \
               -H "Authorization: Bearer ${VERCEL_TOKEN}" \
-              "https://api.vercel.com/v13/deployments/${ID}?teamId=${VERCEL_ORG_ID}") || HTTP="000"
+              "https://api.vercel.com/v13/deployments/${id}?teamId=${VERCEL_ORG_ID}") || http="000"
+            echo "${http}"
+          }
+
+          for ID in "${IDS[@]}"; do
+            HTTP=$(do_delete "${ID}")
 
             if [[ "${HTTP}" == "200" || "${HTTP}" == "202" || "${HTTP}" == "204" ]]; then
               echo "  ✓ deleted ${ID}"
               DELETED=$((DELETED + 1))
-            else
-              echo "::error::Failed to delete ${ID} (HTTP ${HTTP}): $(cat /tmp/vercel_del_response 2>/dev/null || echo '<no body>')"
-              FAILED=$((FAILED + 1))
+              continue
             fi
+
+            if [[ "${HTTP}" == "429" ]]; then
+              RATE_LIMITED=$((RATE_LIMITED + 1))
+              WAIT_S=$(python3 /tmp/wait_seconds.py < /tmp/vercel_del_response)
+              echo "::warning::429 rate-limited on ${ID}; sleeping ${WAIT_S}s then retrying once"
+              sleep "${WAIT_S}"
+              RETRY_HTTP=$(do_delete "${ID}")
+              if [[ "${RETRY_HTTP}" == "200" || "${RETRY_HTTP}" == "202" || "${RETRY_HTTP}" == "204" ]]; then
+                echo "  ✓ deleted ${ID} (on retry)"
+                DELETED=$((DELETED + 1))
+                RETRY_SUCCEEDED=$((RETRY_SUCCEEDED + 1))
+              else
+                echo "::warning::retry of ${ID} still failed (HTTP ${RETRY_HTTP})"
+                RETRY_FAILED=$((RETRY_FAILED + 1))
+                FAILED=$((FAILED + 1))
+              fi
+              continue
+            fi
+
+            echo "::error::Failed to delete ${ID} (HTTP ${HTTP}): $(cat /tmp/vercel_del_response 2>/dev/null || echo '<no body>')"
+            FAILED=$((FAILED + 1))
           done
 
           echo ""
           echo "Cleanup summary for branch '${PR_BRANCH}': ${DELETED} deleted, ${FAILED} failed (total ${TOTAL})."
+          echo "Rate-limit handling: ${RATE_LIMITED} 429s, ${RETRY_SUCCEEDED} retries succeeded, ${RETRY_FAILED} retries failed"
 
           if [[ "${FAILED}" -gt 0 ]]; then
             echo "::error::${FAILED} deployment(s) failed to delete — see log above."

--- a/.github/workflows/cleanup-stale-branch-deploys.yml
+++ b/.github/workflows/cleanup-stale-branch-deploys.yml
@@ -274,29 +274,86 @@ jobs:
           fi
 
           # Live mode — execute deletes.
+          #
+          # Vercel's DELETE endpoint enforces a "now-rm" rate limit of 200
+          # deletes per 10 minutes (observed during KAN-238 first live run,
+          # 2026-05-17 — undocumented but visible in 429 response bodies).
+          # When we hit it, parse error.limit.reset (epoch ms), sleep
+          # until then (capped at 900s), and retry the same deletion
+          # once. Tracked under KAN-240.
+
+          # Helper script writes the rate-limit-reset wait seconds to stdout.
+          # Reads response body from stdin.
+          cat > /tmp/wait_seconds.py <<'WS_PY'
+          import json, sys, time, math
+          try:
+              body = json.load(sys.stdin)
+              reset_ms = (body.get("error") or {}).get("limit", {}).get("reset", 0)
+              if not reset_ms:
+                  print(60)
+              else:
+                  now_ms = int(time.time() * 1000)
+                  delta_s = math.ceil((reset_ms - now_ms) / 1000.0) + 5
+                  print(min(max(delta_s, 5), 900))
+          except Exception:
+              print(60)
+          WS_PY
+
+          RATE_LIMITED=0
+          RETRY_SUCCEEDED=0
+          RETRY_FAILED=0
+
+          do_delete() {
+            local id="$1"
+            local http
+            http=$(curl -s -o /tmp/del_resp -w '%{http_code}' \
+              -X DELETE \
+              -H "Authorization: Bearer ${VERCEL_TOKEN}" \
+              "https://api.vercel.com/v13/deployments/${id}?teamId=${VERCEL_ORG_ID}") || http="000"
+            echo "${http}"
+          }
+
           while IFS= read -r line; do
             DECISION=$(echo "${line}" | python3 -c "import json,sys; print(json.loads(sys.stdin.read())['decision'])")
             if [[ "${DECISION}" != "delete" ]]; then
               continue
             fi
             ID=$(echo "${line}" | python3 -c "import json,sys; print(json.loads(sys.stdin.read())['id'])")
-            HTTP=$(curl -s -o /tmp/del_resp -w '%{http_code}' \
-              -X DELETE \
-              -H "Authorization: Bearer ${VERCEL_TOKEN}" \
-              "https://api.vercel.com/v13/deployments/${ID}?teamId=${VERCEL_ORG_ID}") || HTTP="000"
+            HTTP=$(do_delete "${ID}")
+
             if [[ "${HTTP}" == "200" || "${HTTP}" == "202" || "${HTTP}" == "204" ]]; then
               DELETED=$((DELETED + 1))
-            else
-              echo "::error::Failed to delete ${ID} (HTTP ${HTTP}): $(cat /tmp/del_resp 2>/dev/null || echo '<no body>')"
-              FAILED=$((FAILED + 1))
+              continue
             fi
+
+            if [[ "${HTTP}" == "429" ]]; then
+              RATE_LIMITED=$((RATE_LIMITED + 1))
+              WAIT_S=$(python3 /tmp/wait_seconds.py < /tmp/del_resp)
+              echo "::warning::429 rate-limited on ${ID}; sleeping ${WAIT_S}s then retrying once"
+              sleep "${WAIT_S}"
+              RETRY_HTTP=$(do_delete "${ID}")
+              if [[ "${RETRY_HTTP}" == "200" || "${RETRY_HTTP}" == "202" || "${RETRY_HTTP}" == "204" ]]; then
+                DELETED=$((DELETED + 1))
+                RETRY_SUCCEEDED=$((RETRY_SUCCEEDED + 1))
+              else
+                echo "::warning::retry of ${ID} still failed (HTTP ${RETRY_HTTP}); next cron will retry"
+                RETRY_FAILED=$((RETRY_FAILED + 1))
+                FAILED=$((FAILED + 1))
+              fi
+              continue
+            fi
+
+            echo "::error::Failed to delete ${ID} (HTTP ${HTTP}): $(cat /tmp/del_resp 2>/dev/null || echo '<no body>')"
+            FAILED=$((FAILED + 1))
           done < "${DEC_PATH}"
 
           echo ""
           echo "Live cleanup: ${DELETED} deleted, ${FAILED} failed (of ${SCHEDULED} scheduled)"
+          echo "Rate-limit handling: ${RATE_LIMITED} 429s, ${RETRY_SUCCEEDED} retries succeeded, ${RETRY_FAILED} retries failed"
           echo "" >> "$GITHUB_STEP_SUMMARY"
           echo "- Live deletes: ${DELETED}" >> "$GITHUB_STEP_SUMMARY"
           echo "- Failed deletes: ${FAILED}" >> "$GITHUB_STEP_SUMMARY"
+          echo "- 429s encountered: ${RATE_LIMITED} (retries: ${RETRY_SUCCEEDED} ok, ${RETRY_FAILED} failed)" >> "$GITHUB_STEP_SUMMARY"
           if [[ "${FAILED}" -gt 0 ]]; then
             echo "::error::${FAILED} deployment(s) failed to delete"
             exit 1


### PR DESCRIPTION
## Summary

KAN-238's first live run hit Vercel's undocumented `now-rm` rate limit (200 deletes / 10 minutes) at delete #201. The workflow correctly failed loud, but didn't make progress past the limit. This adds 429 detection + a single retry per ID after sleeping until the reset epoch returned in the response body.

Applies to both cleanup workflows (KAN-237 PR-close + KAN-238 daily cron) — same DELETE call shape, same backoff.

## Behavior

- On HTTP 429: parse `error.limit.reset` (epoch ms) from the response, sleep `min(max(reset - now + 5, 5), 900)` seconds (capped at 15 min, with a 60s fallback if the field is missing), retry the deletion once.
- After retry: success → counted as deleted; still failing → counted as failed and the next cron/PR-close picks it up.
- New summary line + step-summary table reporting `429s encountered` / `retries succeeded` / `retries failed`.

## Notes

- Implementation lives in a `/tmp/wait_seconds.py` helper written at step start, called as `python3 /tmp/wait_seconds.py < /tmp/del_resp`. Inline heredocs inside `run: |` block scalars need their `)` closing command-substitution at the right YAML indent — easier to keep the helper separate (initial attempt tripped on this and yaml.safe_load caught it pre-push).
- 900s cap prevents runaway loops on a misparsed reset value.
- 60s fallback covers the rare case where Vercel returns 429 without the standard `error.limit.reset` field.

## Test plan

- [x] YAML valid for both workflows.
- [x] Pre-merge grep checks clean.
- [ ] After this lands on main, intentionally force a 429 (re-dispatch KAN-238 with `retention_days=7` to push the queue over the 200/10min limit) and verify the workflow sleeps + retries instead of failing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)