### PR TITLE
docs: route security & risk work to the new SEC Jira project

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -151,9 +151,12 @@ git worktree prune
 
 ## Jira Ticket Standard
 
-All work must be tracked in Jira. KAN project for design/deployment, BUGS project for bug tracking.
+All work must be tracked in Jira. **KAN** for design/deployment, **BUGS** for bug tracking, and **SEC** (Security & Risk — team-managed) for all security and risk findings: vulnerabilities, data-protection/compliance, ops-resilience and governance. Route any security or risk-audit work to **SEC**, not KAN/BUGS.
 
-Every KAN Task/Story description MUST include all six sections:
+- The second-line **Lyra Risk Register** (Confluence space TWC) is the index of findings; the Jira epic **SEC-1** ("2026-06 Second-line Risk & Security Audit") is their tracking home.
+- **SEC transition IDs** (for `transitionJiraIssue`): `11` = To Do, `21` = In Progress, `31` = Done. (cf. KAN `21`/`41`, BUGS `21`/`31`/`41`.)
+
+Every KAN/SEC Task/Story description MUST include all six sections:
 
 1. **What & Why**
 2. **Implementation steps**


### PR DESCRIPTION
Adds the new **SEC** (Security & Risk) project to the Jira routing guidance in `CLAUDE.md` so future sessions file security/risk work in SEC rather than KAN/BUGS.

- **SEC** = team-managed; holds all risk-audit findings (epic **SEC-1**).
- Points to the **Lyra Risk Register** (Confluence space TWC).
- Records SEC transition IDs: `11`=To Do, `21`=In Progress, `31`=Done.

Doc-only change, from the 2026-06-20/21 second-line risk audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)