### PR TITLE
test(BUGS-28): regression guard for oauth_connections secret-column lockdown

### DIFF
--- a/tests/unit/convene/oauth-secret-guard-migration.test.ts
+++ b/tests/unit/convene/oauth-secret-guard-migration.test.ts
@@ -1,0 +1,65 @@
+/**
+ * SEC-06 / BUGS-28 — regression guard for the oauth_connections secret-column
+ * lockdown migration.
+ *
+ * The migration installs a BEFORE INSERT/UPDATE trigger that blocks
+ * authenticated/anon clients from inserting connection rows or rewriting the
+ * Vault token-reference columns (refresh_token_secret_id /
+ * access_token_secret_id) — while still allowing the service-role OAuth
+ * callback and the authenticated disconnect (deleted_at/status) flow.
+ *
+ * This test pins the migration's content so the protection can't be silently
+ * weakened. (Applied live across dev/staging/prod via the Supabase MCP on
+ * 2026-06-21; the trigger function is byte-identical across all three.)
+ */
+
+import fs from 'fs';
+import path from 'path';
+
+const MIGRATION = path.join(
+  __dirname,
+  '..',
+  '..',
+  '..',
+  'supabase',
+  'migrations',
+  '20260621120000_sec06_oauth_connections_secret_columns_lockdown.sql'
+);
+
+describe('SEC-06 / BUGS-28 oauth_connections secret-column guard', () => {
+  test('migration file exists', () => {
+    expect(fs.existsSync(MIGRATION)).toBe(true);
+  });
+
+  const sql = fs.existsSync(MIGRATION) ? fs.readFileSync(MIGRATION, 'utf8') : '';
+
+  test('defines the guard function with a pinned search_path', () => {
+    expect(sql).toMatch(/create or replace function public\.oauth_connections_guard_secret_cols/);
+    expect(sql).toMatch(/set search_path = ''/);
+  });
+
+  test('exempts the service-role backend only', () => {
+    expect(sql).toMatch(/auth\.role\(\)\s*=\s*'service_role'/);
+  });
+
+  test('blocks authenticated/anon INSERTs (service-role only)', () => {
+    expect(sql).toMatch(/tg_op\s*=\s*'INSERT'/);
+    expect(sql).toMatch(/inserts are service-role only/i);
+  });
+
+  test('blocks changing either Vault token-secret column', () => {
+    expect(sql).toMatch(/refresh_token_secret_id is distinct from old\.refresh_token_secret_id/);
+    expect(sql).toMatch(/access_token_secret_id is distinct from old\.access_token_secret_id/);
+    expect(sql).toMatch(/token-secret columns are service-role only/i);
+  });
+
+  test('wires the guard as a BEFORE INSERT OR UPDATE row trigger', () => {
+    expect(sql).toMatch(
+      /create trigger oauth_connections_guard_secret_cols\s+before insert or update on public\.oauth_connections\s+for each row/
+    );
+  });
+
+  test('documents a rollback path', () => {
+    expect(sql).toMatch(/drop trigger if exists oauth_connections_guard_secret_cols/);
+  });
+});


### PR DESCRIPTION
**[BUGS-28](https://checklyra.atlassian.net/browse/BUGS-28) / SEC-06** — Convene security gate for the KAN-302 beta launch.

The secret-column guard migration (`20260621120000_sec06_oauth_connections_secret_columns_lockdown.sql`, BEFORE INSERT/UPDATE trigger `oauth_connections_guard_secret_cols`) was authored in an earlier security pass but had only been applied to **dev**. This session:

- Applied it to **staging** and **prod** via the Supabase MCP (both had the exploitable grants).
- Harmonised **dev**'s function so the trigger is **byte-identical across all three envs** (`pg_get_functiondef` md5 `6fb31c1f…`).
- Verified the trigger is present on dev/staging/prod.

The trigger blocks `authenticated`/`anon` from inserting `oauth_connections` rows or rewriting the Vault token-reference columns (`refresh_token_secret_id` / `access_token_secret_id`), while still allowing the service-role OAuth callback and the authenticated disconnect (`deleted_at`/`status`) flow. Prod has 0 connection rows, so there was no data impact.

This PR adds the **regression test** that pins the migration content so the protection can't be silently weakened (no test existed). Migration file itself is already on `develop`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[BUGS-28]: https://checklyra.atlassian.net/browse/BUGS-28?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ