### PR TITLE
feat(KAN-303/304): Convene nav + Contacts/People page

### DIFF
--- a/src/app/dashboard/convene/contacts/actions.ts
+++ b/src/app/dashboard/convene/contacts/actions.ts
@@ -1,0 +1,204 @@
+'use server';
+
+/**
+ * KAN-304 — Contacts/People server actions.
+ *
+ * All writes go through the RLS client (`createClient` from supabase-server):
+ * `contacts`, `contact_methods` and `tribes` are owner-scoped by RLS
+ * (`owner_user_id = auth.uid()` / parent-derived), so we stamp
+ * `owner_user_id = user.id` and let Postgres enforce ownership — no
+ * service-role escalation is needed here (unlike the gathering actions, which
+ * escalate only to write the append-only audit log).
+ *
+ * MCP parity (KAN-222): mirrors `lyra_add_contact` / `lyra_link_contact_profile`
+ * in lyra-mcp-server (KAN-307).
+ */
+
+import { createClient } from '@/lib/supabase-server';
+import { revalidatePath } from 'next/cache';
+import { rateLimit } from '@/lib/rate-limit';
+import {
+  type AddContactInput,
+  type UpdateContactInput,
+  type DirectoryProfile,
+  CONTACT_LIMITS,
+  DIRECTORY_SEARCH_RATE_LIMIT,
+  normaliseEmail,
+  normalisePhone,
+  isValidEmail,
+  sanitiseDirectoryQuery,
+} from './contacts-helpers';
+
+type Result = { ok: true } | { ok: false; error: string };
+type AddResult = { ok: true; contactId: string } | { ok: false; error: string };
+type SearchResult = { ok: true; matches: DirectoryProfile[] } | { ok: false; error: string };
+
+const CONTACTS_PATH = '/dashboard/convene/contacts';
+
+async function authed() {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  return { supabase, user };
+}
+
+export async function addContact(input: AddContactInput): Promise<AddResult> {
+  const { supabase, user } = await authed();
+  if (!user) return { ok: false, error: 'Not authenticated' };
+
+  const name = (input.display_name ?? '').trim();
+  if (!name) return { ok: false, error: 'A name is required' };
+  if (name.length > CONTACT_LIMITS.displayName) return { ok: false, error: 'That name is too long' };
+
+  const email = normaliseEmail(input.email);
+  if (email && !isValidEmail(email)) return { ok: false, error: 'That email address looks invalid' };
+  const phone = normalisePhone(input.phone);
+
+  const { data: contact, error } = await supabase
+    .from('contacts')
+    .insert({
+      owner_user_id: user.id,
+      display_name: name,
+      city: (input.city ?? '').trim() || null,
+      country: (input.country ?? '').trim() || null,
+      notes: (input.notes ?? '').trim() || null,
+    })
+    .select('id')
+    .single();
+  if (error || !contact) return { ok: false, error: 'Could not add contact' };
+
+  const methods: Array<{ contact_id: string; kind: string; value: string; is_primary: boolean }> = [];
+  if (email) methods.push({ contact_id: contact.id, kind: 'email', value: email, is_primary: true });
+  if (phone) methods.push({ contact_id: contact.id, kind: 'phone', value: phone, is_primary: true });
+  if (methods.length > 0) {
+    const { error: mErr } = await supabase.from('contact_methods').insert(methods);
+    if (mErr) return { ok: false, error: 'Contact added, but saving the email/phone failed' };
+  }
+
+  revalidatePath(CONTACTS_PATH);
+  return { ok: true, contactId: contact.id };
+}
+
+export async function updateContact(input: UpdateContactInput): Promise<Result> {
+  const { supabase, user } = await authed();
+  if (!user) return { ok: false, error: 'Not authenticated' };
+  if (!input.contact_id) return { ok: false, error: 'Missing contact' };
+
+  // RLS scopes this to the owner; the read also gives a clean "not found".
+  const { data: existing } = await supabase
+    .from('contacts')
+    .select('id')
+    .eq('id', input.contact_id)
+    .is('deleted_at', null)
+    .maybeSingle();
+  if (!existing) return { ok: false, error: 'Contact not found' };
+
+  const update: Record<string, unknown> = {};
+  if (input.display_name !== undefined) {
+    const name = input.display_name.trim();
+    if (!name) return { ok: false, error: 'A name is required' };
+    if (name.length > CONTACT_LIMITS.displayName) return { ok: false, error: 'That name is too long' };
+    update.display_name = name;
+  }
+  if (input.city !== undefined) update.city = (input.city ?? '').trim() || null;
+  if (input.country !== undefined) update.country = (input.country ?? '').trim() || null;
+  if (input.notes !== undefined) update.notes = (input.notes ?? '').trim() || null;
+
+  if (Object.keys(update).length > 0) {
+    const { error } = await supabase.from('contacts').update(update).eq('id', input.contact_id);
+    if (error) return { ok: false, error: 'Could not update contact' };
+  }
+
+  // Reconcile primary email/phone. undefined = leave as-is; '' / null = clear.
+  for (const kind of ['email', 'phone'] as const) {
+    const raw = kind === 'email' ? input.email : input.phone;
+    if (raw === undefined) continue;
+    const value = kind === 'email' ? normaliseEmail(raw) : normalisePhone(raw);
+    if (kind === 'email' && value && !isValidEmail(value)) {
+      return { ok: false, error: 'That email address looks invalid' };
+    }
+    // Replace any existing method of this kind with the new value (or clear it).
+    await supabase.from('contact_methods').delete().eq('contact_id', input.contact_id).eq('kind', kind);
+    if (value) {
+      const { error } = await supabase
+        .from('contact_methods')
+        .insert({ contact_id: input.contact_id, kind, value, is_primary: true });
+      if (error) return { ok: false, error: `Could not update ${kind}` };
+    }
+  }
+
+  revalidatePath(CONTACTS_PATH);
+  return { ok: true };
+}
+
+export async function deleteContact(contactId: string): Promise<Result> {
+  const { supabase, user } = await authed();
+  if (!user) return { ok: false, error: 'Not authenticated' };
+  if (!contactId) return { ok: false, error: 'Missing contact' };
+
+  // Soft delete (matches the contacts.deleted_at convention).
+  const { error } = await supabase
+    .from('contacts')
+    .update({ deleted_at: new Date().toISOString() })
+    .eq('id', contactId)
+    .is('deleted_at', null);
+  if (error) return { ok: false, error: 'Could not delete contact' };
+
+  revalidatePath(CONTACTS_PATH);
+  return { ok: true };
+}
+
+export async function linkContactToProfile(contactId: string, profileId: string | null): Promise<Result> {
+  const { supabase, user } = await authed();
+  if (!user) return { ok: false, error: 'Not authenticated' };
+  if (!contactId) return { ok: false, error: 'Missing contact' };
+
+  if (profileId) {
+    const { data: profile } = await supabase
+      .from('profiles')
+      .select('id, is_published')
+      .eq('id', profileId)
+      .maybeSingle();
+    if (!profile) return { ok: false, error: 'That profile could not be found' };
+    if (profile.is_published === false) return { ok: false, error: 'That profile is not published' };
+  }
+
+  const { error } = await supabase
+    .from('contacts')
+    .update({ linked_profile_id: profileId })
+    .eq('id', contactId)
+    .is('deleted_at', null);
+  if (error) return { ok: false, error: 'Could not update the profile link' };
+
+  revalidatePath(CONTACTS_PATH);
+  return { ok: true };
+}
+
+/**
+ * Directory search to find a published Lyra profile to link a contact to.
+ * Only published profiles are visible (RLS); the result carries no PII beyond
+ * what a public profile already shows.
+ */
+export async function searchDirectoryProfiles(query: string): Promise<SearchResult> {
+  const { supabase, user } = await authed();
+  if (!user) return { ok: false, error: 'Not authenticated' };
+
+  const safe = sanitiseDirectoryQuery(query);
+  if (safe.length < 2) return { ok: true, matches: [] };
+
+  const limit = rateLimit(`contact-directory-search:${user.id}`, DIRECTORY_SEARCH_RATE_LIMIT);
+  if (limit.limited) {
+    return { ok: false, error: `Too many searches. Please try again in ${limit.retryAfter}s.` };
+  }
+
+  const { data, error } = await supabase
+    .from('profiles')
+    .select('id, display_name, slug, city')
+    .eq('is_published', true)
+    .ilike('display_name', `%${safe}%`)
+    .limit(10);
+  if (error) return { ok: false, error: 'Search failed. Please try again.' };
+
+  return { ok: true, matches: (data ?? []) as DirectoryProfile[] };
+}

--- a/src/app/dashboard/convene/contacts/contacts-client.tsx
+++ b/src/app/dashboard/convene/contacts/contacts-client.tsx
@@ -1,0 +1,340 @@
+'use client';
+
+/**
+ * KAN-304 — Contacts/People client island.
+ *
+ * List + add + edit + delete contacts, and link a contact to a published Lyra
+ * profile via a directory search. Mutations call the server actions in
+ * ./actions and then router.refresh() (the established convene convention,
+ * see gatherings/[id]/gathering-actions.tsx).
+ */
+
+import { useState, useTransition } from 'react';
+import { useRouter } from 'next/navigation';
+import Link from 'next/link';
+import {
+  addContact,
+  updateContact,
+  deleteContact,
+  linkContactToProfile,
+  searchDirectoryProfiles,
+} from './actions';
+import type { ContactView, DirectoryProfile } from './contacts-helpers';
+
+const inputCls =
+  'w-full px-3 py-2 rounded-lg border border-[var(--color-border)] text-sm text-[var(--color-ink)] bg-white focus:outline-none focus:ring-1 focus:ring-[var(--color-sage)]';
+const primaryBtn =
+  'px-4 py-2 rounded-lg bg-[var(--color-sage)] text-white text-sm font-medium hover:opacity-90 disabled:opacity-50';
+const secondaryBtn =
+  'px-3 py-1.5 rounded-lg border border-[var(--color-border)] text-sm text-[var(--color-ink)] hover:bg-[var(--color-paper)] disabled:opacity-50';
+const destructiveBtn =
+  'px-3 py-1.5 rounded-lg border border-rose-300 text-rose-700 text-sm hover:bg-rose-50 disabled:opacity-50';
+
+function methodValue(c: ContactView, kind: 'email' | 'phone'): string {
+  return c.methods.find((m) => m.kind === kind)?.value ?? '';
+}
+
+export default function ContactsClient({ contacts }: { contacts: ContactView[] }) {
+  const router = useRouter();
+  const [pending, startTransition] = useTransition();
+  const [adding, setAdding] = useState(false);
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [linkingId, setLinkingId] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  function run(fn: () => Promise<{ ok: true } | { ok: false; error: string }>, onOk?: () => void) {
+    setError(null);
+    startTransition(async () => {
+      const res = await fn();
+      if (res.ok) {
+        onOk?.();
+        router.refresh();
+      } else {
+        setError(res.error);
+      }
+    });
+  }
+
+  return (
+    <div className="space-y-4">
+      {error && (
+        <div className="bg-rose-50 border border-rose-200 rounded-lg px-4 py-3 text-sm text-rose-900">
+          {error}
+        </div>
+      )}
+
+      <div className="flex justify-end">
+        <button type="button" className={primaryBtn} disabled={pending} onClick={() => setAdding((v) => !v)}>
+          {adding ? 'Close' : '+ Add contact'}
+        </button>
+      </div>
+
+      {adding && (
+        <ContactForm
+          pending={pending}
+          submitLabel="Add contact"
+          onCancel={() => setAdding(false)}
+          onSubmit={(values) =>
+            run(() => addContact(values), () => setAdding(false))
+          }
+        />
+      )}
+
+      {contacts.length === 0 && !adding && (
+        <div className="bg-white rounded-xl border border-[var(--color-border)] p-6 text-center text-sm text-[var(--color-muted)]">
+          No contacts yet. Add the first person you’d like to organise something with.
+        </div>
+      )}
+
+      <ul className="space-y-3">
+        {contacts.map((c) => (
+          <li key={c.id} className="bg-white rounded-xl border border-[var(--color-border)] p-5">
+            {editingId === c.id ? (
+              <ContactForm
+                pending={pending}
+                submitLabel="Save"
+                initial={{
+                  display_name: c.display_name,
+                  email: methodValue(c, 'email'),
+                  phone: methodValue(c, 'phone'),
+                  city: c.city ?? '',
+                  country: c.country ?? '',
+                  notes: c.notes ?? '',
+                }}
+                onCancel={() => setEditingId(null)}
+                onSubmit={(values) =>
+                  run(
+                    () =>
+                      updateContact({
+                        contact_id: c.id,
+                        display_name: values.display_name,
+                        email: values.email ?? '',
+                        phone: values.phone ?? '',
+                        city: values.city ?? '',
+                        country: values.country ?? '',
+                        notes: values.notes ?? '',
+                      }),
+                    () => setEditingId(null)
+                  )
+                }
+              />
+            ) : (
+              <div className="flex items-start justify-between gap-4">
+                <div className="min-w-0">
+                  <div className="flex items-center gap-2 flex-wrap">
+                    <span className="font-medium text-[var(--color-ink)]">{c.display_name}</span>
+                    {c.linked_profile_id && (
+                      <span className="inline-block px-2 py-0.5 rounded-md border border-[var(--color-border)] text-xs text-[var(--color-muted)]">
+                        🔗 {c.linked_profile_name ?? 'Linked profile'}
+                      </span>
+                    )}
+                  </div>
+                  <div className="mt-1 text-sm text-[var(--color-muted)] space-y-0.5">
+                    {methodValue(c, 'email') && <div>{methodValue(c, 'email')}</div>}
+                    {methodValue(c, 'phone') && <div>{methodValue(c, 'phone')}</div>}
+                    {(c.city || c.country) && (
+                      <div>{[c.city, c.country].filter(Boolean).join(', ')}</div>
+                    )}
+                    {c.notes && <div className="italic">{c.notes}</div>}
+                  </div>
+                </div>
+                <div className="flex flex-col items-end gap-2 shrink-0">
+                  <Link
+                    href={`/dashboard/convene/organise?contact=${c.id}`}
+                    className={primaryBtn + ' text-center'}
+                  >
+                    Organise →
+                  </Link>
+                  <div className="flex gap-2">
+                    <button type="button" className={secondaryBtn} disabled={pending} onClick={() => setEditingId(c.id)}>
+                      Edit
+                    </button>
+                    <button
+                      type="button"
+                      className={secondaryBtn}
+                      disabled={pending}
+                      onClick={() => setLinkingId(linkingId === c.id ? null : c.id)}
+                    >
+                      {c.linked_profile_id ? 'Link…' : 'Link profile'}
+                    </button>
+                    <button
+                      type="button"
+                      className={destructiveBtn}
+                      disabled={pending}
+                      onClick={() => {
+                        if (confirm(`Delete ${c.display_name}? This cannot be undone.`)) {
+                          run(() => deleteContact(c.id));
+                        }
+                      }}
+                    >
+                      Delete
+                    </button>
+                  </div>
+                </div>
+              </div>
+            )}
+
+            {linkingId === c.id && editingId !== c.id && (
+              <LinkProfilePanel
+                contact={c}
+                pending={pending}
+                onLink={(profileId) =>
+                  run(() => linkContactToProfile(c.id, profileId), () => setLinkingId(null))
+                }
+                onUnlink={() => run(() => linkContactToProfile(c.id, null), () => setLinkingId(null))}
+              />
+            )}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+interface FormValues {
+  display_name: string;
+  email?: string;
+  phone?: string;
+  city?: string;
+  country?: string;
+  notes?: string;
+}
+
+function ContactForm({
+  initial,
+  submitLabel,
+  pending,
+  onSubmit,
+  onCancel,
+}: {
+  initial?: FormValues;
+  submitLabel: string;
+  pending: boolean;
+  onSubmit: (values: FormValues) => void;
+  onCancel: () => void;
+}) {
+  const [values, setValues] = useState<FormValues>(
+    initial ?? { display_name: '', email: '', phone: '', city: '', country: '', notes: '' }
+  );
+  const set = (k: keyof FormValues) => (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) =>
+    setValues((v) => ({ ...v, [k]: e.target.value }));
+
+  return (
+    <form
+      className="bg-white rounded-xl border border-[var(--color-border)] p-5 space-y-3"
+      onSubmit={(e) => {
+        e.preventDefault();
+        onSubmit(values);
+      }}
+    >
+      <div>
+        <label className="block text-sm text-[var(--color-muted)] mb-1">Name *</label>
+        <input className={inputCls} value={values.display_name} onChange={set('display_name')} required maxLength={200} />
+      </div>
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+        <div>
+          <label className="block text-sm text-[var(--color-muted)] mb-1">Email</label>
+          <input className={inputCls} type="email" value={values.email} onChange={set('email')} maxLength={320} />
+        </div>
+        <div>
+          <label className="block text-sm text-[var(--color-muted)] mb-1">Phone</label>
+          <input className={inputCls} value={values.phone} onChange={set('phone')} maxLength={40} />
+        </div>
+        <div>
+          <label className="block text-sm text-[var(--color-muted)] mb-1">City</label>
+          <input className={inputCls} value={values.city} onChange={set('city')} maxLength={120} />
+        </div>
+        <div>
+          <label className="block text-sm text-[var(--color-muted)] mb-1">Country</label>
+          <input className={inputCls} value={values.country} onChange={set('country')} maxLength={120} />
+        </div>
+      </div>
+      <div>
+        <label className="block text-sm text-[var(--color-muted)] mb-1">Notes</label>
+        <textarea className={inputCls} rows={2} value={values.notes} onChange={set('notes')} maxLength={2000} />
+      </div>
+      <div className="flex gap-2 justify-end">
+        <button type="button" className={secondaryBtn} disabled={pending} onClick={onCancel}>
+          Cancel
+        </button>
+        <button type="submit" className={primaryBtn} disabled={pending || !values.display_name.trim()}>
+          {submitLabel}
+        </button>
+      </div>
+    </form>
+  );
+}
+
+function LinkProfilePanel({
+  contact,
+  pending,
+  onLink,
+  onUnlink,
+}: {
+  contact: ContactView;
+  pending: boolean;
+  onLink: (profileId: string) => void;
+  onUnlink: () => void;
+}) {
+  const [query, setQuery] = useState('');
+  const [results, setResults] = useState<DirectoryProfile[]>([]);
+  const [searching, setSearching] = useState(false);
+  const [searchError, setSearchError] = useState<string | null>(null);
+
+  async function doSearch() {
+    setSearching(true);
+    setSearchError(null);
+    const res = await searchDirectoryProfiles(query);
+    setSearching(false);
+    if (res.ok) setResults(res.matches);
+    else setSearchError(res.error);
+  }
+
+  return (
+    <div className="mt-4 border-t border-[var(--color-border)] pt-4 space-y-3">
+      {contact.linked_profile_id && (
+        <div className="flex items-center justify-between text-sm">
+          <span className="text-[var(--color-muted)]">
+            Linked to {contact.linked_profile_name ?? 'a profile'}.
+          </span>
+          <button type="button" className={destructiveBtn} disabled={pending} onClick={onUnlink}>
+            Unlink
+          </button>
+        </div>
+      )}
+      <div className="flex gap-2">
+        <input
+          className={inputCls}
+          placeholder="Search Lyra profiles by name…"
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter') {
+              e.preventDefault();
+              doSearch();
+            }
+          }}
+        />
+        <button type="button" className={secondaryBtn} disabled={searching || query.trim().length < 2} onClick={doSearch}>
+          {searching ? 'Searching…' : 'Search'}
+        </button>
+      </div>
+      {searchError && <p className="text-sm text-rose-700">{searchError}</p>}
+      {results.length > 0 && (
+        <ul className="space-y-2">
+          {results.map((p) => (
+            <li key={p.id} className="flex items-center justify-between text-sm">
+              <span className="text-[var(--color-ink)]">
+                {p.display_name}
+                {p.city ? <span className="text-[var(--color-muted)]"> · {p.city}</span> : null}
+              </span>
+              <button type="button" className={secondaryBtn} disabled={pending} onClick={() => onLink(p.id)}>
+                Link
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/src/app/dashboard/convene/contacts/contacts-helpers.ts
+++ b/src/app/dashboard/convene/contacts/contacts-helpers.ts
@@ -1,0 +1,96 @@
+/**
+ * KAN-304 — constants, types, and pure helpers for the Contacts/People page.
+ *
+ * Sibling to the `'use server'` actions file (Gotcha #18 / BUGS-12): anything
+ * with a runtime value (consts, classes, non-async functions) MUST live here,
+ * because a `'use server'` file may export async functions only. `export type`
+ * is fine in the action file, but these helpers + consts are imported from it.
+ */
+
+export type ContactMethodKind = 'email' | 'phone';
+
+export interface ContactMethodView {
+  id: string;
+  kind: string;
+  value: string;
+  is_primary: boolean;
+}
+
+export interface ContactView {
+  id: string;
+  display_name: string;
+  city: string | null;
+  country: string | null;
+  notes: string | null;
+  linked_profile_id: string | null;
+  linked_profile_name: string | null;
+  methods: ContactMethodView[];
+}
+
+export interface AddContactInput {
+  display_name: string;
+  email?: string;
+  phone?: string;
+  city?: string;
+  country?: string;
+  notes?: string;
+}
+
+export interface UpdateContactInput {
+  contact_id: string;
+  display_name?: string;
+  /** undefined = leave as-is; '' / null = clear the primary email method. */
+  email?: string | null;
+  phone?: string | null;
+  city?: string | null;
+  country?: string | null;
+  notes?: string | null;
+}
+
+export interface DirectoryProfile {
+  id: string;
+  display_name: string;
+  slug: string | null;
+  city: string | null;
+}
+
+export const CONTACT_LIMITS = {
+  displayName: 200,
+  email: 320,
+  phone: 40,
+  city: 120,
+  country: 120,
+  notes: 2000,
+} as const;
+
+/** Directory search: 20 lookups per user per hour (mirrors discoverability search). */
+export const DIRECTORY_SEARCH_RATE_LIMIT = { limit: 20, windowSeconds: 3600 } as const;
+
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+/** Normalise an email: trim + lowercase. Returns null if blank. */
+export function normaliseEmail(raw: string | null | undefined): string | null {
+  const v = (raw ?? '').trim().toLowerCase();
+  return v.length > 0 ? v : null;
+}
+
+/** Loose email validity check (the DB has no email format constraint). */
+export function isValidEmail(value: string): boolean {
+  return EMAIL_RE.test(value) && value.length <= CONTACT_LIMITS.email;
+}
+
+/** Normalise a phone: collapse internal whitespace, trim. Returns null if blank. */
+export function normalisePhone(raw: string | null | undefined): string | null {
+  const v = (raw ?? '').replace(/\s+/g, ' ').trim();
+  return v.length > 0 ? v : null;
+}
+
+/**
+ * Strip characters that are significant inside a PostgREST filter value so a
+ * directory `ilike` search can't be turned into an injection vector
+ * (mirrors the SEC-09 / F-06 hardening for `.or()` queries). We deliberately
+ * drop, rather than escape, these characters.
+ */
+export function sanitiseDirectoryQuery(raw: string | null | undefined): string {
+  return (raw ?? '').replace(/[%,()*\\]/g, ' ').replace(/\s+/g, ' ').trim().slice(0, 80);
+}

--- a/src/app/dashboard/convene/contacts/page.tsx
+++ b/src/app/dashboard/convene/contacts/page.tsx
@@ -1,0 +1,130 @@
+import { createClient } from '@/lib/supabase-server';
+import { redirect } from 'next/navigation';
+import Link from 'next/link';
+import Image from 'next/image';
+import { isConveneEnabled } from '@/lib/convene/flags';
+import ContactsClient from './contacts-client';
+import type { ContactView } from './contacts-helpers';
+
+export const metadata = {
+  title: 'People — Lyra',
+  description: 'Your Convene address book — the people you organise gatherings with.',
+};
+
+function NotEnabled() {
+  return (
+    <main className="min-h-screen bg-[var(--color-paper)]">
+      <header className="border-b border-[var(--color-border)] bg-white">
+        <div className="max-w-3xl mx-auto px-4 py-4 flex items-center justify-between">
+          <Link href="/dashboard" className="flex items-center">
+            <Image src="/lyra-logo.png" alt="Lyra" width={32} height={32} className="h-8 w-auto" />
+          </Link>
+          <span className="text-sm text-[var(--color-muted)]">People</span>
+        </div>
+      </header>
+      <div className="max-w-3xl mx-auto px-4 py-16 text-center">
+        <p className="text-[var(--color-muted)]">Convene is not enabled.</p>
+      </div>
+    </main>
+  );
+}
+
+interface ContactRow {
+  id: string;
+  display_name: string;
+  city: string | null;
+  country: string | null;
+  notes: string | null;
+  linked_profile_id: string | null;
+  contact_methods: { id: string; kind: string; value: string; is_primary: boolean }[] | null;
+}
+
+export default async function ContactsPage() {
+  if (!isConveneEnabled()) return <NotEnabled />;
+
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) redirect('/login?next=/dashboard/convene/contacts');
+
+  const { data: rows } = await supabase
+    .from('contacts')
+    .select('id, display_name, city, country, notes, linked_profile_id, contact_methods(id, kind, value, is_primary)')
+    .eq('owner_user_id', user.id)
+    .is('deleted_at', null)
+    .order('display_name', { ascending: true });
+
+  const contactRows = (rows ?? []) as unknown as ContactRow[];
+
+  // Resolve linked-profile display names in one follow-up query (avoids
+  // depending on the FK-embed constraint name; RLS only returns published ones).
+  const linkedIds = Array.from(
+    new Set(contactRows.map((c) => c.linked_profile_id).filter((v): v is string => !!v))
+  );
+  const nameById = new Map<string, string>();
+  if (linkedIds.length > 0) {
+    const { data: profiles } = await supabase
+      .from('profiles')
+      .select('id, display_name')
+      .in('id', linkedIds);
+    for (const p of (profiles ?? []) as { id: string; display_name: string | null }[]) {
+      if (p.display_name) nameById.set(p.id, p.display_name);
+    }
+  }
+
+  const contacts: ContactView[] = contactRows.map((c) => ({
+    id: c.id,
+    display_name: c.display_name,
+    city: c.city,
+    country: c.country,
+    notes: c.notes,
+    linked_profile_id: c.linked_profile_id,
+    linked_profile_name: c.linked_profile_id ? nameById.get(c.linked_profile_id) ?? null : null,
+    methods: (c.contact_methods ?? []).map((m) => ({
+      id: m.id,
+      kind: m.kind,
+      value: m.value,
+      is_primary: m.is_primary,
+    })),
+  }));
+
+  return (
+    <main className="min-h-screen bg-[var(--color-paper)]">
+      <header className="border-b border-[var(--color-border)] bg-white">
+        <div className="max-w-3xl mx-auto px-4 py-4 flex items-center justify-between">
+          <Link href="/dashboard" className="flex items-center">
+            <Image src="/lyra-logo.png" alt="Lyra" width={32} height={32} className="h-8 w-auto" />
+          </Link>
+          <span className="text-sm text-[var(--color-muted)]">People</span>
+        </div>
+      </header>
+
+      <div className="max-w-3xl mx-auto px-4 py-8 space-y-6">
+        <div className="flex items-start justify-between gap-4">
+          <div>
+            <h1 className="text-2xl font-medium text-[var(--color-ink)]">People</h1>
+            <p className="text-sm text-[var(--color-muted)] mt-1">
+              Your address book for Convene. Add the people you want to organise gatherings with, then
+              link them to a Lyra profile to unlock shared availability (with their consent).
+            </p>
+          </div>
+          <Link
+            href="/dashboard/convene/gatherings"
+            className="shrink-0 px-3 py-1.5 rounded-lg border border-[var(--color-border)] text-sm text-[var(--color-ink)] hover:bg-[var(--color-paper)]"
+          >
+            Gatherings →
+          </Link>
+        </div>
+
+        <ContactsClient contacts={contacts} />
+
+        <div className="pt-2">
+          <Link href="/dashboard" className="text-sm text-[var(--color-sage)] hover:underline">
+            ← Back to dashboard
+          </Link>
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -4,6 +4,7 @@ import Link from 'next/link';
 import Image from 'next/image';
 import { signOut } from '../(auth)/actions';
 import ShareProfile from './share-profile';
+import { isConveneEnabled } from '@/lib/convene/flags';
 
 export const metadata = {
   title: 'Dashboard — Lyra',
@@ -25,6 +26,10 @@ export default async function DashboardPage() {
     .eq('user_id', user.id)
     .single();
 
+  // KAN-303 — Convene nav + landing card are gated on the feature flag so they
+  // stay hidden until Convene is enabled (beta).
+  const conveneEnabled = isConveneEnabled();
+
   return (
     <main className="min-h-screen">
       <header className="border-b border-[var(--color-border)] bg-white">
@@ -36,6 +41,11 @@ export default async function DashboardPage() {
             <span className="text-sm text-[var(--color-muted)]">
               {user.email}
             </span>
+            {conveneEnabled && (
+              <Link href="/dashboard/convene/gatherings" className="text-sm text-[var(--color-muted)] hover:text-[var(--color-ink)] transition-colors">
+                Convene
+              </Link>
+            )}
             <Link href="/dashboard/settings" className="text-sm text-[var(--color-muted)] hover:text-[var(--color-ink)] transition-colors">
               Settings
             </Link>
@@ -115,6 +125,30 @@ export default async function DashboardPage() {
             />
           )}
         </div>
+
+        {conveneEnabled && (
+          <div className="bg-white rounded-xl border border-[var(--color-border)] p-6 mt-6">
+            <h3 className="text-lg font-medium text-[var(--color-ink)] mb-1">Convene</h3>
+            <p className="text-sm text-[var(--color-muted)] mb-4">
+              Organise gatherings with the people in your life — pick a time that works, suggest a
+              place, and send invites.
+            </p>
+            <div className="flex flex-wrap gap-3">
+              <Link
+                href="/dashboard/convene/gatherings"
+                className="px-4 py-2 rounded-lg bg-[var(--color-sage)] text-white text-sm font-medium hover:opacity-90 transition-opacity"
+              >
+                Your gatherings
+              </Link>
+              <Link
+                href="/dashboard/convene/contacts"
+                className="px-4 py-2 rounded-lg bg-[#f4efe7] text-[var(--color-ink)] text-sm font-medium hover:bg-[#ece7df] transition-colors"
+              >
+                People
+              </Link>
+            </div>
+          </div>
+        )}
       </div>
     </main>
   );

--- a/src/app/dashboard/profile/edit-profile-form.tsx
+++ b/src/app/dashboard/profile/edit-profile-form.tsx
@@ -186,6 +186,7 @@ export function EditProfileForm({
   files,
   conversationPrompts,
   conversationAnswers,
+  conveneEnabled = false,
 }: {
   profile: WizardProfile;
   items: WizardItem[];
@@ -195,6 +196,7 @@ export function EditProfileForm({
   files: WizardFile[];
   conversationPrompts: ConversationPrompt[];
   conversationAnswers: ConversationAnswer[];
+  conveneEnabled?: boolean;
 }) {
   const router = useRouter();
   const [isPending, startTransition] = useTransition();
@@ -262,6 +264,14 @@ export function EditProfileForm({
             <Image src="/lyra-logo.png" alt="Lyra" width={32} height={32} className="h-8 w-auto" />
           </Link>
           <div className="flex items-center gap-4">
+            {conveneEnabled && (
+              <Link
+                href="/dashboard/convene/gatherings"
+                className="text-sm text-[var(--color-muted)] hover:text-[var(--color-ink)] transition-colors"
+              >
+                Convene
+              </Link>
+            )}
             {profile.is_published && (
               <Link
                 href={`/${profile.slug}`}

--- a/src/app/dashboard/profile/page.tsx
+++ b/src/app/dashboard/profile/page.tsx
@@ -2,6 +2,7 @@ import { createClient } from '@/lib/supabase-server';
 import { redirect } from 'next/navigation';
 import { EditProfileForm } from './edit-profile-form';
 import type { ManualOfMe } from './manual-of-me-fields';
+import { isConveneEnabled } from '@/lib/convene/flags';
 
 export const metadata = {
   title: 'Edit your profile — Lyra',
@@ -102,6 +103,7 @@ export default async function ProfilePage() {
       files={files || []}
       conversationPrompts={conversationPrompts || []}
       conversationAnswers={conversationAnswers}
+      conveneEnabled={isConveneEnabled()}
     />
   );
 }

--- a/tests/unit/convene/contacts-actions.test.ts
+++ b/tests/unit/convene/contacts-actions.test.ts
@@ -1,0 +1,292 @@
+/**
+ * KAN-304 — unit tests for the Contacts/People server actions.
+ *
+ * Covers add/update/delete/link/search, auth + ownership, input validation,
+ * contact_methods reconciliation, directory-search rate limiting, and that the
+ * directory search only ever queries published profiles.
+ *
+ * Supabase (RLS client), next/cache and the rate-limiter are mocked.
+ */
+
+const mockRevalidatePath = jest.fn();
+jest.mock('next/cache', () => ({
+  revalidatePath: (...args: unknown[]) => mockRevalidatePath(...args),
+}));
+
+const mockRateLimit = jest.fn();
+jest.mock('@/lib/rate-limit', () => {
+  const actual = jest.requireActual('@/lib/rate-limit');
+  return {
+    ...actual,
+    rateLimit: (key: string, config: { limit: number; windowSeconds: number }) => mockRateLimit(key, config),
+  };
+});
+
+// ── Mutable mock state ─────────────────────────────────────
+let mockUserId: string | null = 'user-1';
+let contactInsertResult: { data: { id: string } | null; error: unknown } = {
+  data: { id: 'contact-1' },
+  error: null,
+};
+let existingContactRow: { id: string } | null = { id: 'contact-1' };
+let profileRow: { id: string; is_published: boolean } | null = { id: 'prof-1', is_published: true };
+let methodInsertError: unknown = null;
+let updateError: unknown = null;
+let dirSearchResult: { data: unknown[]; error: unknown } = {
+  data: [{ id: 'prof-1', display_name: 'Alice', slug: 'alice', city: 'London' }],
+  error: null,
+};
+
+const captured = {
+  contactInsert: [] as Record<string, unknown>[],
+  methodInsert: [] as unknown[],
+  contactUpdate: [] as Record<string, unknown>[],
+  methodDelete: [] as string[],
+  linkUpdate: [] as Record<string, unknown>[],
+  deleteUpdate: [] as Record<string, unknown>[],
+  rpcRecord: [] as unknown[],
+};
+
+function fromImpl(table: string) {
+  return {
+    insert: (rows: Record<string, unknown> | Record<string, unknown>[]) => {
+      if (table === 'contacts') {
+        captured.contactInsert.push(rows as Record<string, unknown>);
+        return { select: () => ({ single: async () => contactInsertResult }) };
+      }
+      if (table === 'contact_methods') {
+        captured.methodInsert.push(rows);
+        return Promise.resolve({ error: methodInsertError });
+      }
+      return Promise.resolve({ error: null });
+    },
+    update: (vals: Record<string, unknown>) => {
+      if (table === 'contacts') {
+        if ('deleted_at' in vals) captured.deleteUpdate.push(vals);
+        else if ('linked_profile_id' in vals) captured.linkUpdate.push(vals);
+        else captured.contactUpdate.push(vals);
+      }
+      const chain: Record<string, unknown> = {};
+      chain.eq = () => chain;
+      chain.is = () => chain;
+      chain.then = (res: (v: unknown) => unknown) => res({ error: updateError });
+      return chain;
+    },
+    delete: () => {
+      captured.methodDelete.push(table);
+      const chain: Record<string, unknown> = {};
+      chain.eq = () => chain;
+      chain.then = (res: (v: unknown) => unknown) => res({ error: null });
+      return chain;
+    },
+    select: () => {
+      const chain: Record<string, unknown> = {};
+      chain.eq = () => chain;
+      chain.is = () => chain;
+      chain.ilike = () => chain;
+      chain.in = () => chain;
+      chain.limit = async () => (table === 'profiles' ? dirSearchResult : { data: [], error: null });
+      chain.maybeSingle = async () => {
+        if (table === 'contacts') return existingContactRow ? { data: existingContactRow, error: null } : { data: null, error: null };
+        if (table === 'profiles') return profileRow ? { data: profileRow, error: null } : { data: null, error: null };
+        return { data: null, error: null };
+      };
+      chain.single = async () => contactInsertResult;
+      return chain;
+    },
+  };
+}
+
+jest.mock('@/lib/supabase-server', () => ({
+  createClient: jest.fn(async () => ({
+    auth: {
+      getUser: jest.fn().mockImplementation(() =>
+        Promise.resolve({ data: { user: mockUserId ? { id: mockUserId } : null } })
+      ),
+    },
+    from: jest.fn().mockImplementation((t: string) => fromImpl(t)),
+  })),
+}));
+
+import {
+  addContact,
+  updateContact,
+  deleteContact,
+  linkContactToProfile,
+  searchDirectoryProfiles,
+} from '@/app/dashboard/convene/contacts/actions';
+
+beforeEach(() => {
+  mockRevalidatePath.mockClear();
+  mockRateLimit.mockClear();
+  mockRateLimit.mockReturnValue({ limited: false });
+  mockUserId = 'user-1';
+  contactInsertResult = { data: { id: 'contact-1' }, error: null };
+  existingContactRow = { id: 'contact-1' };
+  profileRow = { id: 'prof-1', is_published: true };
+  methodInsertError = null;
+  updateError = null;
+  dirSearchResult = { data: [{ id: 'prof-1', display_name: 'Alice', slug: 'alice', city: 'London' }], error: null };
+  captured.contactInsert = [];
+  captured.methodInsert = [];
+  captured.contactUpdate = [];
+  captured.methodDelete = [];
+  captured.linkUpdate = [];
+  captured.deleteUpdate = [];
+});
+
+describe('addContact', () => {
+  test('adds a contact stamped with owner_user_id and creates email/phone methods', async () => {
+    const res = await addContact({ display_name: 'Bob', email: 'BOB@Example.com ', phone: '07700 900111' });
+    expect(res).toEqual({ ok: true, contactId: 'contact-1' });
+    expect(captured.contactInsert).toHaveLength(1);
+    expect(captured.contactInsert[0].owner_user_id).toBe('user-1');
+    expect(captured.contactInsert[0].display_name).toBe('Bob');
+    const methods = captured.methodInsert[0] as { kind: string; value: string }[];
+    expect(methods.find((m) => m.kind === 'email')?.value).toBe('bob@example.com'); // normalised
+    expect(methods.find((m) => m.kind === 'phone')?.value).toBe('07700 900111');
+    expect(mockRevalidatePath).toHaveBeenCalledWith('/dashboard/convene/contacts');
+  });
+
+  test('rejects an empty name', async () => {
+    const res = await addContact({ display_name: '   ' });
+    expect(res.ok).toBe(false);
+    expect(captured.contactInsert).toHaveLength(0);
+  });
+
+  test('rejects an invalid email without creating the contact', async () => {
+    const res = await addContact({ display_name: 'Bob', email: 'not-an-email' });
+    expect(res.ok).toBe(false);
+    expect(captured.contactInsert).toHaveLength(0);
+  });
+
+  test('rejects unauthenticated callers', async () => {
+    mockUserId = null;
+    const res = await addContact({ display_name: 'Bob' });
+    expect(res.ok).toBe(false);
+    expect(captured.contactInsert).toHaveLength(0);
+  });
+
+  test('a name-only contact creates no contact_methods', async () => {
+    const res = await addContact({ display_name: 'Carol' });
+    expect(res.ok).toBe(true);
+    expect(captured.methodInsert).toHaveLength(0);
+  });
+});
+
+describe('updateContact', () => {
+  test('updates scalar fields and reconciles the email method', async () => {
+    const res = await updateContact({ contact_id: 'contact-1', display_name: 'Bobby', email: 'new@example.com' });
+    expect(res).toEqual({ ok: true });
+    expect(captured.contactUpdate[0].display_name).toBe('Bobby');
+    // email reconcile = delete existing then insert new
+    expect(captured.methodDelete).toContain('contact_methods');
+    const inserted = captured.methodInsert[0] as { kind: string; value: string };
+    expect(inserted.kind).toBe('email');
+    expect(inserted.value).toBe('new@example.com');
+  });
+
+  test('clearing the email deletes the method and inserts nothing', async () => {
+    const res = await updateContact({ contact_id: 'contact-1', email: '' });
+    expect(res).toEqual({ ok: true });
+    expect(captured.methodDelete).toContain('contact_methods');
+    expect(captured.methodInsert).toHaveLength(0);
+  });
+
+  test('returns not-found when the contact does not exist / is not owned', async () => {
+    existingContactRow = null;
+    const res = await updateContact({ contact_id: 'nope', display_name: 'X' });
+    expect(res.ok).toBe(false);
+    expect(captured.contactUpdate).toHaveLength(0);
+  });
+
+  test('rejects unauthenticated callers', async () => {
+    mockUserId = null;
+    const res = await updateContact({ contact_id: 'contact-1', display_name: 'X' });
+    expect(res.ok).toBe(false);
+  });
+});
+
+describe('deleteContact', () => {
+  test('soft-deletes by setting deleted_at', async () => {
+    const res = await deleteContact('contact-1');
+    expect(res).toEqual({ ok: true });
+    expect(captured.deleteUpdate).toHaveLength(1);
+    expect(captured.deleteUpdate[0].deleted_at).toBeTruthy();
+  });
+
+  test('rejects unauthenticated callers', async () => {
+    mockUserId = null;
+    const res = await deleteContact('contact-1');
+    expect(res.ok).toBe(false);
+    expect(captured.deleteUpdate).toHaveLength(0);
+  });
+});
+
+describe('linkContactToProfile', () => {
+  test('links to a published profile after verifying it', async () => {
+    const res = await linkContactToProfile('contact-1', 'prof-1');
+    expect(res).toEqual({ ok: true });
+    expect(captured.linkUpdate[0].linked_profile_id).toBe('prof-1');
+  });
+
+  test('refuses to link to an unpublished profile', async () => {
+    profileRow = { id: 'prof-1', is_published: false };
+    const res = await linkContactToProfile('contact-1', 'prof-1');
+    expect(res.ok).toBe(false);
+    expect(captured.linkUpdate).toHaveLength(0);
+  });
+
+  test('refuses to link to a non-existent profile', async () => {
+    profileRow = null;
+    const res = await linkContactToProfile('contact-1', 'ghost');
+    expect(res.ok).toBe(false);
+    expect(captured.linkUpdate).toHaveLength(0);
+  });
+
+  test('unlink (null) clears the link without a profile lookup', async () => {
+    const res = await linkContactToProfile('contact-1', null);
+    expect(res).toEqual({ ok: true });
+    expect(captured.linkUpdate[0].linked_profile_id).toBeNull();
+  });
+
+  test('rejects unauthenticated callers', async () => {
+    mockUserId = null;
+    const res = await linkContactToProfile('contact-1', 'prof-1');
+    expect(res.ok).toBe(false);
+  });
+});
+
+describe('searchDirectoryProfiles', () => {
+  test('returns published-profile matches', async () => {
+    const res = await searchDirectoryProfiles('Ali');
+    expect(res.ok).toBe(true);
+    if (res.ok) expect(res.matches[0].display_name).toBe('Alice');
+  });
+
+  test('short queries return empty without hitting the DB or rate limiter', async () => {
+    const res = await searchDirectoryProfiles('a');
+    expect(res).toEqual({ ok: true, matches: [] });
+    expect(mockRateLimit).not.toHaveBeenCalled();
+  });
+
+  test('rate-limit blocks the search', async () => {
+    mockRateLimit.mockReturnValue({ limited: true, retryAfter: 42 });
+    const res = await searchDirectoryProfiles('Alice');
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.error).toMatch(/42/);
+  });
+
+  test('rejects unauthenticated callers', async () => {
+    mockUserId = null;
+    const res = await searchDirectoryProfiles('Alice');
+    expect(res.ok).toBe(false);
+  });
+
+  test('per-user rate-limit keyspace', async () => {
+    await searchDirectoryProfiles('Alice');
+    const [key, config] = mockRateLimit.mock.calls[0];
+    expect(key).toBe('contact-directory-search:user-1');
+    expect(config).toEqual({ limit: 20, windowSeconds: 3600 });
+  });
+});

--- a/tests/unit/convene/contacts-ui.test.ts
+++ b/tests/unit/convene/contacts-ui.test.ts
@@ -1,0 +1,84 @@
+/**
+ * KAN-304 — Contacts/People UI structural tests.
+ *
+ * Verifies the page/client/actions/helpers files exist, carry the expected
+ * feature-gate + ownership + Gotcha-#18 properties, and wire together.
+ */
+
+import fs from 'fs';
+import path from 'path';
+
+const ROOT = path.join(__dirname, '..', '..', '..');
+const base = 'src/app/dashboard/convene/contacts';
+const pagePath = path.join(ROOT, base, 'page.tsx');
+const clientPath = path.join(ROOT, base, 'contacts-client.tsx');
+const actionsPath = path.join(ROOT, base, 'actions.ts');
+const helpersPath = path.join(ROOT, base, 'contacts-helpers.ts');
+
+describe('Convene contacts UI (KAN-304)', () => {
+  test('all four files exist', () => {
+    expect(fs.existsSync(pagePath)).toBe(true);
+    expect(fs.existsSync(clientPath)).toBe(true);
+    expect(fs.existsSync(actionsPath)).toBe(true);
+    expect(fs.existsSync(helpersPath)).toBe(true);
+  });
+
+  describe('page', () => {
+    const src = fs.readFileSync(pagePath, 'utf8');
+    test('gates on isConveneEnabled', () => expect(src).toMatch(/isConveneEnabled\(\)/));
+    test('redirects unauthenticated users to /login with ?next', () =>
+      expect(src).toMatch(/redirect\(['"]\/login\?next=\/dashboard\/convene\/contacts/));
+    test('scopes the contacts query to owner_user_id', () =>
+      expect(src).toMatch(/\.eq\(['"]owner_user_id['"],\s*user\.id\)/));
+    test('excludes soft-deleted contacts', () =>
+      expect(src).toMatch(/\.is\(['"]deleted_at['"],\s*null\)/));
+  });
+
+  describe('server actions', () => {
+    const src = fs.readFileSync(actionsPath, 'utf8');
+    test("'use server' directive at top", () => expect(src).toMatch(/^['"]use server['"]/m));
+    test('exports the five actions', () => {
+      for (const fn of [
+        'addContact',
+        'updateContact',
+        'deleteContact',
+        'linkContactToProfile',
+        'searchDirectoryProfiles',
+      ]) {
+        expect(src).toMatch(new RegExp(`export async function ${fn}\\b`));
+      }
+    });
+    test('addContact stamps owner_user_id from the authed user', () =>
+      expect(src).toMatch(/owner_user_id:\s*user\.id/));
+    test('deleteContact is a soft delete (sets deleted_at)', () =>
+      expect(src).toMatch(/deleted_at:\s*new Date\(\)\.toISOString\(\)/));
+    test('linkContactToProfile verifies the profile is published', () =>
+      expect(src).toMatch(/is_published/));
+    test('directory search only queries published profiles', () =>
+      expect(src).toMatch(/\.eq\(['"]is_published['"],\s*true\)/));
+    test('exports NO non-async runtime values (Gotcha #18)', () => {
+      expect(src).not.toMatch(/export const /);
+      expect(src).not.toMatch(/export function (?!async)/);
+    });
+  });
+
+  describe('helpers (sibling module)', () => {
+    const src = fs.readFileSync(helpersPath, 'utf8');
+    test('is NOT a use-server file', () => expect(src).not.toMatch(/^['"]use server['"]/m));
+    test('exports runtime constants/helpers', () => {
+      expect(src).toMatch(/export const CONTACT_LIMITS/);
+      expect(src).toMatch(/export function normaliseEmail/);
+      expect(src).toMatch(/export function sanitiseDirectoryQuery/);
+    });
+  });
+
+  describe('client island', () => {
+    const src = fs.readFileSync(clientPath, 'utf8');
+    test("'use client' directive at top", () => expect(src).toMatch(/^['"]use client['"]/m));
+    test('imports the contact actions', () =>
+      expect(src).toMatch(/from ['"]\.\/actions['"]/));
+    test('offers an Organise entry point per contact', () =>
+      expect(src).toMatch(/\/dashboard\/convene\/organise\?contact=/));
+    test('confirms before deleting', () => expect(src).toMatch(/confirm\(/));
+  });
+});

--- a/tests/unit/convene/convene-nav.test.ts
+++ b/tests/unit/convene/convene-nav.test.ts
@@ -1,0 +1,48 @@
+/**
+ * KAN-303 — Convene navigation entry points are feature-flag gated.
+ *
+ * Structural assertions that the dashboard header + landing card and the
+ * profile-page header only surface the Convene link behind isConveneEnabled().
+ */
+
+import fs from 'fs';
+import path from 'path';
+
+const ROOT = path.join(__dirname, '..', '..', '..');
+const dashboardPath = path.join(ROOT, 'src/app/dashboard/page.tsx');
+const profileFormPath = path.join(ROOT, 'src/app/dashboard/profile/edit-profile-form.tsx');
+const profilePagePath = path.join(ROOT, 'src/app/dashboard/profile/page.tsx');
+
+describe('Convene nav entry points (KAN-303)', () => {
+  describe('dashboard page', () => {
+    const src = fs.readFileSync(dashboardPath, 'utf8');
+    test('imports the convene flag', () =>
+      expect(src).toMatch(/import \{ isConveneEnabled \} from ['"]@\/lib\/convene\/flags['"]/));
+    test('computes conveneEnabled from the flag', () =>
+      expect(src).toMatch(/const conveneEnabled = isConveneEnabled\(\)/));
+    test('gates the header Convene link on the flag', () => {
+      expect(src).toMatch(/conveneEnabled &&[\s\S]{0,200}\/dashboard\/convene\/gatherings/);
+    });
+    test('gates a landing card on the flag and links to People', () => {
+      expect(src).toMatch(/\/dashboard\/convene\/contacts/);
+      // Both the header link and the landing card are wrapped in `conveneEnabled &&`.
+      expect((src.match(/conveneEnabled &&/g) || []).length).toBeGreaterThanOrEqual(2);
+    });
+  });
+
+  describe('profile editor header', () => {
+    const src = fs.readFileSync(profileFormPath, 'utf8');
+    test('accepts a conveneEnabled prop (default false)', () =>
+      expect(src).toMatch(/conveneEnabled\s*=\s*false/));
+    test('declares conveneEnabled in the props type', () =>
+      expect(src).toMatch(/conveneEnabled\?:\s*boolean/));
+    test('renders the Convene link only when the flag is on', () =>
+      expect(src).toMatch(/conveneEnabled &&[\s\S]{0,200}\/dashboard\/convene\/gatherings/));
+  });
+
+  describe('profile page wiring', () => {
+    const src = fs.readFileSync(profilePagePath, 'utf8');
+    test('passes the live flag value into the editor', () =>
+      expect(src).toMatch(/conveneEnabled=\{isConveneEnabled\(\)\}/));
+  });
+});


### PR DESCRIPTION
Part of epic **[KAN-302](https://checklyra.atlassian.net/browse/KAN-302)** — the host GUI for Convene Beta. All UI is gated on `isConveneEnabled()` so nothing renders until the flag is on (beta).

## KAN-303 — navigation + entry point
- `src/app/dashboard/page.tsx`: a **Convene** header link + a landing card (Gatherings / People), both `conveneEnabled`-gated.
- `src/app/dashboard/profile/edit-profile-form.tsx`: header link behind an **optional** `conveneEnabled` prop (default `false` → existing call sites/tests unaffected), wired from `profile/page.tsx`.

## KAN-304 — Contacts/People page (`src/app/dashboard/convene/contacts/`)
- `page.tsx` — flag-gated, owner-scoped contacts fetch (`+ contact_methods`, resolves linked-profile names).
- `contacts-client.tsx` — add / edit / delete contacts, link-to-profile via directory search, per-contact **Organise →** entry point.
- `actions.ts` (`'use server'`, RLS client — owner-scoped by RLS, no service-role): `addContact`, `updateContact`, `deleteContact` (soft), `linkContactToProfile`, `searchDirectoryProfiles` (published-only, rate-limited 20/h, PostgREST-sanitised).
- `contacts-helpers.ts` — sibling module for consts/types/pure helpers (Gotcha #18; the action file exports async functions only).

## Tests
Behavioural action suite (`contacts-actions.test.ts`) + structural UI/nav suites. Convene dir now **17 suites / 285 tests**, all green. `tsc` + `eslint` clean.

## MCP coverage (KAN-222 lockstep)
Satisfied by **KAN-307** (`lyra_add_contact`, `lyra_create_tribe`, `lyra_add_contact_to_tribe`, `lyra_link_contact_profile`) — [lyra-mcp-server#75](https://github.com/luisa-sys/lyra-mcp-server/pull/75), already merged to `main` and deployed to MCP (`build_sha 940f4ee`). Deploy order honoured: MCP first, then this web PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[KAN-302]: https://checklyra.atlassian.net/browse/KAN-302?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ