### PR TITLE
fix(security): lock down SECURITY DEFINER fns + private profile-files bucket (BUGS-44, BUGS-33)

### DIFF
--- a/src/app/[slug]/page.tsx
+++ b/src/app/[slug]/page.tsx
@@ -224,11 +224,26 @@ export default async function PublicProfilePage({ params }: Props) {
     .in('visibility', allowedVisibility)
     .order('sort_order', { ascending: true })
     .order('created_at', { ascending: true });
-  const typedFiles = (filesRaw ?? []).filter((f) =>
+  const visibleFiles = (filesRaw ?? []).filter((f) =>
     isAuthenticated
       ? f.visibility === 'public' || f.visibility === 'members_only'
       : f.visibility === 'public',
   );
+  // BUGS-33 (SEC-03b): profile-files is now a PRIVATE bucket. Mint a short-lived
+  // signed URL (service-role) for each file the viewer is allowed to see, instead
+  // of a public direct URL. Files filtered out above never get a signed URL, so
+  // private/connections files are never world-readable by direct link.
+  const fileSb = getSupabase();
+  const typedFiles = (
+    await Promise.all(
+      visibleFiles.map(async (f) => {
+        const { data: signed } = await fileSb.storage
+          .from('profile-files')
+          .createSignedUrl(f.storage_path as string, 60 * 60);
+        return { ...f, url: signed?.signedUrl ?? null };
+      }),
+    )
+  ).filter((f) => f.url);
 
   const { data: starterRowsRaw } = await getSupabase()
     .from('profile_conversation_starters')
@@ -534,7 +549,7 @@ export default async function PublicProfilePage({ params }: Props) {
               <SectionQ>📎 Files &amp; media</SectionQ>
               <div className="bg-white border border-[#ece7df] rounded-[10px] px-[18px] py-[15px] mt-3 space-y-1">
                 {typedFiles.map((f) => {
-                  const url = `${env.supabaseUrl()}/storage/v1/object/public/profile-files/${f.storage_path}`;
+                  const url = f.url as string;
                   const isImage = f.mime_type.startsWith('image/');
                   const isPdf = f.mime_type === 'application/pdf';
                   return (

--- a/supabase/migrations/20260621120000_revoke_secdef_exec_bugs44.sql
+++ b/supabase/migrations/20260621120000_revoke_secdef_exec_bugs44.sql
@@ -1,0 +1,35 @@
+-- BUGS-44 / SEC-07: lock down public SECURITY DEFINER functions.
+--
+-- Several SECURITY DEFINER functions in the public schema were EXECUTE-able by
+-- anon / authenticated:
+--   * the no-arg functions (rls_auto_enable, refresh_relationship_signals,
+--     oauth_connect_state_purge_expired, handle_new_user,
+--     prevent_beta_self_elevation) had their EXECUTE grant reset to PUBLIC by a
+--     later CREATE OR REPLACE (e.g. oauth_connect_state_purge_expired was
+--     revoked at creation in 20260516250000, then reset).
+--   * get_metrics_for_window had explicit anon/authenticated grants.
+--
+-- Fix: REVOKE EXECUTE from PUBLIC + anon + authenticated, then re-GRANT to
+-- service_role only (used by the post-event sweep + maintenance/metrics crons).
+-- Trigger functions still fire regardless of caller EXECUTE — verified on dev
+-- that handle_new_user still creates the profile row on signup after the revoke.
+--
+-- Applied to dev + staging + prod (DB history) 2026-06-21.
+
+revoke execute on function public.get_metrics_for_window(timestamptz, timestamptz) from public, anon, authenticated;
+grant  execute on function public.get_metrics_for_window(timestamptz, timestamptz) to service_role;
+
+revoke execute on function public.rls_auto_enable() from public, anon, authenticated;
+grant  execute on function public.rls_auto_enable() to service_role;
+
+revoke execute on function public.refresh_relationship_signals() from public, anon, authenticated;
+grant  execute on function public.refresh_relationship_signals() to service_role;
+
+revoke execute on function public.oauth_connect_state_purge_expired() from public, anon, authenticated;
+grant  execute on function public.oauth_connect_state_purge_expired() to service_role;
+
+revoke execute on function public.handle_new_user() from public, anon, authenticated;
+grant  execute on function public.handle_new_user() to service_role;
+
+revoke execute on function public.prevent_beta_self_elevation() from public, anon, authenticated;
+grant  execute on function public.prevent_beta_self_elevation() to service_role;

--- a/supabase/migrations/20260621120100_profile_files_private_bugs33.sql
+++ b/supabase/migrations/20260621120100_profile_files_private_bugs33.sql
@@ -1,0 +1,19 @@
+-- BUGS-33 / SEC-03b: make the profile-files storage bucket private.
+--
+-- The profile-files bucket was public=true. A public bucket serves objects via
+-- /storage/v1/object/public/<bucket>/<path> WITHOUT evaluating the (already
+-- owner-scoped, per BUGS-25) RLS SELECT policy — so private/connections-visibility
+-- files were world-readable by anyone holding the direct URL.
+--
+-- Fix: make the bucket private. Object access now requires the owner-scoped RLS
+-- (authenticated API) or a short-lived signed URL. The public profile page
+-- (src/app/[slug]/page.tsx) mints per-file signed URLs via the service role for
+-- only the files the viewer is allowed to see (visibility already filtered).
+--
+-- profile-photos stays public — avatars are public on a published profile and
+-- have no per-file visibility.
+--
+-- Applied to dev + staging + prod (DB history) 2026-06-21. Both buckets were
+-- empty (0 objects) at the time, so no in-flight object access was affected.
+
+update storage.buckets set public = false where id = 'profile-files';

--- a/tests/unit/public-profile.test.js
+++ b/tests/unit/public-profile.test.js
@@ -38,4 +38,12 @@ describe('Public Profile', () => {
     expect(content).toContain('gift_ideas');
     expect(content).toContain('boundaries');
   });
+
+  // BUGS-33 (SEC-03b): profile-files is a private bucket; files must be served
+  // via short-lived signed URLs, never the public direct-object URL.
+  test('profile files are served via signed URLs, not public bucket URLs', () => {
+    const content = fs.readFileSync(path.join(root, 'src/app/[slug]/page.tsx'), 'utf8');
+    expect(content).toContain('createSignedUrl');
+    expect(content).not.toContain('object/public/profile-files');
+  });
 });


### PR DESCRIPTION
Closes the two remaining confirmed-live items from the 2026-06 security audit, verified against prod.

## BUGS-44 / SEC-07 — SECURITY DEFINER functions anon/authenticated-executable
Six public SECURITY DEFINER functions could be `EXECUTE`'d by anon/authenticated — the no-arg ones had their grant reset to **PUBLIC** by a later `CREATE OR REPLACE`; `get_metrics_for_window` had explicit grants. The anon-reachable ones (`rls_auto_enable`, `refresh_relationship_signals`, `oauth_connect_state_purge_expired`) were callable via the public RPC API.

**Fix:** `REVOKE EXECUTE … FROM PUBLIC, anon, authenticated` + `GRANT … TO service_role`. Trigger functions still fire regardless of caller EXECUTE — **verified on dev that `handle_new_user` still creates the profile on signup**. **Applied dev+staging+prod; verified `0/9` public SECURITY DEFINER fns are anon/auth-executable on prod.**

## BUGS-33 / SEC-03b — profile-files world-readable by direct URL
The `profile-files` bucket was `public=true`, so files (incl. private/connections visibility) were readable by direct URL, bypassing the owner-scoped RLS.

**Fix:** bucket → `public=false`; the public profile page mints short-lived per-file **signed URLs** (service-role) only for files the viewer is allowed to see. `profile-photos` stays public (avatars). **Applied dev+staging+prod (buckets empty → no in-flight impact).**

## Tests
typecheck + lint clean; full unit suite green (**1496**); new assertion that the profile page serves files via `createSignedUrl`, never `object/public/profile-files`.

## Notes
DB migrations were applied directly (the established pattern for these security fixes) and are now also recorded in the repo (partial **BUGS-45** progress). MCP coverage: deferred — internal security hardening, no public data-model change.

Closes BUGS-44, BUGS-33.

🤖 Generated with [Claude Code](https://claude.com/claude-code)