### PR TITLE
security(P0): sanitise search, encode JSON-LD, harden auth redirect + lock oauth_connections secret cols

### DIFF
--- a/src/app/[slug]/page.tsx
+++ b/src/app/[slug]/page.tsx
@@ -5,6 +5,7 @@ import Image from 'next/image';
 import type { Metadata } from 'next';
 import type { ReactNode } from 'react';
 import { env } from '@/lib/env';
+import { jsonLdSafe } from '@/lib/json-ld';
 import { createClient as createSupabaseServerClient } from '@/lib/supabase-server';
 import {
   coerceSectionVisibility,
@@ -350,7 +351,7 @@ export default async function PublicProfilePage({ params }: Props) {
 
   return (
     <>
-      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }} />
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: jsonLdSafe(jsonLd) }} />
       <main className="min-h-screen bg-[#fdfcf8]">
         {/* Brand bar */}
         <nav aria-label="Profile navigation" className="border-b border-[#ece7df] bg-[#fdfcf8]/85 backdrop-blur-md">

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -3,6 +3,7 @@ import Image from "next/image";
 import { createClient } from "@supabase/supabase-js";
 import { env } from "@/lib/env";
 import { isProdDeploy } from "@/lib/beta-access/flow";
+import { jsonLdSafe } from "@/lib/json-ld";
 
 /**
  * KAN-272 — minimal, Google-like homepage (June-2026 redesign).
@@ -232,7 +233,7 @@ export default async function Home({
     <>
       <script
         type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+        dangerouslySetInnerHTML={{ __html: jsonLdSafe(jsonLd) }}
       />
       <Nav />
       <main role="main" className="px-6">

--- a/src/app/search/page.tsx
+++ b/src/app/search/page.tsx
@@ -3,6 +3,7 @@ import Link from 'next/link';
 import Image from 'next/image';
 import type { Metadata } from 'next';
 import { env } from '@/lib/env';
+import { sanitiseSearchTerm } from '@/lib/sanitise';
 
 function getSupabase() {
   return createClient(env.supabaseUrl(), env.supabaseServiceRoleKey());
@@ -62,12 +63,15 @@ export default async function SearchPage({
 }) {
   const params = await searchParams;
   const query = (params.q || '').trim();
+  // SEC-09 (TDD 2026-06-21): strip PostgREST filter metacharacters before
+  // interpolating the term into .or(). `query` is kept raw only for display.
+  const safeQuery = sanitiseSearchTerm(query);
 
   let profiles: SearchProfile[] = [];
 
-  if (query) {
+  if (safeQuery) {
     const supabase = getSupabase();
-    const pattern = `%${query}%`;
+    const pattern = `%${safeQuery}%`;
     const { data } = await supabase
       .from('profiles')
       .select('id, display_name, slug, headline, city, country, avatar_url')

--- a/src/lib/beta-access/flow.ts
+++ b/src/lib/beta-access/flow.ts
@@ -25,10 +25,15 @@ export function betaRedirectUrl(opts: {
   approved: boolean;
   next: string;
 }): string {
-  // Guard against open redirects: only same-origin absolute paths, never a
-  // protocol-relative ("//evil.com") or absolute URL.
+  // Guard against open redirects (SEC-07): accept only a same-origin relative
+  // path — it must start with a single "/", never a protocol-relative "//evil.com"
+  // or a backslash variant "/\evil.com" (which some browsers normalise to "//"),
+  // and never an absolute URL.
   const path =
-    opts.next && opts.next.startsWith('/') && !opts.next.startsWith('//')
+    opts.next &&
+    opts.next.startsWith('/') &&
+    !opts.next.startsWith('//') &&
+    !opts.next.startsWith('/\\')
       ? opts.next
       : '/dashboard';
   if (opts.isProd) {

--- a/src/lib/json-ld.ts
+++ b/src/lib/json-ld.ts
@@ -1,0 +1,23 @@
+/**
+ * Safe serialisation for JSON-LD embedded in a <script type="application/ld+json">
+ * block via dangerouslySetInnerHTML.
+ *
+ * SEC-08 (TDD 2026-06-21): JSON.stringify does NOT escape `<`, so a user-controlled
+ * field containing `</script><script>...` would break out of the JSON-LD block and
+ * execute. Lyra already strips HTML from profile fields on write (sanitiseText), so
+ * this is defence-in-depth -- but output encoding is the correct place to guarantee
+ * the <script> context can never be escaped, regardless of upstream sanitisation or
+ * of fields written via other surfaces (MCP, admin).
+ *
+ * Escapes characters that can terminate or confuse the script context:
+ *   <  >  &  U+2028 (line separator)  U+2029 (paragraph separator)
+ * The output is still valid JSON (these are valid JSON string escapes).
+ */
+export function jsonLdSafe(data: unknown): string {
+  return JSON.stringify(data)
+    .replace(/</g, '\\u003c')
+    .replace(/>/g, '\\u003e')
+    .replace(/&/g, '\\u0026')
+    .replace(/\u2028/g, '\\u2028')
+    .replace(/\u2029/g, '\\u2029');
+}

--- a/src/lib/sanitise.ts
+++ b/src/lib/sanitise.ts
@@ -51,5 +51,24 @@ export function sanitiseUrl(input: string, maxLength = 2048): string {
   }
 }
 
+/**
+ * Sanitise a free-text search term before interpolating it into a PostgREST
+ * `.or()` / `.ilike()` filter string.
+ *
+ * SEC-09 (TDD 2026-06-21): user input is interpolated raw into
+ * `.or('display_name.ilike.${pattern},…')`. PostgREST parses `.or()` as a filter
+ * DSL, so `,` `(` `)` could alter the filter tree, and `%` `_` are ilike wildcards
+ * that could turn the query into a match-all. Strip those metacharacters (and the
+ * backslash) before the term reaches the query builder. Returns '' when nothing
+ * usable remains so the caller can skip the query rather than match everything.
+ */
+export function sanitiseSearchTerm(input: string, maxLength = 100): string {
+  return input
+    .replace(/[,()*%_\\]/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim()
+    .slice(0, maxLength);
+}
+
 /** Standard action result type — replaces throw new Error() */
 export type ActionResult = { success: true } | { success: false; error: string };

--- a/supabase/migrations/20260621120000_sec06_oauth_connections_secret_columns_lockdown.sql
+++ b/supabase/migrations/20260621120000_sec06_oauth_connections_secret_columns_lockdown.sql
@@ -1,0 +1,70 @@
+-- SEC-06 (BUGS-28, TDD 2026-06-21): lock down oauth_connections token-secret columns.
+--
+-- Problem
+-- -------
+-- The oauth_connections_owner_insert / _update RLS policies
+-- (20260516230000_convene_identity_consent.sql) check only
+-- `auth.uid() = owner_user_id`. The Vault-reference columns
+-- refresh_token_secret_id / access_token_secret_id are therefore writable by the
+-- authenticated browser client: a user could INSERT/UPDATE their own connection
+-- row while pointing a *_secret_id at ANOTHER user's Vault secret UUID
+-- (cross-account token reference). Pairs with SEC-01/BUGS-24 (anon-executable
+-- vault RPCs) to form a token-theft chain.
+--
+-- Why a trigger (not REVOKE)
+-- --------------------------
+-- Postgres column-level REVOKE does not override a table-level grant, and
+-- Supabase grants table-level INSERT/UPDATE to `authenticated`. The legitimate
+-- disconnect flow (src/.../connections-client.tsx) UPDATEs non-secret columns
+-- (deleted_at, status) as the authenticated user, so we cannot simply drop the
+-- UPDATE policy. A BEFORE INSERT/UPDATE trigger enforces exactly the needed rule
+-- regardless of grants:
+--   * service_role (backend OAuth callback) may set the Vault references;
+--   * authenticated/anon may NOT insert connection rows, and may NOT change the
+--     *_secret_id columns on update (but may still set deleted_at/status, etc.).
+--
+-- Non-destructive: no data change; RLS policies are left intact (defence in depth).
+--
+-- Rollback:
+--   drop trigger if exists oauth_connections_guard_secret_cols on public.oauth_connections;
+--   drop function if exists public.oauth_connections_guard_secret_cols();
+--
+-- Apply order: dev -> staging -> prod (per Supabase Migration Rules). After each
+-- apply, smoke-test the Convene connect (service-role insert) AND disconnect
+-- (authenticated update of deleted_at/status) flows.
+
+create or replace function public.oauth_connections_guard_secret_cols()
+returns trigger
+language plpgsql
+set search_path = ''
+as $$
+begin
+  -- Backend writes use the service-role key (auth.role() = 'service_role') and are
+  -- the only path allowed to create connections or set the Vault token references.
+  if auth.role() = 'service_role' then
+    return new;
+  end if;
+
+  if tg_op = 'INSERT' then
+    raise exception
+      'oauth_connections: inserts are service-role only (SEC-06)'
+      using errcode = '42501';
+  end if;
+
+  -- UPDATE by a non-service-role client: permit everything EXCEPT changing the
+  -- token-secret references.
+  if new.refresh_token_secret_id is distinct from old.refresh_token_secret_id
+     or new.access_token_secret_id is distinct from old.access_token_secret_id then
+    raise exception
+      'oauth_connections: token-secret columns are service-role only (SEC-06)'
+      using errcode = '42501';
+  end if;
+
+  return new;
+end;
+$$;
+
+create trigger oauth_connections_guard_secret_cols
+  before insert or update on public.oauth_connections
+  for each row
+  execute function public.oauth_connections_guard_secret_cols();

--- a/tests/unit/beta-access-flow.test.ts
+++ b/tests/unit/beta-access-flow.test.ts
@@ -39,6 +39,17 @@ describe('betaRedirectUrl', () => {
       betaRedirectUrl({ origin: 'https://checklyra.com', isProd: true, approved: true, next: 'https://evil.com' }),
     ).toBe('https://beta.checklyra.com/dashboard');
   });
+
+  it('rejects backslash and userinfo open-redirect tricks (SEC-07)', () => {
+    // `/\evil.com` and `/\/evil.com` start with a single "/" so a naive guard
+    // would let them through; some browsers normalise "\" to "/" → "//evil.com".
+    // `@evil.com` / `.evil.com` would escape the origin via `${origin}${next}`.
+    for (const evil of ['/\\evil.com', '/\\/evil.com', '@evil.com', '.evil.com', '\\evil.com']) {
+      expect(
+        betaRedirectUrl({ origin: 'https://checklyra.com', isProd: true, approved: true, next: evil }),
+      ).toBe('https://beta.checklyra.com/dashboard');
+    }
+  });
 });
 
 // KAN-278: only the real production deploy hops users to beta.

--- a/tests/unit/json-ld.test.ts
+++ b/tests/unit/json-ld.test.ts
@@ -1,0 +1,30 @@
+/**
+ * SEC-08 (TDD 2026-06-21): jsonLdSafe must escape characters that could break out
+ * of a <script type="application/ld+json"> block, so user-controlled profile
+ * fields cannot inject markup even though JSON.stringify alone does not escape `<`.
+ */
+import { jsonLdSafe } from '@/lib/json-ld';
+
+describe('jsonLdSafe (SEC-08)', () => {
+  test('neutralises a </script> breakout attempt in a string value', () => {
+    const out = jsonLdSafe({ name: '</script><script>alert(1)</script>' });
+    expect(out).not.toContain('</script>');
+    expect(out).not.toContain('<script>');
+    expect(out).toContain('\\u003c');
+  });
+
+  test('escapes < > & and the unicode line/paragraph separators', () => {
+    const out = jsonLdSafe({ a: '<', b: '>', c: '&', d: '\u2028', e: '\u2029' });
+    expect(out).not.toMatch(/[<>&]/);
+    expect(out).toContain('\\u003c');
+    expect(out).toContain('\\u003e');
+    expect(out).toContain('\\u0026');
+    expect(out).toContain('\\u2028');
+    expect(out).toContain('\\u2029');
+  });
+
+  test('output is still valid JSON that parses back to the original object', () => {
+    const obj = { '@type': 'Person', name: 'Alice <3 & Bob', city: 'Paris' };
+    expect(JSON.parse(jsonLdSafe(obj))).toEqual(obj);
+  });
+});

--- a/tests/unit/sanitise.test.ts
+++ b/tests/unit/sanitise.test.ts
@@ -15,7 +15,7 @@
  */
 import * as fs from 'fs';
 import * as path from 'path';
-import { stripHtml, sanitiseText, sanitiseUrl } from '@/lib/sanitise';
+import { stripHtml, sanitiseText, sanitiseUrl, sanitiseSearchTerm } from '@/lib/sanitise';
 
 // ── Source verification ────────────────────────────────
 // Light-touch sanity check that the imports resolve to functions and the
@@ -191,5 +191,42 @@ describe('sanitiseUrl', () => {
 
   test('handles empty string', () => {
     expect(sanitiseUrl('')).toBe('');
+  });
+});
+
+// ── sanitiseSearchTerm (SEC-09) ────────────────────────
+// Strips PostgREST .or()/ilike metacharacters from a free-text search term so a
+// public search query can't alter the filter tree or become a match-all.
+describe('sanitiseSearchTerm', () => {
+  test('passes a normal query through unchanged', () => {
+    expect(sanitiseSearchTerm('Alice Smith')).toBe('Alice Smith');
+  });
+
+  test('strips commas/parentheses that could alter the PostgREST filter tree', () => {
+    const out = sanitiseSearchTerm('a,is_suspended.eq.true)(b');
+    expect(out).not.toContain(',');
+    expect(out).not.toContain('(');
+    expect(out).not.toContain(')');
+  });
+
+  test('strips ilike wildcards so the query cannot become a match-all', () => {
+    expect(sanitiseSearchTerm('%')).toBe('');
+    expect(sanitiseSearchTerm('a%_b')).toBe('a b');
+  });
+
+  test('strips backslashes', () => {
+    expect(sanitiseSearchTerm('a\\b')).toBe('a b');
+  });
+
+  test('collapses whitespace and trims', () => {
+    expect(sanitiseSearchTerm('  a   b  ')).toBe('a b');
+  });
+
+  test('caps length at 100', () => {
+    expect(sanitiseSearchTerm('a'.repeat(500)).length).toBe(100);
+  });
+
+  test('returns empty string when only metacharacters are supplied', () => {
+    expect(sanitiseSearchTerm(',(),%_')).toBe('');
   });
 });


### PR DESCRIPTION
## What & why

P0 remediations from the **2026-06-21 technical due-diligence review**. These overlap the same-day red-team audit (`Lyra-Security-Assessment-2026-06-21.md`) — see reconciliation below. Paired with the MCP PR (`security/tdd-p0-search-2026-06-21`) per the MCP-main lockstep policy.

| Change | Finding | Notes |
|---|---|---|
| `sanitiseSearchTerm()` on public `/search` | **SEC-09 / F-06** | strips PostgREST `.or()`/ilike metachars (`, ( ) * % _ \`) |
| `jsonLdSafe()` output-encoding (profile + homepage) | **SEC-08** | defence-in-depth — fields already HTML-stripped on write; red-team assessed XSS surface closed |
| harden `betaRedirectUrl` open-redirect guard (reject `/\`) + tests | **SEC-07 / F-12** | `develop`/`main` already guard `//` and non-`/` via KAN-278; this adds the backslash edge + regression tests |
| migration: trigger blocking non-service-role writes to `oauth_connections.*_secret_id` | **SEC-06 / BUGS-28** | **NOT applied to any DB** — gated; apply dev→staging→prod under sign-off, smoke-test connect/disconnect |

## Tests
Extended `tests/unit/sanitise.test.ts` + `beta-access-flow.test.ts`; new `tests/unit/json-ld.test.ts`. 104 unit tests green locally.

## Reconciliation with the red-team audit
SEC-09==F-06, SEC-07==F-12 (the audit filed these; this PR is the remediation). SEC-08 is defence-in-depth only. SEC-06 is additive (audit deemed `oauth_connections` RLS otherwise correct). Duplicate tickets BUGS-29/BUGS-35 to be closed against F-06/F-12.

## ⚠️ Not in this PR (gated)
- Applying the SEC-06 migration to any environment.
- Any promotion/deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
