### PR TITLE
feat(KAN-212) P8: post-event loop + materialised view refresh

### DIFF
--- a/src/app/api/convene/cron/post-event/route.ts
+++ b/src/app/api/convene/cron/post-event/route.ts
@@ -1,0 +1,34 @@
+/**
+ * /api/convene/cron/post-event — KAN-212 P8.
+ *
+ * Daily cron. Marks completed gatherings, auto-attendance, refreshes the
+ * relationship_signals view. Schedule: `0 4 * * *` (04:00 UTC daily,
+ * outside the user-facing peak; well after any UK / Europe gathering).
+ *
+ * Auth: Vercel Cron sends `Authorization: Bearer ${CRON_SECRET}`.
+ * Gate: `CONVENE_ENABLED=true` or 404.
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { isConveneEnabled } from '@/lib/convene/flags';
+import { runPostEventSweep } from '@/lib/convene/post-event';
+
+export const maxDuration = 60;
+
+export async function GET(req: NextRequest) {
+  if (!isConveneEnabled()) {
+    return NextResponse.json({ ok: false, error: 'convene_disabled' }, { status: 404 });
+  }
+  const expected = process.env.CRON_SECRET;
+  if (!expected || req.headers.get('authorization') !== `Bearer ${expected}`) {
+    return NextResponse.json({ ok: false, error: 'unauthorised' }, { status: 401 });
+  }
+
+  try {
+    const summary = await runPostEventSweep();
+    return NextResponse.json({ ok: true, summary });
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : 'unknown';
+    return NextResponse.json({ ok: false, error: msg }, { status: 500 });
+  }
+}

--- a/src/lib/convene/post-event.ts
+++ b/src/lib/convene/post-event.ts
@@ -1,0 +1,127 @@
+/**
+ * Post-event loop — KAN-212 P8.
+ *
+ * Daily-cron logic that:
+ *   1. Finds gatherings past their finalised_slot_end + 2 hour buffer that
+ *      are still in a non-terminal state (live, rescheduled,
+ *      awaiting_responses). The 2-hour buffer covers the actual event
+ *      runtime — we don't mark a gathering complete the second it
+ *      "should have ended".
+ *   2. Transitions them to 'completed' and writes a gathering_completed
+ *      event log row.
+ *   3. Auto-marks invitees still in 'accepted' status as 'attended' so
+ *      relationship_signals counts them correctly. (Hosts can override
+ *      to 'no_show' via lyra_record_rsvp.)
+ *   4. Refreshes the relationship_signals materialised view so the
+ *      attendee scorer picks up the latest engagement data on the next
+ *      lyra_propose_attendees call.
+ *
+ * Idempotent: re-running on the same set of past gatherings is a no-op
+ * because the WHERE clause filters out already-completed rows.
+ */
+
+import { createClient, type SupabaseClient } from '@supabase/supabase-js';
+import { env } from '@/lib/env';
+
+export interface PostEventSummary {
+  scanned: number;
+  completed: number;
+  invitees_marked_attended: number;
+  view_refreshed: boolean;
+  errors: string[];
+}
+
+interface Gathering {
+  id: string;
+  host_user_id: string;
+  status: string;
+  finalised_slot_end: string;
+  title: string;
+}
+
+const POST_EVENT_BUFFER_HOURS = 2;
+const BATCH_SIZE = 100;
+
+function admin(): SupabaseClient {
+  return createClient(env.supabaseUrl(), env.supabaseServiceRoleKey(), {
+    auth: { persistSession: false },
+  });
+}
+
+export async function runPostEventSweep(): Promise<PostEventSummary> {
+  const sb = admin();
+  const summary: PostEventSummary = {
+    scanned: 0,
+    completed: 0,
+    invitees_marked_attended: 0,
+    view_refreshed: false,
+    errors: [],
+  };
+
+  const cutoff = new Date(Date.now() - POST_EVENT_BUFFER_HOURS * 60 * 60 * 1000);
+
+  // 1. Find candidates.
+  // ownership-ok: scanning across all hosts is the cron's purpose (KAN-212)
+  const { data: rows, error } = await sb
+    .from('gatherings')
+    .select('id, host_user_id, status, finalised_slot_end, title')
+    .in('status', ['live', 'rescheduled', 'awaiting_responses'])
+    .not('finalised_slot_end', 'is', null)
+    .lt('finalised_slot_end', cutoff.toISOString())
+    .is('deleted_at', null)
+    .order('finalised_slot_end', { ascending: true })
+    .limit(BATCH_SIZE);
+  if (error) {
+    summary.errors.push(`scan: ${error.message}`);
+    return summary;
+  }
+  const candidates = (rows as Gathering[]) ?? [];
+  summary.scanned = candidates.length;
+
+  // 2 + 3. For each, mark completed + flip accepted → attended.
+  for (const g of candidates) {
+    try {
+      await sb
+        .from('gatherings')
+        .update({ status: 'completed', updated_at: new Date().toISOString() })
+        .eq('id', g.id);
+
+      const { count: attendedCount } = await sb
+        .from('gathering_invitees')
+        .update({
+          status: 'attended',
+          responded_at: new Date().toISOString(),
+        }, { count: 'exact' })
+        .eq('gathering_id', g.id)
+        .eq('status', 'accepted');
+      summary.invitees_marked_attended += attendedCount ?? 0;
+
+      await sb.from('gathering_events_log').insert({
+        gathering_id: g.id,
+        actor_user_id: g.host_user_id,
+        event_type: 'gathering_completed',
+        metadata: {
+          source: 'post_event_cron',
+          attendees_marked: attendedCount ?? 0,
+          finalised_slot_end: g.finalised_slot_end,
+        },
+      });
+      summary.completed += 1;
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : 'unknown';
+      summary.errors.push(`${g.id}: ${msg.slice(0, 120)}`);
+    }
+  }
+
+  // 4. Refresh the materialised view (best-effort; if it fails it's not fatal).
+  try {
+    const { error: rErr } = await sb.rpc('refresh_relationship_signals');
+    if (rErr) throw new Error(rErr.message);
+    summary.view_refreshed = true;
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : 'unknown';
+    summary.errors.push(`refresh_relationship_signals: ${msg.slice(0, 120)}`);
+  }
+
+  return summary;
+}

--- a/tests/unit/convene/post-event.test.ts
+++ b/tests/unit/convene/post-event.test.ts
@@ -1,0 +1,95 @@
+/**
+ * KAN-212 P8 — post-event loop tests.
+ *
+ * Structural-only — the actual sweep is exercised against the live dev
+ * Supabase post-deploy. We verify shape: cron route gating, lib exports,
+ * vercel.json schedule.
+ */
+
+import fs from 'fs';
+import path from 'path';
+
+const ROOT = path.join(__dirname, '..', '..', '..');
+
+describe('post-event sweep library (KAN-212 P8)', () => {
+  const src = fs.readFileSync(path.join(ROOT, 'src/lib/convene/post-event.ts'), 'utf8');
+
+  test('exports runPostEventSweep + PostEventSummary type', () => {
+    expect(src).toMatch(/export async function runPostEventSweep/);
+    expect(src).toMatch(/export interface PostEventSummary/);
+  });
+
+  test('uses a 2-hour buffer past finalised_slot_end before completing', () => {
+    expect(src).toMatch(/POST_EVENT_BUFFER_HOURS\s*=\s*2/);
+    expect(src).toMatch(/POST_EVENT_BUFFER_HOURS \* 60 \* 60 \* 1000/);
+  });
+
+  test('only sweeps non-terminal states', () => {
+    expect(src).toMatch(/\.in\(\s*['"]status['"]\s*,\s*\[\s*['"]live['"]\s*,\s*['"]rescheduled['"]\s*,\s*['"]awaiting_responses['"]/);
+  });
+
+  test('marks gatherings completed + writes gathering_completed audit', () => {
+    expect(src).toMatch(/status:\s*['"]completed['"]/);
+    expect(src).toMatch(/event_type:\s*['"]gathering_completed['"]/);
+  });
+
+  test('flips accepted invitees to attended', () => {
+    expect(src).toMatch(/status:\s*['"]attended['"]/);
+    expect(src).toMatch(/\.eq\(\s*['"]status['"]\s*,\s*['"]accepted['"]\s*\)/);
+  });
+
+  test('refreshes the relationship_signals materialised view', () => {
+    expect(src).toMatch(/refresh_relationship_signals/);
+    expect(src).toMatch(/view_refreshed/);
+  });
+
+  test('caps batch size to 100 per run', () => {
+    expect(src).toMatch(/BATCH_SIZE\s*=\s*100/);
+    expect(src).toMatch(/\.limit\(BATCH_SIZE\)/);
+  });
+
+  test('errors array collects per-row failures without crashing the sweep', () => {
+    expect(src).toMatch(/summary\.errors\.push/);
+    expect(src).toMatch(/catch \(e\)/);
+  });
+
+  test('idempotent: filters out already-completed rows via status whitelist', () => {
+    expect(src).not.toMatch(/\.eq\(\s*['"]status['"]\s*,\s*['"]completed['"]/);
+  });
+});
+
+describe('post-event cron route (KAN-212 P8)', () => {
+  const p = path.join(ROOT, 'src/app/api/convene/cron/post-event/route.ts');
+  test('route file exists', () => {
+    expect(fs.existsSync(p)).toBe(true);
+  });
+  test('gates on isConveneEnabled + CRON_SECRET bearer', () => {
+    const src = fs.readFileSync(p, 'utf8');
+    expect(src).toMatch(/isConveneEnabled\(\)/);
+    expect(src).toMatch(/`Bearer \$\{expected\}`/);
+  });
+  test('delegates to runPostEventSweep', () => {
+    const src = fs.readFileSync(p, 'utf8');
+    expect(src).toMatch(/runPostEventSweep\(\)/);
+  });
+  test('maxDuration ≥ 30s (refresh can take a while)', () => {
+    const src = fs.readFileSync(p, 'utf8');
+    const m = src.match(/maxDuration\s*=\s*(\d+)/);
+    expect(m).not.toBeNull();
+    expect(Number(m![1])).toBeGreaterThanOrEqual(30);
+  });
+});
+
+describe('vercel.json post-event schedule (KAN-212 P8)', () => {
+  const cfg = JSON.parse(fs.readFileSync(path.join(ROOT, 'vercel.json'), 'utf8'));
+  test('post-event cron registered', () => {
+    const paths = (cfg.crons ?? []).map((c: { path: string }) => c.path);
+    expect(paths).toContain('/api/convene/cron/post-event');
+  });
+  test('runs daily at 04:00 UTC (outside peak)', () => {
+    const e = (cfg.crons ?? []).find(
+      (c: { path: string }) => c.path === '/api/convene/cron/post-event'
+    );
+    expect(e?.schedule).toBe('0 4 * * *');
+  });
+});

--- a/vercel.json
+++ b/vercel.json
@@ -10,6 +10,10 @@
     {
       "path": "/api/convene/cron/send-invites",
       "schedule": "*/10 * * * *"
+    },
+    {
+      "path": "/api/convene/cron/post-event",
+      "schedule": "0 4 * * *"
     }
   ]
 }


### PR DESCRIPTION
Daily cron at 04:00 UTC marks past gatherings 'completed', flips accepted invitees to 'attended' (so relationship_signals counts are right), and refreshes the relationship_signals materialised view so the attendee scorer picks up the latest engagement signal.

Idempotent. 2-hour buffer past finalised_slot_end before completing.

Verified: 15/15 new tests; tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)