### PR TITLE
ci: add Claude Code GitHub Action (@claude responder)

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,0 +1,37 @@
+name: Claude Code
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  issues:
+    types: [opened, assigned]
+  pull_request_review:
+    types: [submitted]
+
+jobs:
+  claude:
+    if: |
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
+      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+      id-token: write
+      actions: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+
+      - name: Run Claude Code
+        id: claude
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}


### PR DESCRIPTION
Adds the Claude Code GitHub Action so Claude responds to `@claude` mentions in issues, PR comments, and reviews.

**Workflow:** `.github/workflows/claude.yml` — canonical Anthropic `claude.yml` (action `anthropics/claude-code-action@v1`), using subscription-token auth.

### Required before this works
1. Install the **Claude GitHub App** on this repo: https://github.com/apps/claude
2. Add the repo secret `CLAUDE_CODE_OAUTH_TOKEN` (generated via `claude setup-token`).

Until both are done the workflow will run on `@claude` mentions but fail at the auth step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)