### PR TITLE
KAN-273: Beta-access programme — open signup → queue → admin approval + cross-domain SSO

### DIFF
--- a/.github/workflows/beta-gate-smoke.yml
+++ b/.github/workflows/beta-gate-smoke.yml
@@ -1,22 +1,31 @@
 name: Beta gate smoke
 
-# KAN-223: end-to-end smoke check for the beta-gate contract on
-# beta.checklyra.com. Complements deploy-beta.yml (which verifies env
-# wiring post-deploy) by exercising actual gate behavior on a recurring
-# schedule, so regressions in Vercel SSO / middleware / waitlist routing
-# are caught within a day even when no deploy is happening.
+# KAN-223 / KAN-279 (epic KAN-273): smoke check for the beta-gate contract
+# on beta.checklyra.com.
+#
+# MODEL CHANGE (KAN-279): beta is no longer gated at the NETWORK layer
+# (Cloudflare Access OTP removed; Vercel SSO already disabled). The only gate
+# is now the in-app middleware:
+#   - IS_BETA_DEPLOY=true  → authenticated-but-not-approved users → /waitlist
+#   - unauthenticated      → /dashboard redirects to /login
+# So this smoke probes the PUBLIC beta directly — no Vercel protection-bypass
+# header — and asserts that app-gate contract.
 #
 # What this catches:
-#   - Accidental SSO disable on the beta Vercel env (would expose beta to
-#     the public internet — SSO-active check fails loudly)
-#   - Auth gate regression (middleware no longer redirects /dashboard to
-#     /login when unauthenticated)
-#   - Beta-env wiring drift (IS_BETA_DEPLOY env var reset, NEXT_PUBLIC_SITE_URL
-#     pointing to wrong domain)
-#   - MCP server drift (mcp.checklyra.com serving stale build_sha)
+#   - Beta down / wrong host (root unreachable)
+#   - A network gate creeping back (root 401) — contradicts the app-gate model
+#   - Auth-gate regression (/dashboard no longer redirects to /login)
+#   - Env wiring drift: IS_BETA_DEPLOY reset (gate OFF → beta ungated!) or
+#     NEXT_PUBLIC_SITE_URL pointing at the wrong host
+#   - MCP server drift (stale build_sha / wrong canonical name)
 #
-# Mirrors the post-merge-deploy-smoke.yml pattern in lyra-mcp-server: fail
-# loud with actionable error messages, never silent-pass.
+# CI caveat (Gotcha #7): GitHub runner IPs can be Cloudflare bot-challenged
+# (HTTP 403) at the checklyra.com edge. A 403 is INCONCLUSIVE — surfaced as a
+# warning and counted, never a silent green and never a hard fail. The final
+# "Gate" step FAILS the job if NOTHING could be verified, so an all-403 run
+# never reports a false pass (KAN-167 integrity policy). Robust fix is
+# user-side (probe the raw Vercel URL, or allowlist the runner / use a CF
+# Access service token) — tracked as a KAN-279 follow-up.
 
 on:
   schedule:
@@ -45,147 +54,114 @@ jobs:
   smoke:
     name: Probe beta-gate contracts
     runs-on: ubuntu-latest
-    # Skip if triggered by a failed deploy-beta run — that workflow's own
-    # alert handles the failure surface.
     if: ${{ github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success' }}
     env:
       BETA_HOST: https://beta.checklyra.com
       MCP_HOST: https://mcp.checklyra.com
-      VERCEL_BYPASS: ${{ secrets.VERCEL_AUTOMATION_BYPASS }}
+      VERIFIED: ${{ runner.temp }}/verified
+      INCONCLUSIVE: ${{ runner.temp }}/inconclusive
     steps:
-      - name: Verify VERCEL_AUTOMATION_BYPASS is set
+      - name: Init counters
         run: |
           set -euo pipefail
-          if [ -z "${VERCEL_BYPASS:-}" ]; then
-            echo "::error::VERCEL_AUTOMATION_BYPASS secret is empty. Required for steps 2-5. See KAN-223."
-            exit 1
-          fi
-          echo "::notice::Bypass header present."
+          : > "${VERIFIED}"
+          : > "${INCONCLUSIVE}"
 
-      - name: 1/6 SSO-active check (must return 401 WITHOUT bypass)
+      - name: 1/5 Reachability (beta is up, no network gate)
         run: |
           set -euo pipefail
-          # If SSO ever gets disabled on the beta Vercel env, this returns
-          # 200/307 instead and beta is exposed to the public internet.
-          # That is a security regression we want to catch within 24h.
-          STATUS=$(curl -sS -o /dev/null -w "%{http_code}" --max-time 15 \
-            "${BETA_HOST}/")
-          echo "Status (no bypass): ${STATUS}"
+          STATUS=$(curl -sS -o /dev/null -w "%{http_code}" --max-time 15 "${BETA_HOST}/")
+          echo "Root: ${STATUS}"
           case "${STATUS}" in
+            200|301|302|307|308)
+              echo "::notice::Beta reachable (HTTP ${STATUS}); network gate removed as expected."
+              echo "reachability" >> "${VERIFIED}" ;;
             401)
-              echo "::notice::SSO active — beta is gated to authorized bypass clients only."
-              ;;
-            200|307|302|308)
-              echo "::error::Beta is PUBLICLY ACCESSIBLE (HTTP ${STATUS} without bypass). Vercel SSO appears to be disabled on the beta env. Re-enable Password Protection in Vercel dashboard immediately. See KAN-223."
-              exit 1
-              ;;
+              echo "::error::Beta root returned 401 — a network-level gate (Vercel SSO?) is still active, contradicting the KAN-279 app-gate model. See KAN-223."
+              exit 1 ;;
+            403)
+              echo "::warning::INCONCLUSIVE: HTTP 403 (likely Cloudflare bot challenge on the CI runner — Gotcha #7). Could not verify from CI. See KAN-279."
+              echo "reachability" >> "${INCONCLUSIVE}" ;;
             *)
-              echo "::warning::Unexpected status ${STATUS} on no-bypass request. Investigate."
-              # Don't fail — could be Cloudflare bot challenge (403) which is OK
-              ;;
+              echo "::error::Beta root returned ${STATUS} — unexpected (outage?). See KAN-223."
+              exit 1 ;;
           esac
 
-      - name: 2/6 Bypass reachability (root with bypass)
+      - name: 2/5 /waitlist public-page check
         run: |
           set -euo pipefail
-          STATUS=$(curl -sS -o /dev/null -w "%{http_code}" --max-time 15 \
-            -H "x-vercel-protection-bypass: ${VERCEL_BYPASS}" \
-            "${BETA_HOST}/")
-          echo "Root with bypass: ${STATUS}"
-          case "${STATUS}" in
-            200|307|302|308)
-              echo "::notice::Bypass header accepted, app responsive."
-              ;;
-            *)
-              echo "::error::Bypass header didn't unlock beta (HTTP ${STATUS}). VERCEL_AUTOMATION_BYPASS may have rotated. Refresh from Vercel dashboard → Settings → Deployment Protection → Protection Bypass for Automation. See KAN-223."
-              exit 1
-              ;;
-          esac
-
-      - name: 3/6 /waitlist public-page check
-        run: |
-          set -euo pipefail
-          # /waitlist is exempt from the beta gate (so the redirect doesn't
-          # loop) AND from auth requirements (it's the landing for
-          # non-eligible users). It must return 200 with bypass.
-          RESPONSE=$(curl -sS --max-time 15 \
-            -H "x-vercel-protection-bypass: ${VERCEL_BYPASS}" \
-            -w "\n%{http_code}" \
-            "${BETA_HOST}/waitlist")
+          RESPONSE=$(curl -sS --max-time 15 -w "\n%{http_code}" "${BETA_HOST}/waitlist")
           STATUS=$(echo "${RESPONSE}" | tail -n1)
           BODY=$(echo "${RESPONSE}" | sed '$d')
           echo "Status: ${STATUS}"
-          if [ "${STATUS}" != "200" ]; then
-            echo "::error::/waitlist returned HTTP ${STATUS}, expected 200. The waitlist landing is broken — non-eligible users will hit an error instead of the holding page. See KAN-223."
+          if [ "${STATUS}" = "403" ]; then
+            echo "::warning::INCONCLUSIVE: /waitlist 403 (Cloudflare bot challenge). See KAN-279."
+            echo "waitlist" >> "${INCONCLUSIVE}"
+          elif [ "${STATUS}" != "200" ]; then
+            echo "::error::/waitlist returned HTTP ${STATUS}, expected 200. The waitlist landing is broken — queued users hit an error instead of the holding page. See KAN-223."
             exit 1
-          fi
-          # Sanity-check the body looks like the waitlist page, not a
-          # generic Next.js error or maintenance redirect.
-          if ! echo "${BODY}" | grep -qiE "waitlist|early access|join the waitlist|coming soon"; then
-            echo "::warning::/waitlist body does not contain expected keywords. Page may have changed — verify manually."
+          elif echo "${BODY}" | grep -qiE "waitlist|early access|join the waitlist|coming soon|queue|you're in"; then
+            echo "::notice::/waitlist 200 + recognizable content."
+            echo "waitlist" >> "${VERIFIED}"
           else
-            echo "::notice::/waitlist returns 200 + recognizable content."
+            echo "::warning::/waitlist 200 but body missing expected keywords — verify manually."
+            echo "waitlist" >> "${INCONCLUSIVE}"
           fi
 
-      - name: 4/6 /dashboard auth-gate check (unauthenticated → /login)
+      - name: 3/5 /dashboard auth-gate (unauthenticated → /login)
         run: |
           set -euo pipefail
-          # Hit /dashboard with bypass but no auth cookie. Middleware
-          # should redirect to /login (auth gate), not /waitlist (beta
-          # gate — that's for authenticated-but-not-eligible users).
-          # Expect 307 with Location pointing to /login.
-          HEADERS=$(curl -sS -o /dev/null -D - --max-time 15 \
-            -H "x-vercel-protection-bypass: ${VERCEL_BYPASS}" \
-            "${BETA_HOST}/dashboard")
+          HEADERS=$(curl -sS -o /dev/null -D - --max-time 15 "${BETA_HOST}/dashboard")
           STATUS_LINE=$(echo "${HEADERS}" | head -n1)
           LOCATION=$(echo "${HEADERS}" | grep -i '^location:' | head -n1 | cut -d' ' -f2- | tr -d '\r')
           echo "Status: ${STATUS_LINE}"
           echo "Location: ${LOCATION}"
-          if ! echo "${STATUS_LINE}" | grep -qE "^HTTP/[12](\.[01])? 30[7]"; then
-            echo "::error::/dashboard returned ${STATUS_LINE} for unauthenticated request, expected 307 redirect to /login. Auth gate has regressed. See KAN-223."
+          if echo "${STATUS_LINE}" | grep -qE " 403"; then
+            echo "::warning::INCONCLUSIVE: /dashboard 403 (Cloudflare bot challenge). See KAN-279."
+            echo "auth-gate" >> "${INCONCLUSIVE}"
+          elif ! echo "${STATUS_LINE}" | grep -qE "^HTTP/[12](\.[01])? 30[78]"; then
+            echo "::error::/dashboard returned ${STATUS_LINE} for an unauthenticated request, expected 307 redirect to /login. Auth gate has regressed. See KAN-223."
             exit 1
-          fi
-          if ! echo "${LOCATION}" | grep -qE "/login(\?|$)"; then
+          elif ! echo "${LOCATION}" | grep -qE "/login(\?|$)"; then
             echo "::error::/dashboard redirected to '${LOCATION}', expected /login. Auth gate routing has regressed. See KAN-223."
             exit 1
+          else
+            echo "::notice::Auth gate redirects /dashboard → /login as expected."
+            echo "auth-gate" >> "${VERIFIED}"
           fi
-          echo "::notice::Auth gate redirects /dashboard → /login as expected."
 
-      - name: 5/6 /api/health env wiring check
+      - name: 4/5 /api/health env wiring (isBetaDeploy=true)
         run: |
           set -euo pipefail
-          # Verifies the beta Vercel env still has IS_BETA_DEPLOY=true
-          # and NEXT_PUBLIC_SITE_URL pointing at beta.checklyra.com.
-          RESPONSE=$(curl -sS --max-time 15 \
-            -H "x-vercel-protection-bypass: ${VERCEL_BYPASS}" \
-            -w "\n%{http_code}" \
-            "${BETA_HOST}/api/health")
+          RESPONSE=$(curl -sS --max-time 15 -w "\n%{http_code}" "${BETA_HOST}/api/health")
           STATUS=$(echo "${RESPONSE}" | tail -n1)
           BODY=$(echo "${RESPONSE}" | sed '$d')
           echo "Status: ${STATUS}"
           echo "Body: ${BODY}"
-          if [ "${STATUS}" != "200" ]; then
+          if [ "${STATUS}" = "403" ]; then
+            echo "::warning::INCONCLUSIVE: /api/health 403 (Cloudflare bot challenge). See KAN-279."
+            echo "health" >> "${INCONCLUSIVE}"
+          elif [ "${STATUS}" != "200" ]; then
             echo "::error::/api/health returned ${STATUS}, expected 200. See KAN-223."
             exit 1
+          else
+            SITE_URL=$(echo "${BODY}" | python3 -c "import json,sys; print(json.load(sys.stdin).get('siteUrl',''))")
+            IS_BETA=$(echo "${BODY}" | python3 -c "import json,sys; print(json.load(sys.stdin).get('isBetaDeploy',False))")
+            if [ "${SITE_URL}" != "https://beta.checklyra.com" ]; then
+              echo "::error::siteUrl='${SITE_URL}', expected 'https://beta.checklyra.com'. NEXT_PUBLIC_SITE_URL drifted on the beta env. See KAN-223."
+              exit 1
+            fi
+            if [ "${IS_BETA}" != "True" ]; then
+              echo "::error::isBetaDeploy=${IS_BETA}, expected True — the in-app gate is OFF, so beta would be ungated. Set IS_BETA_DEPLOY=true on the beta Vercel env. See KAN-223."
+              exit 1
+            fi
+            echo "::notice::Env wiring verified (siteUrl=${SITE_URL}, isBetaDeploy=${IS_BETA})."
+            echo "health" >> "${VERIFIED}"
           fi
-          SITE_URL=$(echo "${BODY}" | python3 -c "import json,sys; d=json.load(sys.stdin); print(d.get('siteUrl',''))")
-          IS_BETA=$(echo "${BODY}" | python3 -c "import json,sys; d=json.load(sys.stdin); print(d.get('isBetaDeploy',False))")
-          if [ "${SITE_URL}" != "https://beta.checklyra.com" ]; then
-            echo "::error::siteUrl='${SITE_URL}', expected 'https://beta.checklyra.com'. NEXT_PUBLIC_SITE_URL drifted on beta env. Fix in Vercel dashboard. See KAN-223."
-            exit 1
-          fi
-          if [ "${IS_BETA}" != "True" ]; then
-            echo "::error::isBetaDeploy=${IS_BETA}, expected True. IS_BETA_DEPLOY env var reset on beta env. Fix in Vercel dashboard. See KAN-223."
-            exit 1
-          fi
-          echo "::notice::Env wiring verified (siteUrl=${SITE_URL}, isBetaDeploy=${IS_BETA})."
 
-      - name: 6/6 MCP cross-check (canonical name + non-stale build_sha)
+      - name: 5/5 MCP cross-check (canonical name + non-stale build_sha)
         run: |
           set -euo pipefail
-          # MCP server isn't in the beta gate but beta depends on it for
-          # any MCP-related functionality. Cross-check it's healthy and
-          # serving the canonical Registry name (BUGS-18 instrumentation).
           RESPONSE=$(curl -sS --max-time 15 -w "\n%{http_code}" \
             "${MCP_HOST}/.well-known/mcp.json")
           STATUS=$(echo "${RESPONSE}" | tail -n1)
@@ -205,20 +181,37 @@ jobs:
           else
             echo "::notice::MCP healthy (name=${NAME}, build_sha=${BUILD_SHA:0:8})."
           fi
+          echo "mcp" >> "${VERIFIED}"
+
+      - name: Gate — fail if nothing could be verified
+        run: |
+          set -euo pipefail
+          V=$(wc -l < "${VERIFIED}" | tr -d ' ')
+          I=$(wc -l < "${INCONCLUSIVE}" | tr -d ' ')
+          echo "verified=${V} inconclusive=${I}"
+          if [ "${V}" -eq 0 ]; then
+            echo "::error::Every beta probe was inconclusive (likely all Cloudflare bot-challenged). The smoke verified NOTHING — treating as a failure rather than a false green (KAN-167). Fix the CI probe path per KAN-279."
+            exit 1
+          fi
+          echo "::notice::${V} check(s) verified, ${I} inconclusive."
 
       - name: Summary
         if: always()
         run: |
           set -euo pipefail
+          V=$( [ -f "${VERIFIED}" ] && wc -l < "${VERIFIED}" | tr -d ' ' || echo 0 )
+          I=$( [ -f "${INCONCLUSIVE}" ] && wc -l < "${INCONCLUSIVE}" | tr -d ' ' || echo 0 )
           {
-            echo "## Beta gate smoke"
+            echo "## Beta gate smoke (KAN-279 app-gate model)"
             echo ""
             echo "Run on: $(date -u +%Y-%m-%dT%H:%M:%SZ)"
             echo "Trigger: ${{ github.event_name }}"
             echo ""
+            echo "Verified: ${V} · Inconclusive (CF challenge): ${I}"
+            echo ""
             if [ "${{ job.status }}" = "success" ]; then
-              echo ":white_check_mark: All 6 checks passed."
+              echo ":white_check_mark: App-gate contract holds (verified ${V} check(s))."
             else
-              echo ":x: One or more checks failed — see annotations above. Runbook: KAN-223."
+              echo ":x: One or more checks failed or nothing could be verified — see annotations. Runbook: KAN-223 / KAN-279."
             fi
           } >> "$GITHUB_STEP_SUMMARY"

--- a/src/app/admin/beta-queue/actions.ts
+++ b/src/app/admin/beta-queue/actions.ts
@@ -1,0 +1,60 @@
+'use server';
+
+import { revalidatePath } from 'next/cache';
+import { getCurrentAdmin, getAdminServiceClient, logModerationAction } from '@/lib/admin';
+import { sendBetaApprovedEmail } from '@/lib/beta-access/email';
+
+/**
+ * KAN-277 (epic KAN-273): approve a queued user into the beta.
+ *
+ * Admin-gated (getCurrentAdmin). Sets beta_access_status='approved' +
+ * is_beta_eligible=true + beta_approved_at via the service-role client (which
+ * passes the admin-only trigger from 20260620120100_beta_access_lockdown.sql),
+ * audit-logs a 'grant_beta_access' moderation action, then emails the user a
+ * "you're in" link (best-effort — degrades gracefully without RESEND_API_KEY).
+ */
+export async function approveBetaUser(formData: FormData): Promise<void> {
+  const admin = await getCurrentAdmin();
+  if (!admin) {
+    throw new Error('Not authorised');
+  }
+
+  const profileId = String(formData.get('profile_id') ?? '').trim();
+  const userId = String(formData.get('user_id') ?? '').trim();
+  if (!profileId || !userId) {
+    throw new Error('Missing target profile');
+  }
+
+  const svc = getAdminServiceClient();
+  const { error } = await svc
+    .from('profiles')
+    .update({
+      beta_access_status: 'approved',
+      is_beta_eligible: true,
+      beta_approved_at: new Date().toISOString(),
+    })
+    .eq('id', profileId);
+  if (error) {
+    throw new Error(`Could not approve: ${error.message}`);
+  }
+
+  await logModerationAction({
+    admin,
+    action: 'grant_beta_access',
+    targetProfileId: profileId,
+    metadata: { user_id: userId },
+  });
+
+  // "You're in" email — never block/abort the approval if email fails.
+  try {
+    const { data } = await svc.auth.admin.getUserById(userId);
+    const email = data?.user?.email;
+    if (email) {
+      await sendBetaApprovedEmail({ to: email });
+    }
+  } catch (e) {
+    console.error('[beta-access] approval email failed', e);
+  }
+
+  revalidatePath('/admin/beta-queue');
+}

--- a/src/app/admin/beta-queue/page.tsx
+++ b/src/app/admin/beta-queue/page.tsx
@@ -1,0 +1,89 @@
+/**
+ * KAN-277 (epic KAN-273): /admin/beta-queue — people awaiting beta approval.
+ *
+ * Admin-gated by the /admin layout (getCurrentAdmin → notFound for non-admins).
+ * Lists profiles with beta_access_status='requested'; each row has an Approve
+ * button wired to the approveBetaUser server action.
+ */
+import { getAdminServiceClient } from '@/lib/admin';
+import { approveBetaUser } from './actions';
+
+export const dynamic = 'force-dynamic';
+
+interface QueueRow {
+  id: string;
+  user_id: string;
+  display_name: string | null;
+  slug: string;
+  beta_requested_at: string | null;
+}
+
+async function listRequested(): Promise<QueueRow[]> {
+  const svc = getAdminServiceClient();
+  const { data } = await svc
+    .from('profiles')
+    .select('id, user_id, display_name, slug, beta_requested_at')
+    .eq('beta_access_status', 'requested')
+    .order('beta_requested_at', { ascending: true })
+    .limit(200);
+  return (data ?? []) as unknown as QueueRow[];
+}
+
+function formatRelative(iso: string | null): string {
+  if (!iso) return '—';
+  const diff = Date.now() - new Date(iso).getTime();
+  const mins = Math.floor(diff / 60000);
+  if (mins < 1) return 'just now';
+  if (mins < 60) return `${mins}m ago`;
+  const hrs = Math.floor(mins / 60);
+  if (hrs < 24) return `${hrs}h ago`;
+  return `${Math.floor(hrs / 24)}d ago`;
+}
+
+export default async function BetaQueuePage() {
+  const rows = await listRequested();
+
+  return (
+    <div className="max-w-6xl mx-auto px-6 py-8 space-y-6">
+      <header>
+        <h1 className="text-2xl font-medium text-[var(--color-ink)] font-[family-name:var(--font-serif)]">
+          Beta queue
+        </h1>
+        <p className="text-sm text-[var(--color-muted)] mt-1">
+          People who have requested access. Approving lets them into the beta and emails them a
+          &ldquo;you&rsquo;re in&rdquo; link.
+        </p>
+      </header>
+
+      <div className="rounded-xl border border-[var(--color-border)] bg-white divide-y divide-[var(--color-border)]">
+        {rows.length === 0 ? (
+          <p className="p-5 text-sm text-[var(--color-muted)]">No one is waiting for approval.</p>
+        ) : (
+          rows.map((r) => (
+            <div key={r.id} className="flex items-center justify-between gap-4 p-4">
+              <div className="min-w-0">
+                <p className="text-sm text-[var(--color-ink)] truncate">
+                  <span className="font-medium">{r.display_name ?? 'Unnamed'}</span>{' '}
+                  <span className="text-[var(--color-muted)]">(/{r.slug})</span>
+                </p>
+                <p className="text-xs text-[var(--color-muted)]">
+                  requested {formatRelative(r.beta_requested_at)}
+                </p>
+              </div>
+              <form action={approveBetaUser}>
+                <input type="hidden" name="profile_id" value={r.id} />
+                <input type="hidden" name="user_id" value={r.user_id} />
+                <button
+                  type="submit"
+                  className="text-xs font-medium px-4 py-2 rounded-full bg-[var(--color-sage)] text-white hover:opacity-90 transition-opacity shrink-0"
+                >
+                  Approve
+                </button>
+              </form>
+            </div>
+          ))
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/app/admin/layout.tsx
+++ b/src/app/admin/layout.tsx
@@ -59,6 +59,12 @@ export default async function AdminLayout({ children }: { children: React.ReactN
                 Users
               </Link>
               <Link
+                href="/admin/beta-queue"
+                className="text-sm text-[var(--color-muted)] hover:text-[var(--color-ink)] transition-colors"
+              >
+                Beta queue
+              </Link>
+              <Link
                 href="/admin/audit"
                 className="text-sm text-[var(--color-muted)] hover:text-[var(--color-ink)] transition-colors"
               >

--- a/src/app/auth/callback/route.ts
+++ b/src/app/auth/callback/route.ts
@@ -1,5 +1,6 @@
 import { createClient } from '@/lib/supabase-server';
 import { NextResponse } from 'next/server';
+import { resolveBetaAccess, betaRedirectUrl, isProdDeploy } from '@/lib/beta-access/flow';
 
 export async function GET(request: Request) {
   const { searchParams, origin } = new URL(request.url);
@@ -10,10 +11,23 @@ export async function GET(request: Request) {
     const supabase = await createClient();
     const { error } = await supabase.auth.exchangeCodeForSession(code);
     if (!error) {
-      return NextResponse.redirect(`${origin}${next}`);
+      // KAN-276/278: record the beta-access lifecycle (none -> requested + notify
+      // the admin on a brand-new signup) and route the user into the gated beta
+      // app — approved users to the dashboard, everyone else to the waitlist.
+      const {
+        data: { user },
+      } = await supabase.auth.getUser();
+      const approved = user
+        ? (await resolveBetaAccess({ id: user.id, email: user.email })).approved
+        : true;
+      return NextResponse.redirect(
+        betaRedirectUrl({ origin, isProd: isProdDeploy(), approved, next }),
+      );
     }
   }
 
   // Auth code exchange failed — redirect to error page
-  return NextResponse.redirect(`${origin}/login?error=${encodeURIComponent('Could not verify your email. Please try again.')}`);
+  return NextResponse.redirect(
+    `${origin}/login?error=${encodeURIComponent('Could not verify your email. Please try again.')}`,
+  );
 }

--- a/src/lib/admin.ts
+++ b/src/lib/admin.ts
@@ -45,7 +45,8 @@ export type ModerationAction =
   | 'resolve_report'
   | 'dismiss_report'
   | 'grant_admin'
-  | 'revoke_admin';
+  | 'revoke_admin'
+  | 'grant_beta_access'; // KAN-273: approve a queued user into the beta
 
 export interface AdminUser {
   userId: string;

--- a/src/lib/beta-access/email.ts
+++ b/src/lib/beta-access/email.ts
@@ -1,0 +1,80 @@
+/**
+ * KAN-276 / KAN-277 (epic KAN-273): transactional emails for the beta-access
+ * programme. Modelled on src/lib/convene/invites/email.ts (Resend REST API).
+ *
+ *   - sendBetaQueueNotice:   tells the admin (Luisa) a new person joined the queue.
+ *   - sendBetaApprovedEmail: tells an approved user "you're in" + the beta link.
+ *
+ * Graceful degradation: if RESEND_API_KEY is unset the send is a no-op that
+ * returns { ok:false, code:'no_api_key' } and logs a WARNING (never a silent
+ * skip). Signup / approval must not crash just because email is unconfigured.
+ *
+ * Recipient + sender are env-overridable:
+ *   - LYRA_BETA_NOTIFY_EMAIL (default luisa@santos-stephens.com) — queue notices
+ *   - LYRA_BETA_FROM_EMAIL   (default hello@checklyra.com)       — From address
+ */
+export type BetaEmailResult =
+  | { ok: true; messageId: string }
+  | { ok: false; code: 'no_api_key' | 'send_failed'; detail?: string };
+
+const BETA_URL = 'https://beta.checklyra.com';
+const from = () => process.env.LYRA_BETA_FROM_EMAIL ?? 'hello@checklyra.com';
+const notifyTo = () => process.env.LYRA_BETA_NOTIFY_EMAIL ?? 'luisa@santos-stephens.com';
+
+function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}
+
+async function send(
+  to: string,
+  subject: string,
+  html: string,
+  text: string,
+): Promise<BetaEmailResult> {
+  const apiKey = process.env.RESEND_API_KEY;
+  if (!apiKey) {
+    console.warn(`[beta-access] RESEND_API_KEY not set — email to ${to} not sent ("${subject}")`);
+    return { ok: false, code: 'no_api_key' };
+  }
+  const res = await fetch('https://api.resend.com/emails', {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${apiKey}`, 'Content-Type': 'application/json' },
+    body: JSON.stringify({ from: `Lyra <${from()}>`, to: [to], subject, html, text }),
+  });
+  if (!res.ok) {
+    const detail = await res.text().catch(() => '');
+    return { ok: false, code: 'send_failed', detail };
+  }
+  const data = (await res.json().catch(() => ({}))) as { id?: string };
+  return { ok: true, messageId: data.id ?? '' };
+}
+
+export function sendBetaQueueNotice(input: {
+  userEmail: string;
+  displayName?: string | null;
+}): Promise<BetaEmailResult> {
+  const name = input.displayName?.trim() || input.userEmail;
+  const subject = `New Lyra beta request: ${input.userEmail}`;
+  const html =
+    `<p>${escapeHtml(name)} (${escapeHtml(input.userEmail)}) just joined the Lyra beta queue.</p>` +
+    `<p>Review &amp; approve them from the admin beta queue.</p>`;
+  const text =
+    `${name} (${input.userEmail}) just joined the Lyra beta queue. ` +
+    `Review & approve them from the admin beta queue.`;
+  return send(notifyTo(), subject, html, text);
+}
+
+export function sendBetaApprovedEmail(input: { to: string }): Promise<BetaEmailResult> {
+  const subject = `You're in — welcome to the Lyra beta`;
+  const html =
+    `<p>Good news — you've been approved for the Lyra beta.</p>` +
+    `<p><a href="${BETA_URL}">Open Lyra</a> and start building your profile.</p>`;
+  const text =
+    `Good news — you've been approved for the Lyra beta. ` +
+    `Open Lyra at ${BETA_URL} and start building your profile.`;
+  return send(input.to, subject, html, text);
+}

--- a/src/lib/beta-access/flow.ts
+++ b/src/lib/beta-access/flow.ts
@@ -1,0 +1,95 @@
+/**
+ * KAN-276 + KAN-278 (epic KAN-273): beta-access recording + routing, run from
+ * the auth callback after a magic-link sign-in.
+ *
+ *  - resolveBetaAccess: records a brand-new signup as 'requested' (none ->
+ *    requested) and notifies the admin ONCE (KAN-276); reports approval status.
+ *    All writes go through the SERVICE ROLE so they pass the admin-only trigger
+ *    from 20260620120100_beta_access_lockdown.sql.
+ *  - betaRedirectUrl: pure — decides where to send the user (KAN-278). On prod
+ *    (the public doorway) everyone is pushed to the beta app, carrying their
+ *    session via the .checklyra.com cookie (KAN-274): approved -> beta dashboard,
+ *    not-yet-approved -> beta waitlist. On beta the in-app middleware gate does
+ *    the waitlist routing, and dev/stage stay on their own origin.
+ */
+import { createClient as createServiceRoleClient } from '@supabase/supabase-js';
+import { env } from '@/lib/env';
+import { sendBetaQueueNotice } from './email';
+
+const BETA_HOST = 'https://beta.checklyra.com';
+
+/** Pure: where to redirect after sign-in. `isProd` = the real production app. */
+export function betaRedirectUrl(opts: {
+  origin: string;
+  isProd: boolean;
+  approved: boolean;
+  next: string;
+}): string {
+  // Guard against open redirects: only same-origin absolute paths, never a
+  // protocol-relative ("//evil.com") or absolute URL.
+  const path =
+    opts.next && opts.next.startsWith('/') && !opts.next.startsWith('//')
+      ? opts.next
+      : '/dashboard';
+  if (opts.isProd) {
+    // Prod is a doorway into the gated beta app.
+    return opts.approved ? `${BETA_HOST}${path}` : `${BETA_HOST}/waitlist`;
+  }
+  // Beta: the IS_BETA_DEPLOY middleware routes ineligible users to /waitlist.
+  // Dev/stage: open — land on the requested page.
+  return `${opts.origin}${path}`;
+}
+
+/** True only on the real production deployment (not beta/dev/stage/local). */
+export function isProdDeploy(e: NodeJS.ProcessEnv = process.env): boolean {
+  return e.NEXT_PUBLIC_SITE_URL === 'https://checklyra.com' && e.VERCEL_ENV === 'production';
+}
+
+/**
+ * Record the user's beta-access state and report approval. Writes via the
+ * service role (admin-only trigger). Defensive: any failure must NOT break
+ * sign-in — we log and treat the user as not-approved (→ waitlist).
+ */
+export async function resolveBetaAccess(user: {
+  id: string;
+  email?: string | null;
+}): Promise<{ approved: boolean }> {
+  try {
+    const svc = createServiceRoleClient(env.supabaseUrl(), env.supabaseServiceRoleKey());
+
+    const { data: profile } = await svc
+      .from('profiles')
+      .select('beta_access_status, is_beta_eligible, display_name')
+      .eq('user_id', user.id)
+      .maybeSingle();
+
+    const status = profile?.beta_access_status as string | undefined;
+    if (profile?.is_beta_eligible === true || status === 'approved') {
+      return { approved: true };
+    }
+
+    // Brand-new signup: record the request once + notify the admin.
+    if (status === undefined || status === 'none') {
+      const { data: updated } = await svc
+        .from('profiles')
+        .update({
+          beta_access_status: 'requested',
+          beta_requested_at: new Date().toISOString(),
+        })
+        .eq('user_id', user.id)
+        .eq('beta_access_status', 'none') // idempotent: only the none->requested transition
+        .select('user_id');
+
+      if (updated && updated.length > 0) {
+        await sendBetaQueueNotice({
+          userEmail: user.email ?? '(unknown)',
+          displayName: (profile?.display_name as string | undefined) ?? null,
+        });
+      }
+    }
+    return { approved: false };
+  } catch (e) {
+    console.error('[beta-access] resolveBetaAccess failed', e);
+    return { approved: false };
+  }
+}

--- a/src/lib/cookie-domain.ts
+++ b/src/lib/cookie-domain.ts
@@ -1,0 +1,42 @@
+/**
+ * KAN-274 (epic KAN-273): cross-domain session-cookie scoping.
+ *
+ * To let a checklyra.com (prod) session carry over to beta.checklyra.com
+ * without a re-login, the Supabase auth cookies are scoped to the parent
+ * domain `.checklyra.com` — but ONLY on prod + beta. dev (dev.checklyra.com)
+ * and stage (stage.checklyra.com) use DIFFERENT Supabase projects and MUST
+ * stay host-scoped, so a session can never be read across environments.
+ *
+ * Detection (no new env vars — reuses existing wiring):
+ *   - beta: IS_BETA_DEPLOY === 'true'
+ *   - prod: NEXT_PUBLIC_SITE_URL === 'https://checklyra.com'
+ *   - everything else (dev / stage / preview / local) → host-scoped (undefined).
+ *
+ * Defence in depth: the Supabase cookie NAME embeds the project ref, so even a
+ * misconfigured domain cannot let prod/beta (shared prod-lyra ref) collide with
+ * dev/stage (different refs). SameSite + Secure are left as Supabase sets them
+ * (Lax + Secure) — correct for a same-site top-level navigation between
+ * checklyra.com and beta.checklyra.com.
+ */
+export const PROD_SITE_URL = 'https://checklyra.com';
+export const PARENT_COOKIE_DOMAIN = '.checklyra.com';
+
+/** The cookie `domain` to use, or undefined to stay host-scoped (dev/stage/local). */
+export function parentCookieDomain(e: NodeJS.ProcessEnv = process.env): string | undefined {
+  const isBeta = e.IS_BETA_DEPLOY === 'true';
+  const isProd = e.NEXT_PUBLIC_SITE_URL === PROD_SITE_URL;
+  return isBeta || isProd ? PARENT_COOKIE_DOMAIN : undefined;
+}
+
+/**
+ * Merge the parent-domain into a cookie-options object when on prod/beta;
+ * leave it untouched (host-scoped) on dev/stage/local. Pure — returns a new
+ * object only when a domain is actually added.
+ */
+export function withParentCookieDomain<T extends object>(
+  options: T,
+  e: NodeJS.ProcessEnv = process.env,
+): T | (T & { domain: string }) {
+  const domain = parentCookieDomain(e);
+  return domain ? { ...options, domain } : options;
+}

--- a/src/lib/supabase-server.ts
+++ b/src/lib/supabase-server.ts
@@ -1,6 +1,7 @@
 import { createServerClient } from '@supabase/ssr';
 import { cookies } from 'next/headers';
 import { env } from '@/lib/env';
+import { withParentCookieDomain } from '@/lib/cookie-domain';
 
 export async function createClient() {
   const cookieStore = await cookies();
@@ -16,7 +17,7 @@ export async function createClient() {
         setAll(cookiesToSet) {
           try {
             cookiesToSet.forEach(({ name, value, options }) =>
-              cookieStore.set(name, value, options)
+              cookieStore.set(name, value, withParentCookieDomain(options))
             );
           } catch {
             // Server Component — ignore

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,6 +1,7 @@
 import { createServerClient } from '@supabase/ssr';
 import { NextResponse, type NextRequest } from 'next/server';
 import { rateLimit, RATE_LIMITS } from '@/lib/rate-limit';
+import { withParentCookieDomain } from '@/lib/cookie-domain';
 
 function getClientIp(request: NextRequest): string {
   return (
@@ -66,7 +67,7 @@ export async function middleware(request: NextRequest) {
           request,
         });
         cookiesToSet.forEach(({ name, value, options }) =>
-          supabaseResponse.cookies.set(name, value, options)
+          supabaseResponse.cookies.set(name, value, withParentCookieDomain(options))
         );
       },
     },

--- a/supabase/migrations/20260620120000_beta_access_status.sql
+++ b/supabase/migrations/20260620120000_beta_access_status.sql
@@ -1,0 +1,48 @@
+-- KAN-275 (epic KAN-273): Beta-access lifecycle on profiles.
+--
+-- The queue/approval flow records each user's beta-access lifecycle:
+--   none -> requested -> approved
+-- Additive + forward-only; no destructive ops. Coexists with the legacy
+-- `is_beta_eligible` flag, which the approval flow continues to set during
+-- the transition.
+--
+-- Applied to:
+--   dev (ilprytcrnqyrsbsrfujj): via apply_migration 2026-06-20
+--   staging / prod: NOT YET — user-gated promotion (epic KAN-273).
+--
+-- Rollback:
+--   drop index if exists public.profiles_beta_access_requested_idx;
+--   alter table public.profiles
+--     drop column if exists beta_access_status,
+--     drop column if exists beta_requested_at,
+--     drop column if exists beta_approved_at;
+--   drop type if exists public.beta_access_status;
+
+-- 1. Enum type (guarded — Postgres has no `create type if not exists`).
+do $$
+begin
+  if not exists (select 1 from pg_type where typname = 'beta_access_status') then
+    create type public.beta_access_status as enum ('none', 'requested', 'approved');
+  end if;
+end$$;
+
+-- 2. Columns on profiles (additive; status NOT NULL default 'none').
+alter table public.profiles
+  add column if not exists beta_access_status public.beta_access_status not null default 'none',
+  add column if not exists beta_requested_at timestamptz,
+  add column if not exists beta_approved_at  timestamptz;
+
+-- 3. Backfill: existing beta-eligible users are already "approved".
+update public.profiles
+set beta_access_status = 'approved',
+    beta_approved_at = coalesce(beta_approved_at, now())
+where is_beta_eligible = true
+  and beta_access_status = 'none';
+
+-- 4. Partial index for the admin queue listing (only 'requested' rows).
+create index if not exists profiles_beta_access_requested_idx
+  on public.profiles (beta_access_status)
+  where beta_access_status = 'requested';
+
+comment on column public.profiles.beta_access_status is
+  'KAN-275: beta-access lifecycle none|requested|approved. Set server-side on signup (requested) and admin approval (approved). Coexists with is_beta_eligible during transition.';

--- a/supabase/migrations/20260620120100_beta_access_lockdown.sql
+++ b/supabase/migrations/20260620120100_beta_access_lockdown.sql
@@ -1,0 +1,55 @@
+-- KAN-273 hardening: beta-access columns are admin-only at the DB layer.
+--
+-- THREAT: the only UPDATE policy on profiles ("Update own profile",
+-- auth.uid() = user_id) plus a table-level UPDATE grant to `authenticated`
+-- means a signed-in user can run a direct Supabase call to set their OWN
+-- is_beta_eligible=true / beta_access_status='approved' and self-approve into
+-- the beta, bypassing the entire gate. The app's ALLOWED_PROFILE_FIELDS
+-- allowlist only guards the UI, not the database.
+--
+-- FIX: a BEFORE UPDATE trigger that rejects any change to the four privileged
+-- beta columns unless the caller has no user JWT (auth.uid() IS NULL) — i.e.
+-- the service role (admin approval via getAdminServiceClient, and the signup
+-- callback's service-role "requested" write) or a SQL migration. Normal
+-- user profile edits (which never touch these columns) are unaffected.
+--
+-- Applied to:
+--   dev (ilprytcrnqyrsbsrfujj): via apply_migration 2026-06-20
+--   staging / prod: NOT YET — user-gated promotion (epic KAN-273).
+--   NOTE: this also closes the pre-existing self-approve hole on the legacy
+--   is_beta_eligible flag, so it is safe + desirable to promote with the rest.
+--
+-- Rollback:
+--   drop trigger if exists profiles_prevent_beta_self_elevation on public.profiles;
+--   drop function if exists public.prevent_beta_self_elevation();
+
+create or replace function public.prevent_beta_self_elevation()
+returns trigger
+language plpgsql
+security definer
+set search_path = public, pg_temp
+as $$
+begin
+  -- Service role / backend jobs / migrations run without a user JWT
+  -- (auth.uid() IS NULL) and ARE allowed to set the privileged columns.
+  if auth.uid() is null then
+    return new;
+  end if;
+
+  -- Any user-context request must NOT change the gate columns.
+  if new.is_beta_eligible   is distinct from old.is_beta_eligible
+  or new.beta_access_status is distinct from old.beta_access_status
+  or new.beta_requested_at  is distinct from old.beta_requested_at
+  or new.beta_approved_at   is distinct from old.beta_approved_at then
+    raise exception 'beta-access columns are admin-only (KAN-273)'
+      using errcode = '42501'; -- insufficient_privilege
+  end if;
+
+  return new;
+end;
+$$;
+
+drop trigger if exists profiles_prevent_beta_self_elevation on public.profiles;
+create trigger profiles_prevent_beta_self_elevation
+  before update on public.profiles
+  for each row execute function public.prevent_beta_self_elevation();

--- a/tests/unit/beta-access-flow.test.ts
+++ b/tests/unit/beta-access-flow.test.ts
@@ -1,0 +1,63 @@
+import { betaRedirectUrl, isProdDeploy } from '@/lib/beta-access/flow';
+
+const asEnv = (o: Record<string, string>) => o as unknown as NodeJS.ProcessEnv;
+
+// KAN-278: where a user lands after sign-in.
+describe('betaRedirectUrl', () => {
+  it('prod + approved -> beta dashboard', () => {
+    expect(
+      betaRedirectUrl({ origin: 'https://checklyra.com', isProd: true, approved: true, next: '/dashboard' }),
+    ).toBe('https://beta.checklyra.com/dashboard');
+  });
+
+  it('prod + not approved -> beta waitlist', () => {
+    expect(
+      betaRedirectUrl({ origin: 'https://checklyra.com', isProd: true, approved: false, next: '/dashboard' }),
+    ).toBe('https://beta.checklyra.com/waitlist');
+  });
+
+  it('prod preserves a safe nested next path', () => {
+    expect(
+      betaRedirectUrl({ origin: 'https://checklyra.com', isProd: true, approved: true, next: '/dashboard/profile' }),
+    ).toBe('https://beta.checklyra.com/dashboard/profile');
+  });
+
+  it('non-prod (beta/dev) stays on the same origin', () => {
+    expect(
+      betaRedirectUrl({ origin: 'https://beta.checklyra.com', isProd: false, approved: false, next: '/dashboard' }),
+    ).toBe('https://beta.checklyra.com/dashboard');
+    expect(
+      betaRedirectUrl({ origin: 'https://dev.checklyra.com', isProd: false, approved: true, next: '/dashboard' }),
+    ).toBe('https://dev.checklyra.com/dashboard');
+  });
+
+  it('rejects open-redirect next values (protocol-relative / absolute)', () => {
+    expect(
+      betaRedirectUrl({ origin: 'https://checklyra.com', isProd: true, approved: true, next: '//evil.com' }),
+    ).toBe('https://beta.checklyra.com/dashboard');
+    expect(
+      betaRedirectUrl({ origin: 'https://checklyra.com', isProd: true, approved: true, next: 'https://evil.com' }),
+    ).toBe('https://beta.checklyra.com/dashboard');
+  });
+});
+
+// KAN-278: only the real production deploy hops users to beta.
+describe('isProdDeploy', () => {
+  it('true only on prod URL + VERCEL_ENV=production', () => {
+    expect(isProdDeploy(asEnv({ NEXT_PUBLIC_SITE_URL: 'https://checklyra.com', VERCEL_ENV: 'production' }))).toBe(true);
+  });
+
+  it('false on beta (different site url)', () => {
+    expect(
+      isProdDeploy(asEnv({ NEXT_PUBLIC_SITE_URL: 'https://beta.checklyra.com', VERCEL_ENV: 'production', IS_BETA_DEPLOY: 'true' })),
+    ).toBe(false);
+  });
+
+  it('false on local (prod url default but no VERCEL_ENV)', () => {
+    expect(isProdDeploy(asEnv({ NEXT_PUBLIC_SITE_URL: 'https://checklyra.com' }))).toBe(false);
+  });
+
+  it('false on dev', () => {
+    expect(isProdDeploy(asEnv({ NEXT_PUBLIC_SITE_URL: 'https://dev.checklyra.com', VERCEL_ENV: 'preview' }))).toBe(false);
+  });
+});

--- a/tests/unit/beta-queue-approve.test.ts
+++ b/tests/unit/beta-queue-approve.test.ts
@@ -1,0 +1,84 @@
+import { approveBetaUser } from '@/app/admin/beta-queue/actions';
+
+jest.mock('next/cache', () => ({ revalidatePath: jest.fn() }));
+
+const mockGetCurrentAdmin = jest.fn();
+const mockUpdateEq = jest.fn();
+const mockGetUserById = jest.fn();
+const mockLog = jest.fn();
+const mockEmail = jest.fn();
+
+jest.mock('@/lib/admin', () => ({
+  getCurrentAdmin: () => mockGetCurrentAdmin(),
+  getAdminServiceClient: () => ({
+    from: () => ({ update: () => ({ eq: (...a: unknown[]) => mockUpdateEq(...a) }) }),
+    auth: { admin: { getUserById: (...a: unknown[]) => mockGetUserById(...a) } },
+  }),
+  logModerationAction: (...a: unknown[]) => mockLog(...a),
+}));
+
+jest.mock('@/lib/beta-access/email', () => ({
+  sendBetaApprovedEmail: (...a: unknown[]) => mockEmail(...a),
+}));
+
+function fd(obj: Record<string, string>): FormData {
+  const f = new FormData();
+  Object.entries(obj).forEach(([k, v]) => f.set(k, v));
+  return f;
+}
+
+const ADMIN = { userId: 'a', profileId: 'ap', email: null, displayName: 'A' };
+
+describe('approveBetaUser (KAN-277)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUpdateEq.mockResolvedValue({ error: null });
+    mockGetUserById.mockResolvedValue({ data: { user: { email: 'new@user.com' } } });
+    mockLog.mockResolvedValue('log-id');
+    mockEmail.mockResolvedValue({ ok: true, messageId: 'm1' });
+  });
+
+  it('rejects non-admins and performs no mutation', async () => {
+    mockGetCurrentAdmin.mockResolvedValue(null);
+    await expect(approveBetaUser(fd({ profile_id: 'p1', user_id: 'u1' }))).rejects.toThrow(
+      'Not authorised',
+    );
+    expect(mockUpdateEq).not.toHaveBeenCalled();
+    expect(mockLog).not.toHaveBeenCalled();
+    expect(mockEmail).not.toHaveBeenCalled();
+  });
+
+  it('rejects a missing target profile', async () => {
+    mockGetCurrentAdmin.mockResolvedValue(ADMIN);
+    await expect(approveBetaUser(fd({ profile_id: '', user_id: '' }))).rejects.toThrow(
+      'Missing target',
+    );
+    expect(mockUpdateEq).not.toHaveBeenCalled();
+  });
+
+  it('approves: updates the profile, audit-logs grant_beta_access, emails the user', async () => {
+    mockGetCurrentAdmin.mockResolvedValue(ADMIN);
+    await approveBetaUser(fd({ profile_id: 'p1', user_id: 'u1' }));
+    expect(mockUpdateEq).toHaveBeenCalledWith('id', 'p1');
+    expect(mockLog).toHaveBeenCalledWith(
+      expect.objectContaining({ action: 'grant_beta_access', targetProfileId: 'p1' }),
+    );
+    expect(mockEmail).toHaveBeenCalledWith({ to: 'new@user.com' });
+  });
+
+  it('still completes if the approval email step throws', async () => {
+    mockGetCurrentAdmin.mockResolvedValue(ADMIN);
+    mockGetUserById.mockRejectedValue(new Error('auth down'));
+    await expect(approveBetaUser(fd({ profile_id: 'p1', user_id: 'u1' }))).resolves.toBeUndefined();
+    expect(mockLog).toHaveBeenCalled();
+  });
+
+  it('throws if the profile update fails (no silent success)', async () => {
+    mockGetCurrentAdmin.mockResolvedValue(ADMIN);
+    mockUpdateEq.mockResolvedValue({ error: { message: 'db down' } });
+    await expect(approveBetaUser(fd({ profile_id: 'p1', user_id: 'u1' }))).rejects.toThrow(
+      'Could not approve',
+    );
+    expect(mockLog).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/cookie-domain.test.ts
+++ b/tests/unit/cookie-domain.test.ts
@@ -1,0 +1,67 @@
+import {
+  parentCookieDomain,
+  withParentCookieDomain,
+  PARENT_COOKIE_DOMAIN,
+} from '@/lib/cookie-domain';
+
+// KAN-274 (epic KAN-273): the session cookie is scoped to the parent domain
+// `.checklyra.com` ONLY on prod + beta, so a checklyra.com session carries over
+// to beta.checklyra.com. dev/stage MUST stay host-scoped (different Supabase
+// projects), so their sessions can never be read cross-environment.
+
+const asEnv = (o: Record<string, string>) => o as unknown as NodeJS.ProcessEnv;
+
+describe('parentCookieDomain', () => {
+  it('scopes to .checklyra.com on beta (IS_BETA_DEPLOY=true)', () => {
+    expect(parentCookieDomain(asEnv({ IS_BETA_DEPLOY: 'true' }))).toBe(PARENT_COOKIE_DOMAIN);
+  });
+
+  it('scopes to .checklyra.com on prod (NEXT_PUBLIC_SITE_URL=https://checklyra.com)', () => {
+    expect(parentCookieDomain(asEnv({ NEXT_PUBLIC_SITE_URL: 'https://checklyra.com' }))).toBe(
+      PARENT_COOKIE_DOMAIN,
+    );
+  });
+
+  it('stays host-scoped on dev (dev.checklyra.com)', () => {
+    expect(
+      parentCookieDomain(asEnv({ NEXT_PUBLIC_SITE_URL: 'https://dev.checklyra.com' })),
+    ).toBeUndefined();
+  });
+
+  it('stays host-scoped on stage (stage.checklyra.com)', () => {
+    expect(
+      parentCookieDomain(asEnv({ NEXT_PUBLIC_SITE_URL: 'https://stage.checklyra.com' })),
+    ).toBeUndefined();
+  });
+
+  it('stays host-scoped with no env (local/preview)', () => {
+    expect(parentCookieDomain(asEnv({}))).toBeUndefined();
+  });
+
+  it('beta flag wins even if the site url looks like dev (defensive)', () => {
+    expect(
+      parentCookieDomain(
+        asEnv({ IS_BETA_DEPLOY: 'true', NEXT_PUBLIC_SITE_URL: 'https://dev.checklyra.com' }),
+      ),
+    ).toBe(PARENT_COOKIE_DOMAIN);
+  });
+
+  it('does not scope when IS_BETA_DEPLOY is the string "false"', () => {
+    expect(parentCookieDomain(asEnv({ IS_BETA_DEPLOY: 'false' }))).toBeUndefined();
+  });
+});
+
+describe('withParentCookieDomain', () => {
+  it('adds domain on prod/beta, preserving existing options', () => {
+    expect(
+      withParentCookieDomain({ path: '/', sameSite: 'lax', secure: true }, asEnv({ IS_BETA_DEPLOY: 'true' })),
+    ).toEqual({ path: '/', sameSite: 'lax', secure: true, domain: PARENT_COOKIE_DOMAIN });
+  });
+
+  it('returns the options untouched (no domain) on dev/stage', () => {
+    const opts = { path: '/', sameSite: 'lax', secure: true };
+    const out = withParentCookieDomain(opts, asEnv({ NEXT_PUBLIC_SITE_URL: 'https://dev.checklyra.com' }));
+    expect(out).toEqual(opts);
+    expect('domain' in out).toBe(false);
+  });
+});


### PR DESCRIPTION
## KAN-273 — Beta-access programme (Option C)

Open public signup on prod → users join a beta queue → admin approves → approved users use beta.checklyra.com. Replaces the closed invite-only gate with a queue/approval model. One commit per child ticket.

### Changes
- **KAN-275** — `beta_access_status` enum (none|requested|approved) + request/approve timestamps + partial index on `profiles`. Migration `20260620120000`.
- **KAN-273 hardening** — `BEFORE UPDATE` trigger blocks user-context changes to the beta-access columns; only the service role may set them. Also closes a pre-existing **self-approval hole** on `is_beta_eligible`. Migration `20260620120100`. Verified on dev (user_blocked=true, service_ok=true).
- **KAN-274** — Supabase session cookie scoped to `.checklyra.com` on **prod+beta only** (dev/stage stay host-scoped). Cross-domain SSO foundation.
- **KAN-276 / KAN-278** — auth callback records new signups as `requested` (service role), emails the admin once, and routes users into the gated beta app on prod (approved→dashboard, else→waitlist). Open-redirect-guarded.
- **KAN-277** — `/admin/beta-queue` approval page + admin-gated `approveBetaUser` action (approved + is_beta_eligible + timestamp, audit-logs `grant_beta_access`, emails the user) + admin nav link.
- **KAN-279** — `beta-gate-smoke` reworked for the Cloudflare-Access-free app-gate model (CI 403 = inconclusive, never a false green).

### Tests
+23 unit tests; **full unit suite green (1491)**; tsc + eslint clean; workflow-integrity greps clean.

### Migrations
Applied to **dev** only (`20260620120000`, `20260620120100`). Staging/prod = user-gated promotion.

### MCP coverage
MCP coverage: deferred — internal beta-access / admin-approval flow with no public profile-data an agent reads/writes (n/a per CLAUDE.md "When it doesn't apply": admin/internal routes).

### User-provisioned to go live (flagged, not done here)
- `RESEND_API_KEY` (+ optional `LYRA_BETA_NOTIFY_EMAIL` / `LYRA_BETA_FROM_EMAIL`) on the relevant Vercel scopes — emails degrade gracefully without it.
- Cross-domain cookie approach (KAN-274) sign-off.
- Remove the Cloudflare Access OTP policy on beta.checklyra.com (KAN-279) — unblocks the cross-domain hop + the smoke.
- Apply both migrations to staging + prod, then the supervised promotions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
