### PR TITLE
Email-on-FAIL alert + doc-sync health-check routine (KAN-296, KAN-249)

### DIFF
--- a/docs/DAILY_SECURITY_CHECK.md
+++ b/docs/DAILY_SECURITY_CHECK.md
@@ -498,6 +498,7 @@ A second, more granular pentest (parent **BUGS-34**, Confluence report) runs alo
 This runs as a **scheduled Claude Code cloud routine**, not a GitHub Action — setup in [`DAILY_SECURITY_CHECK_ROUTINE.md`](./DAILY_SECURITY_CHECK_ROUTINE.md):
 - **`scripts/daily-security-check.sh`** — the deterministic HTTP/port probes (§A, §C transport). Read-only; reports PASS/FAIL/**UNVERIFIED** (an unreachable / egress-blocked / bot-challenged host is UNVERIFIED, never a false PASS *or* false FAIL); exit 2 on FAIL, 1 on UNVERIFIED-only. Guarded by `tests/scripts/daily-security-check.test.js`.
 - **The agent** drives the MCP-tool probes (§B Supabase advisors/SQL incl. B9, §D/E GitHub & supply-chain, §A8 Cloudflare), compares to the regression map, files a BUGS ticket for any NEW 🔴/🟠, and appends a run-log row via draft PR.
+- **Email on FAIL** — `scripts/security-alert-email.sh` (Resend) sends an alert on any 🔴/FAIL; it **fails loud** if `RESEND_API_KEY` is missing or Resend returns non-2xx (never a silent-skip).
 
 **Apply the Workflow & Backup Integrity Policy** everywhere: no silent-skip, validate every probe output, fail loud. A security check that silently skips and reports green is the worst possible outcome.
 

--- a/docs/DAILY_SECURITY_CHECK_ROUTINE.md
+++ b/docs/DAILY_SECURITY_CHECK_ROUTINE.md
@@ -34,6 +34,8 @@ Two ways to fix, pick one:
 
 Until one of those is true, the routine has nothing to run.
 
+> **Symptom you hit:** the run says *"the script and doc don't exist"* and then improvises (reads RUNBOOK, checks Jira). That means the routine's prompt is **not** checking out `develop` — it cloned the default branch (`main`) and found nothing. Fix: replace the routine's instructions with the **Step 6 prompt** below *verbatim*; its first lines fetch + check out `develop` and **STOP** if the script still isn't there, instead of improvising.
+
 ---
 
 ## Step 1 — Setup script: leave it EMPTY
@@ -55,9 +57,11 @@ checklyra.com
 *.checklyra.com
 mcp.checklyra.com
 mcp-dev.checklyra.com
+api.resend.com
 ```
 
 Tick **“Also include default list of common package managers.”**
+- `api.resend.com` is for the **email-on-FAIL** alert (Step 6 / `scripts/security-alert-email.sh`).
 - Add `*.supabase.co` **only** if you want the optional raw storage-enumeration curl (B5). It is **not** needed otherwise — the agent checks bucket flags/policies via the Supabase **connector** (the B5 SQL), which routes through Anthropic and needs no allowlist entry.
 - **MCP connectors need no allowlist entries** — only the direct `curl` hosts above.
 
@@ -70,7 +74,7 @@ On the routine form's **Connectors** tab, keep **Supabase, GitHub, Cloudflare, A
 There is **no read-only permission picker** for routines (autonomous sessions don't prompt for approval). The real guardrails are:
 
 - **Leave “Allow unrestricted branch pushes” OFF** (the default). Claude can then only push `claude/`-prefixed branches — it **cannot** push to `main`/`beta`/`staging`/`develop`. The run-log change goes out as a PR from a `claude/` branch.
-- **Put no write secrets in the environment.** There is no secrets store yet and env vars are visible to anyone who can edit the environment. This routine needs **none** — Supabase/GitHub/Cloudflare/Atlassian all authenticate through their connectors, not container env vars.
+- **Env vars / secrets:** the routine needs **exactly one** — `RESEND_API_KEY`, for the FAIL-alert email (Step 6). Everything else (Supabase/GitHub/Cloudflare/Atlassian) authenticates through its **connector**, not container env vars. There's no secrets store yet and env vars are visible to anyone who can edit the environment, so keep it to that one key. Optionally set `ALERT_TO` / `ALERT_FROM` (defaults `luisa@santos-stephens.com` / `security@checklyra.com`, which must be a Resend-verified sender).
 - **The prompt enforces read-only behaviour** (below). Be aware this is behavioural, not sandboxed: the Supabase connector *could* run a write query, so the prompt is explicit that it must not, and we don't ask it to.
 
 ## Step 5 — Schedule
@@ -82,6 +86,8 @@ In **Select a trigger → Schedule**, pick **Daily** at your local time (e.g. **
 ```
 First, if scripts/daily-security-check.sh is not present on the checked-out branch,
 run: git fetch origin develop --depth=1 && git checkout develop
+Then verify it exists; if it still does not, STOP and reply that the develop checkout
+failed — do NOT improvise probes, read other docs, or proceed.
 
 You are running the daily security check for checklyra.com (KAN-294). Work READ-ONLY:
 no probe may mutate prod; you may only (a) create Jira tickets and (b) append the run
@@ -105,7 +111,9 @@ log via a PR from a claude/ branch.
 5. Append one run-log row to docs/DAILY_SECURITY_CHECK.md (date, runner=cloud-routine,
    🔴/🟠 counts, new tickets, one-line notes) and open a PR from a claude/ branch with
    only that change.
-6. If any 🔴: put a clear "PAGE:" summary at the very top of your final reply.
+6. If any 🔴/FAIL: (a) email an alert — pipe a one-paragraph summary into
+   `bash scripts/security-alert-email.sh "Lyra daily security check: <N> FAIL"`; and
+   (b) put a clear "PAGE:" summary at the very top of your final reply.
    If clean: state "all green" with the PASS/UNVERIFIED counts; still append the log row.
 ```
 
@@ -114,7 +122,7 @@ log via a PR from a claude/ branch.
 ## Output & alerting
 
 - The run's session transcript + the run-log PR are the record. A **green run-list status only means the session didn't hit an infra error** — open the run (or read the `PAGE:` line) to see the actual result.
-- **Optional next step (KAN-296 step 5):** add a Resend email on FAIL, reusing the `weekly-report.yml` Resend plumbing, so a red run reaches the inbox without opening the session — under the Workflow & Backup Integrity Policy (fail loud, never silent-skip).
+- **Email on FAIL (built):** on any 🔴/FAIL the routine pipes a summary into `scripts/security-alert-email.sh`, which POSTs to Resend (`api.resend.com`) using `RESEND_API_KEY`. It **fails loud** if the key is missing or Resend returns non-2xx — never a silent-skip. Set `RESEND_API_KEY` in the routine env and add `api.resend.com` to the allowlist (Steps 2/4).
 
 ## Why not a GitHub Action?
 

--- a/docs/DOC_SYNC_HEALTHCHECK_ROUTINE.md
+++ b/docs/DOC_SYNC_HEALTHCHECK_ROUTINE.md
@@ -1,0 +1,65 @@
+# Doc-Sync Health-Check — Claude Code routine
+
+> **Ticket:** KAN-249 (the doc-sync job this watches) · runs **weekdays** · mirrors the structure of `DAILY_SECURITY_CHECK_ROUTINE.md`.
+> Confluence space **TWC**, cloudId `fde496ba-2db8-481a-8544-39d6e9122101`.
+
+This routine health-checks the **KAN-249 Confluence doc-sync automation** — the weekday job that keeps a 7-page TWC doc tree in step with `luisa-sys/lyra` and `luisa-sys/lyra-mcp-server` `main`. It catches the failure mode where the log claims "in sync" but a repo's real `main` has moved ahead (the 2026-06-19 stall, when `lyra-mcp-server` was stuck at `c2451b9d`).
+
+## How the run is split
+
+| Layer | Driven by | Covers |
+|---|---|---|
+| Read recorded state | agent, **Atlassian** connector | Doc Sync Log (page `19922947`), KAN-249 comments, tools page (`19955714`) |
+| Real `main` SHAs | agent, **GitHub** connector (`get_commit` ref `main`) | the source of truth to compare against |
+| Compare + day logic | `scripts/doc-sync-healthcheck.sh` | match / weekend-grace / weekday-FAIL, exit codes |
+
+## ⚠️ Prerequisite — same as the security routine
+
+Routines clone the **default branch** (`main`); the script lives on `develop` (and reaches `main` only via release promotion). **The routine prompt's first lines must check out `develop`** (see Step 6), or the run will say the script "doesn't exist" and improvise.
+
+## Setup
+
+- **Connectors:** keep **Atlassian** + **GitHub**; remove the rest.
+- **Network:** if the agent passes real SHAs from the GitHub connector (recommended, per the prompt), the script needs **no** network. Only if you let the script fetch SHAs itself does it need `api.github.com` (already in the **Trusted** default allowlist).
+- **Schedule:** **Weekdays** at your local time (the job itself runs weekdays; checking then matches its cadence). The script still handles weekend runs gracefully.
+- **Permissions:** leave "Allow unrestricted branch pushes" OFF. This check is **read-only** — it reports; it does not edit Confluence or push. No env secrets needed.
+
+## The routine prompt
+
+```
+First run: git fetch origin develop && git checkout develop
+Then verify scripts/doc-sync-healthcheck.sh exists; if not, STOP and say the checkout
+failed — do NOT improvise.
+
+Health-check the KAN-249 Confluence doc-sync job (Atlassian cloudId
+fde496ba-2db8-481a-8544-39d6e9122101). READ-ONLY.
+
+1. Read the Doc Sync Log table on Confluence page 19922947; take the MOST RECENT row's
+   date + lyra SHA + lyra-mcp-server SHA + summary. Also read the latest KAN-249 comments.
+2. Get the REAL latest main SHAs via the GitHub connector:
+   get_commit(luisa-sys/lyra, main) and get_commit(luisa-sys/lyra-mcp-server, main).
+3. Run: bash scripts/doc-sync-healthcheck.sh <rec_lyra> <rec_mcp> <real_lyra> <real_mcp>
+   (pass all four short SHAs; the script applies the weekday/weekend logic).
+4. Confirm Confluence page 19955714 still lists BOTH lyra_update_school AND
+   lyra_update_manual_of_me. If either is missing -> FAIL.
+5. Report CONCISELY:
+   - PASS: quote the latest row's date + both SHAs and confirm they match real main.
+   - OK (weekend): "OK — weekend, job idle", plus latest recorded state and whether docs
+     are currently in sync with both repos' main (note any commit the Monday run must pick up).
+   - FAIL: what's wrong + likely cause (missed/stalled commit, job not running, or a tool
+     dropped from page 19955714). Name the specific repo + SHAs.
+   Keep it short.
+```
+
+## PASS / OK / FAIL rules (encoded in the script + this prompt)
+
+- **PASS** — the latest log row's SHAs equal both repos' real `main` (docs in sync, nothing undocumented).
+- **OK — weekend, job idle** — today is Sat/Sun and no row dated today; report the latest recorded state and whether docs currently match real `main`. A `main` that advanced *today* is expected to be picked up at the next weekday run.
+- **FAIL** —
+  - the latest row claims "in sync"/"no changes" but a repo's real `main` is **ahead** of the recorded SHA on a **weekday** (job missed/stalled — the 2026-06-19 `c2451b9d` mode); or
+  - it's a weekday, `main` advanced, and **no new log row** was added for the most recent expected run (job not running); or
+  - `lyra_update_school` or `lyra_update_manual_of_me` is **missing** from page `19955714`.
+
+## Baseline (for drift reference)
+
+As of the 2026-06-20 manual run: lyra `main` `abe4bb17`, lyra-mcp-server `main` `60e8cbbd` (PR #70 / `60e8cbbd` — June-2026 profile-redesign data points, incl. the two write tools above). Earlier baseline `c2451b9d` (mcp) was the pre-#70 SHA.

--- a/scripts/doc-sync-healthcheck.sh
+++ b/scripts/doc-sync-healthcheck.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+#
+# doc-sync-healthcheck.sh — health-check for the KAN-249 Confluence doc-sync job
+# (the weekday automation that keeps the 7-page TWC doc tree in step with the two
+# repos' main branches). See docs/DOC_SYNC_HEALTHCHECK_ROUTINE.md for the full
+# routine; this script is the DETERMINISTIC comparison + day-of-week half.
+#
+# The agent reads the Doc Sync Log (Confluence page 19922947) for the RECORDED
+# SHAs and gets the REAL main SHAs via the GitHub connector, then passes all four
+# here. If the real SHAs are omitted, the script fetches them from the public
+# GitHub API (the repos are public) and reports UNVERIFIED if it can't.
+#
+# Usage:
+#   bash scripts/doc-sync-healthcheck.sh <rec_lyra> <rec_mcp> [<real_lyra> <real_mcp>]
+#   (SHAs may be short or full; comparison is case-insensitive on the first 8.)
+#
+# Output: PASS / OK / FAIL / UNVERIFIED lines + a structured summary.
+# Exit: 2 if any FAIL; 1 if any UNVERIFIED; 0 on PASS/OK.
+#
+# NB: `set -e` is off — we run every check and aggregate; nothing is swallowed.
+set -uo pipefail
+
+REC_LYRA="${1:-}"; REC_MCP="${2:-}"
+REAL_LYRA_ARG="${3:-}"; REAL_MCP_ARG="${4:-}"
+DOW="$(date -u +%A)"; TODAY="$(date -u +%Y-%m-%d)"
+LYRA_REPO="luisa-sys/lyra"; MCP_REPO="luisa-sys/lyra-mcp-server"
+
+is_weekend() { case "$DOW" in Saturday|Sunday) return 0 ;; *) return 1 ;; esac; }
+norm() { printf '%s' "${1:-}" | tr 'A-Z' 'a-z' | cut -c1-8; }
+
+# Fetch the real main short-SHA via the public GitHub API (no token; repos are
+# public). Prints an 8-char sha, or "UNVERIFIED" if unreachable / non-200.
+real_sha() { # $1 = owner/repo
+  local body code
+  body="$(curl -sS -w '\n%{http_code}' --max-time 20 \
+    -H 'Accept: application/vnd.github+json' \
+    "https://api.github.com/repos/$1/commits/main" 2>/dev/null)" || { printf 'UNVERIFIED'; return; }
+  code="$(printf '%s' "$body" | tail -n1)"
+  if [ "$code" != "200" ]; then printf 'UNVERIFIED'; return; fi
+  printf '%s' "$body" | sed '$d' \
+    | grep -oE '"sha"[[:space:]]*:[[:space:]]*"[0-9a-f]{40}"' | head -1 \
+    | grep -oE '[0-9a-f]{40}' | cut -c1-8
+}
+
+FAIL=0; UNV=0
+echo "# doc-sync-healthcheck $TODAY ($DOW)"
+
+if [ -z "$REC_LYRA" ] || [ -z "$REC_MCP" ]; then
+  echo "UNVERIFIED	args	recorded SHAs not supplied — agent must pass them from Confluence page 19922947"
+  UNV=$((UNV+1))
+fi
+
+check_repo() { # $1 label $2 repo $3 recorded $4 real-or-empty
+  local label="$1" repo="$2" rec real
+  rec="$(norm "$3")"
+  if [ -n "$4" ]; then real="$(norm "$4")"; else real="$(real_sha "$repo")"; fi
+  if [ "$real" = "unverifi" ] || [ "$real" = "UNVERIFIED" ]; then
+    echo "UNVERIFIED	$label	could not determine real main SHA for $repo (pass it from the GitHub connector, or allowlist api.github.com)"
+    UNV=$((UNV+1)); return
+  fi
+  if [ -z "$rec" ]; then
+    echo "UNVERIFIED	$label	real main=$real but no recorded SHA to compare"
+    UNV=$((UNV+1)); return
+  fi
+  if [ "$real" = "$rec" ]; then
+    echo "PASS	$label	in sync (recorded=$rec == real main=$real)"
+  elif is_weekend; then
+    echo "OK	$label	real main=$real AHEAD of recorded=$rec, but today is $DOW — job runs weekdays, so this is expected until the next weekday run (verify it documents the new commit)"
+  else
+    echo "FAIL	$label	real main=$real AHEAD of recorded=$rec on a weekday — doc-sync missed/stalled on a commit, or has not run for the most recent expected day"
+    FAIL=$((FAIL+1))
+  fi
+}
+
+check_repo lyra "$LYRA_REPO" "$REC_LYRA" "$REAL_LYRA_ARG"
+check_repo mcp  "$MCP_REPO"  "$REC_MCP"  "$REAL_MCP_ARG"
+
+echo "# NOTE: the agent must separately confirm (Atlassian connector) that page"
+echo "#       19955714 still lists lyra_update_school AND lyra_update_manual_of_me,"
+echo "#       and that the most recent EXPECTED weekday run added a fresh log row."
+
+echo "# ---"
+echo "# summary	FAIL=$FAIL	UNVERIFIED=$UNV	day=$DOW"
+if [ "$FAIL" -gt 0 ]; then echo "# RESULT: FAIL"; exit 2; fi
+if [ "$UNV" -gt 0 ]; then echo "# RESULT: UNVERIFIED"; exit 1; fi
+if is_weekend; then echo "# RESULT: OK (weekend — job idle)"; else echo "# RESULT: PASS"; fi
+exit 0

--- a/scripts/security-alert-email.sh
+++ b/scripts/security-alert-email.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+#
+# security-alert-email.sh — send a daily-security-check FAIL alert via Resend.
+# Called by the cloud routine (docs/DAILY_SECURITY_CHECK_ROUTINE.md) ONLY when a
+# run has a FAIL/🔴. It just sends an email; it does not touch the app.
+#
+# Usage:
+#   echo "summary text" | bash scripts/security-alert-email.sh "Subject line"
+#   bash scripts/security-alert-email.sh "Subject" < summary.txt
+#
+# Env:
+#   RESEND_API_KEY   (required) — fails LOUD if missing (never silent-skip)
+#   ALERT_TO         (default luisa@santos-stephens.com)
+#   ALERT_FROM       (default security@checklyra.com — must be Resend-verified)
+#
+# Exit: 0 on a 2xx from Resend; 1 on any misconfig or non-2xx (fail loud).
+#
+# NB: `set -e` is off; we handle each step explicitly and never swallow an error.
+set -uo pipefail
+
+SUBJECT="${1:-Lyra daily security check: FAIL}"
+TO="${ALERT_TO:-luisa@santos-stephens.com}"
+FROM="${ALERT_FROM:-security@checklyra.com}"
+
+if [ -z "${RESEND_API_KEY:-}" ]; then
+  echo "::error:: RESEND_API_KEY not set — cannot send the security alert. Failing loud (no silent-skip)." >&2
+  exit 1
+fi
+
+BODY="$(cat)"
+[ -z "$BODY" ] && BODY="(no body provided)"
+
+# Build the JSON payload safely (python3 is pre-installed; avoids quoting bugs).
+payload="$(BODY="$BODY" SUBJECT="$SUBJECT" TO="$TO" FROM="$FROM" python3 - <<'PY'
+import json, os
+print(json.dumps({
+    "from": os.environ["FROM"],
+    "to": [os.environ["TO"]],
+    "subject": os.environ["SUBJECT"],
+    "text": os.environ["BODY"],
+}))
+PY
+)" || { echo "::error:: failed to build email payload" >&2; exit 1; }
+
+resp="$(curl -sS -w '\n%{http_code}' --max-time 30 \
+  -X POST https://api.resend.com/emails \
+  -H "Authorization: Bearer ${RESEND_API_KEY}" \
+  -H 'Content-Type: application/json' \
+  --data "$payload" 2>/dev/null)" || { echo "::error:: Resend request failed (network)" >&2; exit 1; }
+
+code="$(printf '%s' "$resp" | tail -n1)"
+out="$(printf '%s' "$resp" | sed '$d')"
+
+if [ "$code" = "200" ] || [ "$code" = "201" ]; then
+  echo "alert sent (HTTP $code): $out"
+  exit 0
+fi
+
+echo "::error:: Resend returned HTTP $code: $out" >&2
+exit 1

--- a/tests/scripts/doc-sync-healthcheck.test.js
+++ b/tests/scripts/doc-sync-healthcheck.test.js
@@ -1,0 +1,70 @@
+const { execSync } = require('child_process');
+const fs = require('fs');
+const path = require('path');
+
+const SCRIPT = path.resolve(__dirname, '../../scripts/doc-sync-healthcheck.sh');
+
+function run(args) {
+  // Returns { code, out }. Real SHAs are passed so the script needs no network.
+  try {
+    const out = execSync(`bash "${SCRIPT}" ${args}`, { stdio: 'pipe' }).toString();
+    return { code: 0, out };
+  } catch (e) {
+    return { code: e.status, out: (e.stdout || Buffer.from('')).toString() };
+  }
+}
+
+describe('scripts/doc-sync-healthcheck.sh', () => {
+  let source = '';
+  beforeAll(() => { source = fs.readFileSync(SCRIPT, 'utf8'); });
+
+  it('exists, is bash, and is syntactically valid', () => {
+    expect(fs.existsSync(SCRIPT)).toBe(true);
+    expect(source.startsWith('#!/usr/bin/env bash')).toBe(true);
+    expect(() => execSync(`bash -n "${SCRIPT}"`, { stdio: 'pipe' })).not.toThrow();
+  });
+
+  it('is hardened and never silent-skips', () => {
+    expect(source).toMatch(/set -uo pipefail/);
+    expect(source).not.toMatch(/\|\|\s*echo\s*"/);
+  });
+
+  it('PASS when recorded SHAs equal real main SHAs', () => {
+    const { code, out } = run('aaaaaaaa bbbbbbbb aaaaaaaa bbbbbbbb');
+    expect(out).toMatch(/PASS\tlyra/);
+    expect(out).toMatch(/PASS\tmcp/);
+    expect(code).toBe(0);
+  });
+
+  it('FAILs (exit 2) when real main is ahead — using a forced weekday', () => {
+    // Force a weekday via the `date` shim on PATH so the test is deterministic.
+    const dir = fs.mkdtempSync(path.join(require('os').tmpdir(), 'dsh-'));
+    fs.writeFileSync(path.join(dir, 'date'), '#!/usr/bin/env bash\necho Monday\n');
+    fs.chmodSync(path.join(dir, 'date'), 0o755);
+    let code = 0;
+    let out = '';
+    try {
+      out = execSync(`bash "${SCRIPT}" aaaaaaaa bbbbbbbb ffffffff bbbbbbbb`, {
+        stdio: 'pipe',
+        env: { ...process.env, PATH: `${dir}:${process.env.PATH}` },
+      }).toString();
+    } catch (e) {
+      code = e.status;
+      out = (e.stdout || Buffer.from('')).toString();
+    }
+    expect(out).toMatch(/FAIL\tlyra/);
+    expect(code).toBe(2);
+  });
+
+  it('OK (exit 0) when real main is ahead on a forced weekend', () => {
+    const dir = fs.mkdtempSync(path.join(require('os').tmpdir(), 'dsh-'));
+    fs.writeFileSync(path.join(dir, 'date'), '#!/usr/bin/env bash\necho Sunday\n');
+    fs.chmodSync(path.join(dir, 'date'), 0o755);
+    const out = execSync(`bash "${SCRIPT}" aaaaaaaa bbbbbbbb ffffffff bbbbbbbb`, {
+      stdio: 'pipe',
+      env: { ...process.env, PATH: `${dir}:${process.env.PATH}` },
+    }).toString();
+    expect(out).toMatch(/OK\tlyra/);
+    expect(out).toMatch(/RESULT: OK \(weekend/);
+  });
+});

--- a/tests/scripts/security-alert-email.test.js
+++ b/tests/scripts/security-alert-email.test.js
@@ -1,0 +1,49 @@
+const { execSync } = require('child_process');
+const fs = require('fs');
+const path = require('path');
+
+const SCRIPT = path.resolve(__dirname, '../../scripts/security-alert-email.sh');
+
+describe('scripts/security-alert-email.sh', () => {
+  let source = '';
+
+  beforeAll(() => {
+    source = fs.readFileSync(SCRIPT, 'utf8');
+  });
+
+  it('exists and is a bash script', () => {
+    expect(fs.existsSync(SCRIPT)).toBe(true);
+    expect(source.startsWith('#!/usr/bin/env bash')).toBe(true);
+  });
+
+  it('is syntactically valid (bash -n)', () => {
+    expect(() => execSync(`bash -n "${SCRIPT}"`, { stdio: 'pipe' })).not.toThrow();
+  });
+
+  it('is hardened with set -uo pipefail', () => {
+    expect(source).toMatch(/set -uo pipefail/);
+  });
+
+  it('fails LOUD when RESEND_API_KEY is missing (no silent-skip)', () => {
+    // Run with an empty env so RESEND_API_KEY is unset; must exit non-zero.
+    let exitCode = 0;
+    try {
+      execSync(`echo "x" | RESEND_API_KEY= bash "${SCRIPT}" "test"`, {
+        stdio: 'pipe',
+        env: { PATH: process.env.PATH },
+      });
+    } catch (e) {
+      exitCode = e.status;
+    }
+    expect(exitCode).toBe(1);
+  });
+
+  it('does not silent-skip on missing secret (no "|| echo" placeholder pattern)', () => {
+    expect(source).not.toMatch(/\|\|\s*echo\s*"/);
+  });
+
+  it('posts to the Resend API and checks the response code', () => {
+    expect(source).toContain('https://api.resend.com/emails');
+    expect(source).toMatch(/exit 1/);
+  });
+});


### PR DESCRIPTION
## What & why

Follow-up to #329 (KAN-294/KAN-296). Two additions:

**1. Email-on-FAIL for the security routine (KAN-296)**
- `scripts/security-alert-email.sh` — sends a Resend email on any 🔴/FAIL. **Fails loud** if `RESEND_API_KEY` is missing or Resend returns non-2xx (never a silent-skip).
- Routine doc + prompt updated: add `api.resend.com` to the allowlist, `RESEND_API_KEY` as the single env var, and an email step on FAIL.
- Hardened the routine prompt to **STOP** (not improvise) if the `develop` checkout didn't land the script — fixes the "script doesn't exist" symptom.

**2. Doc-sync health-check routine (KAN-249)**
- `scripts/doc-sync-healthcheck.sh` — compares the recorded Doc Sync Log SHAs to the repos' real `main` SHAs with weekday/weekend logic (PASS / OK-weekend / weekday-FAIL / UNVERIFIED). Accepts connector-fetched SHAs so it needs no network in the routine.
- `docs/DOC_SYNC_HEALTHCHECK_ROUTINE.md` — the Claude Code routine (Atlassian + GitHub connectors + the script), mirroring the security routine.

Both scripts have tests under `tests/scripts/` (`bash -n`, hardening header, no `|| echo` masking, PASS/FAIL/OK exit codes).

## Validated live
- `security-alert-email.sh`: fails loud with exit 1 when `RESEND_API_KEY` unset. ✅
- `doc-sync-healthcheck.sh` live run (Sunday): **OK — weekend, job idle**; both repos' `main` advanced today (lyra `abe4bb17→7baa8f6a`, mcp `60e8cbbd→c8b51881`) — expected, Monday's run should document them. Forced-weekday-ahead case → FAIL exit 2. ✅

## Scope / safety
Read-only checks + scripts. The only secret introduced is `RESEND_API_KEY` (routine env var, for the alert email). No app/runtime code touched.

Refs: KAN-294, KAN-296, KAN-249.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HYgKdkByGfyYN311CjTnYK)_