### PR TITLE
fix(staging-tests): gate Lighthouse SEO assertion to indexable hosts only

### DIFF
--- a/lighthouserc.cjs
+++ b/lighthouserc.cjs
@@ -11,12 +11,20 @@
  * this, every request would 401 and every score would be ~0.
  *
  * Budgets (assert thresholds):
- *   - Performance     >= 80
- *   - Accessibility   >= 90
- *   - Best Practices  >= 90
- *   - SEO             >= 90
+ *   - Performance     >= 80    (error)
+ *   - Accessibility   >= 90    (error)
+ *   - Best Practices  >= 90    (error)
+ *   - SEO             >= 90    (error on indexable hosts only — see below)
  *
- * Any regression below these thresholds fails the workflow.
+ * SEO assertion is conditional on the target being indexable. Per KAN-175,
+ * staging/dev/Vercel-preview URLs emit `<meta name="robots" content=
+ * "noindex,…">` by design (the `is-page-indexable` audit then drops the
+ * SEO category to ~0.69). Asserting SEO ≥ 0.9 on a deliberately-noindex
+ * target is a false-positive failure that fired daily through May 2026.
+ * We only enforce SEO when LHCI_TARGET_URL is on `checklyra.com` (prod
+ * + beta); on Vercel preview hosts SEO drops to `warn` (reported, not
+ * failing). A separate prod-Lighthouse job is the right place for hard
+ * SEO assertions and is tracked as a follow-up.
  *
  * CommonJS (.cjs) because the rest of the repo is ESM-by-default
  * (`"type": "module"` would otherwise force ESM parsing) and lhci's
@@ -40,6 +48,19 @@ if (!bypass) {
   );
 }
 
+// Is the target an indexable host? Only checklyra.com (prod + beta) is.
+// Vercel preview URLs and dev/staging custom domains are noindex by design.
+let targetIsIndexable = false;
+try {
+  targetIsIndexable = new URL(targetUrl).hostname.endsWith('checklyra.com');
+} catch {
+  // Malformed URL — let lhci's collect step surface that error; for the
+  // assertion gate, treat as non-indexable to avoid a false positive.
+  targetIsIndexable = false;
+}
+
+const seoAssertLevel = targetIsIndexable ? 'error' : 'warn';
+
 module.exports = {
   ci: {
     collect: {
@@ -61,7 +82,7 @@ module.exports = {
         'categories:performance': ['error', { minScore: 0.8 }],
         'categories:accessibility': ['error', { minScore: 0.9 }],
         'categories:best-practices': ['error', { minScore: 0.9 }],
-        'categories:seo': ['error', { minScore: 0.9 }],
+        'categories:seo': [seoAssertLevel, { minScore: 0.9 }],
       },
     },
     upload: {

--- a/tests/unit/lighthouserc.test.js
+++ b/tests/unit/lighthouserc.test.js
@@ -1,0 +1,119 @@
+/**
+ * Tests for the SEO-assertion-level gating in lighthouserc.cjs.
+ *
+ * Staging is `noindex` by design (KAN-175), so Lighthouse's SEO category
+ * scores ~0.69 against any non-production target. The config now demotes
+ * the SEO assertion from `error` to `warn` whenever the target host
+ * isn't on `checklyra.com`, so the staging-tests workflow stops failing
+ * on a false positive.
+ */
+
+const path = require('path');
+
+const RC_PATH = path.resolve(__dirname, '../../lighthouserc.cjs');
+
+function loadConfig({ targetUrl, bypass = 'test-bypass-token' }) {
+  // The config is cached on first require; isolate the module registry so
+  // each call re-reads process.env. jest.isolateModules() is the supported
+  // way to do this without poking at require.cache directly.
+  let mod;
+  jest.isolateModules(() => {
+    const prevUrl = process.env.LHCI_TARGET_URL;
+    const prevBypass = process.env.VERCEL_AUTOMATION_BYPASS;
+    process.env.LHCI_TARGET_URL = targetUrl;
+    process.env.VERCEL_AUTOMATION_BYPASS = bypass;
+    try {
+      mod = require(RC_PATH);
+    } finally {
+      if (prevUrl === undefined) delete process.env.LHCI_TARGET_URL;
+      else process.env.LHCI_TARGET_URL = prevUrl;
+      if (prevBypass === undefined) delete process.env.VERCEL_AUTOMATION_BYPASS;
+      else process.env.VERCEL_AUTOMATION_BYPASS = prevBypass;
+    }
+  });
+  return mod;
+}
+
+function seoAssertionFor(config) {
+  return config.ci.assert.assertions['categories:seo'];
+}
+
+describe('lighthouserc.cjs — SEO assertion gating (KAN-176 follow-up)', () => {
+  test('checklyra.com root → SEO is enforced at error level', () => {
+    const cfg = loadConfig({ targetUrl: 'https://checklyra.com/' });
+    expect(seoAssertionFor(cfg)).toEqual(['error', { minScore: 0.9 }]);
+  });
+
+  test('beta.checklyra.com → SEO is enforced at error level', () => {
+    const cfg = loadConfig({ targetUrl: 'https://beta.checklyra.com/' });
+    expect(seoAssertionFor(cfg)).toEqual(['error', { minScore: 0.9 }]);
+  });
+
+  test('staging Vercel preview URL → SEO drops to warn (deliberately noindex)', () => {
+    const cfg = loadConfig({
+      targetUrl: 'https://lyra-rfgj4k15s-luisa-sys-projects.vercel.app/',
+    });
+    expect(seoAssertionFor(cfg)).toEqual(['warn', { minScore: 0.9 }]);
+  });
+
+  test('dev.checklyra.com → SEO is enforced (still on the checklyra.com apex)', () => {
+    // dev.checklyra.com is technically noindex too, but the URL-only
+    // heuristic can't distinguish — keep this honest. If/when dev SEO
+    // becomes noisy this test will tell us we need a smarter check.
+    const cfg = loadConfig({ targetUrl: 'https://dev.checklyra.com/' });
+    expect(seoAssertionFor(cfg)).toEqual(['error', { minScore: 0.9 }]);
+  });
+
+  test('stage.checklyra.com → SEO is enforced (apex match)', () => {
+    // Same caveat as dev — apex match doesn't distinguish indexability
+    // by subdomain. In practice staging-tests targets the Vercel direct
+    // URL, not stage.checklyra.com, so this branch isn't hit by CI.
+    const cfg = loadConfig({ targetUrl: 'https://stage.checklyra.com/' });
+    expect(seoAssertionFor(cfg)).toEqual(['error', { minScore: 0.9 }]);
+  });
+
+  test('malformed URL → SEO drops to warn (safe default)', () => {
+    const cfg = loadConfig({ targetUrl: 'not a url' });
+    expect(seoAssertionFor(cfg)).toEqual(['warn', { minScore: 0.9 }]);
+  });
+
+  test('other Lighthouse categories stay at error regardless of target', () => {
+    const cfg = loadConfig({
+      targetUrl: 'https://lyra-rfgj4k15s-luisa-sys-projects.vercel.app/',
+    });
+    const a = cfg.ci.assert.assertions;
+    expect(a['categories:performance']).toEqual(['error', { minScore: 0.8 }]);
+    expect(a['categories:accessibility']).toEqual(['error', { minScore: 0.9 }]);
+    expect(a['categories:best-practices']).toEqual(['error', { minScore: 0.9 }]);
+  });
+
+  test('missing LHCI_TARGET_URL → load throws', () => {
+    expect(() =>
+      jest.isolateModules(() => {
+        const prev = process.env.LHCI_TARGET_URL;
+        delete process.env.LHCI_TARGET_URL;
+        process.env.VERCEL_AUTOMATION_BYPASS = 'x';
+        try {
+          require(RC_PATH);
+        } finally {
+          if (prev !== undefined) process.env.LHCI_TARGET_URL = prev;
+        }
+      }),
+    ).toThrow(/LHCI_TARGET_URL is not set/);
+  });
+
+  test('missing VERCEL_AUTOMATION_BYPASS → load throws', () => {
+    expect(() =>
+      jest.isolateModules(() => {
+        const prev = process.env.VERCEL_AUTOMATION_BYPASS;
+        delete process.env.VERCEL_AUTOMATION_BYPASS;
+        process.env.LHCI_TARGET_URL = 'https://checklyra.com/';
+        try {
+          require(RC_PATH);
+        } finally {
+          if (prev !== undefined) process.env.VERCEL_AUTOMATION_BYPASS = prev;
+        }
+      }),
+    ).toThrow(/VERCEL_AUTOMATION_BYPASS is not set/);
+  });
+});


### PR DESCRIPTION
## Summary
Closes the daily 'Staging Tests' workflow failure that's fired since 2026-05-21 (Lighthouse SEO 0.69 vs 0.9 threshold).

## Root cause
Per KAN-175, staging / dev / Vercel-preview URLs all emit `<meta name="robots" content="noindex,...">` by design. Lighthouse's `is-page-indexable` audit then drops the SEO category to ~0.69, and the static `categories:seo ≥ 0.9` assertion in `lighthouserc.cjs` fires every run. This isn't a regression in the app — it's a config mismatch between an intentional noindex flag and a static SEO threshold.

## Change
- `lighthouserc.cjs`: compute the SEO assert level at config-load time. Targets on `checklyra.com` (prod + beta) → `error`. Vercel preview hosts (and any other non-checklyra.com URL) → `warn`. Performance / accessibility / best-practices stay at `error` everywhere.
- New `tests/unit/lighthouserc.test.js` with 9 cases covering all branches (prod/beta indexable, Vercel preview demoted, malformed URL safe default, other categories unchanged, missing-env throws preserved).

## Why not skip SEO entirely?
Lighthouse only fails the SEO *category* on `is-page-indexable` here. Every other SEO sub-audit (meta description, link text, viewport, hreflang, etc.) still runs and is still informative as a 'warn'. The report keeps the diagnostic data; the workflow stops false-failing.

## Follow-up
Production-facing SEO assertion (hard `error` against `https://checklyra.com/`) should be its own Lighthouse job. Tracking separately.

## Test plan
- [x] `npx jest tests/unit/lighthouserc.test.js`: 9 / 9 pass
- [x] `npx jest` (full): 1396 unit tests pass (baseline 1387 + 9 new; same 3 Playwright e2e suites fail identically pre/post — pre-existing config issue, not introduced here)
- [x] `npx tsc --noEmit`: clean
- [x] `npx eslint lighthouserc.cjs tests/unit/lighthouserc.test.js`: 0 errors
- [ ] Next 'Staging Tests' workflow run on develop passes (after merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)