### PR TITLE
Weekly health + regression + autonomous bug-fix routine (manual prod gate)

### DIFF
--- a/docs/WEEKLY_HEALTH_REGRESSION_ROUTINE.md
+++ b/docs/WEEKLY_HEALTH_REGRESSION_ROUTINE.md
@@ -1,0 +1,92 @@
+# Weekly Health + Regression + Autonomous Bug-Fix — Claude Code routine
+
+> Runs **weekly**, **global coverage** (both repos, all test types). Mirrors the structure of `DAILY_SECURITY_CHECK_ROUTINE.md`.
+> Deterministic test/build runner: `scripts/weekly-health-regression.sh`. The agent does triage, autonomous fixes (on `develop` via `claude/*` PRs), Jira logging, and a **release rehearsal that stops at the manual production gate**.
+
+This routine checks Lyra is healthy, runs the full regression + E2E + build suite across `luisa-sys/lyra` and `luisa-sys/lyra-mcp-server`, **fixes the bugs it can on a fully autonomous basis**, logs everything in Jira, and **rehearses the release pipeline** — stopping before the one step the project forbids automating.
+
+## 🚦 Hard boundaries (do not cross — encoded in the prompt)
+
+1. **Production promote is MANUAL — never automated.** `CLAUDE.md`: *"Promotion to production … always manual — never automated"* and *"Never push directly to staging, beta, or main."* The routine validates the chain and **prepares** the prod release, then **STOPS** and reports the exact command for you to run. It must not run `promote-to-production.yml`, push to `main/beta/staging`, or `vercel promote` to production.
+2. **Test Integrity Policy.** A failing test means the *code* is wrong, not the test. The routine must **never** modify, weaken, skip, or delete a test to go green. If a fix would require a test change, it **STOPS and reports** for sign-off.
+3. **Autonomy with a stop-line.** Fix what's unambiguous and low-risk on a `claude/*` branch → PR to `develop`. For anything ambiguous, architectural, security-sensitive, data-model/RLS/migration, or requiring a test change → **STOP and report to the user**. (Mirrors your instruction: "Stop where you are unsure … otherwise act autonomously.")
+4. **No self-merge to protected branches.** Open PRs; the routine may merge its own fix PR to `develop` **only** when CI is green and the change is low-risk — never to `staging/beta/main`.
+
+## How the run is split
+
+| Layer | Driven by | Covers |
+|---|---|---|
+| Tests + build | `scripts/weekly-health-regression.sh` | lint, type-check, unit, scripts, integration, E2E, build — honest PASS/FAIL/UNVERIFIED |
+| Live health | agent (curl / connectors) | `*/api/health`, MCP `/health`, deploy SHAs, CI status |
+| Triage + fix | agent | open `claude/*` PR per fix, log Jira (BUGS/SEC), respect the boundaries above |
+| Release rehearsal | agent (GitHub connector) | verify chain is promotable; **prepare** prod release; STOP at the manual gate |
+| Self-update | agent | propose improvements to THIS routine's script/prompt/doc via a PR (never silent) |
+
+## Prerequisite (same as the other routines)
+
+Routines clone the **default branch (`main`)**; this tooling lives on `develop`. The prompt's first lines check out `develop` (and STOP if the script isn't there).
+
+## Setup
+
+- **Connectors:** GitHub + Atlassian (+ Supabase/Cloudflare/Vercel if you want the agent to read deploy/runtime state). Remove the rest.
+- **Setup script** (this routine *does* need one — it runs the suite):
+  ```bash
+  npm ci
+  npx playwright install --with-deps   # for E2E
+  ```
+  Repeat for `lyra-mcp-server` if covering it in the same run (or use a second routine).
+- **Network:** **Custom** allowlist with `*.checklyra.com`, `mcp.checklyra.com`, `mcp-dev.checklyra.com` (for live health + E2E targets) + the default package registries (for `npm ci`).
+- **Schedule:** **Weekly** (e.g. Monday 06:00 local — before the workweek; note the Sunday 23:00 UTC develop→staging auto-promote already runs).
+- **Permissions:** leave **"Allow unrestricted branch pushes" OFF** (so it can only push `claude/*` — this is what keeps it off `main/beta/staging`). No prod tokens in the env.
+
+## The routine prompt
+
+```
+FIRST run: git fetch origin develop && git checkout develop
+Then verify scripts/weekly-health-regression.sh exists; if not, STOP and say the
+checkout failed — do NOT improvise.
+
+Read the repo for context first: CLAUDE.md, docs/RUNBOOK.md, docs/RELEASE_POLICY.md,
+docs/ARCHITECTURE.md. Obey them. Two rules are absolute:
+  (A) PRODUCTION PROMOTE IS MANUAL — never run promote-to-production.yml, never push
+      to main/beta/staging, never vercel-promote to prod. You prepare + report only.
+  (B) TEST INTEGRITY — never modify/skip/weaken/delete a test to make it pass. If a fix
+      needs a test change, STOP and report for sign-off.
+
+GOAL: confirm Lyra is healthy, run full regression + E2E, fix what you safely can,
+log everything, and rehearse the release pipeline up to (not through) the prod gate.
+
+1. HEALTH: curl https://checklyra.com/api/health and https://mcp.checklyra.com/health;
+   check the latest CI run on develop is green (GitHub connector). Note anything red.
+2. REGRESSION + E2E: run  RUN_E2E=1 bash scripts/weekly-health-regression.sh  and capture
+   the PASS/FAIL/UNVERIFIED lines. (For lyra-mcp-server coverage, clone/build/test it too.)
+3. TRIAGE + FIX (autonomous, bounded):
+   - For each FAIL, find the ROOT CAUSE in the application code and fix it on a new
+     claude/ branch. Re-run the suite to confirm green WITHOUT touching any test.
+   - Open a PR to develop. If CI is green and the fix is low-risk, you may merge it to
+     develop. NEVER merge to staging/beta/main.
+   - STOP and report (do not fix) anything ambiguous, architectural, security/RLS/auth,
+     migration/data-model, or that would require a test change. List it for the user.
+   - Log every bug + fix in Jira the usual way: BUGS (6-section) for defects, SEC for
+     security findings, with the failing output + your diagnosis + the PR link.
+4. RESIDUAL BUGS: also scan for residual/known issues (open BUGS/SEC tickets, TODO/FIXME,
+   flaky tests, Dependabot/CodeQL alerts) and fix the safe ones under the same rules.
+5. RELEASE REHEARSAL (NO prod deploy):
+   - Confirm develop is green and promotable. You MAY trigger develop→staging
+     (promote-to-staging.yml is sanctioned/automatable) and confirm staging is healthy.
+   - Verify beta and prod are PROMOTABLE (branches in sync, smoke endpoints up) but DO
+     NOT promote them. Prepare the production release and STOP.
+   - Report: "Pipeline validated through staging; production promote is READY and is the
+     manual step — run: gh workflow run promote-to-production.yml -f confirm=PRODUCTION".
+6. SELF-UPDATE: if you found a way this routine (script/prompt/doc) should improve, open a
+   PR proposing it — do NOT silently change your own behaviour.
+7. REPORT + LOG: append a run-log row to this doc (date, PASS/FAIL counts, bugs fixed +
+   tickets, what you STOPPED on, release-readiness) via a claude/ PR. If anything is red
+   or you stopped on something, put a clear "ACTION NEEDED:" summary at the top of your reply.
+```
+
+## Run log
+
+| Date | Runner | Suite result | Bugs fixed → tickets/PRs | Stopped-on (needs user) | Release-ready? |
+|---|---|---|---|---|---|
+| 2026-06-21 | _(initial — routine authored)_ | — | — | — | manual gate by design |

--- a/scripts/weekly-health-regression.sh
+++ b/scripts/weekly-health-regression.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+#
+# weekly-health-regression.sh — run Lyra's regression / E2E / build suite and
+# emit a single honest PASS / FAIL / UNVERIFIED summary.
+#
+# READ-ONLY w.r.t. infra: it runs tests and the build only. It NEVER deploys,
+# pushes, promotes, or merges — those are the wrapping routine's job, and the
+# production promote stays a MANUAL gate (CLAUDE.md: "production … always manual
+# — never automated"). See docs/WEEKLY_HEALTH_REGRESSION_ROUTINE.md.
+#
+# A phase whose tooling/deps are missing is UNVERIFIED (loud), never a silent
+# green pass (Workflow & Backup Integrity Policy). A failing phase is FAIL — and
+# the fix is NEVER to weaken/skip a test (Test Integrity Policy).
+#
+# Usage: bash scripts/weekly-health-regression.sh
+# Env:
+#   RUN_E2E=1   also run integration + Playwright E2E (need deps + browsers; E2E
+#               needs a reachable target).
+#   PHASES="…"  override the phase list (default: lint type-check unit scripts build).
+#
+# Exit: 2 if any phase FAILs; 1 if any UNVERIFIED and no FAIL; 0 if all PASS.
+#
+# NB: `set -e` is off — we run EVERY phase and aggregate; nothing is swallowed.
+set -uo pipefail
+
+PASS=0; FAIL=0; UNV=0
+PHASES="${PHASES:-lint type-check unit scripts build}"
+[ "${RUN_E2E:-0}" = "1" ] && PHASES="$PHASES integration e2e"
+
+record() { # $1=STATUS $2=label $3=detail
+  printf '%s\t%s\t%s\n' "$1" "$2" "${3:-}"
+  case "$1" in PASS) PASS=$((PASS+1)) ;; FAIL) FAIL=$((FAIL+1)) ;; UNVERIFIED) UNV=$((UNV+1)) ;; esac
+}
+
+cmd_for() { case "$1" in
+  lint)        echo "npm run lint" ;;
+  type-check)  echo "npm run type-check" ;;
+  unit)        echo "npm run test:unit" ;;
+  scripts)     echo "npm run test:scripts" ;;
+  integration) echo "npm run test:integration" ;;
+  e2e)         echo "npm run test:e2e" ;;
+  build)       echo "npm run build" ;;
+  *)           echo "" ;;
+esac; }
+
+echo "# weekly-health-regression $(date -u +%Y-%m-%dT%H:%M:%SZ)  phases: $PHASES"
+
+[ -f package.json ] || record UNVERIFIED repo "no package.json in $(pwd) — wrong dir/branch? (did you checkout develop?)"
+[ -d node_modules ] || record UNVERIFIED deps "node_modules missing — run 'npm ci' (and 'npx playwright install' for E2E) in the setup script first"
+
+run_phase() { # $1 label
+  local label="$1" c rc log; c="$(cmd_for "$label")"
+  [ -z "$c" ] && { record UNVERIFIED "$label" "no command mapped"; return; }
+  [ -d node_modules ] || { record UNVERIFIED "$label" "skipped — deps not installed"; return; }
+  log="$(mktemp)"
+  if $c >"$log" 2>&1; then
+    record PASS "$label" "ok"
+  else
+    rc=$?
+    record FAIL "$label" "exit $rc — $(tail -n 3 "$log" | tr '\n' ' ' | cut -c1-300)"
+  fi
+  rm -f "$log"
+}
+
+for p in $PHASES; do run_phase "$p"; done
+
+echo "# ---"
+echo "# summary	PASS=$PASS	FAIL=$FAIL	UNVERIFIED=$UNV"
+if [ "$FAIL" -gt 0 ]; then
+  echo "# RESULT: FAIL — fix the failing phase(s) at the SOURCE; never weaken/skip a test to go green (Test Integrity Policy)"
+  exit 2
+fi
+if [ "$UNV" -gt 0 ]; then
+  echo "# RESULT: UNVERIFIED — install deps / set a target and re-run; do not treat as a pass"
+  exit 1
+fi
+echo "# RESULT: PASS"
+exit 0

--- a/tests/scripts/weekly-health-regression.test.js
+++ b/tests/scripts/weekly-health-regression.test.js
@@ -1,0 +1,44 @@
+const { execSync } = require('child_process');
+const fs = require('fs');
+const path = require('path');
+
+const SCRIPT = path.resolve(__dirname, '../../scripts/weekly-health-regression.sh');
+
+describe('scripts/weekly-health-regression.sh', () => {
+  let source = '';
+  beforeAll(() => { source = fs.readFileSync(SCRIPT, 'utf8'); });
+
+  it('exists, is bash, and is syntactically valid', () => {
+    expect(fs.existsSync(SCRIPT)).toBe(true);
+    expect(source.startsWith('#!/usr/bin/env bash')).toBe(true);
+    expect(() => execSync(`bash -n "${SCRIPT}"`, { stdio: 'pipe' })).not.toThrow();
+  });
+
+  it('is hardened and never silent-skips', () => {
+    expect(source).toMatch(/set -uo pipefail/);
+    expect(source).not.toMatch(/\|\|\s*echo\s*"/);
+    expect(source).toMatch(/UNVERIFIED/);
+  });
+
+  it('covers the expected phases', () => {
+    for (const p of ['lint', 'type-check', 'unit', 'scripts', 'integration', 'e2e', 'build']) {
+      expect(source).toContain(p);
+    }
+  });
+
+  it('exits non-zero on FAIL (2) and UNVERIFIED-only (1)', () => {
+    expect(source).toMatch(/exit 2/);
+    expect(source).toMatch(/exit 1/);
+  });
+
+  it('is READ-ONLY: never deploys, pushes, promotes, or merges', () => {
+    // The safety boundary, enforced at test time: this runner must not contain
+    // any deploy/push/promote/merge invocation. Those belong to the wrapping
+    // routine, and the production promote stays a MANUAL gate.
+    expect(source).not.toMatch(/git\s+push/);
+    expect(source).not.toMatch(/gh\s+workflow\s+run/);
+    expect(source).not.toMatch(/promote-to-production/);
+    expect(source).not.toMatch(/vercel\s/);
+    expect(source).not.toMatch(/merge_pull_request/);
+  });
+});


### PR DESCRIPTION
## What & why

A **weekly** Claude Code routine for whole-system health + regression + autonomous bug-fixing, same scripted pattern as the security/doc-sync routines.

- `scripts/weekly-health-regression.sh` — runs lint / type-check / unit / scripts / integration / E2E / build and emits one honest **PASS/FAIL/UNVERIFIED** summary. **READ-ONLY**: it never deploys, pushes, promotes, or merges (asserted by the test). Missing deps/tooling = UNVERIFIED, never a silent green pass.
- `docs/WEEKLY_HEALTH_REGRESSION_ROUTINE.md` — the routine: full regression + E2E, live health, **autonomous bug-fixing on `develop` via `claude/*` PRs**, Jira logging, and a release **rehearsal** that validates the chain and **STOPS at the manual production gate**.
- `tests/scripts/weekly-health-regression.test.js` — guards the hardening + the read-only/no-deploy boundary.

## Hard boundaries (encoded, per `CLAUDE.md`)
1. **Production promote is MANUAL — never automated.** The routine prepares + reports the prod release; it does not run `promote-to-production.yml` or push to `main/beta/staging`.
2. **Test Integrity** — never weaken/skip/delete a test to go green; stop and report instead.
3. **Stop-and-report** on anything ambiguous / architectural / security / RLS / migration / test-changing; otherwise fix autonomously.
4. **No self-merge to protected branches.**

## Validated
`bash -n` clean; script confirmed hardened, no `|| echo` masking, correct exit codes, all phases present, and **no deploy/push/promote/merge** invocation.

Note: this is the safe build of the request. The "unattended weekly production release" part was deliberately **not** automated — it conflicts with the project's "production … always manual — never automated" rule and is irreversible; the routine rehearses up to that gate and hands over the manual command.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HYgKdkByGfyYN311CjTnYK)_