### PR TITLE
KAN-272 fix: restore WCAG AA contrast on footer/nav muted text

### DIFF
--- a/src/app/footer.tsx
+++ b/src/app/footer.tsx
@@ -62,7 +62,7 @@ export function Footer() {
           in your own words. Keep it about you.
         </p>
 
-        <p className="text-[11.5px] text-[var(--color-muted)]/85 leading-relaxed max-w-[46em] mx-auto">
+        <p className="text-[11.5px] text-[var(--color-muted)] leading-relaxed max-w-[46em] mx-auto">
           © {new Date().getFullYear()} Lyra · a trading name of CheckLyra Ltd,
           registered in England &amp; Wales (company no. 16351012), 71–75
           Shelton Street, Covent Garden, London, WC2H 9JQ.

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -94,7 +94,7 @@ function Nav() {
           {/* De-emphasised sign-in, per the mock-up. */}
           <Link
             href="/login"
-            className="text-sm text-[var(--color-muted)]/80 hover:text-[var(--color-ink)] transition-colors"
+            className="text-sm text-[var(--color-muted)] hover:text-[var(--color-ink)] transition-colors"
           >
             Sign in
           </Link>


### PR DESCRIPTION
Follow-up to #321. The staging axe-core e2e gate caught a **WCAG AA color-contrast** regression introduced by the new site-wide footer (and the de-emphasised homepage Sign-in link) — caught before it reached beta, which is exactly what that gate is for.

## Root cause
Two pieces of small text used an **opacity modifier on the muted token**, which lightens it toward the paper background below the 4.5:1 threshold:
- `footer.tsx` legal line — `text-[var(--color-muted)]/85` → rendered `#847e77` = **3.9:1** (on every page, since the footer is site-wide)
- `page.tsx` Sign-in link — `text-[var(--color-muted)]/80` → rendered `#8b867e` = **3.52:1**

## Fix
Drop the opacity on both. Full `--color-muted` (`#6f6860`) on paper `#fdfcf8` is **5.34:1** — comfortably AA, and visually still muted. No other opacity-on-text usages remain in `src/` (verified).

This clears all 12 staging axe failures (homepage, login, signup, privacy, terms, waitlist × chromium + mobile-safari). No test weakened.