### PR TITLE
fix(ci): beta-gate-smoke runner.temp workflow-parse error (KAN-279)

### DIFF
--- a/.github/workflows/beta-gate-smoke.yml
+++ b/.github/workflows/beta-gate-smoke.yml
@@ -58,14 +58,14 @@ jobs:
     env:
       BETA_HOST: https://beta.checklyra.com
       MCP_HOST: https://mcp.checklyra.com
-      VERIFIED: ${{ runner.temp }}/verified
-      INCONCLUSIVE: ${{ runner.temp }}/inconclusive
     steps:
       - name: Init counters
         run: |
           set -euo pipefail
-          : > "${VERIFIED}"
-          : > "${INCONCLUSIVE}"
+          echo "VERIFIED=${RUNNER_TEMP}/verified" >> "$GITHUB_ENV"
+          echo "INCONCLUSIVE=${RUNNER_TEMP}/inconclusive" >> "$GITHUB_ENV"
+          : > "${RUNNER_TEMP}/verified"
+          : > "${RUNNER_TEMP}/inconclusive"
 
       - name: 1/5 Reachability (beta is up, no network gate)
         run: |


### PR DESCRIPTION
Tiny follow-up to #326. `${{ runner.temp }}` isn't valid in job-level `env:` (runner context is step-only) → 0s parse failure. Sets the counter paths via $GITHUB_ENV/$RUNNER_TEMP in the Init step instead. Workflow-only; no app code change.