### PR TITLE
feat(KAN-233): self-healing rollback email alert + RUNBOOK docs

### DIFF
--- a/.github/workflows/promote-to-production.yml
+++ b/.github/workflows/promote-to-production.yml
@@ -439,6 +439,10 @@ jobs:
 
   auto-rollback:
     name: Auto-rollback on failure
+    # BUGS-9 + KAN-233: triggers on any failure in the smoke-tests OR the
+    # earlier pipeline (verify-source). `failure()` is true when any
+    # ancestor in `needs` has status=failure, so a smoke-test failure
+    # alone is enough to fire — even though merge-and-push succeeded.
     needs: [verify-source, smoke-tests]
     if: failure()
     runs-on: ubuntu-latest
@@ -447,6 +451,7 @@ jobs:
         with:
           fetch-depth: 1
       - name: Roll production back to pre-merge SHA (BUGS-9)
+        id: rollback
         env:
           TARGET_SHA: ${{ needs.verify-source.outputs.main_sha_before_merge }}
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
@@ -458,3 +463,59 @@ jobs:
         # string "NONE", then swallowed the error with `|| echo ::warning::`,
         # producing a false-positive success. See run 25324541577.
         run: python3 scripts/rollback-to-sha.py
+
+      # KAN-233 — alert the human on a self-healed rollback. Without this,
+      # an auto-rollback that fires at 03:00 UTC could go unnoticed for
+      # hours. Resend is already wired for weekly-report + security-audit.
+      - name: Email rollback alert via Resend
+        if: always()
+        env:
+          RESEND_API_KEY: ${{ secrets.RESEND_API_KEY }}
+          ROLLBACK_STATUS: ${{ steps.rollback.outcome }}
+          ROLLBACK_TARGET_SHA: ${{ needs.verify-source.outputs.main_sha_before_merge }}
+          GITHUB_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          if [ -z "${RESEND_API_KEY:-}" ]; then
+            # KAN-167: missing-secret must be loud, not silent. Emit an
+            # ::error:: annotation but don't fail the rollback itself —
+            # the email is advisory; the rollback already ran.
+            echo "::error::RESEND_API_KEY not set — rollback fired but no email alert was sent"
+            exit 0
+          fi
+
+          STATUS_EMOJI="✅"
+          STATUS_WORD="succeeded"
+          if [ "$ROLLBACK_STATUS" != "success" ]; then
+            STATUS_EMOJI="❌"
+            STATUS_WORD="FAILED (manual intervention required)"
+          fi
+
+          export SUBJECT="$STATUS_EMOJI Lyra auto-rollback $STATUS_WORD — production"
+          export BODY_HTML="<p><strong>The Lyra production deploy was auto-rolled back.</strong></p><ul><li>Target SHA: <code>$ROLLBACK_TARGET_SHA</code></li><li>Rollback step status: <strong>$ROLLBACK_STATUS</strong></li><li><a href=\"$GITHUB_RUN_URL\">View the workflow run for details</a></li></ul><p>If status=success, production is back on the pre-merge SHA. Investigate the failing smoke test, fix on develop, re-promote.</p><p>If status=failure, the rollback itself failed — production may be in an inconsistent state. See <code>docs/RUNBOOK.md</code> &rarr; \"Self-healing flows\" for the manual recovery procedure.</p>"
+
+          python3 -c "
+          import json, os
+          payload = {
+              'from': 'Lyra Ops <ops@checklyra.com>',
+              'to': ['luisa@santos-stephens.com'],
+              'subject': os.environ['SUBJECT'],
+              'html': os.environ['BODY_HTML'],
+          }
+          with open('/tmp/rollback-email.json', 'w') as f:
+              json.dump(payload, f)
+          " || { echo "::error::failed to build email payload"; exit 1; }
+
+          RESPONSE=$(curl -s -w '\n%{http_code}' -X POST 'https://api.resend.com/emails' \
+            -H "Authorization: Bearer $RESEND_API_KEY" \
+            -H 'Content-Type: application/json' \
+            -d @/tmp/rollback-email.json)
+          HTTP_CODE=$(echo "$RESPONSE" | tail -1)
+          BODY=$(echo "$RESPONSE" | head -n -1)
+
+          if [ "$HTTP_CODE" = "200" ]; then
+            echo "✓ Rollback alert sent (Resend id: $(echo "$BODY" | python3 -c 'import sys,json;print(json.load(sys.stdin).get("id","?"))'))"
+          else
+            echo "::error::Resend returned HTTP $HTTP_CODE: $(echo "$BODY" | head -c 300)"
+            exit 1
+          fi

--- a/docs/RUNBOOK.md
+++ b/docs/RUNBOOK.md
@@ -107,6 +107,52 @@ curl -sf -H "Authorization: Bearer $VERCEL_TOKEN" \
 
 Both SHAs should match. If they don't, suspect the CodeQL alert dashboard mismatch (alerts only auto-resolve against `main`'s state, may take 24h after merge to refresh).
 
+## Self-Healing Flows (KAN-233)
+
+The KAN-63 epic established a tiered self-healing automation. As of KAN-233 the **smoke-failure auto-rollback** and **abuse-log foundation** are in place; auto-restart and auto-block at the network edge are tracked under KAN-246 / KAN-247 and require user-provisioned secrets.
+
+### Smoke-failure auto-rollback (Part A — shipped)
+
+**What fires it:** `promote-to-production.yml` `smoke-tests` job fails (post-deploy smoke against `checklyra.com` or `mcp.checklyra.com` returned an unexpected response).
+
+**What happens:**
+
+1. `auto-rollback` job runs (lives at the bottom of `promote-to-production.yml`).
+2. `scripts/rollback-to-sha.py` promotes the **pre-merge** SHA back to production on Vercel using the captured `verify-source.outputs.main_sha_before_merge`.
+3. An alert email is sent via Resend to `luisa@santos-stephens.com` with the SHA, the rollback step's outcome, and a link to the workflow run.
+
+**What you do when it fires:**
+
+1. Read the email. If status was `success`, production is back on the previous green SHA — proceed to step 2.
+2. Investigate the failing smoke test in the workflow run (linked from the email).
+3. Fix on `develop` → promote `develop → staging → beta` and verify the smoke test passes locally / on beta.
+4. Re-run `promote-to-production.yml` once you're confident.
+
+**If the rollback itself fails** (`status: failure` in the email): production is in an inconsistent state. Follow "Deployment Rollback → Via Vercel Dashboard" below to roll back manually, then file a Highest-priority BUGS ticket so the root-cause of the failed auto-rollback is fixed.
+
+**Reference:** BUGS-9 captured the original auto-rollback, KAN-233 added the alerting layer.
+
+### Tier-2 abuse-detection logging (Part of KAN-232, shipped)
+
+Every MCP request now writes a row to `public.mcp_tool_call_log` on the Supabase project the MCP server points at. Aggregated as `mcp_per_ip_recent_count` (rolling 1-hour count per IP). The MCP server gates this behind `MCP_TOOL_CALL_LOG_ENABLED=true` — default OFF; flip the env var on Railway per environment after the migration is promoted.
+
+To inspect:
+
+```sql
+-- Top noisy IPs in the last hour (on the relevant Supabase project)
+select ip, request_count, last_seen
+from public.mcp_per_ip_recent_count
+order by request_count desc limit 20;
+```
+
+### MCP restart on health-check failure (Part B — deferred, KAN-246)
+
+Not yet shipped. The current `health-check.yml` cron creates a GitHub issue on failure but does not auto-restart the Railway service. Tracked under KAN-246; needs a `RAILWAY_API_TOKEN` secret scoped to restart on the `lyra-mcp-server` project.
+
+### Cloudflare auto-block on abuse threshold (Part C — deferred, KAN-247)
+
+Not yet shipped. KAN-232 built the logging foundation; KAN-247 will consume `mcp_per_ip_recent_count` and add Cloudflare WAF rules for IPs over the threshold. Needs a `CLOUDFLARE_API_TOKEN` with `Zone WAF:Edit` on `checklyra.com`.
+
 ## Deployment Rollback
 
 ### Via Vercel Dashboard (recommended)


### PR DESCRIPTION
## Summary

Ship Parts **A** + **D** of KAN-233 / KAN-63 Tier 3. Parts **B** and **C** need user-provisioned secrets and have been filed as KAN-246 + KAN-247.

## What landed

- **Auto-rollback alert email** — `promote-to-production.yml`'s `auto-rollback` job now sends a Resend email after the rollback runs, with the rolled-back SHA, the rollback step's outcome (success / failure), and a link to the workflow run. Same Resend-via-curl pattern as `weekly-report.yml` and `security-audit.yml`. Missing `RESEND_API_KEY` emits `::error::` (per KAN-167 — no silent skip).
- **Auto-rollback `if:` clarified** — the existing `needs: [verify-source, smoke-tests]` + `if: failure()` already fires on smoke-test failures. Added a comment so the next reader doesn't have to reason this out from scratch.
- **`docs/RUNBOOK.md`** — new "Self-healing flows" section documents what fires today (rollback + KAN-232 abuse logging) and what is deferred.

## Why Parts B & C aren't here

Both need a high-privilege secret the user has to provision:

- **KAN-246** (Part B): Railway auto-restart on 3 consecutive health-check failures — needs `RAILWAY_API_TOKEN`
- **KAN-247** (Part C): Cloudflare WAF auto-block when an IP crosses the KAN-232 threshold — needs `CLOUDFLARE_WAF_TOKEN` with `Zone:WAF:Edit`

Shipping the workflows now without those secrets would produce noisy `::error::` alerts on every run, so they're staged behind their respective follow-up tickets.

## Test plan

- [x] `yaml.safe_load` on the modified workflow file — clean
- [x] KAN-167 grep checks on the new shell block — no forbidden patterns (`if: env.X != ''`, `|| echo "X"`, `continue-on-error: true`)
- [x] RUNBOOK.md renders correctly (manual check)
- [ ] Live trigger: cannot exercise an auto-rollback without breaking production. The Resend email path is identical to the security-audit + weekly-report flows that fire weekly and are known-good.

🤖 Generated with [Claude Code](https://claude.com/claude-code)