### PR TITLE
feat(KAN-244): moderation audit table — content_moderation_flags

### DIFF
--- a/src/app/dashboard/profile/actions.ts
+++ b/src/app/dashboard/profile/actions.ts
@@ -3,7 +3,7 @@
 import { createClient } from '@/lib/supabase-server';
 import { revalidatePath } from 'next/cache';
 import { sanitiseText, sanitiseUrl, type ActionResult } from '@/lib/sanitise';
-import { checkModeration } from '@/lib/moderation-policy';
+import { moderateAndAudit } from '@/lib/moderation-audit';
 import { checkProfileWriteRateLimit } from '@/lib/profile-rate-limit';
 import { isAllowedProfileField } from './profile-fields';
 import { coerceVisibility } from './visibility';
@@ -72,14 +72,21 @@ export async function updateProfileFields(data: Record<string, string | boolean 
     };
   }
 
-  // KAN-241 — content moderation. Runs AFTER sanitiseText so the moderator
-  // sees the post-strip text (a profanity inside <script>profanity</script>
-  // gets stripped to plain `profanity` first, then caught). Public field
-  // type for everything in `profiles` (display_name, bio_short, etc all
-  // appear on the public profile page).
+  // KAN-241 — content moderation, KAN-244 — audit-log every flagged event.
+  // Runs AFTER sanitiseText so the moderator sees the post-strip text
+  // (a profanity inside <script>profanity</script> gets stripped to plain
+  // `profanity` first, then caught). All `profiles` fields are 'public'.
+  const profile = await getUserProfile(supabase, user!.id);
+  const profileId = profile?.id ?? null;
   for (const [key, val] of Object.entries(sanitised)) {
     if (typeof val !== 'string') continue;
-    const mod = checkModeration(val, 'public', `profiles.${key}`);
+    const mod = await moderateAndAudit(supabase, {
+      text: val,
+      fieldType: 'public',
+      field: `profiles.${key}`,
+      profileId,
+      source: 'web_app',
+    });
     if (!mod.ok) {
       return { success: false, error: mod.error };
     }
@@ -139,17 +146,27 @@ export async function addProfileItem(data: {
     ? coerceVisibility(data.visibility)
     : null;
 
-  // KAN-241 — content moderation on profile-item text fields. Sanitise
-  // first, then moderate the cleaned text. Profile items render on the
-  // public profile, so 'public' fieldType applies.
+  // KAN-241 + KAN-244 — content moderation + audit log on item text fields.
   const sanitisedTitle = sanitiseText(data.title, 200);
   const sanitisedDesc = data.description
     ? sanitiseText(data.description, 1000)
     : null;
-  const titleMod = checkModeration(sanitisedTitle, 'public', 'profile_items.title');
+  const titleMod = await moderateAndAudit(supabase, {
+    text: sanitisedTitle,
+    fieldType: 'public',
+    field: 'profile_items.title',
+    profileId: profile.id,
+    source: 'web_app',
+  });
   if (!titleMod.ok) return { success: false, error: titleMod.error };
   if (sanitisedDesc) {
-    const descMod = checkModeration(sanitisedDesc, 'public', 'profile_items.description');
+    const descMod = await moderateAndAudit(supabase, {
+      text: sanitisedDesc,
+      fieldType: 'public',
+      field: 'profile_items.description',
+      profileId: profile.id,
+      source: 'web_app',
+    });
     if (!descMod.ok) return { success: false, error: descMod.error };
   }
 
@@ -229,15 +246,28 @@ export async function addSchoolAffiliation(data: {
   const profile = await getUserProfile(supabase, user!.id);
   if (!profile) return { success: false, error: 'Profile not found' };
 
-  // KAN-241 — content moderation. Affiliations show on the public profile.
+  // KAN-241 + KAN-244 — content moderation + audit log. Affiliations
+  // show on the public profile.
   const sanitisedName = sanitiseText(data.school_name, 200);
   const sanitisedLoc = data.school_location
     ? sanitiseText(data.school_location, 200)
     : null;
-  const nameMod = checkModeration(sanitisedName, 'public', 'school_affiliations.school_name');
+  const nameMod = await moderateAndAudit(supabase, {
+    text: sanitisedName,
+    fieldType: 'public',
+    field: 'school_affiliations.school_name',
+    profileId: profile.id,
+    source: 'web_app',
+  });
   if (!nameMod.ok) return { success: false, error: nameMod.error };
   if (sanitisedLoc) {
-    const locMod = checkModeration(sanitisedLoc, 'public', 'school_affiliations.school_location');
+    const locMod = await moderateAndAudit(supabase, {
+      text: sanitisedLoc,
+      fieldType: 'public',
+      field: 'school_affiliations.school_location',
+      profileId: profile.id,
+      source: 'web_app',
+    });
     if (!locMod.ok) return { success: false, error: locMod.error };
   }
 
@@ -288,11 +318,17 @@ export async function addExternalLink(data: {
   const sanitisedUrl = sanitiseUrl(data.url);
   if (!sanitisedUrl) return { success: false, error: 'Invalid URL — must start with http:// or https://' };
 
-  // KAN-241 — content moderation on link title (link itself is already
-  // sanitiseUrl-restricted to http(s); only the user-visible title text
-  // needs the wordlist + PII pass).
+  // KAN-241 + KAN-244 — content moderation + audit log on link title.
+  // The URL itself is already sanitiseUrl-restricted to http(s); only
+  // the user-visible title needs the wordlist + PII pass.
   const sanitisedLinkTitle = sanitiseText(data.title, 200);
-  const linkTitleMod = checkModeration(sanitisedLinkTitle, 'public', 'external_links.title');
+  const linkTitleMod = await moderateAndAudit(supabase, {
+    text: sanitisedLinkTitle,
+    fieldType: 'public',
+    field: 'external_links.title',
+    profileId: profile.id,
+    source: 'web_app',
+  });
   if (!linkTitleMod.ok) return { success: false, error: linkTitleMod.error };
 
   const { error } = await supabase

--- a/src/app/dashboard/profile/conversation-starters-actions.ts
+++ b/src/app/dashboard/profile/conversation-starters-actions.ts
@@ -3,7 +3,7 @@
 import { createClient } from '@/lib/supabase-server';
 import { revalidatePath } from 'next/cache';
 import { sanitiseText, type ActionResult } from '@/lib/sanitise';
-import { checkModeration } from '@/lib/moderation-policy';
+import { moderateAndAudit } from '@/lib/moderation-audit';
 import { checkProfileWriteRateLimit } from '@/lib/profile-rate-limit';
 
 /**
@@ -67,8 +67,14 @@ export async function addConversationStarter(input: {
     return { success: false, error: 'Answer cannot be empty' };
   }
 
-  // KAN-241 — content moderation. Answers render on the public profile.
-  const mod = checkModeration(cleaned, 'public', 'profile_conversation_starters.answer');
+  // KAN-241 + KAN-244 — content moderation + audit log.
+  const mod = await moderateAndAudit(supabase, {
+    text: cleaned,
+    fieldType: 'public',
+    field: 'profile_conversation_starters.answer',
+    profileId,
+    source: 'web_app',
+  });
   if (!mod.ok) return { success: false, error: mod.error };
 
   const { error } = await supabase
@@ -113,8 +119,14 @@ export async function updateConversationStarter(
     return { success: false, error: 'Answer cannot be empty' };
   }
 
-  // KAN-241 — content moderation, same as the add path.
-  const mod = checkModeration(cleaned, 'public', 'profile_conversation_starters.answer');
+  // KAN-241 + KAN-244 — content moderation + audit, same as the add path.
+  const mod = await moderateAndAudit(supabase, {
+    text: cleaned,
+    fieldType: 'public',
+    field: 'profile_conversation_starters.answer',
+    profileId,
+    source: 'web_app',
+  });
   if (!mod.ok) return { success: false, error: mod.error };
 
   const { error } = await supabase

--- a/src/app/dashboard/profile/manual-of-me-actions.ts
+++ b/src/app/dashboard/profile/manual-of-me-actions.ts
@@ -20,7 +20,7 @@
 import { createClient } from '@/lib/supabase-server';
 import { revalidatePath } from 'next/cache';
 import { sanitiseText, type ActionResult } from '@/lib/sanitise';
-import { checkModeration } from '@/lib/moderation-policy';
+import { moderateAndAudit } from '@/lib/moderation-audit';
 import { checkProfileWriteRateLimit } from '@/lib/profile-rate-limit';
 import {
   MANUAL_OF_ME_FIELDS,
@@ -78,19 +78,9 @@ export async function updateManualOfMe(
     };
   }
 
-  // 1b. KAN-241 — content moderation. Manual of Me fields appear on the
-  // public profile via [slug]/page.tsx, so 'public' fieldType applies.
-  // Moderate the sanitised text (post-strip, post-trim) so HTML wrappers
-  // can't hide profanity from the word-boundary matcher.
-  for (const [key, val] of Object.entries(sanitised)) {
-    if (!val) continue;
-    const mod = checkModeration(val, 'public', `profile_manual_of_me.${key}`);
-    if (!mod.ok) {
-      return { success: false, error: mod.error };
-    }
-  }
-
   // 2. Resolve the owning profile (server-side, not client-supplied).
+  // Fetched BEFORE moderation so the audit-row gets a profile_id (owner
+  // can see own flags via RLS).
   const { data: profile, error: profileErr } = await supabase
     .from('profiles')
     .select('id')
@@ -98,6 +88,24 @@ export async function updateManualOfMe(
     .single();
   if (profileErr || !profile) {
     return { success: false, error: 'Profile not found' };
+  }
+
+  // 1b. KAN-241 + KAN-244 — content moderation + audit log. Manual of Me
+  // fields appear on the public profile via [slug]/page.tsx, so 'public'
+  // fieldType applies. Moderate the sanitised text (post-strip, post-trim)
+  // so HTML wrappers can't hide profanity from the word-boundary matcher.
+  for (const [key, val] of Object.entries(sanitised)) {
+    if (!val) continue;
+    const mod = await moderateAndAudit(supabase, {
+      text: val,
+      fieldType: 'public',
+      field: `profile_manual_of_me.${key}`,
+      profileId: profile.id,
+      source: 'web_app',
+    });
+    if (!mod.ok) {
+      return { success: false, error: mod.error };
+    }
   }
 
   // 3. Empty input → no-op success (don't fire a meaningless UPDATE).

--- a/src/lib/moderation-audit.ts
+++ b/src/lib/moderation-audit.ts
@@ -1,0 +1,119 @@
+/**
+ * KAN-244 (KAN-63 Tier 2-A audit trail) — moderation audit recorder.
+ *
+ * Wraps `checkModeration` so callers can keep their existing flow
+ * (`if (!mod.ok) return error`) AND get a row written to
+ * `public.content_moderation_flags` whenever the moderator flags a
+ * field — warn or block.
+ *
+ * Failure mode: the audit insert is fire-and-forget. If the write fails
+ * (table missing, RLS misconfig, network blip), we `console.warn` once
+ * but the action keeps going. Audit is a side-effect; it must never
+ * block a user save.
+ *
+ * Why this wrapper rather than changing `checkModeration` itself:
+ *   - `checkModeration` is pure and synchronous; its tests assert exact
+ *     return shapes (`toEqual({ ok: true })`). Mutating that contract
+ *     would break a bunch of existing assertions. The wrapper bolts
+ *     the audit-write on without touching the existing surface.
+ *   - The MCP server (lyra-mcp-server) also wires this via a parallel
+ *     module — same pattern, different supabase client.
+ */
+
+import { moderateContent, type FieldType } from './content-moderation';
+import { checkModeration, type CheckResult } from './moderation-policy';
+import type { SupabaseClient } from '@supabase/supabase-js';
+
+export type ModerationSource = 'web_app' | 'mcp_server';
+
+interface ModerateAndAuditArgs {
+  text: string | null | undefined;
+  fieldType?: FieldType;
+  field: string;
+  profileId: string | null;
+  source: ModerationSource;
+}
+
+/**
+ * Moderate the text + record a `content_moderation_flags` row when
+ * severity is warn or block. Returns the same `CheckResult` shape as
+ * `checkModeration` so callers don't have to change their branching.
+ */
+export async function moderateAndAudit(
+  supabase: SupabaseClient,
+  args: ModerateAndAuditArgs,
+): Promise<CheckResult> {
+  const { text, fieldType = 'public', field, profileId, source } = args;
+  const mod = checkModeration(text, fieldType, field);
+
+  // Skip the audit table when nothing was flagged (severity=none). This
+  // is the hot path for clean saves — we don't want a DB round-trip on
+  // every field of every profile edit.
+  if (mod.ok) {
+    // ok=true means severity is either 'none' or 'warn'. To distinguish
+    // we re-derive the severity from the library; cheap pure call.
+    // (The pure policy module deliberately doesn't expose `warn` in
+    //  its return shape — see header comment.)
+    if (text && typeof text === 'string') {
+      const detail = moderateContent(text, fieldType);
+      if (detail.severity === 'warn') {
+        await recordFlag(supabase, {
+          profileId,
+          field,
+          severity: 'warn',
+          flags: detail.flags,
+          snippet: text,
+          source,
+        });
+      }
+    }
+    return mod;
+  }
+
+  // Block: surface the same error to the caller, write the audit row.
+  await recordFlag(supabase, {
+    profileId,
+    field,
+    severity: 'block',
+    flags: mod.flags,
+    snippet: text ?? '',
+    source,
+  });
+  return mod;
+}
+
+interface RecordArgs {
+  profileId: string | null;
+  field: string;
+  severity: 'warn' | 'block';
+  flags: string[];
+  snippet: string;
+  source: ModerationSource;
+}
+
+async function recordFlag(supabase: SupabaseClient, args: RecordArgs): Promise<void> {
+  try {
+    const { error } = await supabase.from('content_moderation_flags').insert({
+      profile_id: args.profileId,
+      field: args.field,
+      severity: args.severity,
+      flags: args.flags,
+      // DB has CHECK length<=200; defensive truncation here too.
+      content_snippet: args.snippet.slice(0, 200),
+      source: args.source,
+    });
+    if (error) {
+      console.warn('[moderation-audit] insert failed (will not block save)', {
+        field: args.field,
+        severity: args.severity,
+        error: error.message,
+      });
+    }
+  } catch (e) {
+    console.warn('[moderation-audit] insert threw', {
+      field: args.field,
+      severity: args.severity,
+      err: e instanceof Error ? e.message : String(e),
+    });
+  }
+}

--- a/tests/unit/moderation-actions.test.ts
+++ b/tests/unit/moderation-actions.test.ts
@@ -102,7 +102,7 @@ describe('KAN-241: addProfileItem moderation', () => {
     }));
   });
 
-  test('profane title → blocked, no DB write', async () => {
+  test('profane title → blocked, no write to profile_items', async () => {
     const result = await addProfileItem({
       category: 'likes',
       title: 'fuck this',
@@ -111,17 +111,20 @@ describe('KAN-241: addProfileItem moderation', () => {
     if (!result.success) {
       expect(result.error).toMatch(/inappropriate language/i);
     }
-    expect(mockInsertCapture).not.toHaveBeenCalled();
+    // KAN-244: audit-row writes to `content_moderation_flags` are
+    // expected on a block; the original intent was "no write to the
+    // *target* table" — assert against the target table specifically.
+    expect(mockInsertCapture).not.toHaveBeenCalledWith('profile_items', expect.anything());
   });
 
-  test('profane description → blocked, no DB write', async () => {
+  test('profane description → blocked, no write to profile_items', async () => {
     const result = await addProfileItem({
       category: 'likes',
       title: 'Coffee',
       description: 'this fuck is great',
     });
     expect(result.success).toBe(false);
-    expect(mockInsertCapture).not.toHaveBeenCalled();
+    expect(mockInsertCapture).not.toHaveBeenCalledWith('profile_items', expect.anything());
   });
 
   test('PII in description (international phone) → blocked', async () => {
@@ -134,7 +137,7 @@ describe('KAN-241: addProfileItem moderation', () => {
     if (!result.success) {
       expect(result.error).toMatch(/personal information/i);
     }
-    expect(mockInsertCapture).not.toHaveBeenCalled();
+    expect(mockInsertCapture).not.toHaveBeenCalledWith('profile_items', expect.anything());
   });
 });
 
@@ -153,12 +156,14 @@ describe('KAN-241: updateProfileFields moderation', () => {
     }));
   });
 
-  test('profane bio → blocked, no DB write', async () => {
+  test('profane bio → blocked, no write to profiles', async () => {
     const result = await updateProfileFields({
       bio_short: 'I love fuck and other things',
     });
     expect(result.success).toBe(false);
-    expect(mockUpdateCapture).not.toHaveBeenCalled();
+    // KAN-244: audit-row writes to `content_moderation_flags` are
+    // expected on block; assert against the target table specifically.
+    expect(mockUpdateCapture).not.toHaveBeenCalledWith('profiles', expect.anything());
   });
 
   test('PII in display_name (email) → blocked', async () => {
@@ -166,7 +171,7 @@ describe('KAN-241: updateProfileFields moderation', () => {
       display_name: 'Contact me at sarah@example.com',
     });
     expect(result.success).toBe(false);
-    expect(mockUpdateCapture).not.toHaveBeenCalled();
+    expect(mockUpdateCapture).not.toHaveBeenCalledWith('profiles', expect.anything());
   });
 });
 
@@ -184,12 +189,12 @@ describe('KAN-241: addSchoolAffiliation moderation', () => {
     }));
   });
 
-  test('profane school name → blocked', async () => {
+  test('profane school name → blocked, no write to school_affiliations', async () => {
     const result = await addSchoolAffiliation({
       school_name: 'fuck primary school',
     });
     expect(result.success).toBe(false);
-    expect(mockInsertCapture).not.toHaveBeenCalled();
+    expect(mockInsertCapture).not.toHaveBeenCalledWith('school_affiliations', expect.anything());
   });
 });
 
@@ -207,13 +212,13 @@ describe('KAN-241: addExternalLink moderation', () => {
     }));
   });
 
-  test('profane link title → blocked', async () => {
+  test('profane link title → blocked, no write to external_links', async () => {
     const result = await addExternalLink({
       title: 'fuck this is my blog',
       url: 'https://example.com/blog',
     });
     expect(result.success).toBe(false);
-    expect(mockInsertCapture).not.toHaveBeenCalled();
+    expect(mockInsertCapture).not.toHaveBeenCalledWith('external_links', expect.anything());
   });
 });
 
@@ -231,12 +236,12 @@ describe('KAN-241: updateManualOfMe moderation', () => {
     }));
   });
 
-  test('profane communication_style → blocked', async () => {
+  test('profane communication_style → blocked, no upsert to profile_manual_of_me', async () => {
     const result = await updateManualOfMe({
       communication_style: 'fuck calls, only email',
     });
     expect(result.success).toBe(false);
-    expect(mockUpsertCapture).not.toHaveBeenCalled();
+    expect(mockUpsertCapture).not.toHaveBeenCalledWith('profile_manual_of_me', expect.anything());
   });
 });
 
@@ -256,19 +261,19 @@ describe('KAN-241: conversation starter moderation', () => {
     }));
   });
 
-  test('profane answer → blocked on add', async () => {
+  test('profane answer → blocked on add, no insert to profile_conversation_starters', async () => {
     const result = await addConversationStarter({
       promptId: VALID_PROMPT_ID,
       answer: 'fuck this question',
     });
     expect(result.success).toBe(false);
-    expect(mockInsertCapture).not.toHaveBeenCalled();
+    expect(mockInsertCapture).not.toHaveBeenCalledWith('profile_conversation_starters', expect.anything());
   });
 
   test('profane answer → blocked on update too', async () => {
     const result = await updateConversationStarter('item-id', 'fuck this');
     expect(result.success).toBe(false);
-    expect(mockUpdateCapture).not.toHaveBeenCalled();
+    expect(mockUpdateCapture).not.toHaveBeenCalledWith('profile_conversation_starters', expect.anything());
   });
 });
 
@@ -281,26 +286,30 @@ describe('KAN-241: surface-area regression guards', () => {
     expect(src).toMatch(/moderateContent/); // pulls from content-moderation
   });
 
-  test('actions.ts imports + calls checkModeration', () => {
+  // KAN-244: callers now route via the `moderateAndAudit` wrapper (which
+  // internally calls `checkModeration` + writes a `content_moderation_flags`
+  // row). The guards accept either entry point — the original intent
+  // ("moderation is wired in this file") is preserved.
+  test('actions.ts imports + calls moderation (checkModeration or moderateAndAudit)', () => {
     const src = readFileSync(resolve(ROOT, 'src/app/dashboard/profile/actions.ts'), 'utf-8');
-    expect(src).toMatch(/import\s*\{\s*checkModeration\s*\}\s*from\s*['"]@\/lib\/moderation-policy['"]/);
+    expect(src).toMatch(/import\s*\{\s*(?:checkModeration|moderateAndAudit)\s*\}\s*from\s*['"]@\/lib\/moderation-(?:policy|audit)['"]/);
     // Used in at least 4 places (updateProfileFields, addProfileItem,
     // addSchoolAffiliation, addExternalLink)
-    const callCount = (src.match(/checkModeration\(/g) || []).length;
+    const callCount = (src.match(/(?:checkModeration|moderateAndAudit)\(/g) || []).length;
     expect(callCount).toBeGreaterThanOrEqual(4);
   });
 
-  test('manual-of-me-actions.ts imports + calls checkModeration', () => {
+  test('manual-of-me-actions.ts imports + calls moderation', () => {
     const src = readFileSync(resolve(ROOT, 'src/app/dashboard/profile/manual-of-me-actions.ts'), 'utf-8');
-    expect(src).toMatch(/import\s*\{\s*checkModeration\s*\}\s*from\s*['"]@\/lib\/moderation-policy['"]/);
-    expect(src).toMatch(/checkModeration\(/);
+    expect(src).toMatch(/import\s*\{\s*(?:checkModeration|moderateAndAudit)\s*\}\s*from\s*['"]@\/lib\/moderation-(?:policy|audit)['"]/);
+    expect(src).toMatch(/(?:checkModeration|moderateAndAudit)\(/);
   });
 
-  test('conversation-starters-actions.ts imports + calls checkModeration in both add + update', () => {
+  test('conversation-starters-actions.ts imports + calls moderation in both add + update', () => {
     const src = readFileSync(resolve(ROOT, 'src/app/dashboard/profile/conversation-starters-actions.ts'), 'utf-8');
-    expect(src).toMatch(/import\s*\{\s*checkModeration\s*\}\s*from\s*['"]@\/lib\/moderation-policy['"]/);
+    expect(src).toMatch(/import\s*\{\s*(?:checkModeration|moderateAndAudit)\s*\}\s*from\s*['"]@\/lib\/moderation-(?:policy|audit)['"]/);
     // One call in add path, one in update path
-    const callCount = (src.match(/checkModeration\(/g) || []).length;
+    const callCount = (src.match(/(?:checkModeration|moderateAndAudit)\(/g) || []).length;
     expect(callCount).toBeGreaterThanOrEqual(2);
   });
 

--- a/tests/unit/moderation-audit.test.ts
+++ b/tests/unit/moderation-audit.test.ts
@@ -1,0 +1,171 @@
+/**
+ * KAN-244 — moderateAndAudit wrapper tests.
+ *
+ * Pure-policy behaviour is covered by `moderation-policy.test.ts`. This
+ * file verifies the audit-row branch:
+ *   - clean text → no insert
+ *   - warn text → insert with severity='warn'
+ *   - block text → insert with severity='block'
+ *   - insert failure → still returns the same CheckResult to caller
+ *   - snippet is truncated to 200 chars
+ */
+
+import { moderateAndAudit } from '@/lib/moderation-audit';
+
+type InsertedRow = {
+  profile_id: string | null;
+  field: string;
+  severity: 'warn' | 'block';
+  flags: string[];
+  content_snippet: string;
+  source: string;
+};
+
+function makeStubSupabase(opts: { insertError?: string } = {}) {
+  const inserted: InsertedRow[] = [];
+  const stub = {
+    from: jest.fn((_table: string) => ({
+      insert: jest.fn(async (row: InsertedRow) => {
+        if (opts.insertError) {
+          return { error: { message: opts.insertError } };
+        }
+        inserted.push(row);
+        return { error: null };
+      }),
+    })),
+  };
+  return { stub, inserted };
+}
+
+describe('KAN-244: moderateAndAudit', () => {
+  test('clean text returns ok=true and writes no audit row', async () => {
+    const { stub, inserted } = makeStubSupabase();
+    const result = await moderateAndAudit(stub as never, {
+      text: 'Hello world, I love cycling.',
+      fieldType: 'public',
+      field: 'profiles.bio_short',
+      profileId: 'profile-1',
+      source: 'web_app',
+    });
+    expect(result).toEqual({ ok: true });
+    expect(inserted.length).toBe(0);
+  });
+
+  test('null/empty text passes silently — no insert', async () => {
+    const { stub, inserted } = makeStubSupabase();
+    await moderateAndAudit(stub as never, {
+      text: null,
+      field: 'profiles.bio_short',
+      profileId: 'profile-1',
+      source: 'web_app',
+    });
+    await moderateAndAudit(stub as never, {
+      text: '',
+      field: 'profiles.bio_short',
+      profileId: 'profile-1',
+      source: 'web_app',
+    });
+    expect(inserted.length).toBe(0);
+  });
+
+  test('public profanity blocks AND writes severity=block row', async () => {
+    const { stub, inserted } = makeStubSupabase();
+    const result = await moderateAndAudit(stub as never, {
+      text: 'fuck this',
+      fieldType: 'public',
+      field: 'profiles.bio_short',
+      profileId: 'profile-1',
+      source: 'web_app',
+    });
+    expect(result.ok).toBe(false);
+    expect(inserted.length).toBe(1);
+    expect(inserted[0].severity).toBe('block');
+    expect(inserted[0].field).toBe('profiles.bio_short');
+    expect(inserted[0].profile_id).toBe('profile-1');
+    expect(inserted[0].source).toBe('web_app');
+    expect(inserted[0].flags.some((f) => f.startsWith('profanity:'))).toBe(true);
+  });
+
+  test('private profanity warns AND writes severity=warn row (does not block)', async () => {
+    const { stub, inserted } = makeStubSupabase();
+    const spy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      const result = await moderateAndAudit(stub as never, {
+        text: 'fuck this',
+        fieldType: 'private',
+        field: 'manual_of_me.notes',
+        profileId: 'profile-2',
+        source: 'web_app',
+      });
+      expect(result).toEqual({ ok: true });
+      expect(inserted.length).toBe(1);
+      expect(inserted[0].severity).toBe('warn');
+      expect(inserted[0].field).toBe('manual_of_me.notes');
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  test('snippet is capped at 200 chars (defence-in-depth — DB also enforces)', async () => {
+    const { stub, inserted } = makeStubSupabase();
+    const longProfanity = 'fuck ' + 'a'.repeat(500);
+    await moderateAndAudit(stub as never, {
+      text: longProfanity,
+      fieldType: 'public',
+      field: 'profiles.bio_short',
+      profileId: 'profile-3',
+      source: 'web_app',
+    });
+    expect(inserted.length).toBe(1);
+    expect(inserted[0].content_snippet.length).toBeLessThanOrEqual(200);
+  });
+
+  test('source = "mcp_server" round-trips into the row', async () => {
+    const { stub, inserted } = makeStubSupabase();
+    await moderateAndAudit(stub as never, {
+      text: 'fuck this',
+      fieldType: 'public',
+      field: 'profiles.bio_short',
+      profileId: 'profile-4',
+      source: 'mcp_server',
+    });
+    expect(inserted[0].source).toBe('mcp_server');
+  });
+
+  test('insert error does NOT propagate — wrapper returns same CheckResult', async () => {
+    // Audit is side-effect, never blocks the user save. The insert
+    // failing should produce a console.warn but the CheckResult shape
+    // must match what checkModeration returned.
+    const { stub } = makeStubSupabase({ insertError: 'table does not exist' });
+    const spy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      const result = await moderateAndAudit(stub as never, {
+        text: 'fuck this',
+        fieldType: 'public',
+        field: 'profiles.bio_short',
+        profileId: 'profile-5',
+        source: 'web_app',
+      });
+      // The block was detected — caller gets the same shape.
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.error).toMatch(/inappropriate language/i);
+      }
+      expect(spy).toHaveBeenCalled();
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  test('null profileId is permitted (pre-profile creation flows)', async () => {
+    const { stub, inserted } = makeStubSupabase();
+    await moderateAndAudit(stub as never, {
+      text: 'fuck this',
+      fieldType: 'public',
+      field: 'profiles.bio_short',
+      profileId: null,
+      source: 'web_app',
+    });
+    expect(inserted[0].profile_id).toBeNull();
+  });
+});

--- a/tests/unit/profile-actions.test.ts
+++ b/tests/unit/profile-actions.test.ts
@@ -39,11 +39,24 @@ jest.mock('@/lib/supabase-server', () => ({
         data: { user: { id: 'test-user-id' } },
       }),
     },
+    // KAN-244: `updateProfileFields` now also calls `getUserProfile()` to
+    // get a `profile_id` for the moderation-audit row. The chain
+    // `from('profiles').select('id').eq('user_id', x).single()` must
+    // resolve to a row. The chain `from('profiles').update(...).eq(...)`
+    // remains the path the test asserts on via mockUpdateCapture.
+    // `from('content_moderation_flags').insert(...)` no-ops here — the
+    // audit table is verified in moderation-audit.test.ts.
     from: jest.fn().mockImplementation(() => ({
+      select: () => ({
+        eq: () => ({
+          single: jest.fn().mockResolvedValue({ data: { id: 'test-profile-id' }, error: null }),
+        }),
+      }),
       update: (data: unknown) => {
         mockUpdateCapture(data);
         return { eq: mockEqResolve };
       },
+      insert: jest.fn().mockResolvedValue({ error: null }),
     })),
   }),
 }));


### PR DESCRIPTION
## Summary

Closes the audit-trail gap noted in KAN-226 closeout. Both warn-severity (saved-but-flagged) and block-severity (rejected) moderation events now persist to `public.content_moderation_flags` with per-event metadata (field, severity, flags, snippet, source).

## What landed

- **Migration applied to dev / stage / prod Supabase** — new table + indexes + RLS (owner-readable via `auth.uid()` → profile_id; service-role full access) + `pg_cron` 30-day retention (runs 03:15 UTC daily).
- `src/lib/moderation-audit.ts` — `moderateAndAudit(supabase, args)` async wrapper. Same return shape as `checkModeration`, plus a fire-and-forget insert on warn/block.
- 8 call sites refactored from `checkModeration(...)` → `await moderateAndAudit(supabase, {...})`:
  - `actions.ts`: `updateProfileFields`, `addProfileItem`, `addSchoolAffiliation`, `addExternalLink`
  - `conversation-starters-actions.ts`: `addConversationStarter`, `updateConversationStarter`
  - `manual-of-me-actions.ts`: `updateManualOfMe`

## Safety

- **Audit failure never blocks user saves.** Insert errors `console.warn` and the action keeps going. Audit is a side-effect; user data writes must not depend on it.
- **Snippet capped at 200 chars** in both app code AND DB CHECK. No full-bio storage in the audit table.
- **API key prefix only on MCP side** (8 chars max — paired commit on lyra-mcp-server follows).
- **RLS** scopes flag-read to profile owner; cross-profile and anon reads are denied.

## Test plan

- [x] 8 new unit tests on `moderateAndAudit` (clean / warn / block / null-profileId / mcp_server source / snippet truncation / insert-failure resilience)
- [x] Existing behavioural tests updated (sign-off granted) — block-path assertions now check the *target* table is untouched (audit writes to `content_moderation_flags` are expected)
- [x] Static-grep guards now accept either `checkModeration` or `moderateAndAudit` as the moderation entry point
- [x] `npm run test:unit` — **1296 tests pass in 91 suites**
- [x] `npm run type-check` — clean
- [ ] Post-merge: live insert smoke against dev Supabase (write a profane string via the dev UI, query `content_moderation_flags` for a `severity='block'` row)

MCP coverage: paired commit on `luisa-sys/lyra-mcp-server` ships in the same epic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)