### PR TITLE
feat(KAN-211) P7: Microsoft Graph calendar adapter

### DIFF
--- a/src/app/api/convene/oauth/microsoft/callback/route.ts
+++ b/src/app/api/convene/oauth/microsoft/callback/route.ts
@@ -1,0 +1,141 @@
+/**
+ * Microsoft OAuth callback — KAN-211 P7.
+ *
+ * Handles the redirect from Microsoft's consent screen. Validates state,
+ * exchanges the authorization code for tokens, fetches /me to capture
+ * provider_account_id + display_name, and upserts the oauth_connections
+ * row.
+ *
+ * Mirrors the Google callback's diagnostic logging shape.
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { createClient as createSupabaseAdmin } from '@supabase/supabase-js';
+import { env } from '@/lib/env';
+import { isConveneEnabled } from '@/lib/convene/flags';
+import { upsertConnection } from '@/lib/convene/oauth-connections';
+import {
+  exchangeCodeForTokens,
+  fetchUserInfo,
+  type MicrosoftTokenResponse,
+} from '@/lib/convene/microsoft/oauth';
+
+export const maxDuration = 30;
+
+function logStep(reqId: string, step: string, extra?: Record<string, unknown>) {
+  console.log(
+    JSON.stringify({ at: 'convene/oauth/microsoft/callback', req: reqId, step, ...extra })
+  );
+}
+
+export async function GET(req: NextRequest) {
+  const reqId = Math.random().toString(36).slice(2, 10);
+  logStep(reqId, 'enter');
+
+  if (!isConveneEnabled()) {
+    return NextResponse.json({ error: 'convene_disabled' }, { status: 404 });
+  }
+
+  const code = req.nextUrl.searchParams.get('code');
+  const state = req.nextUrl.searchParams.get('state');
+  const errorParam = req.nextUrl.searchParams.get('error');
+  const errorDesc = req.nextUrl.searchParams.get('error_description');
+  logStep(reqId, 'params', {
+    has_code: !!code,
+    has_state: !!state,
+    error: errorParam,
+    error_description: errorDesc?.slice(0, 200),
+  });
+
+  if (errorParam) {
+    return NextResponse.redirect(
+      new URL(`/dashboard?convene_oauth=error&reason=${encodeURIComponent(errorParam)}`, req.url)
+    );
+  }
+  if (!code || !state) {
+    return NextResponse.json({ error: 'missing_code_or_state' }, { status: 400 });
+  }
+
+  const admin = createSupabaseAdmin(env.supabaseUrl(), env.supabaseServiceRoleKey(), {
+    auth: { persistSession: false },
+  });
+
+  // ownership-ok: state token is unguessable + single-use (KAN-211)
+  const { data: stateRow, error: stateErr } = await admin
+    .from('oauth_connect_state')
+    .select('user_id, provider, expires_at')
+    .eq('state', state)
+    .maybeSingle();
+  logStep(reqId, 'state_lookup_done', { found: !!stateRow, err: stateErr?.message });
+
+  if (stateErr || !stateRow) {
+    return NextResponse.json({ error: 'bad_state' }, { status: 400 });
+  }
+  if (new Date(stateRow.expires_at) < new Date()) {
+    await admin.from('oauth_connect_state').delete().eq('state', state);
+    return NextResponse.json({ error: 'state_expired' }, { status: 400 });
+  }
+  if (stateRow.provider !== 'microsoft') {
+    return NextResponse.json({ error: 'state_provider_mismatch' }, { status: 400 });
+  }
+  await admin.from('oauth_connect_state').delete().eq('state', state);
+
+  let tokens: MicrosoftTokenResponse;
+  try {
+    tokens = await exchangeCodeForTokens(code);
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : 'unknown';
+    logStep(reqId, 'token_exchange_failed', { msg });
+    return NextResponse.json({ error: 'token_exchange_failed', detail: msg }, { status: 502 });
+  }
+
+  if (!tokens.refresh_token) {
+    return NextResponse.json(
+      {
+        error: 'no_refresh_token',
+        hint: 'offline_access scope is required — check Azure AD app config',
+      },
+      { status: 400 }
+    );
+  }
+
+  let userInfo;
+  try {
+    userInfo = await fetchUserInfo(tokens.access_token);
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : 'unknown';
+    logStep(reqId, 'userinfo_failed', { msg });
+    return NextResponse.json({ error: 'userinfo_failed', detail: msg }, { status: 502 });
+  }
+
+  try {
+    await upsertConnection({
+      userId: stateRow.user_id,
+      provider: 'microsoft',
+      providerAccountId: userInfo.id,
+      displayName: userInfo.mail ?? userInfo.userPrincipalName ?? userInfo.displayName,
+      refreshToken: tokens.refresh_token,
+      scopeGranted: tokens.scope,
+    });
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : 'unknown';
+    logStep(reqId, 'upsert_failed', { msg });
+    return NextResponse.json({ error: 'persist_failed', detail: msg }, { status: 500 });
+  }
+
+  // ownership-ok: audit for verified state user (KAN-211)
+  await admin.from('consent_log').insert({
+    user_id: stateRow.user_id,
+    event_type: 'oauth_granted',
+    subject_kind: 'provider',
+    subject_id: 'microsoft',
+    metadata: {
+      scope: tokens.scope,
+      account: userInfo.mail ?? userInfo.userPrincipalName ?? userInfo.id,
+    },
+  });
+
+  return NextResponse.redirect(
+    new URL('/dashboard?convene_oauth=connected&provider=microsoft', req.url)
+  );
+}

--- a/src/app/api/convene/oauth/microsoft/initiate/route.ts
+++ b/src/app/api/convene/oauth/microsoft/initiate/route.ts
@@ -1,0 +1,53 @@
+/**
+ * Microsoft OAuth initiate — KAN-211 P7.
+ *
+ * Mirrors /api/convene/oauth/google/initiate. Generates a state token,
+ * stores it in oauth_connect_state with provider='microsoft', and
+ * redirects (or returns JSON for MCP) to Microsoft's authorize URL.
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { randomBytes } from 'crypto';
+import { createClient as createSupabaseServer } from '@/lib/supabase-server';
+import { createClient as createSupabaseAdmin } from '@supabase/supabase-js';
+import { env } from '@/lib/env';
+import { isConveneEnabled } from '@/lib/convene/flags';
+import { buildAuthorizeUrl } from '@/lib/convene/microsoft/oauth';
+
+export async function GET(req: NextRequest) {
+  if (!isConveneEnabled()) {
+    return NextResponse.json({ error: 'convene_disabled' }, { status: 404 });
+  }
+
+  const sb = await createSupabaseServer();
+  const {
+    data: { user },
+  } = await sb.auth.getUser();
+  if (!user) {
+    return NextResponse.json({ error: 'unauthenticated' }, { status: 401 });
+  }
+
+  const state = randomBytes(32).toString('base64url');
+  const admin = createSupabaseAdmin(env.supabaseUrl(), env.supabaseServiceRoleKey(), {
+    auth: { persistSession: false },
+  });
+  // ownership-ok: writing the user's own state row (KAN-211)
+  const { error } = await admin.from('oauth_connect_state').insert({
+    state,
+    user_id: user.id,
+    provider: 'microsoft',
+  });
+  if (error) {
+    return NextResponse.json(
+      { error: 'state_persist_failed', detail: error.message },
+      { status: 500 }
+    );
+  }
+
+  const wantsJson = req.headers.get('accept')?.includes('application/json');
+  const authorizeUrl = buildAuthorizeUrl(state);
+  if (wantsJson) {
+    return NextResponse.json({ authorize_url: authorizeUrl, state });
+  }
+  return NextResponse.redirect(authorizeUrl);
+}

--- a/src/lib/convene/calendar/microsoft.ts
+++ b/src/lib/convene/calendar/microsoft.ts
@@ -1,0 +1,168 @@
+/**
+ * Microsoft Graph Calendar adapter — KAN-211 P7.
+ *
+ * Implements the canonical CalendarAdapter interface against Microsoft
+ * Graph (calendar endpoints under /v1.0/me/calendar/*). Mirrors
+ * google.ts in shape; provider-specific quirks (timezone marshalling,
+ * dateTime envelope shape) are handled here.
+ *
+ * Tokens come from src/lib/convene/oauth-connections.ts (Vault round-trip
+ * + provider-aware refresh). Event titles are sent to Microsoft but
+ * NEVER persisted on our side — only IDs and start/end times come back.
+ */
+
+import type {
+  CalendarAdapter,
+  GatheringEventData,
+  TimeWindow,
+  BusyBlock,
+} from './types';
+import { getFreshAccessToken } from '../oauth-connections';
+
+const BASE = 'https://graph.microsoft.com/v1.0';
+const FETCH_TIMEOUT_MS = 8_000;
+
+async function msFetch(
+  accessToken: string,
+  method: 'GET' | 'POST' | 'PATCH' | 'DELETE',
+  path: string,
+  body?: unknown
+): Promise<Response> {
+  return fetch(`${BASE}${path}`, {
+    method,
+    headers: {
+      authorization: `Bearer ${accessToken}`,
+      ...(body ? { 'content-type': 'application/json' } : {}),
+    },
+    body: body ? JSON.stringify(body) : undefined,
+    signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+  });
+}
+
+async function readErrorOrThrow(res: Response, op: string): Promise<never> {
+  let detail = '';
+  try {
+    detail = await res.text();
+  } catch {
+    /* ignore */
+  }
+  const err = new Error(
+    `Microsoft ${op} failed (${res.status}): ${detail.slice(0, 200)}`
+  ) as Error & { status: number; retryable: boolean };
+  err.status = res.status;
+  err.retryable = res.status >= 500 || res.status === 429;
+  throw err;
+}
+
+export const microsoftCalendarAdapter: CalendarAdapter = {
+  async getFreeBusy(connectionId: string, window: TimeWindow): Promise<BusyBlock[]> {
+    const { accessToken } = await getFreshAccessToken(connectionId);
+    // Microsoft's /getSchedule expects ISO 8601 with TZ. Graph's responses
+    // include both 'start' and 'end' as { dateTime, timeZone } objects.
+    const res = await msFetch(accessToken, 'POST', '/me/calendar/getSchedule', {
+      schedules: ['me'],
+      startTime: { dateTime: window.start.toISOString(), timeZone: 'UTC' },
+      endTime: { dateTime: window.end.toISOString(), timeZone: 'UTC' },
+      availabilityViewInterval: 30,
+    });
+    if (!res.ok) await readErrorOrThrow(res, 'getSchedule');
+    const json = (await res.json()) as {
+      value?: Array<{
+        scheduleItems?: Array<{
+          status: string;
+          start: { dateTime: string; timeZone: string };
+          end: { dateTime: string; timeZone: string };
+        }>;
+      }>;
+    };
+    const items = json.value?.[0]?.scheduleItems ?? [];
+    return items
+      .filter((i) => i.status === 'busy' || i.status === 'oof' || i.status === 'tentative')
+      .map((i) => ({
+        start: normaliseToUtcISO(i.start.dateTime, i.start.timeZone),
+        end: normaliseToUtcISO(i.end.dateTime, i.end.timeZone),
+      }));
+  },
+
+  async createEvent(connectionId: string, data: GatheringEventData) {
+    const { accessToken } = await getFreshAccessToken(connectionId);
+    const res = await msFetch(accessToken, 'POST', '/me/events', {
+      subject: data.title,
+      body: data.description
+        ? { contentType: 'text', content: data.description }
+        : undefined,
+      location: data.location ? { displayName: data.location } : undefined,
+      start: { dateTime: data.startISO, timeZone: 'UTC' },
+      end: { dateTime: data.endISO, timeZone: 'UTC' },
+      attendees: data.attendees?.map((a) => ({
+        emailAddress: { address: a.email, name: a.displayName ?? a.email },
+        type: a.optional ? 'optional' : 'required',
+      })),
+    });
+    if (!res.ok) await readErrorOrThrow(res, 'createEvent');
+    const json = (await res.json()) as { id: string };
+    return { providerEventId: json.id };
+  },
+
+  async updateEvent(connectionId: string, providerEventId: string, data: GatheringEventData) {
+    const { accessToken } = await getFreshAccessToken(connectionId);
+    const res = await msFetch(
+      accessToken,
+      'PATCH',
+      `/me/events/${encodeURIComponent(providerEventId)}`,
+      {
+        subject: data.title,
+        body: data.description
+          ? { contentType: 'text', content: data.description }
+          : undefined,
+        location: data.location ? { displayName: data.location } : undefined,
+        start: { dateTime: data.startISO, timeZone: 'UTC' },
+        end: { dateTime: data.endISO, timeZone: 'UTC' },
+        attendees: data.attendees?.map((a) => ({
+          emailAddress: { address: a.email, name: a.displayName ?? a.email },
+          type: a.optional ? 'optional' : 'required',
+        })),
+      }
+    );
+    if (!res.ok) await readErrorOrThrow(res, 'updateEvent');
+  },
+
+  async deleteEvent(connectionId: string, providerEventId: string) {
+    const { accessToken } = await getFreshAccessToken(connectionId);
+    const res = await msFetch(
+      accessToken,
+      'DELETE',
+      `/me/events/${encodeURIComponent(providerEventId)}`
+    );
+    // 404/410 → already gone; idempotent success.
+    if (!res.ok && res.status !== 404 && res.status !== 410) {
+      await readErrorOrThrow(res, 'deleteEvent');
+    }
+  },
+
+  async revokeAtProvider() {
+    // Microsoft Graph does not expose a direct token revoke endpoint
+    // for delegated tokens — refresh tokens are invalidated when the
+    // user removes the app from https://account.microsoft.com/privacy
+    // or when the IT admin revokes via Azure AD. We surface this in
+    // the disconnect copy on the dashboard.
+  },
+};
+
+/**
+ * Convert Microsoft Graph's { dateTime, timeZone } shape into a UTC ISO
+ * string. Graph emits the local time in the named timezone; we treat the
+ * local time as if it were UTC (a small lie) when the timeZone is 'UTC'
+ * (which we always request). For freeBusy this is fine because we
+ * explicitly send UTC bounds.
+ */
+function normaliseToUtcISO(dateTime: string, tz: string): string {
+  if (tz === 'UTC') {
+    // Graph returns 'YYYY-MM-DDTHH:mm:ss.SSSSSSS' without a Z suffix even
+    // when timezone is UTC. Append Z to make it explicit + parseable.
+    return dateTime.endsWith('Z') ? dateTime : `${dateTime}Z`;
+  }
+  // Fall back to Date parsing for non-UTC zones; less precise but
+  // acceptable for busy-block detection.
+  return new Date(`${dateTime}Z`).toISOString();
+}

--- a/src/lib/convene/env.ts
+++ b/src/lib/convene/env.ts
@@ -27,4 +27,13 @@ export const conveneEnv = {
   googleClientSecret: () => requireEnv('GOOGLE_CALENDAR_CLIENT_SECRET'),
   googleRedirectUri: () =>
     requireEnv('GOOGLE_CALENDAR_REDIRECT_URI'),
+
+  // Microsoft Graph OAuth client used for Outlook Calendar (KAN-211 P7).
+  // Register at https://portal.azure.com → Azure AD → App registrations.
+  // Set redirect_uri to https://<deploy>/api/convene/oauth/microsoft/callback.
+  // Required delegated permissions: offline_access, User.Read,
+  // Calendars.ReadWrite.
+  microsoftClientId: () => requireEnv('MICROSOFT_CALENDAR_CLIENT_ID'),
+  microsoftClientSecret: () => requireEnv('MICROSOFT_CALENDAR_CLIENT_SECRET'),
+  microsoftRedirectUri: () => requireEnv('MICROSOFT_CALENDAR_REDIRECT_URI'),
 };

--- a/src/lib/convene/microsoft/oauth.ts
+++ b/src/lib/convene/microsoft/oauth.ts
@@ -1,0 +1,104 @@
+/**
+ * Microsoft Graph OAuth 2.0 helpers — KAN-211 P7.
+ *
+ * Mirrors src/lib/convene/google/oauth.ts shape. Uses the v2.0 endpoints
+ * on /common (multi-tenant + personal accounts).
+ *
+ * No npm dependency on @microsoft/microsoft-graph-client — we use fetch
+ * directly to keep the surface small and auditable.
+ */
+
+import { conveneEnv } from '../env';
+
+export const MICROSOFT_SCOPES = [
+  'offline_access',
+  'User.Read',
+  'Calendars.ReadWrite',
+] as const;
+
+const AUTHORIZE_URL = 'https://login.microsoftonline.com/common/oauth2/v2.0/authorize';
+const TOKEN_URL = 'https://login.microsoftonline.com/common/oauth2/v2.0/token';
+
+export interface MicrosoftTokenResponse {
+  access_token: string;
+  expires_in: number;
+  refresh_token?: string;
+  scope: string;
+  token_type: 'Bearer';
+  id_token?: string;
+}
+
+export function buildAuthorizeUrl(state: string): string {
+  const params = new URLSearchParams({
+    client_id: conveneEnv.microsoftClientId(),
+    redirect_uri: conveneEnv.microsoftRedirectUri(),
+    response_type: 'code',
+    response_mode: 'query',
+    scope: MICROSOFT_SCOPES.join(' '),
+    state,
+    prompt: 'consent',
+  });
+  return `${AUTHORIZE_URL}?${params.toString()}`;
+}
+
+async function postToken(form: URLSearchParams): Promise<MicrosoftTokenResponse> {
+  const res = await fetch(TOKEN_URL, {
+    method: 'POST',
+    headers: { 'content-type': 'application/x-www-form-urlencoded' },
+    body: form.toString(),
+    signal: AbortSignal.timeout(8_000),
+  });
+  if (!res.ok) {
+    const text = await res.text().catch(() => '');
+    throw new Error(`Microsoft token endpoint ${res.status}: ${text.slice(0, 200)}`);
+  }
+  return (await res.json()) as MicrosoftTokenResponse;
+}
+
+export async function exchangeCodeForTokens(code: string): Promise<MicrosoftTokenResponse> {
+  return postToken(
+    new URLSearchParams({
+      client_id: conveneEnv.microsoftClientId(),
+      client_secret: conveneEnv.microsoftClientSecret(),
+      code,
+      redirect_uri: conveneEnv.microsoftRedirectUri(),
+      grant_type: 'authorization_code',
+    })
+  );
+}
+
+export async function refreshAccessToken(refreshToken: string): Promise<MicrosoftTokenResponse> {
+  return postToken(
+    new URLSearchParams({
+      client_id: conveneEnv.microsoftClientId(),
+      client_secret: conveneEnv.microsoftClientSecret(),
+      refresh_token: refreshToken,
+      grant_type: 'refresh_token',
+      scope: MICROSOFT_SCOPES.join(' '),
+    })
+  );
+}
+
+/**
+ * Fetch the basic Microsoft Graph /me profile so we can resolve a
+ * `providerAccountId` to store on the oauth_connections row.
+ */
+export async function fetchUserInfo(
+  accessToken: string
+): Promise<{ id: string; userPrincipalName?: string; mail?: string; displayName?: string }> {
+  const res = await fetch('https://graph.microsoft.com/v1.0/me', {
+    method: 'GET',
+    headers: { authorization: `Bearer ${accessToken}` },
+    signal: AbortSignal.timeout(6_000),
+  });
+  if (!res.ok) {
+    const text = await res.text().catch(() => '');
+    throw new Error(`Microsoft /me failed ${res.status}: ${text.slice(0, 200)}`);
+  }
+  return (await res.json()) as {
+    id: string;
+    userPrincipalName?: string;
+    mail?: string;
+    displayName?: string;
+  };
+}

--- a/src/lib/convene/oauth-connections.ts
+++ b/src/lib/convene/oauth-connections.ts
@@ -8,7 +8,8 @@
 
 import { createClient } from '@supabase/supabase-js';
 import { env } from '@/lib/env';
-import { refreshAccessToken } from '@/lib/convene/google/oauth';
+import { refreshAccessToken as refreshGoogleAccessToken } from '@/lib/convene/google/oauth';
+import { refreshAccessToken as refreshMicrosoftAccessToken } from '@/lib/convene/microsoft/oauth';
 import {
   vaultReadRefreshToken,
   vaultStoreRefreshToken,
@@ -73,7 +74,7 @@ export async function getConnectionForUser(
 
 interface UpsertConnectionInput {
   userId: string;
-  provider: 'google';
+  provider: 'google' | 'microsoft';
   providerAccountId: string;
   displayName?: string;
   refreshToken: string;
@@ -184,11 +185,11 @@ export async function getFreshAccessToken(
   // For now, always refresh — refresh tokens are cheap and we want simplicity.
   const refreshToken = await vaultReadRefreshToken(conn.refresh_token_secret_id);
 
-  if (conn.provider !== 'google') {
-    throw new Error(`Provider ${conn.provider} not yet implemented (P7)`);
+  if (conn.provider !== 'google' && conn.provider !== 'microsoft') {
+    throw new Error(`Provider ${conn.provider} not yet implemented`);
   }
 
-  const tokens = await refreshWithBackoff(refreshToken);
+  const tokens = await refreshWithBackoff(refreshToken, conn.provider);
   const expiresAt = new Date(Date.now() + tokens.expires_in * 1000);
 
   // Update last_used_at + expires (best-effort).
@@ -204,11 +205,16 @@ export async function getFreshAccessToken(
   return { accessToken: tokens.access_token, expiresAt };
 }
 
-async function refreshWithBackoff(refreshToken: string, attempts = 3) {
+async function refreshWithBackoff(
+  refreshToken: string,
+  provider: 'google' | 'microsoft',
+  attempts = 3
+) {
+  const refresher = provider === 'google' ? refreshGoogleAccessToken : refreshMicrosoftAccessToken;
   let lastErr: unknown;
   for (let i = 0; i < attempts; i++) {
     try {
-      return await refreshAccessToken(refreshToken);
+      return await refresher(refreshToken);
     } catch (e) {
       lastErr = e;
       // Exponential backoff: 200ms, 800ms, 3.2s

--- a/tests/unit/convene/microsoft-calendar.test.ts
+++ b/tests/unit/convene/microsoft-calendar.test.ts
@@ -1,0 +1,150 @@
+/**
+ * KAN-211 P7 — Microsoft Graph adapter + OAuth helpers — structural tests.
+ *
+ * The adapter is a thin HTTP shim around Microsoft Graph; behaviour tests
+ * (round-tripping a real freeBusy / createEvent) are deferred to the
+ * post-deploy smoke test once the user wires the Azure AD app.
+ */
+
+import fs from 'fs';
+import path from 'path';
+
+const ROOT = path.join(__dirname, '..', '..', '..');
+
+describe('microsoft/oauth.ts (KAN-211 P7)', () => {
+  const src = fs.readFileSync(path.join(ROOT, 'src/lib/convene/microsoft/oauth.ts'), 'utf8');
+
+  test('declares the documented Microsoft Graph scopes', () => {
+    expect(src).toMatch(/offline_access/);
+    expect(src).toMatch(/Calendars\.ReadWrite/);
+    expect(src).toMatch(/User\.Read/);
+  });
+
+  test('uses v2.0 endpoints on the /common tenant', () => {
+    expect(src).toMatch(/login\.microsoftonline\.com\/common\/oauth2\/v2\.0\/authorize/);
+    expect(src).toMatch(/login\.microsoftonline\.com\/common\/oauth2\/v2\.0\/token/);
+  });
+
+  test('buildAuthorizeUrl includes PKCE-friendly query params', () => {
+    expect(src).toMatch(/response_type:\s*['"]code['"]/);
+    expect(src).toMatch(/response_mode:\s*['"]query['"]/);
+    expect(src).toMatch(/prompt:\s*['"]consent['"]/);
+  });
+
+  test('exchangeCodeForTokens uses grant_type=authorization_code', () => {
+    expect(src).toMatch(/grant_type:\s*['"]authorization_code['"]/);
+  });
+
+  test('refreshAccessToken uses grant_type=refresh_token', () => {
+    expect(src).toMatch(/grant_type:\s*['"]refresh_token['"]/);
+  });
+
+  test('all fetches carry AbortSignal.timeout', () => {
+    expect(src).toMatch(/AbortSignal\.timeout/);
+  });
+
+  test('fetchUserInfo hits /v1.0/me', () => {
+    expect(src).toMatch(/graph\.microsoft\.com\/v1\.0\/me/);
+  });
+});
+
+describe('microsoft.ts calendar adapter (KAN-211 P7)', () => {
+  const src = fs.readFileSync(path.join(ROOT, 'src/lib/convene/calendar/microsoft.ts'), 'utf8');
+
+  test('exports microsoftCalendarAdapter implementing CalendarAdapter', () => {
+    expect(src).toMatch(/export const microsoftCalendarAdapter:\s*CalendarAdapter/);
+  });
+
+  test('getFreeBusy uses /me/calendar/getSchedule with UTC envelope', () => {
+    expect(src).toMatch(/\/me\/calendar\/getSchedule/);
+    expect(src).toMatch(/timeZone:\s*['"]UTC['"]/);
+  });
+
+  test('createEvent sends MS Graph-shaped attendees (emailAddress + type)', () => {
+    expect(src).toMatch(/emailAddress:\s*\{\s*address:\s*a\.email/);
+    expect(src).toMatch(/type:\s*a\.optional\s*\?\s*['"]optional['"]\s*:\s*['"]required['"]/);
+  });
+
+  test('updateEvent uses PATCH /me/events/{id}', () => {
+    expect(src).toMatch(/PATCH/);
+    expect(src).toMatch(/\/me\/events\/\$\{encodeURIComponent\(providerEventId\)\}/);
+  });
+
+  test('deleteEvent treats 404/410 as idempotent success', () => {
+    expect(src).toMatch(/res\.status !== 404 && res\.status !== 410/);
+  });
+
+  test('readErrorOrThrow flags 5xx / 429 as retryable', () => {
+    expect(src).toMatch(/err\.retryable =\s*res\.status >= 500 \|\| res\.status === 429/);
+  });
+
+  test('busy filter includes oof + tentative blocks too', () => {
+    expect(src).toMatch(/i\.status === ['"]busy['"]/);
+    expect(src).toMatch(/i\.status === ['"]oof['"]/);
+    expect(src).toMatch(/i\.status === ['"]tentative['"]/);
+  });
+});
+
+describe('Microsoft OAuth routes (KAN-211 P7)', () => {
+  test('/api/convene/oauth/microsoft/initiate route exists + gated by Convene flag', () => {
+    const p = path.join(ROOT, 'src/app/api/convene/oauth/microsoft/initiate/route.ts');
+    expect(fs.existsSync(p)).toBe(true);
+    const src = fs.readFileSync(p, 'utf8');
+    expect(src).toMatch(/isConveneEnabled\(\)/);
+    expect(src).toMatch(/provider:\s*['"]microsoft['"]/);
+    expect(src).toMatch(/buildAuthorizeUrl\(state\)/);
+  });
+
+  test('/api/convene/oauth/microsoft/callback exists + validates state.provider', () => {
+    const p = path.join(ROOT, 'src/app/api/convene/oauth/microsoft/callback/route.ts');
+    expect(fs.existsSync(p)).toBe(true);
+    const src = fs.readFileSync(p, 'utf8');
+    expect(src).toMatch(/stateRow\.provider !== ['"]microsoft['"]/);
+    expect(src).toMatch(/exchangeCodeForTokens\(code\)/);
+    expect(src).toMatch(/upsertConnection\(/);
+    expect(src).toMatch(/provider:\s*['"]microsoft['"]/);
+  });
+
+  test('callback consumes the state row (single-use)', () => {
+    const src = fs.readFileSync(
+      path.join(ROOT, 'src/app/api/convene/oauth/microsoft/callback/route.ts'),
+      'utf8'
+    );
+    expect(src).toMatch(/\.delete\(\)\.eq\(['"]state['"]/);
+  });
+
+  test('callback rejects when offline_access scope missing (no refresh_token)', () => {
+    const src = fs.readFileSync(
+      path.join(ROOT, 'src/app/api/convene/oauth/microsoft/callback/route.ts'),
+      'utf8'
+    );
+    expect(src).toMatch(/no_refresh_token/);
+    expect(src).toMatch(/offline_access/);
+  });
+});
+
+describe('oauth-connections provider dispatch (KAN-211 P7)', () => {
+  const src = fs.readFileSync(path.join(ROOT, 'src/lib/convene/oauth-connections.ts'), 'utf8');
+
+  test('imports both refresh functions under aliases', () => {
+    expect(src).toMatch(/refreshAccessToken as refreshGoogleAccessToken/);
+    expect(src).toMatch(/refreshAccessToken as refreshMicrosoftAccessToken/);
+  });
+
+  test('refreshWithBackoff dispatches on provider', () => {
+    expect(src).toMatch(/provider === ['"]google['"]\s*\?\s*refreshGoogleAccessToken\s*:\s*refreshMicrosoftAccessToken/);
+  });
+
+  test('getFreshAccessToken accepts microsoft provider', () => {
+    expect(src).toMatch(/conn\.provider !== ['"]google['"] && conn\.provider !== ['"]microsoft['"]/);
+  });
+});
+
+describe('conveneEnv microsoft entries (KAN-211 P7)', () => {
+  const src = fs.readFileSync(path.join(ROOT, 'src/lib/convene/env.ts'), 'utf8');
+  test('declares MICROSOFT_CALENDAR_CLIENT_ID/SECRET/REDIRECT_URI', () => {
+    expect(src).toMatch(/MICROSOFT_CALENDAR_CLIENT_ID/);
+    expect(src).toMatch(/MICROSOFT_CALENDAR_CLIENT_SECRET/);
+    expect(src).toMatch(/MICROSOFT_CALENDAR_REDIRECT_URI/);
+  });
+});


### PR DESCRIPTION
Outlook + Microsoft 365 + personal Microsoft accounts now have a calendar adapter mirroring Google's shape. Refresh-token path dispatches on provider. New /api/convene/oauth/microsoft/{initiate,callback} routes register/handle the Azure AD OAuth dance.

Ops: needs an Azure AD app registration with redirect URI `https://<deploy>/api/convene/oauth/microsoft/callback` and env vars `MICROSOFT_CALENDAR_CLIENT_ID/SECRET/REDIRECT_URI` on Vercel.

Verified: 22/22 new tests; build clean; both routes registered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)