### PR TITLE
docs(legal): align privacy & cookie pages with current product (KAN-261)

### DIFF
--- a/src/app/(legal)/cookies/page.tsx
+++ b/src/app/(legal)/cookies/page.tsx
@@ -19,7 +19,7 @@ export default function CookiePolicyPage() {
 
       <article className="max-w-3xl mx-auto px-6 py-10 prose prose-stone prose-sm">
         <h1 className="text-2xl font-[family-name:var(--font-serif)] text-[var(--color-ink)]">Cookie Policy</h1>
-        <p className="text-sm text-[var(--color-muted)]">Last updated: 16 May 2026</p>
+        <p className="text-sm text-[var(--color-muted)]">Last updated: 17 June 2026</p>
 
         <h2>What are cookies?</h2>
         <p>Cookies are small text files stored on your device when you visit a website. They help websites remember your preferences and keep you signed in.</p>
@@ -45,7 +45,7 @@ export default function CookiePolicyPage() {
             </tr>
             <tr>
               <td><code>sb-*-auth-token-code-verifier</code></td>
-              <td>Used during the OAuth sign-in flow (e.g. Google Sign-In) to prevent cross-site request forgery.</td>
+              <td>Used during passwordless sign-in (your email magic-link, or Google) to secure the exchange (PKCE) and prevent cross-site request forgery.</td>
               <td>Session</td>
               <td>Essential</td>
             </tr>

--- a/src/app/(legal)/privacy/page.tsx
+++ b/src/app/(legal)/privacy/page.tsx
@@ -19,19 +19,19 @@ export default function PrivacyPolicyPage() {
 
       <article className="max-w-3xl mx-auto px-6 py-10 prose prose-stone prose-sm">
         <h1 className="text-2xl font-[family-name:var(--font-serif)] text-[var(--color-ink)]">Privacy Policy</h1>
-        <p className="text-sm text-[var(--color-muted)]">Last updated: 16 May 2026</p>
+        <p className="text-sm text-[var(--color-muted)]">Last updated: 17 June 2026</p>
 
         <h2>Who we are</h2>
-        <p>Lyra (&quot;we&quot;, &quot;us&quot;, &quot;our&quot;) operates the website checklyra.com. We are committed to protecting your privacy and handling your personal data transparently.</p>
+        <p>Lyra is operated by <strong>CheckLyra Ltd</strong> (&quot;we&quot;, &quot;us&quot;, &quot;our&quot;), a company registered in England &amp; Wales (company no. 16351012; registered office: 71–75 Shelton Street, Covent Garden, London, WC2H 9JQ). CheckLyra Ltd is the data controller for the personal data described here, and is registered with the UK Information Commissioner&apos;s Office (ICO). We are committed to protecting your privacy and handling your personal data transparently.</p>
 
         <h2>What data we collect</h2>
         <p>When you create a Lyra profile, we collect:</p>
         <ul>
-          <li><strong>Account data:</strong> Email address, password (encrypted), display name</li>
+          <li><strong>Account data:</strong> Email address and display name. Sign-in is passwordless — we email you a secure one-time link, so there&apos;s no password to store.</li>
           <li><strong>Profile data:</strong> Headline, bio, city, country, preferences, gift ideas, likes, dislikes, boundaries, school affiliations, external links, and profile photo — all provided voluntarily by you</li>
           <li><strong>Usage data:</strong> Page views and basic analytics (via Vercel Analytics), collected anonymously unless you opt in</li>
         </ul>
-        <p>We do <strong>not</strong> collect: payment information, precise location data, browsing history, data from third-party sources, or any data from children under 13.</p>
+        <p>Lyra is for adults — you must be <strong>18 or over</strong> to create a profile, and it is not intended for children. We do <strong>not</strong> collect: payment information, precise location data, browsing history, or data from third-party sources.</p>
 
         <h2>Why we collect it (lawful basis)</h2>
         <ul>
@@ -45,7 +45,7 @@ export default function PrivacyPolicyPage() {
           <li>To show your profile in Lyra&apos;s search/browse page when published</li>
           <li>To enable AI companions (via MCP) to help people find gift ideas and understand your preferences</li>
           <li>To improve the Lyra service through anonymised analytics</li>
-          <li>To send essential account emails (confirmation, password reset)</li>
+          <li>To send essential account emails (your sign-in link and account notices)</li>
         </ul>
         <p>We will <strong>never</strong> sell your data, use it for targeted advertising, or share it with third parties for their marketing purposes.</p>
 

--- a/tests/unit/legal-pages.test.js
+++ b/tests/unit/legal-pages.test.js
@@ -55,8 +55,10 @@ describe('KAN-126: Privacy policy page', () => {
     expect(content).toContain('authentication');
   });
 
-  test('covers children policy', () => {
-    expect(content).toContain('13');
+  test('covers children policy (adults only, 18+)', () => {
+    // KAN-261: Lyra is adults-only (18+); the old "children under 13"
+    // wording was removed in favour of an explicit 18+ statement.
+    expect(content).toContain('18 or over');
   });
 
   test('provides contact email', () => {

--- a/tests/unit/privacy-affiliate-disclosure.test.js
+++ b/tests/unit/privacy-affiliate-disclosure.test.js
@@ -69,7 +69,7 @@ describe('KAN-193: privacy policy — Affiliate partners section', () => {
   });
 
   test('Last updated date reflects this PR', () => {
-    expect(content).toContain('16 May 2026');
+    expect(content).toContain('17 June 2026');
   });
 });
 
@@ -108,7 +108,7 @@ describe('KAN-193: cookie policy — Affiliate links section', () => {
   });
 
   test('Last updated date reflects this PR', () => {
-    expect(content).toContain('16 May 2026');
+    expect(content).toContain('17 June 2026');
   });
 });
 


### PR DESCRIPTION
## What & why
**KAN-261 — Plan A.** The on-site `/privacy` and `/cookies` pages are well-written, but pre-dated recent decisions and had become inaccurate. Copy-only refresh to align them with reality before friends-&-family:

- **Who we are:** now names the data controller — **CheckLyra Ltd**, company no. 16351012, registered office 71–75 Shelton Street, Covent Garden, London, WC2H 9JQ — and notes ICO registration. (Was vague.)
- **Passwordless:** "we email a one-time sign-in link; no password to store" (was "password (encrypted)" + "password reset").
- **Adults only:** must be **18+** to create a profile (was "no data from children under 13").
- **Cookies:** the `code-verifier` note generalised to the passwordless/OAuth (PKCE) flow; "last updated" bumped to 17 Jun 2026.

The accurate sections (providers, Sovrn affiliate disclosure, retention, rights, ICO contact) were **left intact**.

## Testing
- `tsc --noEmit` clean; eslint clean.
- e2e anchors preserved (`/privacy` `<h1>` "Privacy Policy" + "Your rights" heading) so `public-pages.spec.ts` stays green.

## Note
Reference copy also lives in `Profile Content Redesign (June 2026)/Lyra-Privacy-and-Cookie-Policy.md`. A specialist review is still recommended before *public* launch (KAN-252) — this is fine for the closed test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)