### PR TITLE
feat(settings): true account deletion — erase auth user + storage (KAN-259)

### DIFF
--- a/src/app/dashboard/settings/actions.ts
+++ b/src/app/dashboard/settings/actions.ts
@@ -1,6 +1,7 @@
 'use server';
 
 import { createClient } from '@/lib/supabase-server';
+import { getAdminServiceClient } from '@/lib/admin';
 import { redirect } from 'next/navigation';
 import { randomBytes, createHash } from 'crypto';
 
@@ -57,30 +58,44 @@ export async function deleteAccount() {
   const { data: { user } } = await supabase.auth.getUser();
   if (!user) return redirect('/login');
 
-  // Delete api_keys (not cascaded via profile FK)
-  await supabase.from('api_keys').delete().eq('user_id', user.id);
+  const userId = user.id;
 
-  // Delete profile photo from storage
-  const { data: profile } = await supabase
-    .from('profiles')
-    .select('avatar_url')
-    .eq('user_id', user.id)
-    .single();
-
-  if (profile?.avatar_url) {
-    const path = `${user.id}/`;
-    await supabase.storage.from('profile-photos').list(path).then(({ data: files }) => {
-      if (files?.length) {
-        const paths = files.map(f => `${path}${f.name}`);
-        supabase.storage.from('profile-photos').remove(paths);
-      }
-    });
+  // True erasure (GDPR). Hard-delete the auth user with the service-role
+  // client: profiles.user_id -> auth.users(id) is ON DELETE CASCADE, and
+  // every profile-owned table cascades from profiles(id), so this removes
+  // ALL of the person's data in one step — profile, items, links, schools,
+  // files, manual-of-me, conversation starters, moderation reports, api
+  // keys, oauth tokens, convene rows. (The previous version only deleted
+  // the profile and left the auth user, and their email, behind.)
+  const admin = getAdminServiceClient();
+  const { error } = await admin.auth.admin.deleteUser(userId);
+  if (error) {
+    // The only expected failure is an account with non-deletable audit
+    // rows (a moderator's moderation_logs are ON DELETE RESTRICT). Don't
+    // half-delete anything — leave the account intact and ask them to
+    // contact us.
+    return redirect(
+      '/dashboard/settings?error=' +
+        encodeURIComponent(
+          "We couldn't delete your account automatically. Please contact us and we'll remove it for you.",
+        ),
+    );
   }
 
-  // Delete profile (cascades to profile_items, external_links, school_affiliations)
-  await supabase.from('profiles').delete().eq('user_id', user.id);
+  // Best-effort: remove now-orphaned storage objects (the DB cascade
+  // doesn't touch storage). Non-fatal — the account and all rows are gone.
+  for (const bucket of ['profile-photos', 'profile-files']) {
+    try {
+      const { data: files } = await admin.storage.from(bucket).list(userId);
+      if (files?.length) {
+        await admin.storage.from(bucket).remove(files.map((f) => `${userId}/${f.name}`));
+      }
+    } catch {
+      // ignore — orphaned-object cleanup isn't worth failing the flow
+    }
+  }
 
-  // Sign out (Supabase Auth user remains but profile data is gone)
+  // Clear the now-invalid session cookie and send them home.
   await supabase.auth.signOut();
   redirect('/');
 }

--- a/tests/unit/account-deletion.test.ts
+++ b/tests/unit/account-deletion.test.ts
@@ -1,0 +1,89 @@
+/**
+ * KAN-259: deleteAccount must be a TRUE erasure — it deletes the auth user
+ * (which cascades to every profile-owned table) and cleans up orphaned
+ * storage objects, rather than only deleting the profile row.
+ */
+
+// next/navigation redirect throws so we can assert the target.
+const mockRedirect = jest.fn();
+jest.mock('next/navigation', () => ({
+  redirect: (...args: unknown[]) => { mockRedirect(...args); throw new Error('REDIRECT'); },
+}));
+
+// Cookie-auth client: only used for getUser + signOut here.
+const mockGetUser = jest.fn();
+const mockSignOut = jest.fn();
+jest.mock('@/lib/supabase-server', () => ({
+  createClient: jest.fn().mockResolvedValue({
+    auth: {
+      getUser: (...a: unknown[]) => mockGetUser(...a),
+      signOut: (...a: unknown[]) => mockSignOut(...a),
+    },
+  }),
+}));
+
+// Service-role admin client: deletes the auth user + storage objects.
+const mockAdminDeleteUser = jest.fn();
+const mockStorageList = jest.fn();
+const mockStorageRemove = jest.fn();
+jest.mock('@/lib/admin', () => ({
+  getAdminServiceClient: () => ({
+    auth: { admin: { deleteUser: (...a: unknown[]) => mockAdminDeleteUser(...a) } },
+    storage: {
+      from: () => ({
+        list: (...a: unknown[]) => mockStorageList(...a),
+        remove: (...a: unknown[]) => mockStorageRemove(...a),
+      }),
+    },
+  }),
+}));
+
+import { deleteAccount } from '@/app/dashboard/settings/actions';
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockGetUser.mockResolvedValue({ data: { user: { id: 'user-123', email: 'a@b.com' } } });
+  mockAdminDeleteUser.mockResolvedValue({ data: {}, error: null });
+  mockStorageList.mockResolvedValue({ data: [] });
+  mockStorageRemove.mockResolvedValue({ error: null });
+  mockSignOut.mockResolvedValue({ error: null });
+});
+
+describe('KAN-259: deleteAccount (true erasure)', () => {
+  test('redirects to /login when not authenticated', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: null } });
+    await expect(deleteAccount()).rejects.toThrow('REDIRECT');
+    expect(mockRedirect).toHaveBeenCalledWith('/login');
+    expect(mockAdminDeleteUser).not.toHaveBeenCalled();
+  });
+
+  test('hard-deletes the auth user (cascade), signs out, and redirects home', async () => {
+    await expect(deleteAccount()).rejects.toThrow('REDIRECT');
+    expect(mockAdminDeleteUser).toHaveBeenCalledWith('user-123');
+    expect(mockSignOut).toHaveBeenCalled();
+    expect(mockRedirect).toHaveBeenLastCalledWith('/');
+  });
+
+  test('removes orphaned storage objects in both buckets', async () => {
+    mockStorageList.mockResolvedValue({ data: [{ name: 'avatar.png' }] });
+    await expect(deleteAccount()).rejects.toThrow('REDIRECT');
+    expect(mockStorageList).toHaveBeenCalledTimes(2); // profile-photos + profile-files
+    expect(mockStorageRemove).toHaveBeenCalledWith(['user-123/avatar.png']);
+  });
+
+  test('does NOT sign out or wipe storage if the auth deletion fails (no partial delete)', async () => {
+    mockAdminDeleteUser.mockResolvedValue({ data: {}, error: { message: 'update or delete on table violates foreign key' } });
+    await expect(deleteAccount()).rejects.toThrow('REDIRECT');
+    expect(mockSignOut).not.toHaveBeenCalled();
+    expect(mockStorageRemove).not.toHaveBeenCalled();
+    expect(mockRedirect.mock.calls.at(-1)?.[0]).toContain('/dashboard/settings?error=');
+  });
+
+  test('a storage-cleanup failure does not block the deletion', async () => {
+    mockStorageList.mockRejectedValue(new Error('storage unavailable'));
+    await expect(deleteAccount()).rejects.toThrow('REDIRECT');
+    expect(mockAdminDeleteUser).toHaveBeenCalled();
+    expect(mockSignOut).toHaveBeenCalled();
+    expect(mockRedirect).toHaveBeenLastCalledWith('/');
+  });
+});

--- a/tests/unit/gdpr-settings.test.js
+++ b/tests/unit/gdpr-settings.test.js
@@ -58,12 +58,13 @@ describe('KAN-140: Account deletion action', () => {
     expect(content).toContain('export async function deleteAccount');
   });
 
-  test('deletes api_keys before profile', () => {
-    const deleteApiKeysPos = content.indexOf("from('api_keys').delete()");
-    const deleteProfilePos = content.indexOf("from('profiles').delete()");
-    expect(deleteApiKeysPos).toBeGreaterThan(-1);
-    expect(deleteProfilePos).toBeGreaterThan(-1);
-    expect(deleteApiKeysPos).toBeLessThan(deleteProfilePos);
+  test('hard-deletes the auth user via the service-role admin client (cascade erasure)', () => {
+    // KAN-259: deletion now removes the auth.users row through the
+    // service-role admin client. profiles, api_keys and all profile data
+    // are removed by ON DELETE CASCADE, so no account/email is left behind
+    // (the previous version only deleted the profile row).
+    expect(content).toContain('getAdminServiceClient');
+    expect(content).toContain('auth.admin.deleteUser');
   });
 
   test('cleans up storage photos', () => {


### PR DESCRIPTION
## What & why
**KAN-259 — Plan A.** "Delete my account" already had a UI and a `deleteAccount()` action, but the action only deleted the profile row + avatar and signed out — it **left the `auth.users` row (and the person's email) behind** (the old code even said so in a comment) and orphaned uploaded files. That's not a real erasure, and "people can get out" is a 🔴 item for the friends-&-family launch.

## The fix
`deleteAccount()` now **hard-deletes the auth user** via the service-role admin client. Because `profiles.user_id → auth.users(id)` is `ON DELETE CASCADE` and every profile-owned table cascades from `profiles(id)`, this removes **everything** in one step: profile, items, links, schools, files, manual-of-me, conversation starters, moderation reports, api keys, oauth tokens, convene rows. It then best-effort cleans up orphaned objects in both storage buckets (`profile-photos`, `profile-files`).

- **No partial deletes:** if the hard delete is blocked (only happens for a moderator whose `moderation_logs` are `ON DELETE RESTRICT`), the account is left fully intact and the person is shown a "contact us" message.
- Storage-cleanup failures are non-fatal (the account + all rows are already gone).
- **UI unchanged** — the settings page already has the "type DELETE to confirm" flow.

## Testing
- New `tests/unit/account-deletion.test.ts` — **5/5 pass**: success path (auth user deleted, signed out, redirect home), not-authenticated, auth-delete-failure (no sign-out / no storage wipe), storage cleanup in both buckets, storage-failure-is-non-fatal.
- `tsc --noEmit` clean; eslint clean on changed files.
- ⚠️ **Preview check before merge:** create a throwaway account on a preview/dev deploy, delete it, and confirm in Supabase that the `auth.users` row and all profile rows/storage are gone.

## Out of scope (later)
Email-confirmation-before-delete; data-export-on-delete (export already exists separately).

🤖 Generated with [Claude Code](https://claude.com/claude-code)