### PR TITLE
feat(prod): waitlist front door for checklyra.com (KAN-273/KAN-287)

### DIFF
--- a/src/app/(auth)/signup/page.tsx
+++ b/src/app/(auth)/signup/page.tsx
@@ -3,6 +3,7 @@ import Image from 'next/image';
 import { signUp } from '../actions';
 import { SocialLoginButtons } from '../social-login-buttons';
 import { env } from '@/lib/env';
+import { isProdDeploy } from '@/lib/beta-access/flow';
 
 export const metadata = {
   title: 'Create your Lyra profile',
@@ -12,13 +13,18 @@ export const metadata = {
 export default async function SignUpPage({
   searchParams,
 }: {
-  searchParams: Promise<{ error?: string; message?: string }>;
+  searchParams: Promise<{ error?: string; message?: string; preview?: string }>;
 }) {
   const params = await searchParams;
   // KAN-258 — during the private phase, account creation needs an invite
   // code and third-party sign-in is hidden, so the only way in is the
   // gated email form.
   const inviteOnly = !!env.inviteCode();
+  // KAN-273/KAN-287 — on the public production deploy, prod is the doorway into
+  // the gated beta app: signing up records a request and lands the user on the
+  // waitlist. Frame the page as "join the waitlist". `?preview=waitlist`
+  // renders this on any deploy so it can be verified before reaching prod.
+  const waitlist = isProdDeploy() || params.preview === 'waitlist';
 
   return (
     <main className="min-h-screen flex items-center justify-center px-4">
@@ -28,12 +34,22 @@ export default async function SignUpPage({
             <Image src="/lyra-logo.png" alt="Lyra" width={48} height={48} className="h-12 w-auto" priority />
           </Link>
           <h1 className="mt-4 text-xl font-medium text-[var(--color-ink)]">
-            Create your profile
+            {waitlist ? 'Join the Lyra waitlist' : 'Create your profile'}
           </h1>
           <p className="mt-1 text-sm text-[var(--color-muted)]">
-            So people in your life never have to guess
+            {waitlist
+              ? "Lyra is opening in stages — sign up and we'll email you when your spot is ready."
+              : 'So people in your life never have to guess'}
           </p>
         </div>
+
+        {waitlist && (
+          <ol className="mb-6 space-y-1.5 text-xs text-[var(--color-muted)] max-w-xs mx-auto">
+            <li>1. Confirm your email with the secure link we send.</li>
+            <li>2. You&rsquo;re added to the waitlist queue.</li>
+            <li>3. We email you the moment a spot opens up.</li>
+          </ol>
+        )}
 
         {params.error && (
           <div className="mb-4 p-3 rounded-lg bg-red-50 border border-red-200 text-sm text-red-700">
@@ -130,7 +146,7 @@ export default async function SignUpPage({
             formAction={signUp}
             className="w-full py-3 rounded-lg bg-[var(--color-sage)] text-white text-base font-medium hover:opacity-90 transition-opacity cursor-pointer"
           >
-            Create account →
+            {waitlist ? 'Join the waitlist →' : 'Create account →'}
           </button>
         </form>
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2,29 +2,30 @@ import Link from "next/link";
 import Image from "next/image";
 import { createClient } from "@supabase/supabase-js";
 import { env } from "@/lib/env";
+import { isProdDeploy } from "@/lib/beta-access/flow";
 
 /**
  * KAN-272 — minimal, Google-like homepage (June-2026 redesign).
+ * KAN-273 follow-up — on the PUBLIC PRODUCTION deploy (checklyra.com), the
+ * homepage is a "sign up → join the waitlist" front door instead of the full
+ * product homepage: prod is the doorway into the gated beta app (KAN-278), so
+ * the public should be greeted with the waitlist framing, not a browseable
+ * directory. Beta/dev/stage keep the normal product homepage. Add
+ * `?preview=waitlist` on any deploy to preview the prod landing.
  *
- * Replaces the long marketing landing page with the mock-up's minimal home:
+ * Product homepage (beta/dev/stage):
  *   1. A vertically-centred hero: the green Lyra logo, the tagline
  *      "Be understood.", and two CTAs (primary "Find someone", ghost
  *      "See example profiles").
  *   2. A bottom band — "A few people to meet" — showing up to 6 published
- *      profiles queried live from the database (beta/prod has ~2 right now;
- *      we render whatever exists, and the band is omitted when there are none).
- *
- * The old marketing sections (Hero, AboutLyra, UseCases, …) are preserved as
- * files in src/app/_marketing/sections.tsx — they're just no longer composed
- * here. The "In your own words / For real life / Calm by design" trio moved to
- * the new /about page (<AboutTrio>).
+ *      profiles queried live from the database.
  *
  * The site-wide <Footer/> is rendered once in the root layout, so this page
  * deliberately has NO inline footer (no double-footer).
  */
 
-// Render fresh so newly-published profiles appear without a redeploy. The
-// "people to meet" band reflects live DB state.
+// Render fresh so newly-published profiles appear without a redeploy, and so
+// the prod/preview waitlist branch is evaluated per request.
 export const dynamic = "force-dynamic";
 
 interface HomeProfile {
@@ -55,7 +56,7 @@ async function getPublishedProfiles(): Promise<HomeProfile[]> {
   }
 }
 
-function Nav() {
+function Nav({ minimal = false }: { minimal?: boolean }) {
   return (
     <nav
       aria-label="Main navigation"
@@ -73,25 +74,30 @@ function Nav() {
           />
         </Link>
         <div className="flex items-center gap-5 sm:gap-6">
-          <Link
-            href="/"
-            className="text-sm text-[var(--color-muted)] hover:text-[var(--color-ink)] transition-colors"
-          >
-            Home
-          </Link>
-          <Link
-            href="/search"
-            className="text-sm text-[var(--color-muted)] hover:text-[var(--color-ink)] transition-colors"
-          >
-            Find someone
-          </Link>
-          <Link
-            href="/signup"
-            className="text-sm text-[var(--color-sage)] hover:text-[var(--color-sage-hover)] transition-colors"
-          >
-            Create your profile
-          </Link>
-          {/* De-emphasised sign-in, per the mock-up. */}
+          {!minimal && (
+            <>
+              <Link
+                href="/"
+                className="text-sm text-[var(--color-muted)] hover:text-[var(--color-ink)] transition-colors"
+              >
+                Home
+              </Link>
+              <Link
+                href="/search"
+                className="text-sm text-[var(--color-muted)] hover:text-[var(--color-ink)] transition-colors"
+              >
+                Find someone
+              </Link>
+              <Link
+                href="/signup"
+                className="text-sm text-[var(--color-sage)] hover:text-[var(--color-sage-hover)] transition-colors"
+              >
+                Create your profile
+              </Link>
+            </>
+          )}
+          {/* De-emphasised sign-in, per the mock-up. On the waitlist front door
+              this is the only nav action (for already-approved users). */}
           <Link
             href="/login"
             className="text-sm text-[var(--color-muted)] hover:text-[var(--color-ink)] transition-colors"
@@ -101,6 +107,61 @@ function Nav() {
         </div>
       </div>
     </nav>
+  );
+}
+
+/**
+ * Production front door (checklyra.com): "sign up → you're on the waitlist".
+ * Prod is the public doorway into the gated beta app — signing up records the
+ * request and routes the user to the beta waitlist (KAN-273/KAN-278). No
+ * browseable directory or real profiles are surfaced here pre-launch.
+ */
+function WaitlistLanding() {
+  return (
+    <>
+      <Nav minimal />
+      <main role="main" className="px-6">
+        <div className="max-w-2xl mx-auto">
+          <section className="min-h-[80vh] flex flex-col items-center justify-center text-center pt-24 pb-12">
+            <Image
+              src="/lyra-logo.png"
+              alt="Lyra"
+              width={320}
+              height={92}
+              className="h-[92px] w-auto"
+              priority
+            />
+            <p className="text-base sm:text-lg text-[var(--color-muted)] mt-4">
+              Be understood.
+            </p>
+            <h1 className="text-2xl sm:text-[28px] font-medium text-[var(--color-ink)] font-[family-name:var(--font-serif)] mt-8 mb-4 leading-snug">
+              We&rsquo;re opening Lyra a few people at a time.
+            </h1>
+            <p className="text-[15px] sm:text-base text-[var(--color-muted)] leading-relaxed max-w-md mb-8">
+              Lyra is a calm place to share who you are &mdash; the things you
+              love, the gifts that land, the boundaries that matter &mdash; with
+              the people in your life. Join the waitlist and we&rsquo;ll email
+              you the moment your spot opens up.
+            </p>
+            <Link
+              href="/signup"
+              className="px-6 py-3 rounded-[10px] bg-[var(--color-sage)] text-white font-semibold text-[15px] hover:bg-[var(--color-sage-hover)] transition-colors"
+            >
+              Join the waitlist
+            </Link>
+            <p className="text-[13px] text-[var(--color-muted)] mt-5">
+              Already have access?{" "}
+              <Link
+                href="/login"
+                className="text-[var(--color-sage)] hover:underline"
+              >
+                Sign in
+              </Link>
+            </p>
+          </section>
+        </div>
+      </main>
+    </>
   );
 }
 
@@ -136,7 +197,18 @@ function PersonCard({ profile }: { profile: HomeProfile }) {
   );
 }
 
-export default async function Home() {
+export default async function Home({
+  searchParams,
+}: {
+  searchParams: Promise<{ preview?: string | string[] }>;
+}) {
+  // Prod (checklyra.com) is the public waitlist doorway. `?preview=waitlist`
+  // renders it on any deploy so it can be verified before reaching prod.
+  const sp = await searchParams;
+  if (isProdDeploy() || sp?.preview === "waitlist") {
+    return <WaitlistLanding />;
+  }
+
   const people = await getPublishedProfiles();
   // Ghost CTA — "See example profiles" — points at the first published
   // profile when one exists, otherwise falls back to search.

--- a/tests/unit/homepage-content.test.js
+++ b/tests/unit/homepage-content.test.js
@@ -154,3 +154,43 @@ describe('KAN-272: About page hosts the moved trio', () => {
     expect(about).toContain('AboutTrio');
   });
 });
+
+describe('KAN-273/287: Production waitlist front door', () => {
+  let home;
+  let signup;
+  const signupPath = path.join(root, 'src/app/(auth)/signup/page.tsx');
+
+  beforeAll(() => {
+    home = fs.readFileSync(homepagePath, 'utf8');
+    signup = fs.readFileSync(signupPath, 'utf8');
+  });
+
+  test('homepage gates a waitlist landing on the prod deploy, with a ?preview=waitlist hatch', () => {
+    expect(home).toContain('isProdDeploy');
+    expect(home).toContain('WaitlistLanding');
+    // Preview hatch so the prod landing is verifiable on non-prod deploys.
+    expect(home).toContain('preview === "waitlist"');
+  });
+
+  test('homepage waitlist landing leads with "join the waitlist" → /signup', () => {
+    expect(home).toContain('Join the waitlist');
+    expect(home).toContain('opening Lyra a few people at a time');
+    expect(home).toContain('href="/signup"');
+  });
+
+  test('the default (non-prod) homepage is unchanged — product homepage preserved', () => {
+    // The prod branch must be ADDITIVE: dev/stage/beta keep the product home.
+    expect(home).toContain('Be understood.');
+    expect(home).toContain('Find someone');
+    expect(home).toContain('A few people to meet');
+  });
+
+  test('signup page reframes as "join the waitlist" on prod / preview', () => {
+    expect(signup).toContain('isProdDeploy');
+    expect(signup).toContain('Join the Lyra waitlist');
+    expect(signup).toContain('Join the waitlist');
+    // Default copy preserved for the non-prod path.
+    expect(signup).toContain('Create your profile');
+    expect(signup).toContain('Create account');
+  });
+});


### PR DESCRIPTION
## What
On the **public production deploy** (checklyra.com), the homepage and signup page reframe as **"join the waitlist"**. Prod is the public doorway into the gated beta app (KAN-273/KAN-278): a new signup is recorded as `requested` and routed to the beta waitlist; approved users go to beta. **Beta/dev/stage keep the full product homepage** — the change is additive.

## How
- Gated on `isProdDeploy()` (`NEXT_PUBLIC_SITE_URL=https://checklyra.com && VERCEL_ENV=production`) — **no new env var**.
- `?preview=waitlist` renders the prod landing on any deploy, so it's verifiable on staging/beta **before** the production promotion.
- `src/app/page.tsx` — `WaitlistLanding`: minimal logo + "We're opening Lyra a few people at a time" + **Join the waitlist → /signup**. No directory/real-profile browsing pre-launch.
- `src/app/(auth)/signup/page.tsx` — "Join the Lyra waitlist" header, waitlist sub-copy, a 3-step "what happens next", and "Join the waitlist →" button.

## Tests
- `type-check` + `lint` clean; full unit suite green (1491); `homepage-content.test.js` extended to assert the waitlist front door **and** that the default product homepage/signup copy is unchanged.

## Verification
Will verify on the staging/beta deploy via `?preview=waitlist` before promoting. **Production promotion stays user-gated.**

MCP coverage: deferred — public marketing/onboarding UX, no user-data model change.

Relates KAN-287, KAN-273.

🤖 Generated with [Claude Code](https://claude.com/claude-code)