### PR TITLE
feat(auth): Plan A Phase 1 — invite gate + passwordless magic-link sign-in (KAN-258)

### DIFF
--- a/src/app/(auth)/actions.ts
+++ b/src/app/(auth)/actions.ts
@@ -25,6 +25,23 @@ export async function signUp(formData: FormData) {
     return redirect('/signup?error=' + encodeURIComponent('Password must be at least 6 characters'));
   }
 
+  // KAN-258 — invite-only phase. When an invite code is configured, a new
+  // account can only be created with the correct code. This check sits
+  // BEFORE supabase.auth.signUp, so no auth.users row (and therefore no
+  // profile, via the handle_new_user trigger) is ever created without it.
+  const requiredInvite = env.inviteCode();
+  if (requiredInvite) {
+    const code = ((formData.get('invite_code') as string | null) ?? '').trim();
+    if (code !== requiredInvite) {
+      return redirect(
+        '/signup?error=' +
+          encodeURIComponent(
+            "That invite code isn't right. Lyra is invite-only while we're in private testing.",
+          ),
+      );
+    }
+  }
+
   const siteUrl = getSiteUrl();
 
   const { error } = await supabase.auth.signUp({

--- a/src/app/(auth)/actions.ts
+++ b/src/app/(auth)/actions.ts
@@ -14,20 +14,15 @@ export async function signUp(formData: FormData) {
   const supabase = await createClient();
 
   const email = formData.get('email') as string;
-  const password = formData.get('password') as string;
   const fullName = formData.get('full_name') as string;
 
-  if (!email || !password || !fullName) {
-    return redirect('/signup?error=' + encodeURIComponent('All fields are required'));
-  }
-
-  if (password.length < 6) {
-    return redirect('/signup?error=' + encodeURIComponent('Password must be at least 6 characters'));
+  if (!email || !fullName) {
+    return redirect('/signup?error=' + encodeURIComponent('Your name and email are required'));
   }
 
   // KAN-258 — invite-only phase. When an invite code is configured, a new
   // account can only be created with the correct code. This check sits
-  // BEFORE supabase.auth.signUp, so no auth.users row (and therefore no
+  // BEFORE any account creation, so no auth.users row (and therefore no
   // profile, via the handle_new_user trigger) is ever created without it.
   const requiredInvite = env.inviteCode();
   if (requiredInvite) {
@@ -44,11 +39,15 @@ export async function signUp(formData: FormData) {
 
   const siteUrl = getSiteUrl();
 
-  const { error } = await supabase.auth.signUp({
+  // KAN-258 — passwordless sign-up. We email a magic link instead of asking
+  // for a password. shouldCreateUser:true so an invited person gets an
+  // account on first click; the handle_new_user trigger reads full_name
+  // from the user metadata we pass here.
+  const { error } = await supabase.auth.signInWithOtp({
     email,
-    password,
     options: {
       emailRedirectTo: `${siteUrl}/auth/callback`,
+      shouldCreateUser: true,
       data: {
         full_name: fullName,
       },
@@ -59,29 +58,38 @@ export async function signUp(formData: FormData) {
     return redirect('/signup?error=' + encodeURIComponent(error.message));
   }
 
-  return redirect('/signup?message=' + encodeURIComponent('Check your email to confirm your account'));
+  return redirect(
+    '/signup?message=' +
+      encodeURIComponent('Check your email for a link to finish creating your account.'),
+  );
 }
 
 export async function signIn(formData: FormData) {
   const supabase = await createClient();
 
   const email = formData.get('email') as string;
-  const password = formData.get('password') as string;
 
-  if (!email || !password) {
-    return redirect('/login?error=' + encodeURIComponent('Email and password are required'));
+  if (!email) {
+    return redirect('/login?error=' + encodeURIComponent('Email is required'));
   }
 
-  const { error } = await supabase.auth.signInWithPassword({
+  // KAN-258 — passwordless sign-in. Email a magic link.
+  // shouldCreateUser:false so this path never creates a new (un-invited)
+  // account — sign-up is the only account-creation path, and it's
+  // invite-gated.
+  const { error } = await supabase.auth.signInWithOtp({
     email,
-    password,
+    options: {
+      emailRedirectTo: `${getSiteUrl()}/auth/callback`,
+      shouldCreateUser: false,
+    },
   });
 
   if (error) {
     return redirect('/login?error=' + encodeURIComponent(error.message));
   }
 
-  return redirect('/dashboard');
+  return redirect('/login?message=' + encodeURIComponent('Check your email for a sign-in link.'));
 }
 
 export async function signOut() {

--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -75,36 +75,18 @@ export default async function LoginPage({
             />
           </div>
 
-          <div>
-            <label htmlFor="password" className="block text-sm font-medium text-[var(--color-ink)] mb-1">
-              Password
-            </label>
-            <input
-              id="password"
-              name="password"
-              type="password"
-              required
-              className="w-full px-3 py-2 rounded-lg border border-stone-300 bg-white text-[var(--color-ink)] text-sm focus:outline-none focus:ring-2 focus:ring-[var(--color-sage)] focus:border-transparent"
-              placeholder="Your password"
-            />
-          </div>
+          <p className="text-xs text-[var(--color-muted)]">
+            No password needed — we&apos;ll email you a secure sign-in link.
+          </p>
 
           <button
             type="submit"
             formAction={signIn}
             className="w-full py-3 rounded-lg bg-[var(--color-sage)] text-white text-base font-medium hover:opacity-90 transition-opacity cursor-pointer"
           >
-            Sign in →
+            Email me a sign-in link →
           </button>
         </form>
-
-        {/* KAN-225: forgot-password escape hatch. Kept under the form
-            so users who know their password aren't distracted by it. */}
-        <p className="mt-4 text-center text-sm">
-          <Link href="/forgot-password" className="text-[var(--color-muted)] hover:text-[var(--color-sage)] hover:underline">
-            Forgot password?
-          </Link>
-        </p>
 
         <p className="mt-4 text-center text-sm text-[var(--color-muted)]">
           Don&apos;t have an account?{' '}

--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -2,6 +2,7 @@ import Link from 'next/link';
 import Image from 'next/image';
 import { signIn } from '../actions';
 import { SocialLoginButtons } from '../social-login-buttons';
+import { env } from '@/lib/env';
 
 export const metadata = {
   title: 'Sign in to Lyra',
@@ -14,6 +15,9 @@ export default async function LoginPage({
   searchParams: Promise<{ error?: string; message?: string }>;
 }) {
   const params = await searchParams;
+  // KAN-258 — hide third-party sign-in during the invite-only phase
+  // (Google sign-in would otherwise create an un-gated account).
+  const inviteOnly = !!env.inviteCode();
 
   return (
     <main className="min-h-screen flex items-center justify-center px-4">
@@ -44,13 +48,17 @@ export default async function LoginPage({
           </div>
         )}
 
-        <SocialLoginButtons />
+        {!inviteOnly && (
+          <>
+            <SocialLoginButtons />
 
-        <div className="flex items-center gap-3 my-6">
-          <div className="flex-1 h-px bg-stone-200" />
-          <span className="text-xs text-[var(--color-muted)]">or</span>
-          <div className="flex-1 h-px bg-stone-200" />
-        </div>
+            <div className="flex items-center gap-3 my-6">
+              <div className="flex-1 h-px bg-stone-200" />
+              <span className="text-xs text-[var(--color-muted)]">or</span>
+              <div className="flex-1 h-px bg-stone-200" />
+            </div>
+          </>
+        )}
 
         <form className="space-y-4">
           <div>

--- a/src/app/(auth)/signup/page.tsx
+++ b/src/app/(auth)/signup/page.tsx
@@ -2,6 +2,7 @@ import Link from 'next/link';
 import Image from 'next/image';
 import { signUp } from '../actions';
 import { SocialLoginButtons } from '../social-login-buttons';
+import { env } from '@/lib/env';
 
 export const metadata = {
   title: 'Create your Lyra profile',
@@ -14,6 +15,10 @@ export default async function SignUpPage({
   searchParams: Promise<{ error?: string; message?: string }>;
 }) {
   const params = await searchParams;
+  // KAN-258 — during the private phase, account creation needs an invite
+  // code and third-party sign-in is hidden, so the only way in is the
+  // gated email form.
+  const inviteOnly = !!env.inviteCode();
 
   return (
     <main className="min-h-screen flex items-center justify-center px-4">
@@ -42,15 +47,39 @@ export default async function SignUpPage({
           </div>
         )}
 
-        <SocialLoginButtons />
+        {!inviteOnly && (
+          <>
+            <SocialLoginButtons />
 
-        <div className="flex items-center gap-3 my-6">
-          <div className="flex-1 h-px bg-stone-200" />
-          <span className="text-xs text-[var(--color-muted)]">or sign up with email</span>
-          <div className="flex-1 h-px bg-stone-200" />
-        </div>
+            <div className="flex items-center gap-3 my-6">
+              <div className="flex-1 h-px bg-stone-200" />
+              <span className="text-xs text-[var(--color-muted)]">or sign up with email</span>
+              <div className="flex-1 h-px bg-stone-200" />
+            </div>
+          </>
+        )}
 
         <form className="space-y-4">
+          {inviteOnly && (
+            <div>
+              <label htmlFor="invite_code" className="block text-sm font-medium text-[var(--color-ink)] mb-1">
+                Invite code
+              </label>
+              <input
+                id="invite_code"
+                name="invite_code"
+                type="text"
+                required
+                autoComplete="off"
+                className="w-full px-3 py-2 rounded-lg border border-stone-300 bg-white text-[var(--color-ink)] text-sm focus:outline-none focus:ring-2 focus:ring-[var(--color-sage)] focus:border-transparent"
+                placeholder="From your invitation"
+              />
+              <p className="mt-1 text-xs text-[var(--color-muted)]">
+                Lyra is invite-only while we&apos;re in private testing.
+              </p>
+            </div>
+          )}
+
           <div>
             <label htmlFor="full_name" className="block text-sm font-medium text-[var(--color-ink)] mb-1">
               Full name

--- a/src/app/(auth)/signup/page.tsx
+++ b/src/app/(auth)/signup/page.tsx
@@ -108,20 +108,9 @@ export default async function SignUpPage({
             />
           </div>
 
-          <div>
-            <label htmlFor="password" className="block text-sm font-medium text-[var(--color-ink)] mb-1">
-              Password
-            </label>
-            <input
-              id="password"
-              name="password"
-              type="password"
-              required
-              minLength={6}
-              className="w-full px-3 py-2 rounded-lg border border-stone-300 bg-white text-[var(--color-ink)] text-sm focus:outline-none focus:ring-2 focus:ring-[var(--color-sage)] focus:border-transparent"
-              placeholder="At least 6 characters"
-            />
-          </div>
+          <p className="text-xs text-[var(--color-muted)]">
+            No password needed — we&apos;ll email you a secure link to finish signing up.
+          </p>
 
           <div className="flex items-start gap-2">
             <input

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -23,5 +23,9 @@ export const env = {
   supabaseAnonKey: () => requireEnv('NEXT_PUBLIC_SUPABASE_ANON_KEY'),
   supabaseServiceRoleKey: () => requireEnv('SUPABASE_SERVICE_ROLE_KEY'),
   siteUrl: () => optionalEnv('NEXT_PUBLIC_SITE_URL', 'https://checklyra.com'),
+  // KAN-258 — shared invite code for the private (invite-only) phase.
+  // When set, creating an account requires this code and third-party
+  // sign-in is hidden. Empty string = gate off (open signup).
+  inviteCode: () => optionalEnv('LYRA_INVITE_CODE', ''),
 };
 // Force rebuild 20260329011858

--- a/tests/e2e/public-pages.spec.ts
+++ b/tests/e2e/public-pages.spec.ts
@@ -20,7 +20,9 @@ test.describe('Login page', () => {
     await expect(page).toHaveTitle(/Sign in to Lyra/i);
     await expect(page.getByRole('heading', { name: /welcome back/i })).toBeVisible();
     await expect(page.getByLabel(/email/i)).toBeVisible();
-    await expect(page.getByLabel(/password/i)).toBeVisible();
+    // KAN-258: passwordless — a magic-link button, and no password field.
+    await expect(page.getByRole('button', { name: /email me a sign-in link/i })).toBeVisible();
+    await expect(page.getByLabel(/password/i)).toHaveCount(0);
   });
 });
 

--- a/tests/unit/auth-actions.test.ts
+++ b/tests/unit/auth-actions.test.ts
@@ -1,6 +1,6 @@
 /**
- * Real auth action tests with mocked Supabase
- * KAN-111: Replace file-existence checks with functional tests
+ * Real auth action tests with mocked Supabase.
+ * KAN-111: functional tests · KAN-258: passwordless (magic-link) sign-in + invite gate
  */
 
 // Mock next/navigation
@@ -26,17 +26,15 @@ jest.mock('@/lib/env', () => ({
   },
 }));
 
-// Mock Supabase client
-const mockSignUp = jest.fn();
-const mockSignInWithPassword = jest.fn();
+// Mock Supabase client — passwordless flow uses signInWithOtp.
+const mockSignInWithOtp = jest.fn();
 const mockSignOut = jest.fn();
 const mockSignInWithOAuth = jest.fn();
 
 jest.mock('@/lib/supabase-server', () => ({
   createClient: jest.fn().mockResolvedValue({
     auth: {
-      signUp: (...args: unknown[]) => mockSignUp(...args),
-      signInWithPassword: (...args: unknown[]) => mockSignInWithPassword(...args),
+      signInWithOtp: (...args: unknown[]) => mockSignInWithOtp(...args),
       signOut: (...args: unknown[]) => mockSignOut(...args),
       signInWithOAuth: (...args: unknown[]) => mockSignInWithOAuth(...args),
     },
@@ -57,107 +55,103 @@ beforeEach(() => {
   mockInviteCode = '';
 });
 
-describe('KAN-111: signUp action', () => {
-  test('redirects with error when fields are missing', async () => {
-    const fd = makeFormData({ email: 'test@example.com', password: '123456' });
-    // full_name is missing
+describe('KAN-258: signUp action (passwordless)', () => {
+  test('redirects with error when name or email is missing', async () => {
+    const fd = makeFormData({ email: 'test@example.com' }); // full_name missing
     await expect(signUp(fd)).rejects.toThrow('REDIRECT');
-    expect(mockRedirect).toHaveBeenCalledWith(
-      expect.stringContaining('/signup?error=')
-    );
-    expect(mockRedirect.mock.calls[0][0]).toContain('All%20fields%20are%20required');
+    expect(mockRedirect.mock.calls[0][0]).toContain('/signup?error=');
+    expect(mockRedirect.mock.calls[0][0]).toContain('name%20and%20email');
+    expect(mockSignInWithOtp).not.toHaveBeenCalled();
   });
 
-  test('redirects with error when password too short', async () => {
-    const fd = makeFormData({ email: 'test@example.com', password: '123', full_name: 'Test' });
+  test('emails a magic link (shouldCreateUser:true) with full_name metadata on valid input', async () => {
+    mockSignInWithOtp.mockResolvedValue({ error: null });
+    const fd = makeFormData({ email: 'test@example.com', full_name: 'Test User' });
     await expect(signUp(fd)).rejects.toThrow('REDIRECT');
-    expect(mockRedirect.mock.calls[0][0]).toContain('Password%20must%20be%20at%20least%206');
-  });
-
-  test('calls supabase signUp with correct params on valid input', async () => {
-    mockSignUp.mockResolvedValue({ error: null });
-    const fd = makeFormData({ email: 'test@example.com', password: 'secure123', full_name: 'Test User' });
-    await expect(signUp(fd)).rejects.toThrow('REDIRECT');
-    expect(mockSignUp).toHaveBeenCalledWith(expect.objectContaining({
+    expect(mockSignInWithOtp).toHaveBeenCalledWith(expect.objectContaining({
       email: 'test@example.com',
-      password: 'secure123',
+      options: expect.objectContaining({
+        shouldCreateUser: true,
+        data: { full_name: 'Test User' },
+      }),
     }));
     expect(mockRedirect.mock.calls[0][0]).toContain('/signup?message=');
   });
 
   test('redirects with supabase error on failure', async () => {
-    mockSignUp.mockResolvedValue({ error: { message: 'User already exists' } });
-    const fd = makeFormData({ email: 'test@example.com', password: 'secure123', full_name: 'Test' });
+    mockSignInWithOtp.mockResolvedValue({ error: { message: 'Signups not allowed' } });
+    const fd = makeFormData({ email: 'test@example.com', full_name: 'Test' });
     await expect(signUp(fd)).rejects.toThrow('REDIRECT');
-    expect(mockRedirect.mock.calls[0][0]).toContain('User%20already%20exists');
+    expect(mockRedirect.mock.calls[0][0]).toContain('Signups%20not%20allowed');
   });
 });
 
 describe('KAN-258: invite-only signup gate', () => {
   test('with no invite code configured, signup is NOT gated (back-compat)', async () => {
-    mockSignUp.mockResolvedValue({ error: null });
-    const fd = makeFormData({ email: 'a@b.com', password: 'secure123', full_name: 'A' });
+    mockSignInWithOtp.mockResolvedValue({ error: null });
+    const fd = makeFormData({ email: 'a@b.com', full_name: 'A' });
     await expect(signUp(fd)).rejects.toThrow('REDIRECT');
-    expect(mockSignUp).toHaveBeenCalled();
+    expect(mockSignInWithOtp).toHaveBeenCalled();
   });
 
   test('rejects signup when an invite code is required but missing', async () => {
     mockInviteCode = 'LET-ME-IN';
-    const fd = makeFormData({ email: 'a@b.com', password: 'secure123', full_name: 'A' });
+    const fd = makeFormData({ email: 'a@b.com', full_name: 'A' });
     await expect(signUp(fd)).rejects.toThrow('REDIRECT');
-    expect(mockSignUp).not.toHaveBeenCalled();
+    expect(mockSignInWithOtp).not.toHaveBeenCalled();
     expect(mockRedirect.mock.calls[0][0]).toContain('/signup?error=');
     expect(mockRedirect.mock.calls[0][0]).toContain('invite-only');
   });
 
   test('rejects signup when the invite code is wrong', async () => {
     mockInviteCode = 'LET-ME-IN';
-    const fd = makeFormData({ email: 'a@b.com', password: 'secure123', full_name: 'A', invite_code: 'nope' });
+    const fd = makeFormData({ email: 'a@b.com', full_name: 'A', invite_code: 'nope' });
     await expect(signUp(fd)).rejects.toThrow('REDIRECT');
-    expect(mockSignUp).not.toHaveBeenCalled();
+    expect(mockSignInWithOtp).not.toHaveBeenCalled();
   });
 
   test('allows signup when the invite code matches', async () => {
     mockInviteCode = 'LET-ME-IN';
-    mockSignUp.mockResolvedValue({ error: null });
-    const fd = makeFormData({ email: 'a@b.com', password: 'secure123', full_name: 'A', invite_code: 'LET-ME-IN' });
+    mockSignInWithOtp.mockResolvedValue({ error: null });
+    const fd = makeFormData({ email: 'a@b.com', full_name: 'A', invite_code: 'LET-ME-IN' });
     await expect(signUp(fd)).rejects.toThrow('REDIRECT');
-    expect(mockSignUp).toHaveBeenCalled();
+    expect(mockSignInWithOtp).toHaveBeenCalled();
     expect(mockRedirect.mock.calls[0][0]).toContain('/signup?message=');
   });
 
   test('trims surrounding whitespace from the invite code', async () => {
     mockInviteCode = 'LET-ME-IN';
-    mockSignUp.mockResolvedValue({ error: null });
-    const fd = makeFormData({ email: 'a@b.com', password: 'secure123', full_name: 'A', invite_code: '  LET-ME-IN  ' });
+    mockSignInWithOtp.mockResolvedValue({ error: null });
+    const fd = makeFormData({ email: 'a@b.com', full_name: 'A', invite_code: '  LET-ME-IN  ' });
     await expect(signUp(fd)).rejects.toThrow('REDIRECT');
-    expect(mockSignUp).toHaveBeenCalled();
+    expect(mockSignInWithOtp).toHaveBeenCalled();
   });
 });
 
-describe('KAN-111: signIn action', () => {
-  test('redirects with error when fields are missing', async () => {
+describe('KAN-258: signIn action (passwordless)', () => {
+  test('redirects with error when email is missing', async () => {
+    const fd = makeFormData({});
+    await expect(signIn(fd)).rejects.toThrow('REDIRECT');
+    expect(mockRedirect.mock.calls[0][0]).toContain('Email%20is%20required');
+    expect(mockSignInWithOtp).not.toHaveBeenCalled();
+  });
+
+  test('emails a sign-in link (shouldCreateUser:false) on valid input', async () => {
+    mockSignInWithOtp.mockResolvedValue({ error: null });
     const fd = makeFormData({ email: 'test@example.com' });
     await expect(signIn(fd)).rejects.toThrow('REDIRECT');
-    expect(mockRedirect.mock.calls[0][0]).toContain('Email%20and%20password%20are%20required');
-  });
-
-  test('calls supabase signInWithPassword on valid input', async () => {
-    mockSignInWithPassword.mockResolvedValue({ error: null });
-    const fd = makeFormData({ email: 'test@example.com', password: 'secure123' });
-    await expect(signIn(fd)).rejects.toThrow('REDIRECT');
-    expect(mockSignInWithPassword).toHaveBeenCalledWith({
+    expect(mockSignInWithOtp).toHaveBeenCalledWith(expect.objectContaining({
       email: 'test@example.com',
-      password: 'secure123',
-    });
-    expect(mockRedirect).toHaveBeenCalledWith('/dashboard');
+      options: expect.objectContaining({ shouldCreateUser: false }),
+    }));
+    expect(mockRedirect.mock.calls[0][0]).toContain('/login?message=');
   });
 
-  test('redirects with error on invalid credentials', async () => {
-    mockSignInWithPassword.mockResolvedValue({ error: { message: 'Invalid login credentials' } });
-    const fd = makeFormData({ email: 'test@example.com', password: 'wrong' });
+  test('redirects with error on failure', async () => {
+    mockSignInWithOtp.mockResolvedValue({ error: { message: 'Email rate limit exceeded' } });
+    const fd = makeFormData({ email: 'test@example.com' });
     await expect(signIn(fd)).rejects.toThrow('REDIRECT');
-    expect(mockRedirect.mock.calls[0][0]).toContain('Invalid%20login%20credentials');
+    expect(mockRedirect.mock.calls[0][0]).toContain('rate%20limit');
   });
 });
 

--- a/tests/unit/auth-actions.test.ts
+++ b/tests/unit/auth-actions.test.ts
@@ -6,7 +6,6 @@
 // Mock next/navigation
 const mockRedirect = jest.fn();
 jest.mock('next/navigation', () => ({
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   redirect: (...args: unknown[]) => { mockRedirect(...args); throw new Error('REDIRECT'); },
 }));
 
@@ -17,9 +16,14 @@ jest.mock('next/headers', () => ({
   }),
 }));
 
-// Mock @/lib/env
+// Mock @/lib/env — `mockInviteCode` is mutated per-test to toggle the
+// KAN-258 invite-only gate (empty string = gate off).
+let mockInviteCode = '';
 jest.mock('@/lib/env', () => ({
-  env: { siteUrl: () => 'https://dev.checklyra.com' },
+  env: {
+    siteUrl: () => 'https://dev.checklyra.com',
+    inviteCode: () => mockInviteCode,
+  },
 }));
 
 // Mock Supabase client
@@ -50,6 +54,7 @@ function makeFormData(data: Record<string, string>): FormData {
 
 beforeEach(() => {
   jest.clearAllMocks();
+  mockInviteCode = '';
 });
 
 describe('KAN-111: signUp action', () => {
@@ -85,6 +90,48 @@ describe('KAN-111: signUp action', () => {
     const fd = makeFormData({ email: 'test@example.com', password: 'secure123', full_name: 'Test' });
     await expect(signUp(fd)).rejects.toThrow('REDIRECT');
     expect(mockRedirect.mock.calls[0][0]).toContain('User%20already%20exists');
+  });
+});
+
+describe('KAN-258: invite-only signup gate', () => {
+  test('with no invite code configured, signup is NOT gated (back-compat)', async () => {
+    mockSignUp.mockResolvedValue({ error: null });
+    const fd = makeFormData({ email: 'a@b.com', password: 'secure123', full_name: 'A' });
+    await expect(signUp(fd)).rejects.toThrow('REDIRECT');
+    expect(mockSignUp).toHaveBeenCalled();
+  });
+
+  test('rejects signup when an invite code is required but missing', async () => {
+    mockInviteCode = 'LET-ME-IN';
+    const fd = makeFormData({ email: 'a@b.com', password: 'secure123', full_name: 'A' });
+    await expect(signUp(fd)).rejects.toThrow('REDIRECT');
+    expect(mockSignUp).not.toHaveBeenCalled();
+    expect(mockRedirect.mock.calls[0][0]).toContain('/signup?error=');
+    expect(mockRedirect.mock.calls[0][0]).toContain('invite-only');
+  });
+
+  test('rejects signup when the invite code is wrong', async () => {
+    mockInviteCode = 'LET-ME-IN';
+    const fd = makeFormData({ email: 'a@b.com', password: 'secure123', full_name: 'A', invite_code: 'nope' });
+    await expect(signUp(fd)).rejects.toThrow('REDIRECT');
+    expect(mockSignUp).not.toHaveBeenCalled();
+  });
+
+  test('allows signup when the invite code matches', async () => {
+    mockInviteCode = 'LET-ME-IN';
+    mockSignUp.mockResolvedValue({ error: null });
+    const fd = makeFormData({ email: 'a@b.com', password: 'secure123', full_name: 'A', invite_code: 'LET-ME-IN' });
+    await expect(signUp(fd)).rejects.toThrow('REDIRECT');
+    expect(mockSignUp).toHaveBeenCalled();
+    expect(mockRedirect.mock.calls[0][0]).toContain('/signup?message=');
+  });
+
+  test('trims surrounding whitespace from the invite code', async () => {
+    mockInviteCode = 'LET-ME-IN';
+    mockSignUp.mockResolvedValue({ error: null });
+    const fd = makeFormData({ email: 'a@b.com', password: 'secure123', full_name: 'A', invite_code: '  LET-ME-IN  ' });
+    await expect(signUp(fd)).rejects.toThrow('REDIRECT');
+    expect(mockSignUp).toHaveBeenCalled();
   });
 });
 

--- a/tests/unit/forgot-reset-password.test.ts
+++ b/tests/unit/forgot-reset-password.test.ts
@@ -238,13 +238,19 @@ describe('KAN-225: surface-area regression guards', () => {
     expect(src).toMatch(/index:\s*false/);
   });
 
-  test('login page has a "Forgot password?" link to /forgot-password', () => {
+  test('login page is passwordless: no password field or reset link, offers a magic-link', () => {
+    // KAN-258: sign-in is passwordless — the login form emails a one-time
+    // sign-in link, so there is no password field and (since there is no
+    // password to reset) no "Forgot password?" link. The /forgot-password
+    // and /reset-password routes remain in place but unlinked, pending a
+    // follow-up that removes the vestigial password-reset flow.
     const src = readFileSync(
       resolve(ROOT, 'src/app/(auth)/login/page.tsx'),
       'utf-8',
     );
-    expect(src).toMatch(/href=["']\/forgot-password["']/);
-    expect(src).toMatch(/Forgot password/);
+    expect(src).not.toMatch(/name=["']password["']/);
+    expect(src).not.toMatch(/href=["']\/forgot-password["']/);
+    expect(src).toMatch(/sign-in link/i);
   });
 
   test('login page surfaces the post-reset success message', () => {


### PR DESCRIPTION
## What & why
**KAN-258 — Plan A (private friends-&-family MVP), Phase 1 auth.** Two related changes, folded into one PR since they touch the same auth files:

### 1. Invite-only account gate
New env var `LYRA_INVITE_CODE`. When set:
- `signUp` requires a matching `invite_code`, validated **before** any account is created — so no `auth.users` row (and no profile, via the `handle_new_user` trigger) without it
- the signup form shows an invite-code field
- **Google sign-in is hidden** on login + signup (OAuth would otherwise create an un-gated account)

When unset → open signup (unchanged), so envs without the var are unaffected.

### 2. Passwordless magic-link sign-in
Replaces email+password with Supabase magic links (`signInWithOtp`):
- **Sign in** emails a link; `shouldCreateUser:false` so it never creates a new account
- **Sign up** (after the invite check) emails a link with `shouldCreateUser:true` + `full_name` metadata
- password fields removed from both pages; "Forgot password?" link removed
- the existing `/auth/callback` code→session exchange already handles the link

## To enable (per environment)
Set `LYRA_INVITE_CODE` in the target env (dev/beta). Also confirm Supabase Auth → URL Configuration lists `{siteUrl}/auth/callback` as a redirect URL (it already does — sign-up used it).

## Testing
- `tests/unit/auth-actions.test.ts` rewritten for the OTP flow + invite gate — **15/15 pass locally**.
- `tsc --noEmit` clean; eslint clean on all changed files.
- `tests/e2e/public-pages.spec.ts` updated (login shows a magic-link button, no password field).
- ⚠️ **Needs a preview check before merge:** with `LYRA_INVITE_CODE` set, confirm wrong/empty code is rejected, the correct code emails a link, the link signs you in (and creates the account on first use), and Google is hidden.

## Follow-ups (not this PR)
Remove the now-vestigial password-reset routes/actions; re-enable Google for public launch (Phase B).

🤖 Generated with [Claude Code](https://claude.com/claude-code)