### PR TITLE
KAN-267: affiliation 'show on my profile' toggle (hidden by default)

### DIFF
--- a/src/app/dashboard/profile/actions.ts
+++ b/src/app/dashboard/profile/actions.ts
@@ -314,6 +314,30 @@ export async function removeSchoolAffiliation(affiliationId: string): Promise<Ac
   return { success: true };
 }
 
+// KAN-267 — affiliations are hidden on the public profile unless the owner
+// opts the row in. Toggling `show_on_profile` is owner-scoped in code as well
+// as RLS (same defence-in-depth pattern as removeSchoolAffiliation).
+export async function updateAffiliationVisibility(
+  affiliationId: string,
+  showOnProfile: boolean,
+): Promise<ActionResult> {
+  const { user, supabase, error: authError } = await getAuthenticatedUser();
+  if (authError) return { success: false, error: authError };
+
+  const profile = await getUserProfile(supabase, user!.id);
+  if (!profile) return { success: false, error: 'Profile not found' };
+
+  const { error } = await supabase
+    .from('school_affiliations')
+    .update({ show_on_profile: showOnProfile })
+    .eq('id', affiliationId)
+    .eq('profile_id', profile.id);
+
+  if (error) return { success: false, error: error.message };
+  revalidatePath('/dashboard/profile');
+  return { success: true };
+}
+
 export async function addExternalLink(data: {
   title: string;
   url: string;

--- a/src/app/dashboard/profile/sections/affiliations-section.tsx
+++ b/src/app/dashboard/profile/sections/affiliations-section.tsx
@@ -20,7 +20,7 @@ import {
   AFFILIATION_SINGULAR,
   type AffiliationType,
 } from '../affiliation-fields';
-import { addSchoolAffiliation, removeSchoolAffiliation } from '../actions';
+import { addSchoolAffiliation, removeSchoolAffiliation, updateAffiliationVisibility } from '../actions';
 import { useRouter } from 'next/navigation';
 
 const AFFILIATION_ORDER: AffiliationType[] = ['school', 'organisation', 'community'];
@@ -42,9 +42,15 @@ export function AffiliationsSection({ schools }: { schools: WizardSchool[] }) {
   return (
     <div className="space-y-6">
       <p className="text-sm text-[var(--color-muted)]">
-        Schools, organisations, and communities you&apos;re part of. Helps people who know you
-        from any of these find your profile.
+        Schools, organisations, and communities you&apos;re part of. These help the right people
+        find you.
       </p>
+      {/* KAN-267: affiliations are private by default. */}
+      <div className="rounded-[9px] bg-[#e9efea] px-3 py-2.5 text-[13px] leading-relaxed text-[var(--color-sage)]">
+        These are <strong>hidden on your public profile</strong> by default — they&apos;re only used
+        to help people who know you find you. Tick <em>&ldquo;Show on my profile&rdquo;</em> on any
+        you&apos;re happy to display.
+      </div>
       {AFFILIATION_ORDER.map((type) => (
         <AffiliationGroup
           key={type}
@@ -66,6 +72,12 @@ export function AffiliationsSection({ schools }: { schools: WizardSchool[] }) {
               if (result.success) router.refresh();
             });
           }}
+          onToggleVisibility={(id, show) => {
+            startTransition(async () => {
+              const result = await updateAffiliationVisibility(id, show);
+              if (result.success) router.refresh();
+            });
+          }}
           isPending={isPending}
         />
       ))}
@@ -74,12 +86,13 @@ export function AffiliationsSection({ schools }: { schools: WizardSchool[] }) {
 }
 
 function AffiliationGroup({
-  type, items, onAdd, onRemove, isPending,
+  type, items, onAdd, onRemove, onToggleVisibility, isPending,
 }: {
   type: AffiliationType;
   items: WizardSchool[];
   onAdd: (name: string, location: string) => void;
   onRemove: (id: string) => void;
+  onToggleVisibility: (id: string, show: boolean) => void;
   isPending: boolean;
 }) {
   const [name, setName] = useState('');
@@ -101,20 +114,32 @@ function AffiliationGroup({
       {items.length > 0 && (
         <div className="space-y-2">
           {items.map((s) => (
-            <div key={s.id} className="flex items-center justify-between bg-white rounded-lg border border-stone-200 px-4 py-3">
-              <div>
-                <p className="text-sm font-medium text-[var(--color-ink)]">{s.school_name}</p>
+            <div key={s.id} className="flex items-center justify-between bg-white rounded-lg border border-stone-200 px-4 py-3 gap-3">
+              <div className="min-w-0">
+                <p className="text-sm font-medium text-[var(--color-ink)] truncate">{s.school_name}</p>
                 {s.school_location && (
-                  <p className="text-xs text-[var(--color-muted)]">{s.school_location}</p>
+                  <p className="text-xs text-[var(--color-muted)] truncate">{s.school_location}</p>
                 )}
               </div>
-              <button
-                onClick={() => onRemove(s.id)}
-                disabled={isPending}
-                className="text-xs text-red-400 hover:text-red-600 disabled:opacity-40"
-              >
-                Remove
-              </button>
+              <div className="flex items-center gap-3 shrink-0">
+                <label className="flex items-center gap-1.5 text-xs text-[var(--color-muted)] cursor-pointer select-none">
+                  <input
+                    type="checkbox"
+                    checked={s.show_on_profile}
+                    onChange={(e) => onToggleVisibility(s.id, e.target.checked)}
+                    disabled={isPending}
+                    className="w-4 h-4 accent-[var(--color-sage)]"
+                  />
+                  Show on my profile
+                </label>
+                <button
+                  onClick={() => onRemove(s.id)}
+                  disabled={isPending}
+                  className="text-xs text-red-400 hover:text-red-600 disabled:opacity-40"
+                >
+                  Remove
+                </button>
+              </div>
             </div>
           ))}
         </div>

--- a/src/app/dashboard/profile/steps/types.tsx
+++ b/src/app/dashboard/profile/steps/types.tsx
@@ -41,6 +41,11 @@ export interface WizardSchool {
   // default — older rows from before migration 20260517010000 have this
   // column with the default value 'school'.
   affiliation_type: string;
+  // KAN-263 / KAN-267: affiliations are hidden on the public profile unless
+  // the owner opts the row in. `description` is an optional short note
+  // ("Class of 2008"). Older rows default to false / null.
+  show_on_profile: boolean;
+  description: string | null;
 }
 
 export interface WizardLink {

--- a/tests/unit/profile-ownership.test.ts
+++ b/tests/unit/profile-ownership.test.ts
@@ -69,6 +69,7 @@ import {
   removeSchoolAffiliation,
   removeExternalLink,
   updateProfileItemVisibility,
+  updateAffiliationVisibility,
 } from '@/app/dashboard/profile/actions';
 
 beforeEach(() => {
@@ -102,6 +103,14 @@ describe('KAN-260: profile mutations are owner-scoped in code (not RLS alone)', 
     const res = await removeSchoolAffiliation('aff-3');
     expect(res).toEqual({ success: true });
     expect(mockEqCalls['school_affiliations']).toContainEqual(['id', 'aff-3']);
+    expect(ownerScoped('school_affiliations')).toBe(true);
+  });
+
+  // KAN-267: toggling an affiliation's public visibility is owner-scoped too.
+  test('updateAffiliationVisibility scopes the update to the caller profile_id', async () => {
+    const res = await updateAffiliationVisibility('aff-7', true);
+    expect(res).toEqual({ success: true });
+    expect(mockEqCalls['school_affiliations']).toContainEqual(['id', 'aff-7']);
     expect(ownerScoped('school_affiliations')).toBe(true);
   });
 


### PR DESCRIPTION
## What
Closes the loop from [#315](https://github.com/luisa-sys/lyra/pull/315): the public profile hides affiliations unless `show_on_profile` is set, so the editor now lets owners opt each row in.

- `updateAffiliationVisibility` server action — owner-scoped in code + RLS, with an owner-scope regression test
- `WizardSchool` gains `show_on_profile` + `description`
- AffiliationsSection: a "hidden by default" privacy note + a per-row **"Show on my profile"** checkbox

## Tests
`tsc` + `eslint` clean; full unit suite green (incl. the new owner-scope test; only the known local-only `version-drift` fails locally).

🤖 Generated with [Claude Code](https://claude.com/claude-code)