### PR TITLE
fix(affiliate-smoke): per-locale source URLs (KAN-194 follow-up)

### DIFF
--- a/src/lib/affiliate/smoke.ts
+++ b/src/lib/affiliate/smoke.ts
@@ -24,8 +24,19 @@
 
 export type MerchantSmokeProbe = {
   merchantId: string;
-  /** A real product URL that won't 404 — used as the link-service input. */
+  /** A real product URL that won't 404 — used as the link-service input.
+   *  Falls back to this when `representativeUrlsByCountry` has no entry
+   *  for the buyer-country (single-locale merchants). */
   representativeUrl: string;
+  /**
+   * Per-country source URL. Required for multi-locale merchants (Amazon,
+   * eBay, Bookshop.org) because pre-Sovrn the runner HEAD-probes the source
+   * URL directly — a US user sent to `amazon.co.uk` will NOT be redirected
+   * to `amazon.com` by `Accept-Language` alone, so the probe must already
+   * point at the locale-correct storefront. Post-Sovrn this still matters:
+   * starting from the wrong region produces unnecessary cross-redirect noise.
+   */
+  representativeUrlsByCountry?: Readonly<Record<string, string>>;
   /**
    * For each (buyer-country) entry, the expected final hostname suffixes
    * the smoke check accepts. When the link service falls back to a raw URL
@@ -39,7 +50,20 @@ export type MerchantSmokeProbe = {
 export const SMOKE_PROBES: readonly MerchantSmokeProbe[] = [
   {
     merchantId: 'amazon',
-    representativeUrl: 'https://www.amazon.co.uk/dp/0241988055', // Atomic Habits
+    representativeUrl: 'https://www.amazon.co.uk/', // GB fallback
+    representativeUrlsByCountry: {
+      GB: 'https://www.amazon.co.uk/',
+      IE: 'https://www.amazon.co.uk/', // IE buyers commonly use the UK store; expectedHosts also allows amazon.de
+      US: 'https://www.amazon.com/',
+      DE: 'https://www.amazon.de/',
+      FR: 'https://www.amazon.fr/',
+      IT: 'https://www.amazon.it/',
+      ES: 'https://www.amazon.es/',
+      NL: 'https://www.amazon.nl/',
+      CA: 'https://www.amazon.ca/',
+      AU: 'https://www.amazon.com.au/',
+      JP: 'https://www.amazon.co.jp/',
+    },
     expectedHostsByCountry: {
       GB: ['amazon.co.uk'],
       IE: ['amazon.co.uk', 'amazon.de'],
@@ -73,7 +97,18 @@ export const SMOKE_PROBES: readonly MerchantSmokeProbe[] = [
   },
   {
     merchantId: 'ebay',
-    representativeUrl: 'https://www.ebay.co.uk/',
+    representativeUrl: 'https://www.ebay.co.uk/', // GB fallback
+    representativeUrlsByCountry: {
+      GB: 'https://www.ebay.co.uk/',
+      US: 'https://www.ebay.com/',
+      DE: 'https://www.ebay.de/',
+      FR: 'https://www.ebay.fr/',
+      IT: 'https://www.ebay.it/',
+      ES: 'https://www.ebay.es/',
+      IE: 'https://www.ebay.co.uk/', // IE has no dedicated eBay; expectedHosts allows .co.uk + .com
+      CA: 'https://www.ebay.ca/',
+      AU: 'https://www.ebay.com.au/',
+    },
     expectedHostsByCountry: {
       GB: ['ebay.co.uk'],
       US: ['ebay.com'],
@@ -103,7 +138,12 @@ export const SMOKE_PROBES: readonly MerchantSmokeProbe[] = [
   },
   {
     merchantId: 'bookshop_org',
-    representativeUrl: 'https://uk.bookshop.org/gift-cards',
+    representativeUrl: 'https://uk.bookshop.org/gift-cards', // GB fallback
+    representativeUrlsByCountry: {
+      GB: 'https://uk.bookshop.org/gift-cards',
+      IE: 'https://uk.bookshop.org/gift-cards',
+      US: 'https://bookshop.org/gift-cards',
+    },
     expectedHostsByCountry: {
       GB: ['uk.bookshop.org', 'bookshop.org'],
       IE: ['uk.bookshop.org', 'bookshop.org'],
@@ -128,14 +168,17 @@ export type SmokeMatrixEntry = {
   expectedHosts: readonly string[];
 };
 
-/** Expand SMOKE_PROBES into a flat list of test cases. */
+/** Expand SMOKE_PROBES into a flat list of test cases. The per-entry
+ *  source URL prefers `representativeUrlsByCountry[country]` when present
+ *  (multi-locale merchants) and falls back to `representativeUrl`. */
 export function buildSmokeMatrix(): SmokeMatrixEntry[] {
   const out: SmokeMatrixEntry[] = [];
   for (const probe of SMOKE_PROBES) {
     for (const [country, hosts] of Object.entries(probe.expectedHostsByCountry)) {
+      const perCountry = probe.representativeUrlsByCountry?.[country];
       out.push({
         merchantId: probe.merchantId,
-        representativeUrl: probe.representativeUrl,
+        representativeUrl: perCountry ?? probe.representativeUrl,
         buyerCountry: country,
         expectedHosts: hosts,
       });

--- a/tests/unit/affiliate-smoke.test.ts
+++ b/tests/unit/affiliate-smoke.test.ts
@@ -80,6 +80,55 @@ describe('KAN-194 buildSmokeMatrix', () => {
       expect(m.representativeUrl).toContain('://');
     }
   });
+
+  // Pre-Sovrn the runner HEAD-probes representativeUrl directly. Sending
+  // amazon.co.uk to a US user doesn't redirect to amazon.com (Accept-
+  // Language alone won't move you off a regional storefront), so each
+  // (merchant × locale) needs its own source URL.
+  test('Amazon uses the locale-matching domain in each matrix row', () => {
+    const matrix = buildSmokeMatrix().filter((m) => m.merchantId === 'amazon');
+    const byCountry = Object.fromEntries(matrix.map((m) => [m.buyerCountry, m.representativeUrl]));
+    expect(byCountry.US).toContain('amazon.com/');
+    expect(byCountry.DE).toContain('amazon.de/');
+    expect(byCountry.FR).toContain('amazon.fr/');
+    expect(byCountry.JP).toContain('amazon.co.jp/');
+    expect(byCountry.GB).toContain('amazon.co.uk/');
+  });
+
+  test('eBay uses the locale-matching domain in each matrix row', () => {
+    const matrix = buildSmokeMatrix().filter((m) => m.merchantId === 'ebay');
+    const byCountry = Object.fromEntries(matrix.map((m) => [m.buyerCountry, m.representativeUrl]));
+    expect(byCountry.US).toContain('ebay.com/');
+    expect(byCountry.DE).toContain('ebay.de/');
+    expect(byCountry.AU).toContain('ebay.com.au/');
+  });
+
+  test('Bookshop.org sends US buyers to bookshop.org, not uk.bookshop.org', () => {
+    const matrix = buildSmokeMatrix().filter((m) => m.merchantId === 'bookshop_org');
+    const us = matrix.find((m) => m.buyerCountry === 'US');
+    expect(us?.representativeUrl).toContain('://bookshop.org/');
+    expect(us?.representativeUrl).not.toContain('uk.bookshop.org');
+  });
+
+  test('single-locale merchants fall back to representativeUrl (no per-country override)', () => {
+    // John Lewis (GB only), Etsy (etsy.com globally) shouldn't need per-country URLs.
+    const matrix = buildSmokeMatrix();
+    const jl = matrix.find((m) => m.merchantId === 'johnlewis' && m.buyerCountry === 'GB');
+    expect(jl?.representativeUrl).toContain('johnlewis.com');
+    for (const m of matrix.filter((x) => x.merchantId === 'etsy')) {
+      expect(m.representativeUrl).toContain('etsy.com');
+    }
+  });
+
+  test('every country listed in representativeUrlsByCountry is also in expectedHostsByCountry', () => {
+    for (const p of SMOKE_PROBES) {
+      if (!p.representativeUrlsByCountry) continue;
+      const expectedCountries = new Set(Object.keys(p.expectedHostsByCountry));
+      for (const c of Object.keys(p.representativeUrlsByCountry)) {
+        expect(expectedCountries.has(c)).toBe(true);
+      }
+    }
+  });
 });
 
 // ── assertLocalisedDomain ──────────────────────────────────────────────


### PR DESCRIPTION
## Summary
Closes the daily 'Affiliate link smoke' workflow failures (20/38 probes failing with `unexpected_host` across US/DE/FR/IT/ES/CA/AU/JP since KAN-194 shipped).

## Root cause
The original probe matrix used a single UK source URL for every locale (e.g. `amazon.co.uk` for US probes) and assumed `Accept-Language: en-US` would bounce the request to `amazon.com`. It won't — Amazon, eBay and Bookshop.org keep users on whatever regional storefront they hit, so the final hostname always came back as `.co.uk` and failed the assertion.

The original design assumed Sovrn would be the redirector (which IS locale-aware); pre-Sovrn the smoke check was effectively broken. Sovrn isn't wired yet, so we need the source URL to already be locale-correct.

## Change
- New optional `representativeUrlsByCountry: Record<Country, URL>` field on `MerchantSmokeProbe`.
- `buildSmokeMatrix()` uses per-country URL when set, else falls back to `representativeUrl` (so single-locale merchants — Etsy, John Lewis, NotOnTheHighStreet, Otto — are untouched).
- Populated per-country URLs for `amazon`, `ebay`, and `bookshop_org`.

## Test plan
- [x] `npx jest tests/unit/affiliate-smoke.test.ts`: 28 passed (added 5 new cases for per-locale routing + fallback)
- [x] `npx jest` (full): 1392 / 1392 unit tests pass (baseline 1387; same 3 Playwright e2e suites fail identically pre/post — pre-existing config issue, not introduced here)
- [x] `npx tsc --noEmit`: clean
- [x] `npm run lint`: 0 errors
- [x] `npm run build`: clean
- [ ] Next `affiliate-link-smoke.yml` run on this branch passes (or, post-merge, on develop)

## Forward-compat note
When Sovrn lands, the per-country URLs still help: starting from the correct region avoids unnecessary cross-redirect noise. Code path is unchanged when only `representativeUrl` is set, so adding Sovrn is independent of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)