### PR TITLE
feat(KAN-213) P9: PWA service worker + offline shell + Convene shortcuts

### DIFF
--- a/public/manifest.webmanifest
+++ b/public/manifest.webmanifest
@@ -58,6 +58,20 @@
       "description": "Search published Lyra profiles",
       "url": "/search?source=pwa",
       "icons": [{ "src": "/lyra-icon-192.png", "sizes": "192x192" }]
+    },
+    {
+      "name": "My gatherings",
+      "short_name": "Gatherings",
+      "description": "Convene — gatherings you're hosting",
+      "url": "/dashboard/convene/gatherings?source=pwa",
+      "icons": [{ "src": "/lyra-icon-192.png", "sizes": "192x192" }]
+    },
+    {
+      "name": "Calendar connections",
+      "short_name": "Calendars",
+      "description": "Manage your connected calendars",
+      "url": "/dashboard/convene/connections?source=pwa",
+      "icons": [{ "src": "/lyra-icon-192.png", "sizes": "192x192" }]
     }
   ]
 }

--- a/public/offline.html
+++ b/public/offline.html
@@ -1,0 +1,60 @@
+<!DOCTYPE html>
+<html lang="en-GB">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
+    <title>Offline — Lyra</title>
+    <link rel="manifest" href="/manifest.webmanifest" />
+    <style>
+      :root {
+        color-scheme: light;
+      }
+      html, body {
+        margin: 0;
+        padding: 0;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Inter, sans-serif;
+        background: #fafaf9;
+        color: #2b2b2b;
+      }
+      main {
+        max-width: 480px;
+        margin: 64px auto;
+        padding: 0 24px;
+        text-align: center;
+      }
+      h1 {
+        font-size: 26px;
+        margin: 24px 0 12px;
+      }
+      p {
+        color: #555;
+        line-height: 1.5;
+      }
+      img {
+        width: 96px;
+        height: auto;
+      }
+      a {
+        display: inline-block;
+        margin-top: 24px;
+        background: #5F7256;
+        color: #fff;
+        padding: 10px 20px;
+        border-radius: 8px;
+        text-decoration: none;
+        font-weight: 600;
+      }
+    </style>
+  </head>
+  <body>
+    <main>
+      <img src="/lyra-icon-192.png" alt="Lyra" />
+      <h1>You're offline</h1>
+      <p>
+        Lyra needs a connection for most pages — they're personalised to you.
+      </p>
+      <p>When you're back online, the page you were trying to reach will load normally.</p>
+      <a href="/">Try again</a>
+    </main>
+  </body>
+</html>

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,0 +1,107 @@
+/**
+ * Lyra service worker — KAN-213 P9.
+ *
+ * Deliberately minimal. The goal is "installable + offline shell", not a
+ * full offline-first app. Dynamic content (authed pages, MCP-style data)
+ * stays network-first; the SW only intercepts static asset failures with
+ * a friendly offline page.
+ *
+ * Strategy:
+ *   - install: cache the offline-shell + icons + manifest.
+ *   - activate: drop old caches.
+ *   - fetch: network-first for everything; on failure, fall through to
+ *     cache; if neither, serve the offline shell for HTML navigations.
+ *
+ * Versioning: bump CACHE_VERSION whenever the offline shell or cached
+ * asset list changes. The activate step removes any cache whose name
+ * doesn't start with the current version prefix.
+ */
+
+const CACHE_VERSION = 'v1-2026-05-18';
+const STATIC_CACHE = `lyra-static-${CACHE_VERSION}`;
+
+// Things we want available offline. Keep the list short — every entry
+// here is bytes the user downloads on install.
+const STATIC_ASSETS = [
+  '/manifest.webmanifest',
+  '/lyra-icon-192.png',
+  '/lyra-icon-512.png',
+  '/lyra-logo.png',
+  '/lyra-logo-nav.png',
+  '/offline.html',
+];
+
+self.addEventListener('install', (event) => {
+  event.waitUntil(
+    caches
+      .open(STATIC_CACHE)
+      .then((cache) => cache.addAll(STATIC_ASSETS))
+      .then(() => self.skipWaiting())
+  );
+});
+
+self.addEventListener('activate', (event) => {
+  event.waitUntil(
+    caches
+      .keys()
+      .then((names) =>
+        Promise.all(
+          names
+            .filter((n) => n.startsWith('lyra-') && !n.endsWith(CACHE_VERSION))
+            .map((n) => caches.delete(n))
+        )
+      )
+      .then(() => self.clients.claim())
+  );
+});
+
+self.addEventListener('fetch', (event) => {
+  const req = event.request;
+
+  // Only handle GETs. Form posts / API calls go straight to network.
+  if (req.method !== 'GET') return;
+
+  // Don't intercept POST-y dynamic routes — they need fresh auth.
+  // Heuristic: anything under /api, /oauth, /auth, /dashboard, /r/, /login.
+  const url = new URL(req.url);
+  if (
+    url.pathname.startsWith('/api') ||
+    url.pathname.startsWith('/oauth') ||
+    url.pathname.startsWith('/auth') ||
+    url.pathname.startsWith('/dashboard') ||
+    url.pathname.startsWith('/r/') ||
+    url.pathname === '/login' ||
+    url.pathname === '/signup' ||
+    url.pathname === '/reset-password' ||
+    url.pathname === '/forgot-password'
+  ) {
+    return;
+  }
+
+  // Cross-origin requests: always network.
+  if (url.origin !== self.location.origin) return;
+
+  event.respondWith(
+    fetch(req)
+      .then((res) => {
+        // Cache successful responses for static assets only.
+        if (res.ok && (url.pathname.endsWith('.png') || url.pathname.endsWith('.webmanifest') || url.pathname.endsWith('.svg') || url.pathname.endsWith('.woff2'))) {
+          const clone = res.clone();
+          caches.open(STATIC_CACHE).then((c) => c.put(req, clone));
+        }
+        return res;
+      })
+      .catch(() =>
+        // Network failed — fall back to cache.
+        caches.match(req).then((cached) => {
+          if (cached) return cached;
+          // For HTML navigations, return the offline shell.
+          if (req.mode === 'navigate' || (req.headers.get('accept') || '').includes('text/html')) {
+            return caches.match('/offline.html');
+          }
+          // Otherwise re-throw — the failed network error.
+          throw new Error('network failure + no cache hit');
+        })
+      )
+  );
+});

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -4,6 +4,7 @@ import { Analytics } from "@vercel/analytics/react";
 import { SpeedInsights } from "@vercel/speed-insights/next";
 import { CookieConsent } from "./cookie-consent";
 import { InstallPrompt } from "./install-prompt";
+import { ServiceWorkerRegister } from "./service-worker-register";
 import "./globals.css";
 
 const dmSans = DM_Sans({
@@ -103,6 +104,7 @@ export default function RootLayout({
         {children}
         <CookieConsent />
         <InstallPrompt />
+        <ServiceWorkerRegister />
         <Analytics />
         <SpeedInsights />
       </body>

--- a/src/app/service-worker-register.tsx
+++ b/src/app/service-worker-register.tsx
@@ -1,0 +1,50 @@
+'use client';
+
+/**
+ * Service-worker registration — KAN-213 P9.
+ *
+ * Mounted once at root layout level. Registers /sw.js on first page
+ * load and lets the browser's installability heuristics take over.
+ *
+ * Why a separate component (not inline in layout): server-side render
+ * has no navigator, and putting 'use client' on layout.tsx would force
+ * the entire tree to client-render. This component is the only client
+ * boundary needed.
+ *
+ * Guards:
+ *   - Skips entirely in dev (NEXT_PUBLIC_VERCEL_ENV) so the SW doesn't
+ *     interfere with hot reload.
+ *   - Skips when serviceWorker is unavailable (older browsers, certain
+ *     embedded WebViews).
+ *   - Fire-and-forget registration: errors are logged but never thrown.
+ */
+
+import { useEffect } from 'react';
+
+export function ServiceWorkerRegister() {
+  useEffect(() => {
+    if (typeof navigator === 'undefined' || !('serviceWorker' in navigator)) {
+      return;
+    }
+    // Skip SW in local dev — Next.js's HMR is incompatible with aggressive
+    // SW caching, and dev environments should never accidentally install
+    // a long-lived SW that survives a deploy of broken code.
+    if (
+      process.env.NODE_ENV !== 'production' ||
+      process.env.NEXT_PUBLIC_VERCEL_ENV === 'development'
+    ) {
+      return;
+    }
+    const controller = navigator.serviceWorker;
+    controller
+      .register('/sw.js', { scope: '/' })
+      .then(() => {
+        // No-op on success. Logging would clutter most users' devtools.
+      })
+      .catch((err) => {
+        // Non-fatal — the app works fine without a SW.
+        console.warn('[sw] registration failed:', err);
+      });
+  }, []);
+  return null;
+}

--- a/tests/unit/pwa-service-worker.test.ts
+++ b/tests/unit/pwa-service-worker.test.ts
@@ -1,0 +1,124 @@
+/**
+ * KAN-213 P9 — PWA service worker + Convene shortcuts tests.
+ *
+ * Structural tests on sw.js, offline.html, manifest.webmanifest, and
+ * the registration component. Runtime SW behaviour (install/activate/
+ * fetch interception) is exercised manually in a real browser after
+ * deploy.
+ */
+
+import fs from 'fs';
+import path from 'path';
+
+const ROOT = path.join(__dirname, '..', '..');
+
+describe('public/sw.js (KAN-213 P9)', () => {
+  const src = fs.readFileSync(path.join(ROOT, 'public/sw.js'), 'utf8');
+
+  test('exists + has a CACHE_VERSION constant for cache busting', () => {
+    expect(src).toMatch(/CACHE_VERSION/);
+  });
+
+  test('registers install + activate + fetch handlers', () => {
+    expect(src).toMatch(/addEventListener\(\s*['"]install['"]/);
+    expect(src).toMatch(/addEventListener\(\s*['"]activate['"]/);
+    expect(src).toMatch(/addEventListener\(\s*['"]fetch['"]/);
+  });
+
+  test('install calls skipWaiting so updates roll out immediately', () => {
+    expect(src).toMatch(/skipWaiting/);
+  });
+
+  test('activate prunes old caches matching the lyra- prefix', () => {
+    expect(src).toMatch(/caches\s*\.keys\(\)/);
+    expect(src).toMatch(/n\.startsWith\(['"]lyra-['"]\)/);
+    expect(src).toMatch(/caches\.delete/);
+  });
+
+  test('fetch handler skips auth-sensitive paths (api/oauth/auth/dashboard/r/login)', () => {
+    expect(src).toMatch(/url\.pathname\.startsWith\(['"]\/api['"]\)/);
+    expect(src).toMatch(/url\.pathname\.startsWith\(['"]\/oauth['"]\)/);
+    expect(src).toMatch(/url\.pathname\.startsWith\(['"]\/auth['"]\)/);
+    expect(src).toMatch(/url\.pathname\.startsWith\(['"]\/dashboard['"]\)/);
+    expect(src).toMatch(/url\.pathname\.startsWith\(['"]\/r\/['"]\)/);
+    expect(src).toMatch(/url\.pathname === ['"]\/login['"]/);
+  });
+
+  test('only handles GET — POSTs / API calls go straight to network', () => {
+    expect(src).toMatch(/req\.method !== ['"]GET['"]/);
+  });
+
+  test('cross-origin requests bypass the SW', () => {
+    expect(src).toMatch(/url\.origin !== self\.location\.origin/);
+  });
+
+  test('serves /offline.html on network-fail HTML navigations', () => {
+    expect(src).toMatch(/\/offline\.html/);
+    expect(src).toMatch(/req\.mode === ['"]navigate['"]/);
+  });
+
+  test('only caches static assets (png/svg/webmanifest/woff2) on the fly', () => {
+    expect(src).toMatch(/\.png/);
+    expect(src).toMatch(/\.svg/);
+    expect(src).toMatch(/\.webmanifest/);
+    expect(src).toMatch(/\.woff2/);
+  });
+});
+
+describe('public/offline.html (KAN-213 P9)', () => {
+  const src = fs.readFileSync(path.join(ROOT, 'public/offline.html'), 'utf8');
+  test('exists', () => {
+    expect(src).toBeTruthy();
+  });
+  test('declares lang + viewport for iOS Safari', () => {
+    expect(src).toMatch(/lang="en-GB"/);
+    expect(src).toMatch(/viewport-fit=cover/);
+  });
+  test('links the manifest so it can still be installed offline', () => {
+    expect(src).toMatch(/rel="manifest" href="\/manifest\.webmanifest"/);
+  });
+  test('uses inline styles only (no network needed)', () => {
+    expect(src).not.toMatch(/<link rel="stylesheet"/);
+  });
+});
+
+describe('manifest.webmanifest Convene shortcuts (KAN-213 P9)', () => {
+  const m = JSON.parse(fs.readFileSync(path.join(ROOT, 'public/manifest.webmanifest'), 'utf8'));
+  test('has the Convene gatherings shortcut', () => {
+    const urls = m.shortcuts.map((s: { url: string }) => s.url);
+    expect(urls).toContain('/dashboard/convene/gatherings?source=pwa');
+  });
+  test('has the Convene connections shortcut', () => {
+    const urls = m.shortcuts.map((s: { url: string }) => s.url);
+    expect(urls).toContain('/dashboard/convene/connections?source=pwa');
+  });
+  test('original profile + search shortcuts preserved', () => {
+    const urls = m.shortcuts.map((s: { url: string }) => s.url);
+    expect(urls).toContain('/dashboard/profile?source=pwa');
+    expect(urls).toContain('/search?source=pwa');
+  });
+});
+
+describe('service-worker-register component (KAN-213 P9)', () => {
+  const src = fs.readFileSync(path.join(ROOT, 'src/app/service-worker-register.tsx'), 'utf8');
+  test("declares 'use client'", () => {
+    expect(src).toMatch(/^['"]use client['"]/);
+  });
+  test('skips when serviceWorker unsupported', () => {
+    expect(src).toMatch(/['"]serviceWorker['"] in navigator/);
+  });
+  test('skips in dev (NODE_ENV !== production)', () => {
+    expect(src).toMatch(/NODE_ENV !== ['"]production['"]/);
+  });
+  test("registers /sw.js with scope '/'", () => {
+    expect(src).toMatch(/register\(['"]\/sw\.js['"],\s*\{\s*scope:\s*['"]\/['"]/);
+  });
+});
+
+describe('layout wires the registration component (KAN-213 P9)', () => {
+  const src = fs.readFileSync(path.join(ROOT, 'src/app/layout.tsx'), 'utf8');
+  test('imports + renders ServiceWorkerRegister', () => {
+    expect(src).toMatch(/import\s*\{\s*ServiceWorkerRegister\s*\}\s*from\s*['"]\.\/service-worker-register['"]/);
+    expect(src).toMatch(/<ServiceWorkerRegister\s*\/>/);
+  });
+});


### PR DESCRIPTION
Adds the missing service worker to make the manifest+install-prompt scaffolding (KAN-69a) into a real installable PWA. Plus two Convene shortcuts in the manifest.

- `public/sw.js` — network-first; bypasses /api, /oauth, /auth, /dashboard, /r/, /login. Caches static assets opportunistically. Serves /offline.html on network failure.
- `public/offline.html` — inline-CSS friendly fallback.
- Convene shortcuts: My gatherings + Calendar connections.
- `ServiceWorkerRegister` component skipped in dev to avoid HMR conflict.

Verified: 21/21 new tests; tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)