### PR TITLE
feat(profile): data-model foundation for the redesign (KAN-263)

### DIFF
--- a/src/app/dashboard/profile/legacy/page.tsx
+++ b/src/app/dashboard/profile/legacy/page.tsx
@@ -14,6 +14,8 @@ const EMPTY_MANUAL_OF_ME: ManualOfMe = {
   working_preferences: null,
   energises_me: null,
   drains_me: null,
+  good_to_know: null,
+  boundaries: null,
 };
 
 /**

--- a/src/app/dashboard/profile/manual-of-me-fields.ts
+++ b/src/app/dashboard/profile/manual-of-me-fields.ts
@@ -23,6 +23,9 @@ export const MANUAL_OF_ME_FIELDS = [
   'working_preferences',
   'energises_me',
   'drains_me',
+  // KAN-263 — the two extra "To understand me a little better" boxes (F3.1/F3.2).
+  'good_to_know',
+  'boundaries',
 ] as const;
 
 export type ManualOfMeField = typeof MANUAL_OF_ME_FIELDS[number];
@@ -34,6 +37,8 @@ export const MANUAL_OF_ME_MAX_LENGTHS: Record<ManualOfMeField, number> = {
   working_preferences: 1000,
   energises_me: 500,
   drains_me: 500,
+  good_to_know: 500,
+  boundaries: 500,
 };
 
 export function isManualOfMeField(key: string): key is ManualOfMeField {
@@ -46,6 +51,8 @@ export interface ManualOfMe {
   working_preferences: string | null;
   energises_me: string | null;
   drains_me: string | null;
+  good_to_know: string | null;
+  boundaries: string | null;
 }
 
 /** True if every field is null or empty-after-trim. Public view uses this to

--- a/src/app/dashboard/profile/page.tsx
+++ b/src/app/dashboard/profile/page.tsx
@@ -13,6 +13,8 @@ const EMPTY_MANUAL_OF_ME: ManualOfMe = {
   working_preferences: null,
   energises_me: null,
   drains_me: null,
+  good_to_know: null,
+  boundaries: null,
 };
 
 /**

--- a/supabase/migrations/20260617120000_about_me_fields.sql
+++ b/supabase/migrations/20260617120000_about_me_fields.sql
@@ -1,0 +1,21 @@
+-- KAN-263: Profile redesign — add the two missing "To understand me a little
+-- better" boxes to profile_manual_of_me.
+--
+-- The redesign's "About me" section is six prompts (F3.1–F3.6). Four already
+-- exist on profile_manual_of_me (communication_style, working_preferences,
+-- energises_me, drains_me); this adds the remaining two:
+--   - good_to_know  (F3.1) — "Good to know about me"
+--   - boundaries    (F3.2) — "My boundaries"
+--
+-- Additive + nullable; no backfill needed. Same RLS as the rest of the table.
+-- (The two existing fields are also being RE-LABELLED in the editor — that's a
+-- UI-only change in a later phase; the column names stay as-is.)
+--
+-- Rollback:
+--   alter table public.profile_manual_of_me
+--     drop column if exists good_to_know,
+--     drop column if exists boundaries;
+
+alter table public.profile_manual_of_me
+  add column if not exists good_to_know text,
+  add column if not exists boundaries text;

--- a/supabase/migrations/20260617120100_affiliation_show_on_profile.sql
+++ b/supabase/migrations/20260617120100_affiliation_show_on_profile.sql
@@ -1,0 +1,23 @@
+-- KAN-263: Profile redesign — affiliations gain an optional short description
+-- and a per-row "show on my profile" flag.
+--
+-- Redesign decisions (F2.c / F2.d, spec D12): schools / organisations /
+-- communities are used to help people FIND you in search, but are HIDDEN on
+-- the public profile by default. `show_on_profile` (default false) opts a
+-- single affiliation in. `description` is a short free-text note
+-- ("Class of 2008"), shown only when the affiliation is visible.
+--
+-- Additive: `description` is nullable; `show_on_profile` is NOT NULL DEFAULT
+-- false, so existing rows backfill to hidden — the privacy-safe default the
+-- redesign wants. NOTE: this column has no effect until the public-profile
+-- render + Find-Someone logic start reading it (later phase); on its own this
+-- migration changes nothing a visitor sees.
+--
+-- Rollback:
+--   alter table public.school_affiliations
+--     drop column if exists description,
+--     drop column if exists show_on_profile;
+
+alter table public.school_affiliations
+  add column if not exists description text,
+  add column if not exists show_on_profile boolean not null default false;

--- a/supabase/migrations/20260617120200_favourites_categories.sql
+++ b/supabase/migrations/20260617120200_favourites_categories.sql
@@ -1,0 +1,20 @@
+-- KAN-263: Profile redesign — three more "favourites" lists.
+--
+-- The redesign's "A few of my favourite things" grid has six lists. Films
+-- (favourite_media), books (favourite_books) and quotes already exist; this
+-- adds the remaining three (F5c / F5e / F5f):
+--   - favourite_tv      — "Favourite TV shows"
+--   - favourite_places  — "Favourite places"
+--   - favourite_music   — "Favourite music & bands"
+--
+-- Reuses the existing profile_items table + RLS + sanitiser — same lightweight
+-- pattern as 20260516160000_add_current_problems_category.sql. The editor +
+-- public-profile UI that surface these come in a later phase; adding the enum
+-- values now is harmless and unblocks that work.
+--
+-- Enum values can't be dropped in Postgres without recreating the type; to
+-- remove, stop using them in code and leave the values in place.
+
+alter type item_category add value if not exists 'favourite_tv';
+alter type item_category add value if not exists 'favourite_places';
+alter type item_category add value if not exists 'favourite_music';

--- a/tests/unit/manual-of-me-actions.test.ts
+++ b/tests/unit/manual-of-me-actions.test.ts
@@ -106,6 +106,20 @@ describe('updateManualOfMe — allowlist + sanitisation', () => {
     });
   });
 
+  test('accepts the two KAN-263 About-me fields (good_to_know + boundaries)', async () => {
+    const result = await updateManualOfMe({
+      good_to_know: 'I think out loud',
+      boundaries: 'Please text before dropping by',
+    });
+    expect(result).toEqual({ success: true });
+    const [payload] = mockUpsertCapture.mock.calls[0];
+    expect(payload).toMatchObject({
+      profile_id: 'profile-1',
+      good_to_know: 'I think out loud',
+      boundaries: 'Please text before dropping by',
+    });
+  });
+
   test('truncates a too-long working_preferences to MANUAL_OF_ME_MAX_LENGTHS', async () => {
     const long = 'A'.repeat(MANUAL_OF_ME_MAX_LENGTHS.working_preferences + 250);
     await updateManualOfMe({ working_preferences: long });
@@ -228,12 +242,14 @@ describe('updateManualOfMe — auth + profile lookup', () => {
 // --- Helper assertions on the field metadata ----------------------------
 
 describe('MANUAL_OF_ME_FIELDS + helpers', () => {
-  test('exposes exactly the v1 four fields', () => {
+  test('exposes the six About-me fields (KAN-263 added good_to_know + boundaries)', () => {
     expect(MANUAL_OF_ME_FIELDS).toEqual([
       'communication_style',
       'working_preferences',
       'energises_me',
       'drains_me',
+      'good_to_know',
+      'boundaries',
     ]);
   });
 
@@ -263,6 +279,8 @@ describe('MANUAL_OF_ME_FIELDS + helpers', () => {
         working_preferences: null,
         energises_me: null,
         drains_me: null,
+        good_to_know: null,
+        boundaries: null,
       })
     ).toBe(true);
   });
@@ -274,6 +292,8 @@ describe('MANUAL_OF_ME_FIELDS + helpers', () => {
         working_preferences: '\n\t',
         energises_me: '',
         drains_me: null,
+        good_to_know: '  ',
+        boundaries: null,
       })
     ).toBe(true);
   });
@@ -285,6 +305,8 @@ describe('MANUAL_OF_ME_FIELDS + helpers', () => {
         working_preferences: null,
         energises_me: null,
         drains_me: null,
+        good_to_know: null,
+        boundaries: null,
       })
     ).toBe(false);
   });


### PR DESCRIPTION
## What & why
**KAN-263 — Phase 1 of building the profile redesign into the app.** The redesign currently exists only as the mock-up + spec; this is the first, **additive, low-risk** step: the data-model fields the new editor + public profile will use. No behaviour changes on its own.

## Changes (all additive)
- **`profile_manual_of_me`**: add `good_to_know` + `boundaries` — the 2 missing "To understand me a little better" boxes (F3.1/F3.2). Wired into `MANUAL_OF_ME_FIELDS` + max-lengths + the `ManualOfMe` type, so `updateManualOfMe` accepts them.
- **`school_affiliations`**: add `description` (short note) + `show_on_profile` (`boolean default false` — affiliations hidden-by-default, per the redesign's privacy decision D12). *Column only* — the public-profile filter + Find-Someone privacy logic come in a later phase, so this changes nothing a visitor sees yet.
- **`item_category` enum**: add `favourite_tv`, `favourite_places`, `favourite_music` (the 3 missing favourites lists), same pattern as `add_current_problems_category`.

## Migrations
3 additive migrations: nullable columns / `default false` / enum `ADD VALUE`. No backfill, no data risk. (Applied to envs via the usual `apply_migration` step.)

## Testing
- `manual-of-me-actions.test.ts` updated: six About-me fields, new fields accepted. **21/21.**
- Full unit suite green (bar the pre-existing shallow-clone version-drift artifact, which passes in CI); `tsc --noEmit` clean; eslint clean.

## Next phases (not this PR)
Editor rebuild, public-profile rebuild, the questions chip-picker (+ D9 consolidation), affiliation show/hide + search-privacy logic, styling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)