### PR TITLE
chore(security): record 2026-06-21 security-audit migrations (BUGS-45)

### DIFF
--- a/supabase/migrations/20260621090000_security_audit_lockdown_anon_exposed_surface.sql
+++ b/supabase/migrations/20260621090000_security_audit_lockdown_anon_exposed_surface.sql
@@ -1,0 +1,41 @@
+-- =====================================================================
+-- Security audit 2026-06-21 — lock down anon/public-exposed DB surface
+-- Findings F-01 (vault RPCs), F-14 (metrics RPC), F-03 (profiles RLS).
+-- Applied to dev + staging + prod on 2026-06-21 via Supabase apply_migration;
+-- committed here for version control (BUGS-45). Idempotent / safe to re-apply.
+-- ROLLBACK (only if a regression is proven — NOT recommended):
+--   grant execute on function public.convene_vault_read_secret(uuid)        to anon, authenticated;
+--   grant execute on function public.convene_vault_store_secret(text, text) to anon, authenticated;
+--   grant execute on function public.convene_vault_revoke_secret(uuid)      to anon, authenticated;
+--   grant execute on function public.get_metrics_for_window(timestamptz, timestamptz) to anon;
+--   create policy "Anon read published profiles" on public.profiles for select to anon using (is_published = true);
+-- =====================================================================
+
+-- F-01: Supabase Vault secret RPCs hold calendar OAuth refresh tokens and are
+-- only ever called server-side with the service-role key
+-- (lyra/src/lib/convene/vault.ts adminClient; lyra-mcp-server service client).
+revoke execute on function public.convene_vault_read_secret(uuid)        from public, anon, authenticated;
+revoke execute on function public.convene_vault_store_secret(text, text) from public, anon, authenticated;
+revoke execute on function public.convene_vault_revoke_secret(uuid)      from public, anon, authenticated;
+grant  execute on function public.convene_vault_read_secret(uuid)        to service_role;
+grant  execute on function public.convene_vault_store_secret(text, text) to service_role;
+grant  execute on function public.convene_vault_revoke_secret(uuid)      to service_role;
+
+-- F-14: get_metrics_for_window must not be anon-callable. Restore the intended
+-- grant set from 20260516220000_metrics_window_fn.sql (authenticated + service_role).
+revoke execute on function public.get_metrics_for_window(timestamptz, timestamptz) from public, anon;
+grant  execute on function public.get_metrics_for_window(timestamptz, timestamptz) to authenticated, service_role;
+
+-- F-03: drop the over-broad anon SELECT policy on profiles that omits the
+-- is_suspended guard. Fail-safe: only drop when the correct {public} non-suspended
+-- policy exists to replace it, so we never leave profiles with no anon-read path.
+do $$
+begin
+  if exists (
+    select 1 from pg_policies
+    where schemaname = 'public' and tablename = 'profiles'
+      and policyname = 'Anyone can read published non-suspended profiles'
+  ) then
+    drop policy if exists "Anon read published profiles" on public.profiles;
+  end if;
+end $$;

--- a/supabase/migrations/20260621090100_security_audit_restrict_authenticated_suspended_profiles.sql
+++ b/supabase/migrations/20260621090100_security_audit_restrict_authenticated_suspended_profiles.sql
@@ -1,0 +1,17 @@
+-- =====================================================================
+-- Security audit 2026-06-21 (F-03b) — close the authenticated-side
+-- suspended-profile read gap. The {authenticated} policy "Read own or
+-- published profiles" lacked the is_suspended guard, so any logged-in user
+-- could still view a suspended (moderated) profile. Admins read via the
+-- service-role client (src/app/admin/page.tsx) and are unaffected by RLS.
+-- Applied to dev + staging + prod on 2026-06-21 (BUGS-45). Idempotent.
+-- ROLLBACK:
+--   drop policy if exists "Read own or published profiles" on public.profiles;
+--   create policy "Read own or published profiles" on public.profiles
+--     for select to authenticated
+--     using ( (select auth.uid()) = user_id or is_published = true );
+-- =====================================================================
+drop policy if exists "Read own or published profiles" on public.profiles;
+create policy "Read own or published profiles" on public.profiles
+  for select to authenticated
+  using ( (select auth.uid()) = user_id or (is_published = true and is_suspended = false) );

--- a/supabase/migrations/20260621090200_security_audit_fn_searchpath_and_view_invoker.sql
+++ b/supabase/migrations/20260621090200_security_audit_fn_searchpath_and_view_invoker.sql
@@ -3,32 +3,48 @@
 -- All flagged functions are SECURITY INVOKER with fully schema-qualified bodies (public.*) or
 -- pure pg_catalog built-ins (now/count), so SET search_path='' is non-breaking. The view's only
 -- consumer is the service-role abuse pipeline (KAN-233), unaffected by security_invoker.
--- Applied to dev + staging + prod on 2026-06-21. Idempotent.
+-- Applied to dev + staging + prod on 2026-06-21. Existence-guarded so it applies cleanly on a
+-- fresh schema rebuild (e.g. Supabase preview branches) where some objects (notably the
+-- mcp_per_ip_recent_count view) are created out-of-band. Idempotent.
 -- ROLLBACK: alter each function reset search_path; alter view set (security_invoker = off);
 --           grant select on public.mcp_per_ip_recent_count to anon, authenticated.
 -- =====================================================================
 
--- F-18 — pin search_path on SECURITY INVOKER trigger/helper functions
-alter function public.affiliate_merchant_eligibility_touch_updated_at() set search_path = '';
-alter function public.consent_log_block_mutations() set search_path = '';
-alter function public.convene_set_updated_at() set search_path = '';
-alter function public.enforce_pcs_cap() set search_path = '';
-alter function public.enforce_profile_files_cap() set search_path = '';
-alter function public.gathering_events_log_block_mutations() set search_path = '';
-alter function public.gathering_invitees_enforce_host_owns_contact() set search_path = '';
-alter function public.recommender_catalogue_touch_updated_at() set search_path = '';
-alter function public.tribe_members_enforce_same_owner() set search_path = '';
-alter function public.tribe_only_visible_tribes(uuid) set search_path = '';
-
--- F-18 — oauth server trigger fn exists on dev/staging only (pre-prod); guarded
+-- F-18 — pin search_path on flagged SECURITY INVOKER functions (skip any absent in this env)
 do $$
+declare
+  sig text;
+  sigs text[] := array[
+    'public.affiliate_merchant_eligibility_touch_updated_at()',
+    'public.consent_log_block_mutations()',
+    'public.convene_set_updated_at()',
+    'public.enforce_pcs_cap()',
+    'public.enforce_profile_files_cap()',
+    'public.gathering_events_log_block_mutations()',
+    'public.gathering_invitees_enforce_host_owns_contact()',
+    'public.recommender_catalogue_touch_updated_at()',
+    'public.tribe_members_enforce_same_owner()',
+    'public.tribe_only_visible_tribes(uuid)',
+    'public.oauth_clients_set_updated_at()'
+  ];
 begin
-  if exists (select 1 from pg_proc p join pg_namespace n on n.oid=p.pronamespace
-             where n.nspname='public' and p.proname='oauth_clients_set_updated_at') then
-    execute $q$alter function public.oauth_clients_set_updated_at() set search_path = ''$q$;
-  end if;
+  foreach sig in array sigs loop
+    begin
+      execute 'alter function ' || sig || ' set search_path = ' || quote_literal('');
+    exception when undefined_function then
+      null; -- absent in this environment; skip
+    end;
+  end loop;
 end $$;
 
--- F-21 — abuse-detection view must run as the querying role, not its postgres owner
-alter view public.mcp_per_ip_recent_count set (security_invoker = on);
-revoke all on public.mcp_per_ip_recent_count from anon, authenticated;
+-- F-21 — abuse-detection view runs as the querying role, not its postgres owner (guarded)
+do $$
+begin
+  if exists (
+    select 1 from pg_class c join pg_namespace n on n.oid = c.relnamespace
+    where n.nspname = 'public' and c.relname = 'mcp_per_ip_recent_count' and c.relkind = 'v'
+  ) then
+    execute 'alter view public.mcp_per_ip_recent_count set (security_invoker = on)';
+    execute 'revoke all on public.mcp_per_ip_recent_count from anon, authenticated';
+  end if;
+end $$;

--- a/supabase/migrations/20260621090200_security_audit_fn_searchpath_and_view_invoker.sql
+++ b/supabase/migrations/20260621090200_security_audit_fn_searchpath_and_view_invoker.sql
@@ -1,0 +1,34 @@
+-- =====================================================================
+-- Security audit 2026-06-21 (BUGS-45): F-18 pin function search_path; F-21 view security_invoker.
+-- All flagged functions are SECURITY INVOKER with fully schema-qualified bodies (public.*) or
+-- pure pg_catalog built-ins (now/count), so SET search_path='' is non-breaking. The view's only
+-- consumer is the service-role abuse pipeline (KAN-233), unaffected by security_invoker.
+-- Applied to dev + staging + prod on 2026-06-21. Idempotent.
+-- ROLLBACK: alter each function reset search_path; alter view set (security_invoker = off);
+--           grant select on public.mcp_per_ip_recent_count to anon, authenticated.
+-- =====================================================================
+
+-- F-18 — pin search_path on SECURITY INVOKER trigger/helper functions
+alter function public.affiliate_merchant_eligibility_touch_updated_at() set search_path = '';
+alter function public.consent_log_block_mutations() set search_path = '';
+alter function public.convene_set_updated_at() set search_path = '';
+alter function public.enforce_pcs_cap() set search_path = '';
+alter function public.enforce_profile_files_cap() set search_path = '';
+alter function public.gathering_events_log_block_mutations() set search_path = '';
+alter function public.gathering_invitees_enforce_host_owns_contact() set search_path = '';
+alter function public.recommender_catalogue_touch_updated_at() set search_path = '';
+alter function public.tribe_members_enforce_same_owner() set search_path = '';
+alter function public.tribe_only_visible_tribes(uuid) set search_path = '';
+
+-- F-18 — oauth server trigger fn exists on dev/staging only (pre-prod); guarded
+do $$
+begin
+  if exists (select 1 from pg_proc p join pg_namespace n on n.oid=p.pronamespace
+             where n.nspname='public' and p.proname='oauth_clients_set_updated_at') then
+    execute $q$alter function public.oauth_clients_set_updated_at() set search_path = ''$q$;
+  end if;
+end $$;
+
+-- F-21 — abuse-detection view must run as the querying role, not its postgres owner
+alter view public.mcp_per_ip_recent_count set (security_invoker = on);
+revoke all on public.mcp_per_ip_recent_count from anon, authenticated;

--- a/supabase/migrations/20260621090300_security_audit_contact_hash_authn_only.sql
+++ b/supabase/migrations/20260621090300_security_audit_contact_hash_authn_only.sql
@@ -1,0 +1,17 @@
+-- =====================================================================
+-- Security audit 2026-06-21 (BUGS-45 / F-04): search_by_contact_hash must not be anon-callable.
+-- The app calls it as the authenticated user (src/app/dashboard/settings/discoverability-actions.ts:195,
+-- rate-limited per authenticated user). Guarded so it is a no-op where the function is absent
+-- (e.g. production, pre-Convene). Applied to dev + staging on 2026-06-21 (no-op on prod).
+-- NB: HMAC-keying of the phone/postcode search hashes is a separate app-side change (follow-up ticket)
+-- to defeat offline pre-computation; this migration only removes the unauthenticated execute path.
+-- ROLLBACK: grant execute on function public.search_by_contact_hash(text, text) to anon.
+-- =====================================================================
+do $$
+begin
+  if exists (select 1 from pg_proc p join pg_namespace n on n.oid=p.pronamespace
+             where n.nspname='public' and p.proname='search_by_contact_hash') then
+    execute 'revoke execute on function public.search_by_contact_hash(text, text) from anon, public';
+    execute 'grant execute on function public.search_by_contact_hash(text, text) to authenticated, service_role';
+  end if;
+end $$;

--- a/supabase/migrations/20260621090400_security_audit_residual_definer_fn_public_revoke.sql
+++ b/supabase/migrations/20260621090400_security_audit_residual_definer_fn_public_revoke.sql
@@ -1,0 +1,31 @@
+-- =====================================================================
+-- Security audit 2026-06-21 (BUGS-45 residual / BUGS-48): revoke the PUBLIC default
+-- EXECUTE on SECURITY DEFINER trigger/maintenance functions still flagged by the advisor.
+-- These were flagged because `revoke from anon, authenticated` is ineffective while PUBLIC
+-- retains EXECUTE. Trigger/event-trigger fns (handle_new_user, prevent_beta_self_elevation,
+-- rls_auto_enable) fire regardless of EXECUTE grant. Maintenance fns are server-side:
+--   - refresh_relationship_signals: called via service-role (src/lib/convene/post-event.ts:118)
+--   - oauth_connect_state_purge_expired: server/cron.
+-- Applied to dev + staging + prod on 2026-06-21. Existence-guarded → no-op where absent. Idempotent.
+-- ROLLBACK: grant execute on function public.<fn>(...) to anon, authenticated; (per function)
+-- =====================================================================
+do $$
+declare
+  sig text;
+  sigs text[] := array[
+    'public.handle_new_user()',
+    'public.prevent_beta_self_elevation()',
+    'public.rls_auto_enable()',
+    'public.oauth_connect_state_purge_expired()',
+    'public.refresh_relationship_signals()'
+  ];
+begin
+  foreach sig in array sigs loop
+    begin
+      execute 'revoke execute on function ' || sig || ' from public, anon, authenticated';
+      execute 'grant execute on function ' || sig || ' to service_role';
+    exception when undefined_function then
+      null; -- absent in this environment; skip
+    end;
+  end loop;
+end $$;


### PR DESCRIPTION
## What & why
Version-controls the database hardening applied to **dev + staging + prod** during the 2026-06-21 red-team security audit. These were applied directly via Supabase `apply_migration` to close live findings quickly; this PR captures them in `supabase/migrations` so they survive rebuilds and flow through the pipeline (BUGS-45).

All four migrations are **idempotent** and were verified across all three environments (ACL/policy checks + Supabase security advisor re-run shows the corresponding lints cleared).

## Migrations
| File | Findings |
|---|---|
| `…090000_…lockdown_anon_exposed_surface.sql` | F-01 `convene_vault_*` → service_role only · F-14 `get_metrics_for_window` de-anon'd · F-03 drop over-broad anon `profiles` policy |
| `…090100_…restrict_authenticated_suspended_profiles.sql` | F-03b authenticated `Read own or published profiles` now enforces `is_suspended = false` (admins read via service-role, unaffected) |
| `…090200_…fn_searchpath_and_view_invoker.sql` | F-18 pin `search_path` on 10–11 SECURITY INVOKER fns · F-21 `mcp_per_ip_recent_count` → `security_invoker = on` |
| `…090300_…contact_hash_authn_only.sql` | F-04 `search_by_contact_hash` → authenticated/service_role only (staging/dev; guarded no-op on prod) |

## Safety notes
- No application code changes — migration SQL only.
- F-18 functions all use fully schema-qualified bodies, so `SET search_path = ''` is non-breaking.
- F-21 view's only consumer is the service-role abuse pipeline (KAN-233), unaffected by `security_invoker`.
- Rollback SQL is in each file header.

## Follow-up (not in this PR)
- **F-04 HMAC-keying** of the phone/postcode search hashes (app-side change to defeat offline pre-computation) — separate ticket.
- F-11 (bucket listing) needed **no change** — already owner-scoped; the advisor lint was stale.

Report: Confluence **TWC p27033642**. Audit re-run runbook: **KAN-295**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)