### PR TITLE
feat(KAN-214) P10: WhatsApp + SMS via Twilio in the send-worker

### DIFF
--- a/src/lib/convene/invites/dispatch.ts
+++ b/src/lib/convene/invites/dispatch.ts
@@ -16,12 +16,14 @@
 import { createClient, type SupabaseClient } from '@supabase/supabase-js';
 import { env } from '@/lib/env';
 import { sendInviteEmail, type SendResult } from './email';
+import { sendTwilioMessage, type SendResult as TwilioSendResult } from './twilio';
 import { buildICS } from './ics';
 import {
   renderInviteSubject,
   renderInvitePlainText,
   renderInviteHtml,
 } from './templates';
+import { renderSmsBody } from './sms-templates';
 
 const SITE_URL = process.env.LYRA_SITE_URL ?? 'https://checklyra.com';
 const DEFAULT_BATCH_SIZE = 25;
@@ -45,7 +47,8 @@ interface QueuedRow {
 }
 
 interface JoinedContext {
-  recipientEmail: string;
+  recipientEmail: string | null;
+  recipientPhone: string | null; // E.164, KAN-214 P10
   recipientName: string;
   rsvpToken: string;
   rsvpExpires: string | null;
@@ -89,15 +92,22 @@ async function loadContext(
   if (!inv.contact) return { ok: false, reason: 'contact link missing' };
   if (!inv.rsvp_token) return { ok: false, reason: 'rsvp_token missing — re-queue from MCP' };
 
-  // 2. Primary email for the contact.
+  // 2. Contact methods — pull email + phone in one query, pick primary of each.
   const { data: methods } = await sb
     .from('contact_methods')
-    .select('value, is_primary')
+    .select('value, kind, is_primary')
     .eq('contact_id', inv.contact.id)
-    .eq('kind', 'email');
-  const allEmails = (methods ?? []) as Array<{ value: string; is_primary: boolean }>;
-  const primary = allEmails.find((m) => m.is_primary) ?? allEmails[0];
-  if (!primary) return { ok: false, reason: 'no email on contact' };
+    .in('kind', ['email', 'phone', 'whatsapp', 'imessage']);
+  const all = (methods ?? []) as Array<{ value: string; kind: string; is_primary: boolean }>;
+  const emails = all.filter((m) => m.kind === 'email');
+  const phones = all.filter(
+    (m) => m.kind === 'phone' || m.kind === 'whatsapp' || m.kind === 'imessage'
+  );
+  const primaryEmail = (emails.find((m) => m.is_primary) ?? emails[0])?.value ?? null;
+  const primaryPhone = (phones.find((m) => m.is_primary) ?? phones[0])?.value ?? null;
+  if (!primaryEmail && !primaryPhone) {
+    return { ok: false, reason: 'no contact methods (email or phone) on contact' };
+  }
 
   // 3. Gathering + venue + host.
   const { data: g, error: gErr } = await sb
@@ -139,7 +149,8 @@ async function loadContext(
   return {
     ok: true,
     ctx: {
-      recipientEmail: primary.value,
+      recipientEmail: primaryEmail,
+      recipientPhone: primaryPhone,
       recipientName: inv.contact.display_name,
       rsvpToken: inv.rsvp_token,
       rsvpExpires: inv.rsvp_token_expires_at,
@@ -171,6 +182,7 @@ export function buildSendInputs(ctx: JoinedContext) {
   const subject = renderInviteSubject(tpl);
   const plainText = renderInvitePlainText(tpl);
   const html = renderInviteHtml(tpl);
+  const recipientEmail = ctx.recipientEmail ?? '';
   const ics = buildICS({
     uid: `gathering-${ctx.gatheringId}@checklyra.com`,
     title: ctx.gatheringTitle,
@@ -179,17 +191,30 @@ export function buildSendInputs(ctx: JoinedContext) {
     location: ctx.venueLabel ?? undefined,
     organizerEmail: ctx.hostEmail,
     organizerName: ctx.hostDisplayName,
-    attendeeEmail: ctx.recipientEmail,
+    attendeeEmail: recipientEmail,
     attendeeName: ctx.recipientName,
   });
   return {
-    to: ctx.recipientEmail,
+    to: recipientEmail,
     fromName: `${ctx.hostDisplayName} via Lyra Convene`,
     subject,
     html,
     plainText,
     icsContent: ics,
   };
+}
+
+/**
+ * Render a one-line SMS / WhatsApp body for a queued invite — KAN-214 P10.
+ */
+export function buildSmsBody(ctx: JoinedContext): string {
+  return renderSmsBody({
+    hostName: ctx.hostDisplayName,
+    recipientName: ctx.recipientName,
+    gatheringTitle: ctx.gatheringTitle,
+    startISO: ctx.startISO,
+    rsvpUrl: `${SITE_URL}/r/${ctx.rsvpToken}`,
+  });
 }
 
 async function processOne(
@@ -219,10 +244,47 @@ async function processOne(
     return;
   }
 
-  const send = buildSendInputs(loaded.ctx);
-  let result: SendResult;
+  const ctx = loaded.ctx;
+  let result: SendResult | TwilioSendResult;
   try {
-    result = await sendInviteEmail(send);
+    if (row.channel === 'sms' || row.channel === 'whatsapp') {
+      if (!ctx.recipientPhone) {
+        await sb
+          .from('gathering_invite_messages')
+          .update({ delivery_status: 'failed', bounce_reason: 'no phone on contact' })
+          .eq('id', row.id);
+        summary.failed++;
+        summary.errors.push(`${row.id}: no phone on contact`);
+        return;
+      }
+      result = await sendTwilioMessage({
+        to: ctx.recipientPhone,
+        channel: row.channel,
+        body: buildSmsBody(ctx),
+      });
+    } else if (row.channel === 'email') {
+      if (!ctx.recipientEmail) {
+        await sb
+          .from('gathering_invite_messages')
+          .update({ delivery_status: 'failed', bounce_reason: 'no email on contact' })
+          .eq('id', row.id);
+        summary.failed++;
+        summary.errors.push(`${row.id}: no email on contact`);
+        return;
+      }
+      result = await sendInviteEmail(buildSendInputs(ctx));
+    } else {
+      await sb
+        .from('gathering_invite_messages')
+        .update({
+          delivery_status: 'failed',
+          bounce_reason: `unsupported channel: ${row.channel}`,
+        })
+        .eq('id', row.id);
+      summary.failed++;
+      summary.errors.push(`${row.id}: unsupported channel ${row.channel}`);
+      return;
+    }
   } catch (e) {
     const msg = e instanceof Error ? e.message : 'unknown';
     summary.failed++;
@@ -310,7 +372,7 @@ export async function dispatchQueuedInvites(
       .from('gathering_invite_messages')
       .select('id, gathering_id, invitee_id, channel, template_name')
       .eq('delivery_status', 'queued')
-      .eq('channel', 'email')
+      .in('channel', ['email', 'sms', 'whatsapp'])
       .in('gathering_id', gatheringIds)
       .order('created_at', { ascending: true })
       .limit(batchSize);
@@ -321,7 +383,7 @@ export async function dispatchQueuedInvites(
       .from('gathering_invite_messages')
       .select('id, gathering_id, invitee_id, channel, template_name')
       .eq('delivery_status', 'queued')
-      .eq('channel', 'email')
+      .in('channel', ['email', 'sms', 'whatsapp'])
       .order('created_at', { ascending: true })
       .limit(batchSize);
     if (error) throw new Error(`queue scan failed: ${error.message}`);

--- a/src/lib/convene/invites/sms-templates.ts
+++ b/src/lib/convene/invites/sms-templates.ts
@@ -1,0 +1,46 @@
+/**
+ * SMS / WhatsApp invite body templates — KAN-214 P10.
+ *
+ * SMS has a hard 160-char limit per segment; WhatsApp doesn't but the
+ * etiquette is short messages. We aim for a single SMS segment in the
+ * common case. Long titles get truncated.
+ *
+ * Format (≤160 chars typical):
+ *   Hi <name>, <host> would like to gather: <title> on <date>. RSVP: <url>
+ *
+ * No personalisation beyond the strict minimum — every char counts.
+ */
+
+export interface SmsTemplateInput {
+  hostName: string;
+  recipientName?: string;
+  gatheringTitle: string;
+  startISO: string;
+  rsvpUrl: string;
+}
+
+function fmtShortDate(iso: string): string {
+  // E.g. "Mon 1 Jun"
+  return new Date(iso).toLocaleString('en-GB', {
+    weekday: 'short',
+    day: 'numeric',
+    month: 'short',
+  });
+}
+
+function firstNameOf(full: string): string {
+  return full.split(' ')[0] ?? full;
+}
+
+const MAX_SMS_TITLE_LEN = 50;
+
+export function renderSmsBody(input: SmsTemplateInput): string {
+  const hostFirst = firstNameOf(input.hostName);
+  const greeting = input.recipientName ? `Hi ${firstNameOf(input.recipientName)}, ` : '';
+  const safeTitle =
+    input.gatheringTitle.length > MAX_SMS_TITLE_LEN
+      ? input.gatheringTitle.slice(0, MAX_SMS_TITLE_LEN - 1) + '…'
+      : input.gatheringTitle;
+  const when = fmtShortDate(input.startISO);
+  return `${greeting}${hostFirst} would like to gather: ${safeTitle} on ${when}. RSVP: ${input.rsvpUrl}`;
+}

--- a/src/lib/convene/invites/twilio.ts
+++ b/src/lib/convene/invites/twilio.ts
@@ -1,0 +1,106 @@
+/**
+ * Twilio sender for Convene invites — KAN-214 P10.
+ *
+ * Sends SMS and WhatsApp messages via Twilio's REST API. Mirrors the
+ * email.ts shape: allowlist gate at the front, fire-and-forget POST,
+ * structured SendResult for the dispatcher to interpret.
+ *
+ * Allowlist gate: CONVENE_INVITE_SMS_ALLOWLIST is a comma-separated
+ * list of phone numbers in E.164 (`+44…`) format, or `*` for wildcard.
+ * Unset/empty → all sends blocked (safety default — same posture as
+ * the email allowlist).
+ *
+ * No npm dependency on the Twilio Node SDK — we hit the REST API with
+ * fetch directly. Twilio's responses are JSON; auth is HTTP Basic with
+ * the Account SID as the user and Auth Token as the password.
+ */
+
+interface SendInput {
+  to: string; // E.164, e.g. +447123456789
+  channel: 'sms' | 'whatsapp';
+  body: string;
+}
+
+export type SendResult =
+  | { ok: true; messageId: string }
+  | {
+      ok: false;
+      code:
+        | 'no_credentials'
+        | 'no_from_number'
+        | 'not_in_allowlist'
+        | 'send_failed';
+      detail?: string;
+    };
+
+function isAllowed(phone: string): boolean {
+  const allowlist = (process.env.CONVENE_INVITE_SMS_ALLOWLIST ?? '').trim();
+  if (allowlist === '*') return true;
+  if (allowlist === '') return false;
+  const target = phone.trim().toLowerCase();
+  return allowlist
+    .split(',')
+    .map((s) => s.trim().toLowerCase())
+    .includes(target);
+}
+
+export async function sendTwilioMessage(input: SendInput): Promise<SendResult> {
+  if (!isAllowed(input.to)) {
+    return { ok: false, code: 'not_in_allowlist' };
+  }
+
+  const sid = process.env.TWILIO_ACCOUNT_SID;
+  const token = process.env.TWILIO_AUTH_TOKEN;
+  if (!sid || !token) {
+    return { ok: false, code: 'no_credentials', detail: 'TWILIO_ACCOUNT_SID/AUTH_TOKEN not set' };
+  }
+
+  const from =
+    input.channel === 'whatsapp'
+      ? process.env.TWILIO_WHATSAPP_FROM
+      : process.env.TWILIO_SMS_FROM;
+  if (!from) {
+    return {
+      ok: false,
+      code: 'no_from_number',
+      detail: `TWILIO_${input.channel === 'whatsapp' ? 'WHATSAPP' : 'SMS'}_FROM not set`,
+    };
+  }
+
+  const fromQualified = input.channel === 'whatsapp' ? `whatsapp:${from}` : from;
+  const toQualified = input.channel === 'whatsapp' ? `whatsapp:${input.to}` : input.to;
+
+  const body = new URLSearchParams({
+    From: fromQualified,
+    To: toQualified,
+    Body: input.body,
+  });
+
+  const authHeader = `Basic ${Buffer.from(`${sid}:${token}`).toString('base64')}`;
+  const res = await fetch(
+    `https://api.twilio.com/2010-04-01/Accounts/${encodeURIComponent(sid)}/Messages.json`,
+    {
+      method: 'POST',
+      headers: {
+        authorization: authHeader,
+        'content-type': 'application/x-www-form-urlencoded',
+      },
+      body: body.toString(),
+      signal: AbortSignal.timeout(10_000),
+    }
+  );
+
+  if (!res.ok) {
+    const text = await res.text().catch(() => '');
+    return {
+      ok: false,
+      code: 'send_failed',
+      detail: `${res.status}: ${text.slice(0, 300)}`,
+    };
+  }
+
+  const json = (await res.json()) as { sid?: string; error_message?: string };
+  return { ok: true, messageId: json.sid ?? 'unknown' };
+}
+
+export const _internal = { isAllowed };

--- a/tests/unit/convene/dispatch.test.ts
+++ b/tests/unit/convene/dispatch.test.ts
@@ -20,6 +20,7 @@ const { buildSendInputs } = _internal;
 describe('buildSendInputs (KAN-209)', () => {
   const ctx = {
     recipientEmail: 'ben@example.com',
+    recipientPhone: null as string | null,
     recipientName: 'Ben Stephens',
     rsvpToken: 'tok_abc123',
     rsvpExpires: '2026-07-01T00:00:00Z',
@@ -28,7 +29,7 @@ describe('buildSendInputs (KAN-209)', () => {
     gatheringType: 'coffee',
     startISO: '2026-06-01T10:00:00Z',
     endISO: '2026-06-01T11:00:00Z',
-    venueLabel: 'Caravan — London',
+    venueLabel: 'Caravan — London' as string | null,
     hostUserId: '22222222-2222-2222-2222-222222222222',
     hostEmail: 'luisa@example.com',
     hostDisplayName: 'Luisa',

--- a/tests/unit/convene/twilio-send.test.ts
+++ b/tests/unit/convene/twilio-send.test.ts
@@ -1,0 +1,151 @@
+/**
+ * KAN-214 P10 — Twilio sender + SMS templates + channel routing tests.
+ */
+
+import { renderSmsBody } from '@/lib/convene/invites/sms-templates';
+import { _internal as twilioInternal } from '@/lib/convene/invites/twilio';
+import fs from 'fs';
+import path from 'path';
+
+const ROOT = path.join(__dirname, '..', '..', '..');
+
+describe('renderSmsBody (KAN-214)', () => {
+  const base = {
+    hostName: 'Luisa Santos-Stephens',
+    recipientName: 'Ben',
+    gatheringTitle: 'Coffee at Caravan',
+    startISO: '2026-06-01T10:00:00Z',
+    rsvpUrl: 'https://checklyra.com/r/abc123',
+  };
+
+  test('starts with greeting and host first name', () => {
+    const body = renderSmsBody(base);
+    expect(body).toContain('Hi Ben,');
+    expect(body).toContain('Luisa would like to gather');
+  });
+
+  test('includes the title + short date + rsvp URL', () => {
+    const body = renderSmsBody(base);
+    expect(body).toContain('Coffee at Caravan');
+    expect(body).toContain('https://checklyra.com/r/abc123');
+  });
+
+  test('truncates over-long titles to ~50 chars', () => {
+    const longTitle = 'A truly extraordinary gathering of close friends and acquaintances in honour of a great occasion';
+    const body = renderSmsBody({ ...base, gatheringTitle: longTitle });
+    expect(body).toMatch(/…/);
+  });
+
+  test('omits greeting when no recipient name given', () => {
+    const body = renderSmsBody({ ...base, recipientName: undefined });
+    expect(body).not.toContain('Hi ,');
+    expect(body.startsWith('Luisa would like to gather')).toBe(true);
+  });
+});
+
+describe('Twilio allowlist gate (KAN-214)', () => {
+  const orig = process.env.CONVENE_INVITE_SMS_ALLOWLIST;
+  afterEach(() => {
+    if (orig === undefined) delete process.env.CONVENE_INVITE_SMS_ALLOWLIST;
+    else process.env.CONVENE_INVITE_SMS_ALLOWLIST = orig;
+  });
+
+  test('blocks all when allowlist unset', () => {
+    delete process.env.CONVENE_INVITE_SMS_ALLOWLIST;
+    expect(twilioInternal.isAllowed('+447777000111')).toBe(false);
+  });
+
+  test('blocks all when allowlist empty', () => {
+    process.env.CONVENE_INVITE_SMS_ALLOWLIST = '';
+    expect(twilioInternal.isAllowed('+447777000111')).toBe(false);
+  });
+
+  test('wildcard * allows all', () => {
+    process.env.CONVENE_INVITE_SMS_ALLOWLIST = '*';
+    expect(twilioInternal.isAllowed('+447777000111')).toBe(true);
+  });
+
+  test('exact match allows', () => {
+    process.env.CONVENE_INVITE_SMS_ALLOWLIST = '+447777000111, +447777000222';
+    expect(twilioInternal.isAllowed('+447777000111')).toBe(true);
+    expect(twilioInternal.isAllowed('+447777000222')).toBe(true);
+  });
+
+  test('non-listed blocked', () => {
+    process.env.CONVENE_INVITE_SMS_ALLOWLIST = '+447777000111';
+    expect(twilioInternal.isAllowed('+447777999999')).toBe(false);
+  });
+});
+
+describe('Twilio source structure (KAN-214)', () => {
+  const src = fs.readFileSync(path.join(ROOT, 'src/lib/convene/invites/twilio.ts'), 'utf8');
+
+  test('uses HTTP Basic auth with TWILIO_ACCOUNT_SID + TWILIO_AUTH_TOKEN', () => {
+    expect(src).toMatch(/TWILIO_ACCOUNT_SID/);
+    expect(src).toMatch(/TWILIO_AUTH_TOKEN/);
+    expect(src).toMatch(/`Basic \$\{Buffer\.from\(`\$\{sid\}:\$\{token\}`\)\.toString\(['"]base64['"]\)\}`/);
+  });
+
+  test('reads TWILIO_SMS_FROM for SMS, TWILIO_WHATSAPP_FROM for WhatsApp', () => {
+    expect(src).toMatch(/TWILIO_SMS_FROM/);
+    expect(src).toMatch(/TWILIO_WHATSAPP_FROM/);
+  });
+
+  test("prefixes whatsapp From/To with 'whatsapp:'", () => {
+    // The qualified prefix appears in both the From and To template literals.
+    expect(src).toMatch(/`whatsapp:\$\{from\}`/);
+    expect(src).toMatch(/`whatsapp:\$\{input\.to\}`/);
+  });
+
+  test('uses the Twilio /2010-04-01 Messages endpoint', () => {
+    expect(src).toMatch(/api\.twilio\.com\/2010-04-01\/Accounts/);
+    expect(src).toMatch(/Messages\.json/);
+  });
+
+  test('returns typed SendResult with not_in_allowlist / no_credentials / no_from_number / send_failed', () => {
+    expect(src).toMatch(/not_in_allowlist/);
+    expect(src).toMatch(/no_credentials/);
+    expect(src).toMatch(/no_from_number/);
+    expect(src).toMatch(/send_failed/);
+  });
+
+  test('carries an AbortSignal.timeout on the fetch', () => {
+    expect(src).toMatch(/AbortSignal\.timeout/);
+  });
+});
+
+describe('dispatch.ts channel routing (KAN-214)', () => {
+  const src = fs.readFileSync(path.join(ROOT, 'src/lib/convene/invites/dispatch.ts'), 'utf8');
+
+  test('imports twilio + sms-templates', () => {
+    expect(src).toMatch(/from\s+['"]\.\/twilio['"]/);
+    expect(src).toMatch(/from\s+['"]\.\/sms-templates['"]/);
+  });
+
+  test('queue scan now accepts email, sms, and whatsapp', () => {
+    expect(src).toMatch(/\.in\(\s*['"]channel['"]\s*,\s*\[\s*['"]email['"]\s*,\s*['"]sms['"]\s*,\s*['"]whatsapp['"]/);
+    expect(src).not.toMatch(/\.eq\(\s*['"]channel['"]\s*,\s*['"]email['"]/);
+  });
+
+  test('processOne branches on row.channel', () => {
+    expect(src).toMatch(/row\.channel === ['"]sms['"]\s*\|\|\s*row\.channel === ['"]whatsapp['"]/);
+    expect(src).toMatch(/row\.channel === ['"]email['"]/);
+  });
+
+  test('sms/whatsapp path calls sendTwilioMessage with buildSmsBody', () => {
+    expect(src).toMatch(/sendTwilioMessage\(\{[\s\S]*?to: ctx\.recipientPhone/);
+    expect(src).toMatch(/body: buildSmsBody\(ctx\)/);
+  });
+
+  test('email path still calls sendInviteEmail with buildSendInputs', () => {
+    expect(src).toMatch(/sendInviteEmail\(buildSendInputs\(ctx\)\)/);
+  });
+
+  test('unknown channel marked failed', () => {
+    expect(src).toMatch(/unsupported channel/);
+  });
+
+  test('loadContext pulls both email + phone in one query', () => {
+    expect(src).toMatch(/\.in\(\s*['"]kind['"]\s*,\s*\[\s*['"]email['"]\s*,\s*['"]phone['"]\s*,\s*['"]whatsapp['"]\s*,\s*['"]imessage['"]/);
+  });
+});


### PR DESCRIPTION
Final Convene phase — channel diversification beyond email. Dispatcher now routes:

- `email` → Resend (P5 part 2)
- `sms` / `whatsapp` → Twilio (this PR)

Adds `twilio.ts` (Basic auth, channel-aware From numbers, AbortSignal.timeout), `sms-templates.ts` (one-segment-friendly body with title truncation), and channel routing in `dispatch.ts`. Queue filter widened, contact-methods query now pulls phone in the same hop.

Env vars to wire when going live: `TWILIO_ACCOUNT_SID/AUTH_TOKEN`, `TWILIO_SMS_FROM/WHATSAPP_FROM` (E.164), `CONVENE_INVITE_SMS_ALLOWLIST`.

MCP-side channel-enum widening is a small follow-up in lyra-mcp-server.

Verified: 35/35 tests pass; tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)