### PR TITLE
fix(affiliate-smoke): swap bookshop.org /gift-cards (404) for homepage probe

### DIFF
--- a/src/lib/affiliate/smoke.ts
+++ b/src/lib/affiliate/smoke.ts
@@ -138,11 +138,14 @@ export const SMOKE_PROBES: readonly MerchantSmokeProbe[] = [
   },
   {
     merchantId: 'bookshop_org',
-    representativeUrl: 'https://uk.bookshop.org/gift-cards', // GB fallback
+    // `/gift-cards` returned 404 across all locales in May 2026 — the page
+    // was deprecated. Switch the probe to the regional homepage, which
+    // 200s on HEAD and reliably resolves to the correct locale.
+    representativeUrl: 'https://uk.bookshop.org/', // GB fallback
     representativeUrlsByCountry: {
-      GB: 'https://uk.bookshop.org/gift-cards',
-      IE: 'https://uk.bookshop.org/gift-cards',
-      US: 'https://bookshop.org/gift-cards',
+      GB: 'https://uk.bookshop.org/',
+      IE: 'https://uk.bookshop.org/',
+      US: 'https://bookshop.org/',
     },
     expectedHostsByCountry: {
       GB: ['uk.bookshop.org', 'bookshop.org'],


### PR DESCRIPTION
## Summary
Follow-up to #290. After the per-locale URL fix landed, the 3 bookshop_org probes still fail because the \`/gift-cards\` path returns 404 — the page was deprecated/removed in May 2026.

## Change
Swap probe URLs from \`/gift-cards\` to the regional homepage (consistent with johnlewis/etsy/otto/notonthehighstreet, which all probe \`/\`).

## Verification
- \`curl -I https://uk.bookshop.org/\` → HTTP 200
- \`curl -I https://bookshop.org/\` → HTTP 307 (locale redirect; resolves clean)
- \`npx jest tests/unit/affiliate-smoke.test.ts\` → 28/28 pass

## Known remaining
\`johnlewis GB\` probe returns HTTP/2 connection refused from GH Actions runners (5s timeout). Not addressed here — that's runner-IP / merchant-bot-protection issue, separate triage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)