### PR TITLE
feat(ci): auto-triage + self-heal for recurring workflow failures (KAN-248)

### DIFF
--- a/.github/workflows/auto-fix-known-failures.yml
+++ b/.github/workflows/auto-fix-known-failures.yml
@@ -1,0 +1,96 @@
+# KAN-63 Tier 4: auto-triage + self-heal for recurring CI failures.
+#
+# When one of the watched workflows fails on main (the noisy ones that
+# currently spam email), this workflow:
+#   1. Picks up the failed run via `workflow_run.completed`
+#   2. Fetches the failed-step log via gh CLI
+#   3. Classifies it against scripts/auto-fix-patterns.json
+#   4. Applies the matched remediation (label create / secret-rotation
+#      issue / PR comment / unknown-pattern issue)
+#
+# Self-test mode runs on every PR via pr-checks to ensure the pattern
+# catalogue stays consistent with its fixtures. See
+# scripts/auto-fix-known-failures.py for design + invocation modes.
+
+name: Auto-fix known failures
+
+on:
+  workflow_run:
+    workflows:
+      - "Anomaly detect (KAN-63-A)"
+      - "Beta gate smoke"
+      - "Staging Tests"
+      - "Affiliate link smoke"
+      - "Auto-promote develop → staging (weekly)"
+    types:
+      - completed
+  workflow_dispatch:
+    inputs:
+      run_id:
+        description: "Workflow run ID to triage (for manual replay)"
+        required: true
+      workflow_name:
+        description: "Display name of the workflow that failed"
+        required: true
+      dry_run:
+        description: "Classify only; do not act"
+        required: false
+        default: "false"
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+  actions: write   # for `gh run rerun`
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  triage:
+    name: Triage and self-heal
+    runs-on: ubuntu-latest
+    # On workflow_run events, only react to failed runs — successes
+    # don't need triage. On workflow_dispatch, always run.
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      github.event.workflow_run.conclusion == 'failure'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 1
+
+      - name: Setup Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Self-test classifier (regression guard)
+        run: |
+          set -euo pipefail
+          python3 scripts/auto-fix-known-failures.py --self-test
+
+      - name: Triage failure
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            RUN_ID="${{ inputs.run_id }}"
+            WF_NAME="${{ inputs.workflow_name }}"
+            DRY="${{ inputs.dry_run }}"
+          else
+            RUN_ID="${{ github.event.workflow_run.id }}"
+            WF_NAME="${{ github.event.workflow_run.name }}"
+            DRY="false"
+          fi
+
+          ARGS=(--run-id "$RUN_ID" --workflow-name "$WF_NAME")
+          if [ "$DRY" = "true" ]; then
+            ARGS+=(--dry-run)
+          fi
+
+          python3 scripts/auto-fix-known-failures.py "${ARGS[@]}"

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -27,6 +27,14 @@ jobs:
         # (build does NOT catch it), so without this guard a regression
         # ships green and breaks every form on the affected page.
         run: bash scripts/check-server-action-exports.sh
+      - name: Auto-heal pattern catalogue self-test (KAN-63 Tier 4)
+        # Verify every entry in scripts/auto-fix-patterns.json still
+        # matches its fixture under tests/fixtures/auto-fix-logs/, and
+        # that no pattern's regex false-positives on a sibling fixture
+        # in the same workflow. This is the regression guard that
+        # prevents the auto-fix workflow from silently breaking when
+        # someone edits a pattern.
+        run: python3 scripts/auto-fix-known-failures.py --self-test
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:

--- a/docs/RUNBOOK.md
+++ b/docs/RUNBOOK.md
@@ -153,6 +153,29 @@ Not yet shipped. The current `health-check.yml` cron creates a GitHub issue on f
 
 Not yet shipped. KAN-232 built the logging foundation; KAN-247 will consume `mcp_per_ip_recent_count` and add Cloudflare WAF rules for IPs over the threshold. Needs a `CLOUDFLARE_API_TOKEN` with `Zone WAF:Edit` on `checklyra.com`.
 
+### CI workflow auto-triage and self-heal (Tier 4 — shipped)
+
+`.github/workflows/auto-fix-known-failures.yml` reacts to `workflow_run.completed` events from the recurring failure-prone workflows (Anomaly detect, Beta gate smoke, Staging Tests, Affiliate link smoke, Auto-promote develop→staging) and runs `scripts/auto-fix-known-failures.py` to classify the failure against `scripts/auto-fix-patterns.json` and apply one of four remediations:
+
+| Remediation kind | What it does | Idempotent? |
+|---|---|---|
+| `create_label` | Creates a missing GitHub label; re-runs the failed workflow | Yes (label_exists check) |
+| `alert_secret_rotation` | Files (or updates) a deduped issue labeled `autoheal-tracked` + `autoheal/needs-human` listing the rotation steps | Yes (issue_upsert) |
+| `pr_pending` | Finds the open PR carrying the fix (by branch substring) and posts a one-time marker comment so the daily failure surfaces on the PR | Yes (marker dedup) |
+| `unknown` (fallback) | Files a deduped issue with the log excerpt under label `autoheal/unknown-pattern` so a new pattern can be added | Yes (issue_upsert) |
+
+**Regression guard:** `scripts/auto-fix-known-failures.py --self-test` runs against fixtures in `tests/fixtures/auto-fix-logs/` on every PR via `pr-checks.yml`. It verifies every catalogued pattern still matches its anchor fixture and no pattern false-positives on a sibling fixture within the same workflow. Adding a new pattern requires adding a fixture in the same commit.
+
+**Adding a new pattern:**
+1. Save the failing log to `tests/fixtures/auto-fix-logs/<workflow-slug>.log` (or augment an existing fixture if the workflow is already covered).
+2. Add a pattern entry to `scripts/auto-fix-patterns.json` — pick a `remediation.kind` from the table above.
+3. Add the (fixture, pattern_id) tuple to `FIXTURE_EXPECTATIONS` in both `scripts/auto-fix-known-failures.py` and `tests/unit/auto-fix-patterns.test.js`.
+4. Run `python3 scripts/auto-fix-known-failures.py --self-test` and `npx jest tests/unit/auto-fix-patterns.test.js` — both must pass before merge.
+
+**Manual replay** (e.g. to test a new pattern against a real run): `gh workflow run auto-fix-known-failures.yml -f run_id=<id> -f workflow_name="<display name>" -f dry_run=true`.
+
+**What it deliberately does NOT do:** edit code, open PRs with code changes, merge anything, push to any branch, restart any external service. The auto-fix layer is bounded to GitHub-native actions (labels, issues, comments, re-runs). Anything beyond that is a follow-up ticket.
+
 ## Deployment Rollback
 
 ### Via Vercel Dashboard (recommended)

--- a/scripts/auto-fix-known-failures.py
+++ b/scripts/auto-fix-known-failures.py
@@ -1,0 +1,647 @@
+#!/usr/bin/env python3
+"""KAN-63 Tier 4: CI workflow auto-triage and self-heal.
+
+Reacts to recurring GitHub Actions workflow failures by matching the log
+output against a known-pattern catalogue (scripts/auto-fix-patterns.json)
+and applying the matched remediation idempotently. Patterns that don't
+match get a deduped GitHub issue so unknown failures don't fester silently.
+
+Design goals:
+  - Stdlib-only Python (matches existing scripts/anomaly-detect.py +
+    scripts/cleanup-phantom-check-suites.py conventions).
+  - Idempotent: safe to re-run on the same failed run with no side effects
+    beyond the first.
+  - Conservative: only takes actions in the remediation catalogue. Unknown
+    patterns are reported, NEVER guessed at.
+  - Auditable: every action emits a `::notice::` line and writes to
+    $GITHUB_STEP_SUMMARY when running in CI.
+
+Modes:
+  --self-test
+      Run the classifier against the fixtures in tests/fixtures/auto-fix-logs/
+      and verify each is correctly identified. No GitHub side effects. Used
+      by CI as a regression guard so the pattern catalogue can't drift away
+      from the fixtures it's tested against.
+
+  --run-id <ID> --workflow-name "<name>"
+      Look up the failed run, fetch its log via `gh run view --log-failed`,
+      classify against patterns, apply remediation. Reads other context
+      from the standard GH_REPOSITORY / GITHUB_REPOSITORY env vars.
+
+  --dry-run
+      Classify only; print what WOULD be done without taking action.
+      Compose with --run-id for one-shot debugging.
+
+Exit code:
+  0 = pattern matched and remediation succeeded (or was a no-op like
+      "PR already open"), or self-test passed
+  1 = no pattern matched OR remediation hit an unrecoverable error
+      (a tracking issue is filed either way)
+  2 = invalid invocation
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+PATTERNS_PATH = REPO_ROOT / "scripts" / "auto-fix-patterns.json"
+FIXTURES_DIR = REPO_ROOT / "tests" / "fixtures" / "auto-fix-logs"
+
+ANSI_RE = re.compile(r"\x1b\[[0-9;]*[mK]")
+
+AUTOHEAL_ISSUE_LABEL = "autoheal-tracked"
+NEEDS_HUMAN_LABEL = "autoheal/needs-human"
+UNKNOWN_PATTERN_LABEL = "autoheal/unknown-pattern"
+
+
+# ── Data plumbing ───────────────────────────────────────────────────────
+
+
+@dataclass
+class Pattern:
+    id: str
+    title: str
+    summary: str
+    workflows: list[str]
+    regex: re.Pattern[str]
+    remediation: dict[str, Any]
+    rerun_workflow_after_fix: bool
+
+    @classmethod
+    def from_json(cls, raw: dict[str, Any]) -> "Pattern":
+        return cls(
+            id=raw["id"],
+            title=raw["title"],
+            summary=raw.get("summary", ""),
+            workflows=list(raw["workflows"]),
+            regex=re.compile(raw["regex"], re.IGNORECASE),
+            remediation=dict(raw["remediation"]),
+            rerun_workflow_after_fix=bool(raw.get("rerun_workflow_after_fix", False)),
+        )
+
+
+def load_patterns(path: Path = PATTERNS_PATH) -> list[Pattern]:
+    raw = json.loads(path.read_text())
+    if raw.get("version") != 1:
+        raise SystemExit(
+            f"auto-fix-patterns.json version {raw.get('version')!r} not supported"
+        )
+    return [Pattern.from_json(p) for p in raw["patterns"]]
+
+
+def strip_ansi(text: str) -> str:
+    """Strip ANSI escape codes that `gh run view --log-failed` embeds."""
+    return ANSI_RE.sub("", text)
+
+
+# ── Classification ──────────────────────────────────────────────────────
+
+
+def workflow_matches(pattern: Pattern, workflow_name: str) -> bool:
+    """Case-insensitive match of the run's workflow name against the
+    pattern's workflows[] list. Accepts both the friendly name ('Anomaly
+    detect (KAN-63-A)') and the file slug ('anomaly-detect')."""
+    if not workflow_name:
+        return False
+    norm = workflow_name.strip().lower()
+    return any(w.strip().lower() == norm for w in pattern.workflows)
+
+
+def classify(
+    log_text: str, workflow_name: str, patterns: list[Pattern]
+) -> tuple[Pattern, re.Match[str]] | None:
+    """Return the first (pattern, match) whose workflow + regex matches.
+    None if nothing matches. ANSI is stripped before matching."""
+    clean = strip_ansi(log_text)
+    for p in patterns:
+        if not workflow_matches(p, workflow_name):
+            continue
+        m = p.regex.search(clean)
+        if m is not None:
+            return (p, m)
+    return None
+
+
+# ── gh CLI helpers ──────────────────────────────────────────────────────
+
+
+def run_gh(args: list[str], *, check: bool = True, capture: bool = True) -> str:
+    """Wrap `gh` invocations. Returns stdout (stripped). Raises on
+    non-zero exit unless check=False."""
+    proc = subprocess.run(
+        ["gh", *args],
+        capture_output=capture,
+        text=True,
+        check=False,
+    )
+    if check and proc.returncode != 0:
+        sys.stderr.write(
+            f"gh {' '.join(args)} failed (exit {proc.returncode}):\n"
+            f"  stdout: {proc.stdout!r}\n  stderr: {proc.stderr!r}\n"
+        )
+        raise SystemExit(1)
+    return (proc.stdout or "").strip()
+
+
+def fetch_failed_log(run_id: str) -> str:
+    """`gh run view <id> --log-failed` returns the failed-step logs. We
+    don't redirect via check=False since some runs have no failed steps
+    (rare but possible if the run was cancelled)."""
+    return run_gh(["run", "view", run_id, "--log-failed"], check=False)
+
+
+def label_exists(label_name: str) -> bool:
+    out = run_gh(
+        ["label", "list", "--search", label_name, "--json", "name", "--jq", ".[].name"],
+        check=False,
+    )
+    return label_name in out.splitlines()
+
+
+def label_create(label_name: str, color: str, description: str) -> bool:
+    """Returns True if the label was created, False if it already existed."""
+    if label_exists(label_name):
+        return False
+    run_gh(
+        [
+            "label",
+            "create",
+            label_name,
+            "--description",
+            description,
+            "--color",
+            color,
+        ]
+    )
+    return True
+
+
+def find_open_issue_by_title(title: str) -> str | None:
+    """Returns the issue number as a string if an open issue with this
+    exact title exists, else None. Used for dedup."""
+    out = run_gh(
+        [
+            "issue",
+            "list",
+            "--state",
+            "open",
+            "--search",
+            f'in:title "{title}"',
+            "--json",
+            "number,title",
+            "--jq",
+            ".[] | select(.title==\"" + title.replace('"', '\\"') + "\") | .number",
+        ],
+        check=False,
+    )
+    nums = [ln for ln in out.splitlines() if ln.strip()]
+    return nums[0] if nums else None
+
+
+def issue_upsert(
+    title: str,
+    body: str,
+    labels: list[str],
+) -> tuple[str, bool]:
+    """Create the issue if absent, else comment on the existing one with
+    the new body. Returns (issue_number, was_created)."""
+    existing = find_open_issue_by_title(title)
+    if existing:
+        run_gh(
+            ["issue", "comment", existing, "--body", body],
+            check=False,
+        )
+        return (existing, False)
+    # Ensure labels exist before applying — gh errors otherwise.
+    for lbl in labels:
+        if not label_exists(lbl):
+            run_gh(
+                [
+                    "label",
+                    "create",
+                    lbl,
+                    "--description",
+                    "Created by auto-fix-known-failures",
+                    "--color",
+                    "ededed",
+                ],
+                check=False,
+            )
+    label_args: list[str] = []
+    for lbl in labels:
+        label_args.extend(["--label", lbl])
+    url = run_gh(["issue", "create", "--title", title, "--body", body, *label_args])
+    # `gh issue create` returns the issue URL on stdout; extract number.
+    match = re.search(r"/issues/(\d+)", url)
+    return ((match.group(1) if match else url), True)
+
+
+def find_open_pr_by_branch(branch_hint: str) -> str | None:
+    """Returns the PR number (as string) for an open PR whose head branch
+    matches branch_hint (substring), else None."""
+    out = run_gh(
+        [
+            "pr",
+            "list",
+            "--state",
+            "open",
+            "--json",
+            "number,headRefName",
+            "--jq",
+            f'.[] | select(.headRefName | contains("{branch_hint}")) | .number',
+        ],
+        check=False,
+    )
+    nums = [ln for ln in out.splitlines() if ln.strip()]
+    return nums[0] if nums else None
+
+
+def pr_comment_once(pr_number: str, marker: str, body: str) -> bool:
+    """Comment on a PR only if a comment containing `marker` doesn't
+    already exist. Returns True if a new comment was posted."""
+    # Fetch existing comments to look for the marker.
+    out = run_gh(
+        ["pr", "view", pr_number, "--json", "comments", "--jq", ".comments[].body"],
+        check=False,
+    )
+    if marker in out:
+        return False
+    run_gh(["pr", "comment", pr_number, "--body", body], check=False)
+    return True
+
+
+def rerun_workflow(run_id: str) -> None:
+    """Re-trigger the failed run after a fix is applied. Best-effort."""
+    run_gh(["run", "rerun", run_id, "--failed"], check=False)
+
+
+# ── Remediation handlers ────────────────────────────────────────────────
+
+
+def remediate_create_label(
+    pattern: Pattern,
+    match: re.Match[str],
+    run_id: str,
+    workflow_name: str,
+    dry_run: bool,
+) -> dict[str, Any]:
+    """Pattern's regex MUST have a capture group 1 = the missing label name."""
+    if not match.groups():
+        return {"ok": False, "reason": "regex has no capture group for label name"}
+    label_name = match.group(1)
+    color = pattern.remediation.get("color", "ededed")
+    description = pattern.remediation.get("description", "")
+    if dry_run:
+        return {"ok": True, "action": "would_create_label", "label": label_name}
+    created = label_create(label_name, color, description)
+    if pattern.rerun_workflow_after_fix and run_id:
+        rerun_workflow(run_id)
+    return {
+        "ok": True,
+        "action": "created_label" if created else "label_already_existed",
+        "label": label_name,
+        "rerun_triggered": pattern.rerun_workflow_after_fix and bool(run_id),
+    }
+
+
+def remediate_alert_secret_rotation(
+    pattern: Pattern,
+    match: re.Match[str],
+    run_id: str,
+    workflow_name: str,
+    dry_run: bool,
+) -> dict[str, Any]:
+    """Create or comment on a deduped issue describing the secret rotation."""
+    secret = pattern.remediation.get("secret_name", "<unknown>")
+    title = f"[auto-heal] {secret} needs rotation — {pattern.id}"
+    steps = pattern.remediation.get("steps", [])
+    related = pattern.remediation.get("related_ticket", "")
+    body_lines = [
+        f"## Pattern: `{pattern.id}`",
+        "",
+        pattern.summary or "",
+        "",
+        f"**Triggering workflow:** {workflow_name} (run [{run_id}](https://github.com/luisa-sys/lyra/actions/runs/{run_id}))" if run_id else f"**Triggering workflow:** {workflow_name}",
+        "",
+        "### Rotation steps",
+        "",
+        *[f"{i + 1}. {step}" for i, step in enumerate(steps)],
+        "",
+        f"_Related_: {related}" if related else "",
+        "",
+        "_This issue was opened automatically by `.github/workflows/auto-fix-known-failures.yml`. It will be updated on each recurrence, not duplicated. Close it once the secret has been rotated._",
+    ]
+    body = "\n".join(ln for ln in body_lines if ln is not None)
+    if dry_run:
+        return {"ok": True, "action": "would_open_secret_rotation_issue", "title": title}
+    issue, created = issue_upsert(
+        title,
+        body,
+        labels=[AUTOHEAL_ISSUE_LABEL, NEEDS_HUMAN_LABEL],
+    )
+    return {
+        "ok": True,
+        "action": "opened_secret_rotation_issue" if created else "updated_secret_rotation_issue",
+        "issue": issue,
+    }
+
+
+def remediate_pr_pending(
+    pattern: Pattern,
+    match: re.Match[str],
+    run_id: str,
+    workflow_name: str,
+    dry_run: bool,
+) -> dict[str, Any]:
+    """If an open PR matches the branch hint, comment on it (once) noting
+    the daily failure recurrence. If no PR, file a tracking issue."""
+    branch_hint = pattern.remediation.get("pr_branch_hint", "")
+    fix_summary = pattern.remediation.get("fix_summary", "")
+    title = f"[auto-heal] {pattern.title} — fix pending on PR"
+    marker = f"<!-- auto-fix-known-failures: {pattern.id} -->"
+    body_for_pr = (
+        f"{marker}\n\n"
+        f":robot: Auto-heal saw `{workflow_name}` fail with the `{pattern.id}` pattern "
+        f"again (run [{run_id}](https://github.com/luisa-sys/lyra/actions/runs/{run_id})).\n\n"
+        f"This PR carries the fix — once it merges to develop and propagates through the "
+        f"pipeline to main, the recurring failure will stop.\n\n"
+        f"_Posted once per PR by `auto-fix-known-failures.yml`. Subsequent failures will "
+        f"NOT add more comments to keep the PR clean._"
+    )
+    pr_number = find_open_pr_by_branch(branch_hint) if branch_hint else None
+    if dry_run:
+        if pr_number:
+            return {"ok": True, "action": "would_comment_on_pr", "pr": pr_number}
+        return {"ok": True, "action": "would_open_tracking_issue", "title": title}
+    if pr_number:
+        posted = pr_comment_once(pr_number, marker, body_for_pr)
+        return {
+            "ok": True,
+            "action": "commented_on_pr" if posted else "pr_already_acknowledged",
+            "pr": pr_number,
+        }
+    # No PR open → file a tracking issue so the work doesn't get lost.
+    body_for_issue = (
+        f"## Pattern: `{pattern.id}`\n\n"
+        f"{pattern.summary}\n\n"
+        f"**Expected fix branch:** `{branch_hint}` (not currently open as a PR)\n\n"
+        f"**Fix summary:** {fix_summary}\n\n"
+        f"**Triggering workflow:** {workflow_name} (run "
+        f"[{run_id}](https://github.com/luisa-sys/lyra/actions/runs/{run_id}))"
+        if run_id else ""
+    )
+    issue, created = issue_upsert(
+        title,
+        body_for_issue,
+        labels=[AUTOHEAL_ISSUE_LABEL],
+    )
+    return {
+        "ok": True,
+        "action": "opened_tracking_issue" if created else "updated_tracking_issue",
+        "issue": issue,
+    }
+
+
+def remediate_unknown(
+    workflow_name: str,
+    run_id: str,
+    log_excerpt: str,
+    dry_run: bool,
+) -> dict[str, Any]:
+    """Pattern didn't match anything. File a deduped 'unknown' issue so
+    the failure surfaces for human triage and a new pattern can be added."""
+    title = f"[auto-heal] Unknown failure pattern: {workflow_name}"
+    body = (
+        f"## Unknown failure\n\n"
+        f"`auto-fix-known-failures` couldn't classify the most recent failure of `{workflow_name}`.\n\n"
+        f"**Run:** [{run_id}](https://github.com/luisa-sys/lyra/actions/runs/{run_id})\n\n"
+        f"### Log excerpt (last 40 lines, ANSI stripped)\n\n"
+        f"```\n{log_excerpt[-3500:]}\n```\n\n"
+        f"### Next steps\n\n"
+        f"1. Triage the failure: is this a real new bug or a flaky run?\n"
+        f"2. If recurring, add a new pattern entry to `scripts/auto-fix-patterns.json` and a fixture under `tests/fixtures/auto-fix-logs/`.\n"
+        f"3. Close this issue once the pattern is captured (or the underlying bug is fixed)."
+    )
+    if dry_run:
+        return {"ok": True, "action": "would_open_unknown_issue", "title": title}
+    issue, created = issue_upsert(
+        title,
+        body,
+        labels=[AUTOHEAL_ISSUE_LABEL, UNKNOWN_PATTERN_LABEL],
+    )
+    return {
+        "ok": False,
+        "action": "opened_unknown_issue" if created else "updated_unknown_issue",
+        "issue": issue,
+    }
+
+
+REMEDIATION_DISPATCH = {
+    "create_label": remediate_create_label,
+    "alert_secret_rotation": remediate_alert_secret_rotation,
+    "pr_pending": remediate_pr_pending,
+}
+
+
+# ── Step-summary writer ─────────────────────────────────────────────────
+
+
+def emit_step_summary(result: dict[str, Any]) -> None:
+    """Append a brief summary of the action taken to GITHUB_STEP_SUMMARY,
+    so the workflow run page shows what was done at a glance."""
+    summary_path = os.environ.get("GITHUB_STEP_SUMMARY")
+    if not summary_path:
+        return
+    pattern_id = result.get("pattern_id", "—")
+    action = result.get("action", "—")
+    lines = [
+        "## auto-fix-known-failures",
+        "",
+        f"- Workflow: `{result.get('workflow_name')}`",
+        f"- Run: [{result.get('run_id')}](https://github.com/luisa-sys/lyra/actions/runs/{result.get('run_id')})",
+        f"- Pattern: `{pattern_id}`",
+        f"- Action: `{action}`",
+    ]
+    if "label" in result:
+        lines.append(f"- Label: `{result['label']}`")
+    if "issue" in result:
+        lines.append(f"- Issue: #{result['issue']}")
+    if "pr" in result:
+        lines.append(f"- PR: #{result['pr']}")
+    Path(summary_path).write_text(
+        (Path(summary_path).read_text() if Path(summary_path).exists() else "")
+        + "\n".join(lines)
+        + "\n"
+    )
+
+
+# ── Main: live mode ─────────────────────────────────────────────────────
+
+
+def handle_live(args: argparse.Namespace) -> int:
+    patterns = load_patterns()
+    run_id = args.run_id
+    workflow_name = args.workflow_name
+    log = fetch_failed_log(run_id)
+    if not log.strip():
+        # Run had no failed steps — likely cancelled or success. No-op.
+        print(f"::notice::Run {run_id} has no failed-step logs; nothing to triage.")
+        return 0
+    classification = classify(log, workflow_name, patterns)
+    if classification is None:
+        excerpt = strip_ansi(log)
+        result = remediate_unknown(workflow_name, run_id, excerpt, args.dry_run)
+        result.update({"workflow_name": workflow_name, "run_id": run_id, "pattern_id": "unknown"})
+        print(f"::warning::Unknown failure pattern — opened issue #{result.get('issue')}.")
+        emit_step_summary(result)
+        # Exit 1 to make the auto-fix workflow itself show as failed when
+        # we couldn't fix anything — this keeps the noise visible.
+        return 1
+    pattern, match = classification
+    handler = REMEDIATION_DISPATCH.get(pattern.remediation["kind"])
+    if handler is None:
+        print(
+            f"::error::Pattern {pattern.id} declares unknown remediation kind "
+            f"{pattern.remediation['kind']!r}; check scripts/auto-fix-patterns.json."
+        )
+        return 1
+    result = handler(pattern, match, run_id, workflow_name, args.dry_run)
+    result.update({"workflow_name": workflow_name, "run_id": run_id, "pattern_id": pattern.id})
+    print(f"::notice::Matched pattern {pattern.id} → action: {result.get('action')}")
+    emit_step_summary(result)
+    return 0 if result.get("ok") else 1
+
+
+# ── Main: self-test mode ────────────────────────────────────────────────
+
+
+# Map fixture filename → expected pattern id. This is the source-of-truth
+# regression contract: every pattern in the catalogue must classify its
+# fixture, and the fixture/pattern wiring must stay consistent.
+FIXTURE_EXPECTATIONS: dict[str, tuple[str, str]] = {
+    "anomaly-detect.log": ("anomaly-detect", "anomaly-missing-github-label"),
+    "beta-gate-smoke.log": ("beta-gate-smoke", "vercel-automation-bypass-rotated"),
+    "staging-tests.log": ("staging-tests", "lighthouse-seo-on-noindex-target"),
+    "affiliate-link-smoke.log": ("affiliate-link-smoke", "affiliate-smoke-locale-mismatch"),
+    "auto-promote-to-staging.log": (
+        "auto-promote-to-staging",
+        "lyra-release-pat-insufficient-scopes",
+    ),
+}
+
+
+def handle_self_test(_args: argparse.Namespace) -> int:
+    patterns = load_patterns()
+    pattern_by_id = {p.id: p for p in patterns}
+    failures: list[str] = []
+
+    # 1. Every catalogued pattern must have a fixture (otherwise the
+    #    regex is untested and may rot silently).
+    expected_ids = {pat_id for (_wf, pat_id) in FIXTURE_EXPECTATIONS.values()}
+    for p in patterns:
+        if p.id not in expected_ids:
+            failures.append(
+                f"pattern {p.id!r} has no fixture in FIXTURE_EXPECTATIONS; add one"
+                f" to tests/fixtures/auto-fix-logs/ so the regex is tested."
+            )
+
+    # 2. Every fixture must classify to its expected pattern.
+    for fixture_name, (workflow_name, expected_pid) in FIXTURE_EXPECTATIONS.items():
+        path = FIXTURES_DIR / fixture_name
+        if not path.exists():
+            failures.append(f"fixture missing: {path}")
+            continue
+        text = path.read_text(errors="replace")
+        result = classify(text, workflow_name, patterns)
+        if result is None:
+            failures.append(
+                f"fixture {fixture_name}: expected pattern {expected_pid!r} but no pattern matched"
+            )
+            continue
+        matched_pattern, _m = result
+        if matched_pattern.id != expected_pid:
+            failures.append(
+                f"fixture {fixture_name}: expected {expected_pid!r}, got {matched_pattern.id!r}"
+            )
+
+    # 3. Cross-fixture cleanliness: no pattern should match a fixture
+    #    that's NOT its own (false-positive guard).
+    for fixture_name, (workflow_name, expected_pid) in FIXTURE_EXPECTATIONS.items():
+        path = FIXTURES_DIR / fixture_name
+        if not path.exists():
+            continue
+        text = strip_ansi(path.read_text(errors="replace"))
+        for p in patterns:
+            if p.id == expected_pid:
+                continue
+            # Only test cross-matches where the workflow name would route
+            # us to the same pattern — otherwise the workflow gate already
+            # protects us. Here, force workflow mismatch by ignoring the
+            # workflow filter and seeing whether the REGEX alone fires.
+            if p.regex.search(text):
+                # Allow if the pattern's workflows would never overlap
+                # with this fixture's workflow.
+                overlap = any(
+                    w.strip().lower() == workflow_name.strip().lower()
+                    for w in p.workflows
+                )
+                if overlap:
+                    failures.append(
+                        f"fixture {fixture_name}: pattern {p.id!r} regex matches "
+                        f"a different fixture's content AND shares a workflow — false positive"
+                    )
+
+    # 4. Every pattern's remediation kind is known.
+    known_kinds = set(REMEDIATION_DISPATCH.keys())
+    for p in patterns:
+        kind = p.remediation.get("kind")
+        if kind not in known_kinds:
+            failures.append(
+                f"pattern {p.id!r} has unknown remediation kind {kind!r}; "
+                f"add a handler to REMEDIATION_DISPATCH in scripts/auto-fix-known-failures.py"
+            )
+
+    if failures:
+        print("self-test FAILED:")
+        for f in failures:
+            print(f"  - {f}")
+        return 1
+
+    print(f"self-test OK — {len(patterns)} patterns × {len(FIXTURE_EXPECTATIONS)} fixtures classified correctly")
+    # Acknowledge unused arg & dispatch for IDE.
+    _ = pattern_by_id
+    return 0
+
+
+# ── CLI ─────────────────────────────────────────────────────────────────
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--self-test", action="store_true", help="Run classifier regression checks against fixtures.")
+    parser.add_argument("--run-id", help="The failed workflow run ID to triage.")
+    parser.add_argument("--workflow-name", help="Display name of the workflow that failed.")
+    parser.add_argument("--dry-run", action="store_true", help="Classify only; do not call gh to take actions.")
+    args = parser.parse_args()
+
+    if args.self_test:
+        return handle_self_test(args)
+
+    if not args.run_id or not args.workflow_name:
+        parser.error("either --self-test, or both --run-id and --workflow-name, are required")
+        return 2
+
+    return handle_live(args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/auto-fix-patterns.json
+++ b/scripts/auto-fix-patterns.json
@@ -1,0 +1,88 @@
+{
+  "version": 1,
+  "comment": "KAN-63 Tier 4: known CI-failure patterns and their auto-remediations. Each pattern maps a (workflow-name, log-regex) tuple to a remediation kind. See scripts/auto-fix-known-failures.py for the dispatcher. Tested against fixtures under tests/fixtures/auto-fix-logs/.",
+  "patterns": [
+    {
+      "id": "anomaly-missing-github-label",
+      "title": "Anomaly detect workflow can't add a missing GitHub label",
+      "summary": "scripts/anomaly-detect-issue.sh calls `gh issue create --label <name>` but the label doesn't exist in the repo. Safe to auto-create.",
+      "workflows": ["Anomaly detect (KAN-63-A)", "anomaly-detect"],
+      "regex": "could not add label: '([a-zA-Z0-9_\\-/]+)' not found",
+      "remediation": {
+        "kind": "create_label",
+        "color": "d73a4a",
+        "description": "Automated alert from CI (auto-created by auto-fix-known-failures workflow)"
+      },
+      "rerun_workflow_after_fix": true,
+      "owner_hint": "ops"
+    },
+    {
+      "id": "vercel-automation-bypass-rotated",
+      "title": "VERCEL_AUTOMATION_BYPASS token has rotated",
+      "summary": "Vercel's Protection Bypass for Automation token has been rotated. The workflow can't bypass SSO and gets a 403 on the beta host. Requires human action — only the user can mint a new token in the Vercel dashboard.",
+      "workflows": ["Beta gate smoke", "beta-gate-smoke"],
+      "regex": "Bypass header didn't unlock beta \\(HTTP 403\\)",
+      "remediation": {
+        "kind": "alert_secret_rotation",
+        "secret_name": "VERCEL_AUTOMATION_BYPASS",
+        "steps": [
+          "Open Vercel dashboard → project lyra → Settings → Deployment Protection → Protection Bypass for Automation",
+          "Click 'Generate New' to mint a fresh bypass token",
+          "Open GitHub → repo Settings → Secrets and variables → Actions → VERCEL_AUTOMATION_BYPASS → Update",
+          "Paste the new token and save",
+          "Re-run the failed Beta gate smoke workflow to verify"
+        ],
+        "related_ticket": "KAN-223"
+      },
+      "owner_hint": "ops"
+    },
+    {
+      "id": "lyra-release-pat-insufficient-scopes",
+      "title": "LYRA_RELEASE_PAT cannot dispatch the promotion workflow",
+      "summary": "The personal access token used for cross-workflow dispatch has been revoked or no longer carries the `workflows` / `contents:write` scopes. Requires human action — only the user can mint a new fine-grained PAT.",
+      "workflows": ["Auto-promote develop → staging (weekly)", "auto-promote-to-staging"],
+      "regex": "could not create workflow dispatch event: HTTP 403: Resource not accessible by personal access token",
+      "remediation": {
+        "kind": "alert_secret_rotation",
+        "secret_name": "LYRA_RELEASE_PAT",
+        "steps": [
+          "Open GitHub → user Settings → Developer settings → Personal access tokens → Fine-grained tokens",
+          "Generate a new token (or update the existing LYRA_RELEASE_PAT) with scopes: `contents:write` + `workflows:write` on `luisa-sys/lyra`",
+          "Open GitHub → repo Settings → Secrets and variables → Actions → LYRA_RELEASE_PAT → Update",
+          "Paste the new token and save",
+          "The next scheduled Auto-promote run (Sunday 23:00 UTC) will verify automatically"
+        ],
+        "related_ticket": "Gotcha #16 in CLAUDE.md"
+      },
+      "owner_hint": "ops"
+    },
+    {
+      "id": "lighthouse-seo-on-noindex-target",
+      "title": "Lighthouse SEO assertion fails against a deliberately-noindex URL",
+      "summary": "The Lighthouse SEO category drops to ~0.69 against any non-production target because staging/dev/preview URLs are noindex by design (KAN-175). Fix is in lighthouserc.cjs to gate the SEO assertion to indexable hosts only.",
+      "workflows": ["Staging Tests", "staging-tests"],
+      "regex": "categories\\b.*\\bseo\\b.*minScore.*assertion",
+      "remediation": {
+        "kind": "pr_pending",
+        "pr_branch_hint": "fix/staging-tests-seo-on-noindex",
+        "fix_summary": "lighthouserc.cjs gates SEO assertion to indexable (checklyra.com) hosts only; demotes SEO to `warn` on Vercel preview URLs",
+        "related_pr_label": "auto-fix-tracked"
+      },
+      "owner_hint": "ci"
+    },
+    {
+      "id": "affiliate-smoke-locale-mismatch",
+      "title": "Affiliate smoke probes hit the wrong regional storefront",
+      "summary": "The smoke runner HEAD-probes a single UK source URL (e.g. amazon.co.uk) and expects per-locale storefronts (amazon.com, amazon.de) — which won't happen pre-Sovrn because Accept-Language alone doesn't move users off a regional domain. Fix is in src/lib/affiliate/smoke.ts adding per-country source URLs.",
+      "workflows": ["Affiliate link smoke", "affiliate-link-smoke"],
+      "regex": "\\[smoke\\] FAIL [a-z_]+ [A-Z]{2}: (unexpected_host|head_http_404)",
+      "remediation": {
+        "kind": "pr_pending",
+        "pr_branch_hint": "fix/affiliate-smoke-locale-urls",
+        "fix_summary": "src/lib/affiliate/smoke.ts adds optional representativeUrlsByCountry; populated for Amazon/eBay/Bookshop.org",
+        "related_pr_label": "auto-fix-tracked"
+      },
+      "owner_hint": "ci"
+    }
+  ]
+}

--- a/tests/fixtures/auto-fix-logs/affiliate-link-smoke.log
+++ b/tests/fixtures/auto-fix-logs/affiliate-link-smoke.log
@@ -1,0 +1,16 @@
+smoke	Run smoke probes	2026-05-27T22:10:30.9324698Z [smoke] FAIL amazon CA: unexpected_host (final=https://www.amazon.co.uk/dp/0241988055) [123ms]
+smoke	Run smoke probes	2026-05-27T22:10:30.9326578Z [smoke] FAIL amazon AU: unexpected_host (final=https://www.amazon.co.uk/dp/0241988055) [121ms]
+smoke	Run smoke probes	2026-05-27T22:10:30.9328037Z [smoke] FAIL amazon JP: unexpected_host (final=https://www.amazon.co.uk/dp/0241988055) [127ms]
+smoke	Run smoke probes	2026-05-27T22:10:30.9329214Z [smoke] FAIL ebay US: unexpected_host (final=https://www.ebay.co.uk/) [598ms]
+smoke	Run smoke probes	2026-05-27T22:10:30.9330315Z [smoke] FAIL ebay DE: unexpected_host (final=https://www.ebay.co.uk/) [428ms]
+smoke	Run smoke probes	2026-05-27T22:10:30.9331428Z [smoke] FAIL ebay FR: unexpected_host (final=https://www.ebay.co.uk/) [194ms]
+smoke	Run smoke probes	2026-05-27T22:10:30.9332433Z [smoke] FAIL ebay IT: unexpected_host (final=https://www.ebay.co.uk/) [308ms]
+smoke	Run smoke probes	2026-05-27T22:10:30.9333353Z [smoke] FAIL ebay ES: unexpected_host (final=https://www.ebay.co.uk/) [350ms]
+smoke	Run smoke probes	2026-05-27T22:10:30.9334356Z [smoke] FAIL ebay CA: unexpected_host (final=https://www.ebay.co.uk/) [347ms]
+smoke	Run smoke probes	2026-05-27T22:10:30.9335119Z [smoke] FAIL ebay AU: unexpected_host (final=https://www.ebay.co.uk/) [201ms]
+smoke	Run smoke probes	2026-05-27T22:10:30.9335697Z [smoke] FAIL johnlewis GB: timeout [5001ms]
+smoke	Run smoke probes	2026-05-27T22:10:30.9336612Z [smoke] FAIL bookshop_org GB: head_http_404 (final=https://uk.bookshop.org/gift-cards) [377ms]
+smoke	Run smoke probes	2026-05-27T22:10:30.9337554Z [smoke] FAIL bookshop_org IE: head_http_404 (final=https://uk.bookshop.org/gift-cards) [118ms]
+smoke	Run smoke probes	2026-05-27T22:10:30.9338337Z [smoke] FAIL bookshop_org US: head_http_404 (final=https://uk.bookshop.org/gift-cards) [115ms]
+smoke	Run smoke probes	2026-05-27T22:10:30.9338911Z [smoke] summary written to smoke-results.json
+smoke	Run smoke probes	2026-05-27T22:10:30.9577978Z ##[error]Process completed with exit code 1.

--- a/tests/fixtures/auto-fix-logs/anomaly-detect.log
+++ b/tests/fixtures/auto-fix-logs/anomaly-detect.log
@@ -1,0 +1,25 @@
+Compare windows against 30d baseline	UNKNOWN STEP	2026-05-27T19:38:46.1431435Z ^[[36;1m  echo "Opening new anomaly issue"^[[0m
+Compare windows against 30d baseline	UNKNOWN STEP	2026-05-27T19:38:46.1431837Z ^[[36;1m  gh issue create --title "$TITLE" --label anomaly --body-file "$BODY_FILE"^[[0m
+Compare windows against 30d baseline	UNKNOWN STEP	2026-05-27T19:38:46.1432211Z ^[[36;1mfi^[[0m
+Compare windows against 30d baseline	UNKNOWN STEP	2026-05-27T19:38:46.1460034Z shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
+Compare windows against 30d baseline	UNKNOWN STEP	2026-05-27T19:38:46.1460362Z env:
+Compare windows against 30d baseline	UNKNOWN STEP	2026-05-27T19:38:46.1460616Z   pythonLocation: /opt/hostedtoolcache/Python/3.12.13/x64
+Compare windows against 30d baseline	UNKNOWN STEP	2026-05-27T19:38:46.1461273Z   PKG_CONFIG_PATH: /opt/hostedtoolcache/Python/3.12.13/x64/lib/pkgconfig
+Compare windows against 30d baseline	UNKNOWN STEP	2026-05-27T19:38:46.1461712Z   Python_ROOT_DIR: /opt/hostedtoolcache/Python/3.12.13/x64
+Compare windows against 30d baseline	UNKNOWN STEP	2026-05-27T19:38:46.1462091Z   Python2_ROOT_DIR: /opt/hostedtoolcache/Python/3.12.13/x64
+Compare windows against 30d baseline	UNKNOWN STEP	2026-05-27T19:38:46.1462458Z   Python3_ROOT_DIR: /opt/hostedtoolcache/Python/3.12.13/x64
+Compare windows against 30d baseline	UNKNOWN STEP	2026-05-27T19:38:46.1462832Z   LD_LIBRARY_PATH: /opt/hostedtoolcache/Python/3.12.13/x64/lib
+Compare windows against 30d baseline	UNKNOWN STEP	2026-05-27T19:38:46.1463457Z   GH_TOKEN: ***
+Compare windows against 30d baseline	UNKNOWN STEP	2026-05-27T19:38:46.1463655Z ##[endgroup]
+Compare windows against 30d baseline	UNKNOWN STEP	2026-05-27T19:38:46.9555078Z Opening new anomaly issue
+Compare windows against 30d baseline	UNKNOWN STEP	2026-05-27T19:38:47.4214732Z could not add label: 'anomaly' not found
+Compare windows against 30d baseline	UNKNOWN STEP	2026-05-27T19:38:47.4241298Z ##[error]Process completed with exit code 1.
+Compare windows against 30d baseline	UNKNOWN STEP	2026-05-27T19:38:47.4337039Z Post job cleanup.
+Compare windows against 30d baseline	UNKNOWN STEP	2026-05-27T19:38:47.5176491Z [command]/usr/bin/git version
+Compare windows against 30d baseline	UNKNOWN STEP	2026-05-27T19:38:47.5214067Z git version 2.54.0
+Compare windows against 30d baseline	UNKNOWN STEP	2026-05-27T19:38:47.5255505Z Temporarily overriding HOME='/home/runner/work/_temp/9267b231-d4ba-4cdf-84d2-124f8f30d0b7' before making global git config changes
+Compare windows against 30d baseline	UNKNOWN STEP	2026-05-27T19:38:47.5256936Z Adding repository directory to the temporary git global config as a safe directory
+Compare windows against 30d baseline	UNKNOWN STEP	2026-05-27T19:38:47.5261784Z [command]/usr/bin/git config --global --add safe.directory /home/runner/work/lyra/lyra
+Compare windows against 30d baseline	UNKNOWN STEP	2026-05-27T19:38:47.5294052Z Removing SSH command configuration
+Compare windows against 30d baseline	UNKNOWN STEP	2026-05-27T19:38:47.5300610Z [command]/usr/bin/git config --local --name-only --get-regexp core\.sshCommand
+Compare windows against 30d baseline	UNKNOWN STEP	2026-05-27T19:38:47.5333207Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'core\.sshCommand' && git config --local --unset-all 'core.sshCommand' || :"

--- a/tests/fixtures/auto-fix-logs/auto-promote-to-staging.log
+++ b/tests/fixtures/auto-fix-logs/auto-promote-to-staging.log
@@ -1,0 +1,17 @@
+Run promote-to-staging	UNKNOWN STEP	2026-05-24T23:49:06.9528773Z ^[[36;1m# those triggers — gotcha #16).^[[0m
+Run promote-to-staging	UNKNOWN STEP	2026-05-24T23:49:06.9529497Z ^[[36;1mgh workflow run promote-to-staging.yml \^[[0m
+Run promote-to-staging	UNKNOWN STEP	2026-05-24T23:49:06.9530168Z ^[[36;1m  --repo "luisa-sys/lyra" \^[[0m
+Run promote-to-staging	UNKNOWN STEP	2026-05-24T23:49:06.9530731Z ^[[36;1m  --ref main \^[[0m
+Run promote-to-staging	UNKNOWN STEP	2026-05-24T23:49:06.9531415Z ^[[36;1m  -f confirm=promote^[[0m
+Run promote-to-staging	UNKNOWN STEP	2026-05-24T23:49:06.9532558Z ^[[36;1mecho "::notice::Dispatched promote-to-staging.yml for develop $DEVELOP_SHA"^[[0m
+Run promote-to-staging	UNKNOWN STEP	2026-05-24T23:49:06.9533626Z ^[[36;1mecho "## Promotion dispatched" >> "$GITHUB_STEP_SUMMARY"^[[0m
+Run promote-to-staging	UNKNOWN STEP	2026-05-24T23:49:06.9534863Z ^[[36;1mecho "Watch the run at: https://github.com/luisa-sys/lyra/actions/workflows/promote-to-staging.yml" >> "$GITHUB_STEP_SUMMARY"^[[0m
+Run promote-to-staging	UNKNOWN STEP	2026-05-24T23:49:06.9986097Z shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
+Run promote-to-staging	UNKNOWN STEP	2026-05-24T23:49:06.9987131Z env:
+Run promote-to-staging	UNKNOWN STEP	2026-05-24T23:49:06.9987785Z   SOAK_HOURS: 24
+Run promote-to-staging	UNKNOWN STEP	2026-05-24T23:49:06.9988907Z   GH_TOKEN: ***
+Run promote-to-staging	UNKNOWN STEP	2026-05-24T23:49:06.9989447Z   DEVELOP_SHA: 5f257902e3bfacf75f1035152820688963706aa7
+Run promote-to-staging	UNKNOWN STEP	2026-05-24T23:49:06.9990219Z ##[endgroup]
+Run promote-to-staging	UNKNOWN STEP	2026-05-24T23:49:07.6685773Z could not create workflow dispatch event: HTTP 403: Resource not accessible by personal access token (https://api.github.com/repos/luisa-sys/lyra/actions/workflows/252840555/dispatches)
+Run promote-to-staging	UNKNOWN STEP	2026-05-24T23:49:07.6706619Z ##[error]Process completed with exit code 1.
+Run promote-to-staging	UNKNOWN STEP	2026-05-24T23:49:07.6823665Z Cleaning up orphan processes

--- a/tests/fixtures/auto-fix-logs/beta-gate-smoke.log
+++ b/tests/fixtures/auto-fix-logs/beta-gate-smoke.log
@@ -1,0 +1,25 @@
+Probe beta-gate contracts	UNKNOWN STEP	2026-05-27T09:00:39.3015349Z ^[[36;1m    echo "::notice::Bypass header accepted, app responsive."^[[0m
+Probe beta-gate contracts	UNKNOWN STEP	2026-05-27T09:00:39.3015976Z ^[[36;1m    ;;^[[0m
+Probe beta-gate contracts	UNKNOWN STEP	2026-05-27T09:00:39.3016341Z ^[[36;1m  *)^[[0m
+Probe beta-gate contracts	UNKNOWN STEP	2026-05-27T09:00:39.3017828Z ^[[36;1m    echo "::error::Bypass header didn't unlock beta (HTTP ${STATUS}). VERCEL_AUTOMATION_BYPASS may have rotated. Refresh from Vercel dashboard → Settings → Deployment Protection → Protection Bypass for Automation. See KAN-223."^[[0m
+Probe beta-gate contracts	UNKNOWN STEP	2026-05-27T09:00:39.3019374Z ^[[36;1m    exit 1^[[0m
+Probe beta-gate contracts	UNKNOWN STEP	2026-05-27T09:00:39.3019762Z ^[[36;1m    ;;^[[0m
+Probe beta-gate contracts	UNKNOWN STEP	2026-05-27T09:00:39.3020136Z ^[[36;1mesac^[[0m
+Probe beta-gate contracts	UNKNOWN STEP	2026-05-27T09:00:39.3053838Z shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
+Probe beta-gate contracts	UNKNOWN STEP	2026-05-27T09:00:39.3054448Z env:
+Probe beta-gate contracts	UNKNOWN STEP	2026-05-27T09:00:39.3055137Z   BETA_HOST: https://beta.checklyra.com
+Probe beta-gate contracts	UNKNOWN STEP	2026-05-27T09:00:39.3055715Z   MCP_HOST: https://mcp.checklyra.com
+Probe beta-gate contracts	UNKNOWN STEP	2026-05-27T09:00:39.3056389Z   VERCEL_BYPASS: ***
+Probe beta-gate contracts	UNKNOWN STEP	2026-05-27T09:00:39.3056794Z ##[endgroup]
+Probe beta-gate contracts	UNKNOWN STEP	2026-05-27T09:00:39.3505883Z Root with bypass: 403
+Probe beta-gate contracts	UNKNOWN STEP	2026-05-27T09:00:39.3595922Z ##[error]Bypass header didn't unlock beta (HTTP 403). VERCEL_AUTOMATION_BYPASS may have rotated. Refresh from Vercel dashboard → Settings → Deployment Protection → Protection Bypass for Automation. See KAN-223.
+Probe beta-gate contracts	UNKNOWN STEP	2026-05-27T09:00:39.3599849Z ##[error]Process completed with exit code 1.
+Probe beta-gate contracts	UNKNOWN STEP	2026-05-27T09:00:39.3683348Z ##[group]Run set -euo pipefail
+Probe beta-gate contracts	UNKNOWN STEP	2026-05-27T09:00:39.3683888Z ^[[36;1mset -euo pipefail^[[0m
+Probe beta-gate contracts	UNKNOWN STEP	2026-05-27T09:00:39.3684314Z ^[[36;1m{^[[0m
+Probe beta-gate contracts	UNKNOWN STEP	2026-05-27T09:00:39.3684697Z ^[[36;1m  echo "## Beta gate smoke"^[[0m
+Probe beta-gate contracts	UNKNOWN STEP	2026-05-27T09:00:39.3685492Z ^[[36;1m  echo ""^[[0m
+Probe beta-gate contracts	UNKNOWN STEP	2026-05-27T09:00:39.3685967Z ^[[36;1m  echo "Run on: $(date -u +%Y-%m-%dT%H:%M:%SZ)"^[[0m
+Probe beta-gate contracts	UNKNOWN STEP	2026-05-27T09:00:39.3686552Z ^[[36;1m  echo "Trigger: schedule"^[[0m
+Probe beta-gate contracts	UNKNOWN STEP	2026-05-27T09:00:39.3687027Z ^[[36;1m  echo ""^[[0m
+Probe beta-gate contracts	UNKNOWN STEP	2026-05-27T09:00:39.3687457Z ^[[36;1m  if [ "failure" = "success" ]; then^[[0m

--- a/tests/fixtures/auto-fix-logs/staging-tests.log
+++ b/tests/fixtures/auto-fix-logs/staging-tests.log
@@ -1,0 +1,25 @@
+Lighthouse budget	UNKNOWN STEP	2026-05-27T08:34:09.6796767Z 
+Lighthouse budget	UNKNOWN STEP	2026-05-27T08:34:09.6797953Z 1 result(s) for ^[[1mhttps://lyra-rfgj4k15s-luisa-sys-projects.vercel.app/^[[0m :
+Lighthouse budget	UNKNOWN STEP	2026-05-27T08:34:09.6798871Z 
+Lighthouse budget	UNKNOWN STEP	2026-05-27T08:34:09.6799993Z   ^[[31m✘^[[0m  ^[[1mcategories^[[0m.seo failure for ^[[1mminScore^[[0m assertion
+Lighthouse budget	UNKNOWN STEP	2026-05-27T08:34:09.6800730Z         expected: >=^[[32m0.9^[[0m
+Lighthouse budget	UNKNOWN STEP	2026-05-27T08:34:09.6801198Z            found: ^[[31m0.69^[[0m
+Lighthouse budget	UNKNOWN STEP	2026-05-27T08:34:09.6801731Z       ^[[2mall values: 0.69^[[0m
+Lighthouse budget	UNKNOWN STEP	2026-05-27T08:34:09.6801997Z 
+Lighthouse budget	UNKNOWN STEP	2026-05-27T08:34:09.6802281Z Assertion failed. Exiting with status code 1.
+Lighthouse budget	UNKNOWN STEP	2026-05-27T08:34:09.6851660Z 
+Lighthouse budget	UNKNOWN STEP	2026-05-27T08:34:11.1661352Z Uploading median LHR of https://lyra-rfgj4k15s-luisa-sys-projects.vercel.app/...success!
+Lighthouse budget	UNKNOWN STEP	2026-05-27T08:34:11.1662554Z Open the report at https://storage.googleapis.com/lighthouse-infrastructure.appspot.com/reports/1779870850918-48152.report.html
+Lighthouse budget	UNKNOWN STEP	2026-05-27T08:34:11.1714297Z No GitHub token set, skipping GitHub status check.
+Lighthouse budget	UNKNOWN STEP	2026-05-27T08:34:11.1825601Z assert command failed. Exiting with status code 1.
+Lighthouse budget	UNKNOWN STEP	2026-05-27T08:34:11.1825988Z 
+Lighthouse budget	UNKNOWN STEP	2026-05-27T08:34:11.1956602Z ##[error]Process completed with exit code 1.
+Lighthouse budget	UNKNOWN STEP	2026-05-27T08:34:11.2038365Z ##[group]Run actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+Lighthouse budget	UNKNOWN STEP	2026-05-27T08:34:11.2038792Z with:
+Lighthouse budget	UNKNOWN STEP	2026-05-27T08:34:11.2039008Z   name: lighthouse-reports
+Lighthouse budget	UNKNOWN STEP	2026-05-27T08:34:11.2039259Z   path: .lighthouseci/
+Lighthouse budget	UNKNOWN STEP	2026-05-27T08:34:11.2039499Z   retention-days: 14
+Lighthouse budget	UNKNOWN STEP	2026-05-27T08:34:11.2039716Z   if-no-files-found: warn
+Lighthouse budget	UNKNOWN STEP	2026-05-27T08:34:11.2039957Z   compression-level: 6
+Lighthouse budget	UNKNOWN STEP	2026-05-27T08:34:11.2040162Z   overwrite: false
+Lighthouse budget	UNKNOWN STEP	2026-05-27T08:34:11.2040376Z   include-hidden-files: false

--- a/tests/unit/auto-fix-patterns.test.js
+++ b/tests/unit/auto-fix-patterns.test.js
@@ -1,0 +1,189 @@
+/**
+ * KAN-63 Tier 4: regression tests for the auto-fix pattern catalogue.
+ *
+ * The Python self-test (`scripts/auto-fix-known-failures.py --self-test`)
+ * is the authoritative regression guard and runs in pr-checks.yml. These
+ * JS tests are belt-and-braces:
+ *
+ *   - JSON schema validation (every pattern has the required shape)
+ *   - Regex validity in JavaScript (so if you ever port the matcher to
+ *     a JS-based tool, the patterns still work)
+ *   - Each pattern matches its anchor fixture
+ *   - No cross-contamination between patterns sharing a workflow
+ *
+ * Patterns use stdlib-friendly regex features only, so JS and Python
+ * regex parse the same strings the same way for our use.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const PATTERNS_PATH = path.resolve(__dirname, '../../scripts/auto-fix-patterns.json');
+const FIXTURES_DIR = path.resolve(__dirname, '../fixtures/auto-fix-logs');
+
+// Same mapping the Python self-test uses; keep them in sync.
+const FIXTURE_EXPECTATIONS = {
+  'anomaly-detect.log': { workflow: 'anomaly-detect', patternId: 'anomaly-missing-github-label' },
+  'beta-gate-smoke.log': { workflow: 'beta-gate-smoke', patternId: 'vercel-automation-bypass-rotated' },
+  'staging-tests.log': { workflow: 'staging-tests', patternId: 'lighthouse-seo-on-noindex-target' },
+  'affiliate-link-smoke.log': { workflow: 'affiliate-link-smoke', patternId: 'affiliate-smoke-locale-mismatch' },
+  'auto-promote-to-staging.log': { workflow: 'auto-promote-to-staging', patternId: 'lyra-release-pat-insufficient-scopes' },
+};
+
+const KNOWN_REMEDIATION_KINDS = new Set([
+  'create_label',
+  'alert_secret_rotation',
+  'pr_pending',
+]);
+
+function stripAnsi(text) {
+  // Same characters the Python ANSI_RE strips: ESC[...m and ESC[...K.
+  return text.replace(/\x1b\[[0-9;]*[mK]/g, '');
+}
+
+function workflowMatches(pattern, workflowName) {
+  const norm = workflowName.trim().toLowerCase();
+  return pattern.workflows.some((w) => w.trim().toLowerCase() === norm);
+}
+
+let catalogue;
+let patterns;
+
+beforeAll(() => {
+  catalogue = JSON.parse(fs.readFileSync(PATTERNS_PATH, 'utf8'));
+  patterns = catalogue.patterns;
+});
+
+describe('KAN-63 Tier 4: auto-fix-patterns.json shape', () => {
+  test('catalogue declares version 1', () => {
+    expect(catalogue.version).toBe(1);
+  });
+
+  test('every pattern has id, title, workflows[], regex, remediation.kind', () => {
+    for (const p of patterns) {
+      expect(typeof p.id).toBe('string');
+      expect(p.id.length).toBeGreaterThan(0);
+      expect(typeof p.title).toBe('string');
+      expect(Array.isArray(p.workflows)).toBe(true);
+      expect(p.workflows.length).toBeGreaterThan(0);
+      expect(typeof p.regex).toBe('string');
+      expect(p.regex.length).toBeGreaterThan(0);
+      expect(p.remediation).toBeDefined();
+      expect(typeof p.remediation.kind).toBe('string');
+    }
+  });
+
+  test('every pattern id is unique', () => {
+    const ids = patterns.map((p) => p.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  test('every pattern uses a known remediation kind', () => {
+    for (const p of patterns) {
+      expect(KNOWN_REMEDIATION_KINDS.has(p.remediation.kind)).toBe(true);
+    }
+  });
+
+  test('every pattern regex compiles in JS', () => {
+    for (const p of patterns) {
+      expect(() => new RegExp(p.regex, 'i')).not.toThrow();
+    }
+  });
+
+  test('create_label patterns have a capture group for the label name', () => {
+    // The Python handler reads match.group(1). If a label-create pattern
+    // has no capture group, it'll error at remediation time. Catch here.
+    for (const p of patterns) {
+      if (p.remediation.kind !== 'create_label') continue;
+      // Look for an unescaped `(` not preceded by `\` and not part of `(?:`.
+      const hasGroup = /(?:^|[^\\])\((?!\?[!:=<])/.test(p.regex);
+      expect(hasGroup).toBe(true);
+    }
+  });
+
+  test('alert_secret_rotation patterns name the secret', () => {
+    for (const p of patterns) {
+      if (p.remediation.kind !== 'alert_secret_rotation') continue;
+      expect(typeof p.remediation.secret_name).toBe('string');
+      expect(p.remediation.secret_name.length).toBeGreaterThan(0);
+      expect(Array.isArray(p.remediation.steps)).toBe(true);
+      expect(p.remediation.steps.length).toBeGreaterThan(0);
+    }
+  });
+
+  test('pr_pending patterns name a branch hint', () => {
+    for (const p of patterns) {
+      if (p.remediation.kind !== 'pr_pending') continue;
+      expect(typeof p.remediation.pr_branch_hint).toBe('string');
+      expect(p.remediation.pr_branch_hint.length).toBeGreaterThan(0);
+    }
+  });
+});
+
+describe('KAN-63 Tier 4: pattern ↔ fixture mapping', () => {
+  test('every expected fixture exists on disk', () => {
+    for (const fixture of Object.keys(FIXTURE_EXPECTATIONS)) {
+      expect(fs.existsSync(path.join(FIXTURES_DIR, fixture))).toBe(true);
+    }
+  });
+
+  test('every catalogued pattern has a fixture in FIXTURE_EXPECTATIONS', () => {
+    const expectedIds = new Set(Object.values(FIXTURE_EXPECTATIONS).map((e) => e.patternId));
+    for (const p of patterns) {
+      expect(expectedIds.has(p.id)).toBe(true);
+    }
+  });
+
+  test.each(Object.entries(FIXTURE_EXPECTATIONS))(
+    'fixture %s classifies as the expected pattern',
+    (fixtureName, expected) => {
+      const text = stripAnsi(fs.readFileSync(path.join(FIXTURES_DIR, fixtureName), 'utf8'));
+      const matching = patterns
+        .filter((p) => workflowMatches(p, expected.workflow))
+        .find((p) => new RegExp(p.regex, 'i').test(text));
+      expect(matching).toBeDefined();
+      expect(matching.id).toBe(expected.patternId);
+    },
+  );
+
+  test('no pattern false-positives on a sibling fixture sharing its workflow', () => {
+    // For each fixture, ensure that ONLY the expected pattern (within
+    // that fixture's workflow scope) fires. Patterns from other workflows
+    // are out of scope here — the workflow gate protects them.
+    for (const [fixtureName, expected] of Object.entries(FIXTURE_EXPECTATIONS)) {
+      const text = stripAnsi(fs.readFileSync(path.join(FIXTURES_DIR, fixtureName), 'utf8'));
+      const inScope = patterns.filter((p) => workflowMatches(p, expected.workflow));
+      const matching = inScope.filter((p) => new RegExp(p.regex, 'i').test(text));
+      expect(matching.length).toBe(1);
+      expect(matching[0].id).toBe(expected.patternId);
+    }
+  });
+});
+
+describe('KAN-63 Tier 4: workflow trigger file references the right names', () => {
+  // The workflow trigger file (.github/workflows/auto-fix-known-failures.yml)
+  // lists workflow display names to react to. Those names must match at
+  // least one workflow listing in the pattern catalogue, or the trigger
+  // is wired to a workflow no pattern handles.
+  test('every workflow_run trigger name has at least one pattern that lists it', () => {
+    const wfPath = path.resolve(
+      __dirname,
+      '../../.github/workflows/auto-fix-known-failures.yml',
+    );
+    const wfYaml = fs.readFileSync(wfPath, 'utf8');
+    // Cheap parse: look for quoted strings under the workflows: section.
+    // The block is short — match every "Foo bar"-style string between
+    // `workflows:` and the closing `types:` line.
+    const block = wfYaml.match(/workflows:\s*([\s\S]*?)\n\s*types:/);
+    expect(block).toBeTruthy();
+    const names = [...block[1].matchAll(/-\s*"([^"]+)"/g)].map((m) => m[1]);
+    expect(names.length).toBeGreaterThan(0);
+    const allListed = new Set();
+    for (const p of patterns) {
+      for (const w of p.workflows) allListed.add(w.trim().toLowerCase());
+    }
+    for (const n of names) {
+      expect(allListed.has(n.trim().toLowerCase())).toBe(true);
+    }
+  });
+});


### PR DESCRIPTION
**Jira:** [KAN-248](https://checklyra.atlassian.net/browse/KAN-248) (Tier 4 of KAN-63 epic)

## Summary
Adds a pattern-driven auto-triage + self-heal layer for the recurring CI-workflow failures that have been emailing daily through May 2026. Five seed patterns cover the current noise; the system is data-driven so adding a new pattern is a fixture file + a JSON entry + an entry in `FIXTURE_EXPECTATIONS` — the regression guard does the rest.

## What lands

| File | Purpose |
|---|---|
| `scripts/auto-fix-patterns.json` | Pattern catalogue (5 seed patterns) |
| `scripts/auto-fix-known-failures.py` | Stdlib classifier + dispatcher (matches existing Python scripts/anomaly-detect.py + cleanup-phantom-check-suites.py convention) |
| `.github/workflows/auto-fix-known-failures.yml` | `workflow_run.completed` trigger on the 5 watched workflows + `workflow_dispatch` for manual replay |
| `tests/unit/auto-fix-patterns.test.js` | 17 JS unit tests |
| `tests/fixtures/auto-fix-logs/*.log` | 5 real failed-step log fixtures |
| `.github/workflows/pr-checks.yml` | Self-test runs on every PR (regression guard) |
| `docs/RUNBOOK.md` | § "CI workflow auto-triage and self-heal (Tier 4 — shipped)" |

## Remediation kinds

| kind | action | idempotent |
|---|---|---|
| `create_label` | `gh label create` + `gh run rerun` | yes (label_exists check) |
| `alert_secret_rotation` | Upsert deduped GH issue with the rotation steps | yes (issue_upsert) |
| `pr_pending` | Comment ONCE on the open PR carrying the fix | yes (marker dedup) |
| `unknown` (fallback) | Upsert deduped issue with log excerpt | yes (issue_upsert) |

## Seed pattern coverage

| pattern | workflow | remediation |
|---|---|---|
| `anomaly-missing-github-label` | Anomaly detect | `create_label` |
| `vercel-automation-bypass-rotated` | Beta gate smoke | `alert_secret_rotation` |
| `lyra-release-pat-insufficient-scopes` | Auto-promote develop→staging | `alert_secret_rotation` |
| `lighthouse-seo-on-noindex-target` | Staging Tests | `pr_pending` → #291 |
| `affiliate-smoke-locale-mismatch` | Affiliate link smoke | `pr_pending` → #290 |

## What it deliberately does NOT do
- Edit code, open PRs with code changes, merge anything, push to any branch
- Call external APIs (no Vercel/Cloudflare/Railway/Resend touches)
- Read secrets directly — logs go through `gh run view --log-failed` which redacts `***`

Bounded to GitHub-native actions (labels, issues, comments, re-runs). Anything beyond is a follow-up.

## Test plan
- [x] `python3 scripts/auto-fix-known-failures.py --self-test` → 5 patterns × 5 fixtures classified correctly
- [x] `npx jest tests/unit/auto-fix-patterns.test.js` → 17/17 pass
- [x] `npx jest` (full) → 1404 / 1404 unit tests (baseline 1387 + 17 new). Same 3 Playwright e2e suites fail identically pre/post — pre-existing jest-vs-playwright config issue
- [x] `npx tsc --noEmit` → clean
- [x] `npx eslint` → 0 errors
- [x] `bash scripts/check-workflow-integrity.sh` → passes
- [x] Real-world `--dry-run` smoke against 3 most recent recurring failures (staging-tests run `26500250833`, affiliate-link-smoke run `26541705445`, beta-gate-smoke run `26501570009`): all classify correctly and the dispatcher picks the right remediation. PR-pending patterns successfully find open PRs (#291, #290) by branch hint.
- [ ] Post-merge: workflow fires automatically on the next live failure

## Adding a new pattern (for future contributors)
1. Save the failing log to `tests/fixtures/auto-fix-logs/<workflow-slug>.log`
2. Add a pattern entry to `scripts/auto-fix-patterns.json`
3. Add the `(fixture, pattern_id)` tuple to `FIXTURE_EXPECTATIONS` in both the Python script and the JS test
4. Run `python3 scripts/auto-fix-known-failures.py --self-test` and `npx jest tests/unit/auto-fix-patterns.test.js` — both must pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[KAN-248]: https://checklyra.atlassian.net/browse/KAN-248?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ