### PR TITLE
fix(KAN-88): prominent account banner on consent screen + switch-account button

### DIFF
--- a/src/app/oauth/authorize/actions.ts
+++ b/src/app/oauth/authorize/actions.ts
@@ -22,6 +22,27 @@ import { getOauthClient } from '@/lib/oauth/clients';
 import { buildSuccessRedirect, buildErrorRedirect } from '@/lib/oauth/authorize';
 import type { DecideInput } from './types';
 
+/**
+ * Switch the signed-in account for a pending OAuth consent — KAN-88
+ * follow-up (2026-05-18 ben/luisa account mix-up).
+ *
+ * Sign out the current Supabase session and bounce the user to /login
+ * with the full /oauth/authorize URL preserved in ?next=… so they
+ * return to the same authorize prompt once signed in as the right
+ * account.
+ */
+export async function switchAccountAndContinue(authorizePathWithQuery: string): Promise<void> {
+  const sb = await createSupabaseServer();
+  await sb.auth.signOut();
+  // The caller passes the exact authorize path + query that they're
+  // currently on. We only use it as the post-login `next` target.
+  // Guard against open-redirect: only accept a relative path that starts
+  // with /oauth/authorize? — anything else falls back to /login.
+  const safeNext =
+    authorizePathWithQuery.startsWith('/oauth/authorize?') ? authorizePathWithQuery : '/login';
+  redirect(`/login?next=${encodeURIComponent(safeNext)}`);
+}
+
 export async function submitConsent(input: DecideInput): Promise<void> {
   // Re-validate the client + redirect URI on the action side. A
   // malicious caller might POST directly to the action with crafted

--- a/src/app/oauth/authorize/page.tsx
+++ b/src/app/oauth/authorize/page.tsx
@@ -13,7 +13,7 @@ import { redirect } from 'next/navigation';
 import { createClient as createSupabaseServer } from '@/lib/supabase-server';
 import { validateAuthorizeRequest, buildErrorRedirect } from '@/lib/oauth/authorize';
 import { getConsent } from '@/lib/oauth/consents';
-import { submitConsent } from './actions';
+import { submitConsent, switchAccountAndContinue } from './actions';
 import type { Metadata } from 'next';
 
 export const metadata: Metadata = {
@@ -102,6 +102,18 @@ export default async function AuthorizePage({ searchParams }: PageProps) {
                      // to the consent screen UI in a follow-up so users
                      // can see "previously granted on …".
 
+  // Build the exact authorize URL we're currently rendering, so that the
+  // "switch account" link can preserve the OAuth state through a re-login.
+  const currentAuthorizeUrl = new URL('/oauth/authorize', 'https://placeholder');
+  currentAuthorizeUrl.searchParams.set('client_id', req.client.client_id);
+  currentAuthorizeUrl.searchParams.set('redirect_uri', req.redirectUri);
+  currentAuthorizeUrl.searchParams.set('response_type', 'code');
+  currentAuthorizeUrl.searchParams.set('scope', req.scope);
+  if (req.state) currentAuthorizeUrl.searchParams.set('state', req.state);
+  currentAuthorizeUrl.searchParams.set('code_challenge', req.codeChallenge);
+  currentAuthorizeUrl.searchParams.set('code_challenge_method', req.codeChallengeMethod);
+  const authorizePathWithQuery = currentAuthorizeUrl.pathname + currentAuthorizeUrl.search;
+
   // Show the consent screen.
   return (
     <main style={{ maxWidth: 560, margin: '64px auto', padding: '0 24px', fontFamily: 'system-ui' }}>
@@ -109,6 +121,55 @@ export default async function AuthorizePage({ searchParams }: PageProps) {
       <p style={{ color: '#555' }}>
         <strong>{req.client.client_name}</strong> wants access to your Lyra account.
       </p>
+
+      {/*
+        Prominent account banner (KAN-88 follow-up, 2026-05-18). Earlier
+        we displayed "Signed in as …" in dim grey at #777, which a real
+        user missed and ended up granting Claude access to the wrong
+        account. Now: a yellow-background banner with bold email + an
+        in-line server-action button that signs out + bounces back to the
+        login screen, preserving this authorize URL through the round-trip.
+      */}
+      <div
+        style={{
+          background: '#fef9e7',
+          border: '1px solid #f0d97d',
+          padding: 16,
+          borderRadius: 8,
+          margin: '24px 0',
+        }}
+      >
+        <p style={{ margin: 0 }}>
+          You will be granting access as{' '}
+          <strong style={{ fontSize: 16 }}>{user!.email}</strong>.
+        </p>
+        <p style={{ margin: '8px 0 0', fontSize: 13, color: '#666' }}>
+          If this isn&apos;t the right account, switch before clicking Allow.
+        </p>
+        <form
+          action={async () => {
+            'use server';
+            await switchAccountAndContinue(authorizePathWithQuery);
+          }}
+          style={{ marginTop: 12 }}
+        >
+          <button
+            type="submit"
+            style={{
+              background: 'transparent',
+              border: '1px solid #c79b1b',
+              color: '#5a4310',
+              padding: '6px 14px',
+              borderRadius: 6,
+              cursor: 'pointer',
+              fontSize: 13,
+              fontWeight: 500,
+            }}
+          >
+            Switch account
+          </button>
+        </form>
+      </div>
 
       <div style={{ background: '#f5f4ef', padding: 16, borderRadius: 8, margin: '24px 0' }}>
         <p style={{ margin: 0, fontWeight: 600 }}>This will let it:</p>
@@ -120,8 +181,7 @@ export default async function AuthorizePage({ searchParams }: PageProps) {
       </div>
 
       <p style={{ fontSize: 14, color: '#777' }}>
-        Signed in as <strong>{user!.email}</strong>. You can revoke this access anytime from your
-        Lyra settings.
+        You can revoke this access anytime from your Lyra settings.
       </p>
 
       <form

--- a/tests/unit/oauth/consent-account-banner.test.ts
+++ b/tests/unit/oauth/consent-account-banner.test.ts
@@ -1,0 +1,71 @@
+/**
+ * KAN-88 consent-screen safety net — tests that the prominent
+ * account banner + switch-account flow are wired correctly.
+ *
+ * Background (2026-05-18): a user with multiple Supabase accounts
+ * granted Claude access from the wrong one because the original
+ * "Signed in as …" text was dim grey and easy to miss. claude.ai
+ * then queried that wrong account's Convene data. Fix: yellow
+ * banner with bold email + a Switch account button that
+ * preserves the OAuth state through a re-login.
+ */
+import fs from 'fs';
+import path from 'path';
+
+const ROOT = path.join(__dirname, '..', '..', '..');
+
+describe('Account banner on /oauth/authorize page (KAN-88)', () => {
+  const src = fs.readFileSync(path.join(ROOT, 'src/app/oauth/authorize/page.tsx'), 'utf8');
+
+  test("the prominent 'granting access as <email>' line exists", () => {
+    expect(src).toMatch(/You will be granting access as/);
+  });
+
+  test('email is displayed in bold inside the banner', () => {
+    expect(src).toMatch(/<strong[^>]*>\{user!?\.email\}<\/strong>/);
+  });
+
+  test('banner has a high-contrast yellow background (not dim grey)', () => {
+    expect(src).toMatch(/background:\s*['"]#fef9e7['"]/);
+    expect(src).toMatch(/border:\s*['"]1px solid #f0d97d['"]/);
+  });
+
+  test('Switch account button is rendered inline', () => {
+    expect(src).toMatch(/Switch account/);
+  });
+
+  test('Switch account button is wired to switchAccountAndContinue', () => {
+    expect(src).toMatch(/switchAccountAndContinue\(authorizePathWithQuery\)/);
+  });
+
+  test('current authorize URL is rebuilt with all params for the preserved next', () => {
+    expect(src).toMatch(/currentAuthorizeUrl\.searchParams\.set\(['"]client_id['"]/);
+    expect(src).toMatch(/currentAuthorizeUrl\.searchParams\.set\(['"]redirect_uri['"]/);
+    expect(src).toMatch(/currentAuthorizeUrl\.searchParams\.set\(['"]code_challenge['"]/);
+    expect(src).toMatch(/currentAuthorizeUrl\.searchParams\.set\(['"]code_challenge_method['"]/);
+  });
+
+  test('imports switchAccountAndContinue from ./actions', () => {
+    expect(src).toMatch(/import\s+\{[^}]*switchAccountAndContinue[^}]*\}\s+from\s+['"]\.\/actions['"]/);
+  });
+});
+
+describe('switchAccountAndContinue server action (KAN-88)', () => {
+  const src = fs.readFileSync(path.join(ROOT, 'src/app/oauth/authorize/actions.ts'), 'utf8');
+
+  test('is an exported async function (use-server safe)', () => {
+    expect(src).toMatch(/export async function switchAccountAndContinue/);
+  });
+
+  test('signs out the Supabase session', () => {
+    expect(src).toMatch(/sb\.auth\.signOut\(\)/);
+  });
+
+  test('redirects to /login with the authorize URL as ?next=…', () => {
+    expect(src).toMatch(/`\/login\?next=\$\{encodeURIComponent\(safeNext\)\}`/);
+  });
+
+  test('open-redirect guarded: only /oauth/authorize? targets accepted', () => {
+    expect(src).toMatch(/authorizePathWithQuery\.startsWith\(['"]\/oauth\/authorize\?['"]\)/);
+  });
+});


### PR DESCRIPTION
Background — a real user with two Supabase accounts (ben@ and luisa@) granted Claude access from the wrong account this morning because the existing 'Signed in as …' hint was at colour #777 and easy to miss. DB confirms: claude.ai's JWT identifies ben@, all Convene tools that need the calendar fail (calendar lives under luisa@).

Fix: yellow banner foregrounds the email + a 'Switch account' button that signs out the current Supabase session and bounces back to /login?next=… preserving the OAuth state. Open-redirect guarded.

Verified: 78/78 OAuth tests pass (11 new in consent-account-banner.test.ts).

🤖 Generated with [Claude Code](https://claude.com/claude-code)