### PR TITLE
KAN-272 polish: site title + social metadata to 'Be understood.'

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -21,17 +21,17 @@ const inter = Inter({
 });
 
 export const metadata: Metadata = {
-  title: "Lyra — Let people know you",
+  title: "Lyra — Be understood.",
   description:
-    "A calm profile where you share your preferences, gift ideas, and boundaries — so people in your life never have to guess.",
+    "A place to be understood — a simple page about who you are, in your own words. For your offline life: no feed, no likes, nothing to keep up with.",
   metadataBase: new URL("https://checklyra.com"),
   alternates: {
     canonical: "/",
   },
   openGraph: {
-    title: "Lyra — Let people know you",
+    title: "Lyra — Be understood.",
     description:
-      "Share preferences, gift ideas, and boundaries. So people in your life never have to guess.",
+      "A place to be understood, in your own words. For your offline life — no feed, no likes.",
     url: "https://checklyra.com",
     siteName: "Lyra",
     type: "website",
@@ -41,15 +41,15 @@ export const metadata: Metadata = {
         url: "/og-image.png",
         width: 1200,
         height: 630,
-        alt: "Lyra — Let people know you",
+        alt: "Lyra — Be understood.",
       },
     ],
   },
   twitter: {
     card: "summary_large_image",
-    title: "Lyra — Let people know you",
+    title: "Lyra — Be understood.",
     description:
-      "Share preferences, gift ideas, and boundaries. So people in your life never have to guess.",
+      "A place to be understood, in your own words. For your offline life — no feed, no likes.",
     images: ["/og-image.png"],
   },
   // KAN-175: only allow indexing on production. On beta and any non-prod

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -148,7 +148,7 @@ export default async function Home() {
     name: "Lyra",
     url: "https://checklyra.com",
     description:
-      "A calm, structured public profile platform where users share preferences, gift ideas, and boundaries so people in their lives never have to guess.",
+      "A place to be understood — honest pages about people you already know, in their own words. For your offline life: no feed, no likes, no DMs.",
     potentialAction: {
       "@type": "SearchAction",
       target: "https://checklyra.com/{slug}",


### PR DESCRIPTION
Final fidelity polish after #321/#322. The visible beta already matches the mock-up; this fixes the non-visible metadata that a shared link still previewed with the old tagline.

- `layout.tsx`: `<title>`, OG title, Twitter title, og:image alt → **'Lyra — Be understood.'**; meta descriptions → the calm 'be understood, in your own words / offline life' positioning.
- `page.tsx`: homepage WebSite JSON-LD description → same.

Left untouched: accurate functional copy (search/signup meta), legal-page data-category copy (privacy/terms), and the preserved-but-unused `_marketing` sections. No test asserted the old copy; type-check + metadata suites green.