### PR TITLE
feat(profile): owner-scope item/link/affiliation mutations + regression tests (KAN-260)

### DIFF
--- a/src/app/dashboard/profile/actions.ts
+++ b/src/app/dashboard/profile/actions.ts
@@ -190,12 +190,15 @@ export async function updateProfileItemVisibility(
   itemId: string,
   visibility: string,
 ): Promise<ActionResult> {
-  const { supabase, error: authError } = await getAuthenticatedUser();
+  const { user, supabase, error: authError } = await getAuthenticatedUser();
   if (authError) return { success: false, error: authError };
 
-  // RLS confines the UPDATE to items the caller owns — no need to filter
-  // by user_id here.
-  //
+  // KAN-260 — belt-and-braces ownership: scope the write to the caller's
+  // own profile in code, not by RLS alone, so an item that isn't yours can
+  // never be edited even if a DB policy were ever misconfigured.
+  const profile = await getUserProfile(supabase, user!.id);
+  if (!profile) return { success: false, error: 'Profile not found' };
+
   // KAN-234: empty string → NULL = "inherit from section default" (hybrid
   // visibility model). Otherwise coerce to one of the three real values.
   const visibilityValue = visibility && visibility !== ''
@@ -205,7 +208,8 @@ export async function updateProfileItemVisibility(
   const { error } = await supabase
     .from('profile_items')
     .update({ visibility: visibilityValue })
-    .eq('id', itemId);
+    .eq('id', itemId)
+    .eq('profile_id', profile.id);
 
   if (error) return { success: false, error: error.message };
   revalidatePath('/dashboard/profile');
@@ -213,13 +217,18 @@ export async function updateProfileItemVisibility(
 }
 
 export async function removeProfileItem(itemId: string): Promise<ActionResult> {
-  const { supabase, error: authError } = await getAuthenticatedUser();
+  const { user, supabase, error: authError } = await getAuthenticatedUser();
   if (authError) return { success: false, error: authError };
+
+  // KAN-260 — owner-scope the delete in code as well as RLS.
+  const profile = await getUserProfile(supabase, user!.id);
+  if (!profile) return { success: false, error: 'Profile not found' };
 
   const { error } = await supabase
     .from('profile_items')
     .delete()
-    .eq('id', itemId);
+    .eq('id', itemId)
+    .eq('profile_id', profile.id);
 
   if (error) return { success: false, error: error.message };
   revalidatePath('/dashboard/profile');
@@ -287,13 +296,18 @@ export async function addSchoolAffiliation(data: {
 }
 
 export async function removeSchoolAffiliation(affiliationId: string): Promise<ActionResult> {
-  const { supabase, error: authError } = await getAuthenticatedUser();
+  const { user, supabase, error: authError } = await getAuthenticatedUser();
   if (authError) return { success: false, error: authError };
+
+  // KAN-260 — owner-scope the delete in code as well as RLS.
+  const profile = await getUserProfile(supabase, user!.id);
+  if (!profile) return { success: false, error: 'Profile not found' };
 
   const { error } = await supabase
     .from('school_affiliations')
     .delete()
-    .eq('id', affiliationId);
+    .eq('id', affiliationId)
+    .eq('profile_id', profile.id);
 
   if (error) return { success: false, error: error.message };
   revalidatePath('/dashboard/profile');
@@ -346,13 +360,18 @@ export async function addExternalLink(data: {
 }
 
 export async function removeExternalLink(linkId: string): Promise<ActionResult> {
-  const { supabase, error: authError } = await getAuthenticatedUser();
+  const { user, supabase, error: authError } = await getAuthenticatedUser();
   if (authError) return { success: false, error: authError };
+
+  // KAN-260 — owner-scope the delete in code as well as RLS.
+  const profile = await getUserProfile(supabase, user!.id);
+  if (!profile) return { success: false, error: 'Profile not found' };
 
   const { error } = await supabase
     .from('external_links')
     .delete()
-    .eq('id', linkId);
+    .eq('id', linkId)
+    .eq('profile_id', profile.id);
 
   if (error) return { success: false, error: error.message };
   revalidatePath('/dashboard/profile');

--- a/tests/unit/phase3-ui-integration.test.ts
+++ b/tests/unit/phase3-ui-integration.test.ts
@@ -60,7 +60,16 @@ jest.mock('@/lib/supabase-server', () => ({
           },
           update: (data: unknown) => {
             mockUpdateCapture(data);
-            return { eq: () => Promise.resolve({ error: null }) };
+            // KAN-260: the action now chains .eq('id').eq('profile_id'),
+            // so return a chainable, awaitable stub — each .eq returns the
+            // same chain, and awaiting it resolves to { error: null }.
+            const chain = {
+              eq() { return chain; },
+              then(resolve: (v: { error: null }) => unknown) {
+                return Promise.resolve({ error: null }).then(resolve);
+              },
+            };
+            return chain;
           },
         };
       }

--- a/tests/unit/profile-ownership.test.ts
+++ b/tests/unit/profile-ownership.test.ts
@@ -1,0 +1,120 @@
+/**
+ * KAN-260: the profile mutations that previously relied on RLS alone must
+ * also scope their write to the caller's own profile_id in code. This is a
+ * regression safety-net for "only you can edit your own profile" — so a
+ * row that isn't yours can never be edited/deleted even if a database
+ * policy were ever misconfigured.
+ */
+
+const mockRevalidatePath = jest.fn();
+jest.mock('next/cache', () => ({
+  revalidatePath: (...a: unknown[]) => mockRevalidatePath(...a),
+}));
+
+// Record every .eq(col, val) call keyed by table so we can assert the
+// owner scope. `mockState` lets a test tweak the auth user / mutation result.
+const mockEqCalls: Record<string, Array<[string, unknown]>> = {};
+const mockState: { userId: string | null; mutationError: { message: string } | null } = {
+  userId: 'user-1',
+  mutationError: null,
+};
+
+jest.mock('@/lib/supabase-server', () => {
+  type Builder = {
+    select: () => Builder;
+    delete: () => Builder;
+    update: () => Builder;
+    insert: () => Builder;
+    eq: (col: string, val: unknown) => Builder;
+    single: () => Promise<{ data: { id: string } | null; error: null }>;
+    then: (
+      resolve: (v: { error: { message: string } | null }) => unknown,
+      reject?: (e: unknown) => unknown,
+    ) => Promise<unknown>;
+  };
+  const build = (table: string): Builder => {
+    const b: Builder = {
+      select: () => b,
+      delete: () => b,
+      update: () => b,
+      insert: () => b,
+      eq: (col, val) => {
+        (mockEqCalls[table] = mockEqCalls[table] ?? []).push([col, val]);
+        return b;
+      },
+      single: () =>
+        Promise.resolve(
+          table === 'profiles'
+            ? { data: { id: 'profile-1' }, error: null }
+            : { data: null, error: null },
+        ),
+      then: (resolve, reject) =>
+        Promise.resolve({ error: mockState.mutationError }).then(resolve, reject),
+    };
+    return b;
+  };
+  return {
+    createClient: jest.fn().mockResolvedValue({
+      auth: {
+        getUser: () =>
+          Promise.resolve({ data: { user: mockState.userId ? { id: mockState.userId } : null } }),
+      },
+      from: (t: string) => build(t),
+    }),
+  };
+});
+
+import {
+  removeProfileItem,
+  removeSchoolAffiliation,
+  removeExternalLink,
+  updateProfileItemVisibility,
+} from '@/app/dashboard/profile/actions';
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  for (const key of Object.keys(mockEqCalls)) delete mockEqCalls[key];
+  mockState.userId = 'user-1';
+  mockState.mutationError = null;
+});
+
+function ownerScoped(table: string): boolean {
+  return (mockEqCalls[table] ?? []).some(
+    ([col, val]) => col === 'profile_id' && val === 'profile-1',
+  );
+}
+
+describe('KAN-260: profile mutations are owner-scoped in code (not RLS alone)', () => {
+  test('removeProfileItem scopes the delete to the caller profile_id', async () => {
+    const res = await removeProfileItem('item-9');
+    expect(res).toEqual({ success: true });
+    expect(mockEqCalls['profile_items']).toContainEqual(['id', 'item-9']);
+    expect(ownerScoped('profile_items')).toBe(true);
+  });
+
+  test('updateProfileItemVisibility scopes the update to the caller profile_id', async () => {
+    const res = await updateProfileItemVisibility('item-9', 'public');
+    expect(res).toEqual({ success: true });
+    expect(ownerScoped('profile_items')).toBe(true);
+  });
+
+  test('removeSchoolAffiliation scopes the delete to the caller profile_id', async () => {
+    const res = await removeSchoolAffiliation('aff-3');
+    expect(res).toEqual({ success: true });
+    expect(mockEqCalls['school_affiliations']).toContainEqual(['id', 'aff-3']);
+    expect(ownerScoped('school_affiliations')).toBe(true);
+  });
+
+  test('removeExternalLink scopes the delete to the caller profile_id', async () => {
+    const res = await removeExternalLink('link-2');
+    expect(res).toEqual({ success: true });
+    expect(ownerScoped('external_links')).toBe(true);
+  });
+
+  test('not authenticated → no write attempted', async () => {
+    mockState.userId = null;
+    const res = await removeProfileItem('item-9');
+    expect(res).toEqual({ success: false, error: 'Not authenticated' });
+    expect(mockEqCalls['profile_items']).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## What & why
**KAN-260 — Plan A safety net.** An audit confirmed "only you can edit your own profile" is already enforced (Supabase RLS owner policies on every profile table + actions scoped to the authed user). But two gaps were worth closing before friends-&-family:
1. **No automated test** asserted cross-user protection — so it could silently regress.
2. Four mutations relied on **RLS alone**, with no explicit owner check in code.

This adds belt-and-braces owner-scoping (and tests) so the guarantee is explicit and regression-protected.

## Changes
- `removeProfileItem`, `removeSchoolAffiliation`, `removeExternalLink`, `updateProfileItemVisibility` now resolve the caller's own `profile_id` (via the existing `getUserProfile`) and add `.eq('profile_id', id)` to the write — matching the pattern `files-actions`/`conversation-starters-actions` already use.
- New `tests/unit/profile-ownership.test.ts`: asserts each mutation is owner-scoped, plus a not-authenticated no-write case.

## Testing
- New tests + existing `profile-actions.test.ts`: **22/22 pass**.
- `tsc --noEmit` clean; eslint clean.

## Note
RLS is still the primary enforcement; this is defence-in-depth. A full DB-level (pgTAP) cross-user RLS integration test is noted as future hardening (no such harness in-repo yet).

🤖 Generated with [Claude Code](https://claude.com/claude-code)