### PR TITLE
chore(security): SECURITY.md + CODEOWNERS (SEC-3 / GOV-01)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,11 @@
+# Code owners for this repository.
+#
+# A review from a code owner is automatically requested on every pull request.
+# Once branch protection requires code-owner review (SEC-3 / GOV-01), this provides a
+# real "second pair of eyes" gate before changes reach a protected branch.
+#
+# TODO (SEC-3): add Ben's GitHub handle alongside @luisa-sys so the author and the
+# required reviewer can differ — true segregation of duties. With a single owner,
+# CODEOWNERS documents ownership but cannot by itself enforce an independent reviewer.
+
+* @luisa-sys

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,36 @@
+# Security Policy
+
+CheckLyra Ltd takes the security of Lyra (checklyra.com) and the personal data it
+processes seriously.
+
+## Reporting a vulnerability
+
+**Please do not report security issues in public GitHub issues or pull requests.**
+
+Use one of these private channels:
+
+1. **GitHub private vulnerability reporting (preferred)** — open the **Security** tab
+   of this repository and click **Report a vulnerability**. This is enabled and routes
+   privately to the maintainers.
+2. **Email** — `security@checklyra.com` with a description, impact, and steps to
+   reproduce.
+
+We aim to acknowledge a report within **3 working days** and to agree a remediation
+timeline after triage. Please allow us a reasonable period to fix the issue before any
+public disclosure (coordinated disclosure).
+
+## Scope
+
+In scope: this repository and the production services it powers — `checklyra.com` and
+`mcp.checklyra.com`. Out of scope: third-party services we rely on (report those to the
+relevant provider), volumetric/denial-of-service testing, and social engineering.
+
+## Supported versions
+
+Lyra is a continuously-deployed service; only the currently-deployed version is
+supported. There are no released versions to back-port fixes to.
+
+## Recognition
+
+We're a small team without a paid bounty programme, but we're glad to credit
+researchers who disclose responsibly.


### PR DESCRIPTION
Adds the governance files from **SEC-3 / GOV-01** (second-line risk audit):

- `SECURITY.md` — coordinated vulnerability-disclosure policy. **GitHub private vulnerability reporting has been enabled** on this repo as the primary private channel.
- `.github/CODEOWNERS` — sets `@luisa-sys` as code owner (auto-requests review). Add Ben's handle for true segregation of duties.

Does **not** change branch protection or LICENSE — those need decisions (see the SEC-3 ticket): branch protection must not break the automated promotion pipeline, and the LICENSE question (mcp is currently MIT) needs a founder call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)