### PR TITLE
feat(KAN-305): Convene organise-event wizard

### DIFF
--- a/src/app/dashboard/convene/organise/actions.ts
+++ b/src/app/dashboard/convene/organise/actions.ts
@@ -1,0 +1,262 @@
+'use server';
+
+/**
+ * KAN-305 — Organise-event wizard server actions.
+ *
+ *   createGatheringDraft — ports the lyra_create_gathering insert sequence
+ *     (gatherings → proposed_slots → invitees → events_log) into the web app.
+ *     Uses the service-role client (like gatherings/[id]/actions.ts) because it
+ *     appends to the append-only audit log; every write is host-scoped with an
+ *     `// ownership-ok:` comment (the static CI guard requires it).
+ *   getHostBusyTimes — the host's own Google free/busy for a window, so the
+ *     wizard can suggest a free slot. Multi-attendee shared availability is the
+ *     consent-gated MCP path (lyra_get_shared_availability, SEC-18).
+ *   suggestVenues — ranks the shared `venues` catalogue with the existing
+ *     scoreVenue engine.
+ *
+ * MCP parity (KAN-222): the agent equivalents already exist —
+ * lyra_create_gathering, lyra_get_shared_availability, lyra_suggest_venues,
+ * lyra_propose_attendees, lyra_finalise_gathering. No new MCP tools needed.
+ */
+
+import { createClient } from '@/lib/supabase-server';
+import { createClient as createSupabaseAdmin } from '@supabase/supabase-js';
+import { env } from '@/lib/env';
+import { moderateAndAudit } from '@/lib/moderation-audit';
+import { scoreVenue } from '@/lib/recommend/convene/score-venue';
+import type { VenueCandidate, VenueContext } from '@/lib/recommend/convene/types';
+import { adapterFor } from '@/lib/convene/calendar';
+import { getConnectionForUser } from '@/lib/convene/oauth-connections';
+import {
+  MAX_PROPOSED_SLOTS,
+  MAX_ATTENDEES,
+  MAX_AVAILABILITY_WINDOW_DAYS,
+  DRAFT_LIMITS,
+  isGatheringType,
+  toNum,
+  type CreateDraftInput,
+  type BusyBlockView,
+  type VenueSuggestion,
+  type VenueSuggestContext,
+} from './organise-fields';
+
+function admin() {
+  return createSupabaseAdmin(env.supabaseUrl(), env.supabaseServiceRoleKey(), {
+    auth: { persistSession: false },
+  });
+}
+
+async function authed() {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  return { supabase, user };
+}
+
+export async function createGatheringDraft(
+  input: CreateDraftInput
+): Promise<{ ok: true; gatheringId: string } | { ok: false; error: string }> {
+  const { supabase, user } = await authed();
+  if (!user) return { ok: false, error: 'Not authenticated' };
+  const userId = user.id;
+
+  const title = (input.title ?? '').trim();
+  if (!title) return { ok: false, error: 'Give your gathering a title' };
+  if (title.length > DRAFT_LIMITS.title) return { ok: false, error: 'That title is too long' };
+  if (!isGatheringType(input.gathering_type)) return { ok: false, error: 'Pick a gathering type' };
+  if (input.capacity_min != null && input.capacity_max != null && input.capacity_max < input.capacity_min) {
+    return { ok: false, error: 'Maximum capacity must be at least the minimum' };
+  }
+
+  const slots = (input.proposed_slots ?? []).slice(0, MAX_PROPOSED_SLOTS);
+  for (const s of slots) {
+    const a = new Date(s.slot_start_iso);
+    const b = new Date(s.slot_end_iso);
+    if (Number.isNaN(a.getTime()) || Number.isNaN(b.getTime())) return { ok: false, error: 'A proposed time is invalid' };
+    if (b <= a) return { ok: false, error: 'Each proposed time must end after it starts' };
+  }
+
+  const contactIds = Array.from(new Set(input.invitee_contact_ids ?? [])).slice(0, MAX_ATTENDEES);
+  if (contactIds.length > 0) {
+    // Service-role bypasses RLS, so confirm the host owns every invitee contact.
+    // ownership-ok: verifying owner_user_id ownership of each invitee contact (KAN-305)
+    const { data: owned } = await supabase
+      .from('contacts')
+      .select('id')
+      .in('id', contactIds)
+      .is('deleted_at', null);
+    const ownedIds = new Set((owned ?? []).map((c) => c.id));
+    if (contactIds.some((id) => !ownedIds.has(id))) {
+      return { ok: false, error: 'One or more selected contacts could not be found' };
+    }
+  }
+
+  // Content moderation on free text (public: title/description/dietary; private: notes).
+  const modFields: Array<[string | null | undefined, 'public' | 'private', string]> = [
+    [title, 'public', 'gatherings.title'],
+    [input.description, 'public', 'gatherings.description'],
+    [input.dietary_summary, 'public', 'gatherings.dietary_summary'],
+    [input.notes, 'private', 'gatherings.notes'],
+  ];
+  for (const [text, fieldType, field] of modFields) {
+    if (text == null || text === '') continue;
+    const mod = await moderateAndAudit(supabase, { text, fieldType, field, profileId: null, source: 'web_app' });
+    if (!mod.ok) return { ok: false, error: mod.error };
+  }
+
+  const sb = admin();
+  // ownership-ok: insert stamps host_user_id = authed user (KAN-305)
+  const { data: gathering, error: insErr } = await sb
+    .from('gatherings')
+    .insert({
+      host_user_id: userId,
+      title,
+      description: (input.description ?? '').trim() || null,
+      gathering_type: input.gathering_type,
+      status: 'draft',
+      target_window_start: input.target_window_start_iso ?? null,
+      target_window_end: input.target_window_end_iso ?? null,
+      capacity_min: input.capacity_min ?? null,
+      capacity_max: input.capacity_max ?? null,
+      dietary_summary: (input.dietary_summary ?? '').trim() || null,
+      notes: (input.notes ?? '').trim() || null,
+    })
+    .select('id')
+    .single();
+  if (insErr || !gathering) return { ok: false, error: 'Could not create the gathering' };
+
+  if (slots.length > 0) {
+    // ownership-ok: slots attach to the gathering just created for this host (KAN-305)
+    const { error } = await sb.from('gathering_proposed_slots').insert(
+      slots.map((s) => ({ gathering_id: gathering.id, slot_start: s.slot_start_iso, slot_end: s.slot_end_iso }))
+    );
+    if (error) return { ok: false, error: 'Saved the gathering, but adding the times failed' };
+  }
+
+  if (contactIds.length > 0) {
+    // ownership-ok: gathering owned by host; DB trigger enforces host owns each contact (KAN-305)
+    const { error } = await sb.from('gathering_invitees').insert(
+      contactIds.map((cid) => ({ gathering_id: gathering.id, contact_id: cid, status: 'invited' }))
+    );
+    if (error) return { ok: false, error: 'Saved the gathering, but adding the people failed' };
+  }
+
+  // ownership-ok: audit row for the gathering this host just created (KAN-305)
+  await sb.from('gathering_events_log').insert({
+    gathering_id: gathering.id,
+    actor_user_id: userId,
+    event_type: 'gathering_created',
+    subject_kind: 'gathering',
+    subject_id: gathering.id,
+    metadata: {
+      title,
+      type: input.gathering_type,
+      proposed_slot_count: slots.length,
+      invitee_count: contactIds.length,
+      source: 'web_organise_wizard',
+    },
+  });
+
+  return { ok: true, gatheringId: gathering.id };
+}
+
+export async function getHostBusyTimes(
+  windowStartISO: string,
+  windowEndISO: string
+): Promise<{ ok: true; connected: boolean; busy: BusyBlockView[]; note?: string } | { ok: false; error: string }> {
+  const { user } = await authed();
+  if (!user) return { ok: false, error: 'Not authenticated' };
+
+  const start = new Date(windowStartISO);
+  const end = new Date(windowEndISO);
+  if (Number.isNaN(start.getTime()) || Number.isNaN(end.getTime()) || end <= start) {
+    return { ok: false, error: 'Pick a valid date range' };
+  }
+  if (end.getTime() - start.getTime() > MAX_AVAILABILITY_WINDOW_DAYS * 86_400_000) {
+    return { ok: false, error: `Pick a window of ${MAX_AVAILABILITY_WINDOW_DAYS} days or less` };
+  }
+
+  const connection = await getConnectionForUser(user.id, 'google');
+  if (!connection) {
+    return {
+      ok: true,
+      connected: false,
+      busy: [],
+      note: 'Connect a Google calendar under Calendar connections to see your busy times here.',
+    };
+  }
+
+  try {
+    const adapter = adapterFor('google');
+    const busy = await adapter.getFreeBusy(connection.id, { start, end });
+    return { ok: true, connected: true, busy: busy.map((b) => ({ start: b.start, end: b.end })) };
+  } catch (e) {
+    return { ok: false, error: e instanceof Error ? e.message : 'Could not read your calendar' };
+  }
+}
+
+export async function suggestVenues(
+  context: VenueSuggestContext
+): Promise<{ ok: true; venues: VenueSuggestion[] } | { ok: false; error: string }> {
+  const { supabase, user } = await authed();
+  if (!user) return { ok: false, error: 'Not authenticated' };
+  if (!isGatheringType(context.intent)) return { ok: false, error: 'Pick a gathering type first' };
+
+  // `venues` is a shared catalogue: any authenticated user may SELECT; writes
+  // are service-role only (populated by lyra_suggest_venues via Google Places).
+  let q = supabase
+    .from('venues')
+    .select(
+      'id, name, venue_type, city, postcode, lat, lng, price_tier, capacity_estimate, accessibility_flags, dietary_flags, external_rating'
+    )
+    .limit(50);
+  const anchor = (context.anchor ?? '').trim();
+  if (anchor && !anchor.includes(',')) {
+    const cityToken = anchor.replace(/[%,()*\\]/g, '').trim();
+    if (cityToken.length >= 2) q = q.ilike('city', `%${cityToken}%`);
+  }
+
+  const { data, error } = await q;
+  if (error) return { ok: false, error: 'Could not load venues' };
+
+  const ctx: VenueContext = {
+    intent: context.intent,
+    anchor: context.anchor ?? null,
+    capacityRequired: context.capacityRequired ?? 0,
+    required: {},
+    preferred: {},
+  };
+
+  const ranked = (data ?? [])
+    .map((v) => {
+      const candidate: VenueCandidate = {
+        venueId: v.id,
+        name: v.name,
+        venueType: v.venue_type,
+        city: v.city,
+        postcode: v.postcode,
+        lat: toNum(v.lat),
+        lng: toNum(v.lng),
+        priceTier: toNum(v.price_tier),
+        capacityEstimate: toNum(v.capacity_estimate),
+        accessibilityFlags: (v.accessibility_flags ?? []) as string[],
+        dietaryFlags: (v.dietary_flags ?? []) as string[],
+        externalRating: toNum(v.external_rating),
+      };
+      return { candidate, score: scoreVenue(candidate, ctx) };
+    })
+    .filter((x) => !x.score.hardFilterFailed)
+    .sort((a, b) => b.score.score - a.score.score)
+    .slice(0, 8)
+    .map(({ candidate, score }) => ({
+      venueId: candidate.venueId,
+      name: candidate.name,
+      venueType: candidate.venueType,
+      city: candidate.city,
+      score: score.score,
+      reasons: score.reasons.slice(0, 3),
+    }));
+
+  return { ok: true, venues: ranked };
+}

--- a/src/app/dashboard/convene/organise/organise-fields.ts
+++ b/src/app/dashboard/convene/organise/organise-fields.ts
@@ -1,0 +1,92 @@
+/**
+ * KAN-305 — constants, types and pure helpers for the Organise-event wizard.
+ *
+ * Sibling to the `'use server'` actions file (Gotcha #18): runtime values live
+ * here so the action file can export async functions only.
+ */
+
+import type { GatheringType } from '@/lib/recommend/convene/types';
+
+export const GATHERING_TYPES: GatheringType[] = [
+  'coffee',
+  'lunch',
+  'dinner',
+  'drinks',
+  'party',
+  'kids_party',
+  'meeting',
+  'date',
+  'walk',
+  'cinema',
+  'other',
+];
+
+export const GATHERING_TYPE_LABELS: Record<GatheringType, string> = {
+  coffee: 'Coffee',
+  lunch: 'Lunch',
+  dinner: 'Dinner',
+  drinks: 'Drinks',
+  party: 'Party',
+  kids_party: "Kids' party",
+  meeting: 'Meeting',
+  date: 'Date',
+  walk: 'Walk',
+  cinema: 'Cinema',
+  other: 'Other',
+};
+
+export const MAX_PROPOSED_SLOTS = 10;
+export const MAX_ATTENDEES = 30;
+export const MAX_AVAILABILITY_WINDOW_DAYS = 14;
+
+export const DRAFT_LIMITS = { title: 200, description: 2000, dietary: 500, notes: 2000 } as const;
+
+export interface ProposedSlotInput {
+  slot_start_iso: string;
+  slot_end_iso: string;
+}
+
+export interface CreateDraftInput {
+  title: string;
+  gathering_type: GatheringType;
+  description?: string;
+  invitee_contact_ids: string[];
+  proposed_slots: ProposedSlotInput[];
+  target_window_start_iso?: string;
+  target_window_end_iso?: string;
+  capacity_min?: number;
+  capacity_max?: number;
+  dietary_summary?: string;
+  notes?: string;
+}
+
+export interface BusyBlockView {
+  start: string;
+  end: string;
+}
+
+export interface VenueSuggestion {
+  venueId: string;
+  name: string;
+  venueType: string;
+  city: string | null;
+  score: number;
+  reasons: string[];
+}
+
+export interface VenueSuggestContext {
+  intent: GatheringType;
+  anchor?: string | null;
+  capacityRequired?: number;
+}
+
+export function isGatheringType(v: string): v is GatheringType {
+  return (GATHERING_TYPES as string[]).includes(v);
+}
+
+/** Coerce a Postgres numeric (which PostgREST may return as a string) to number|null. */
+export function toNum(v: unknown): number | null {
+  if (v === null || v === undefined || v === '') return null;
+  const n = Number(v);
+  return Number.isFinite(n) ? n : null;
+}

--- a/src/app/dashboard/convene/organise/organise-wizard.tsx
+++ b/src/app/dashboard/convene/organise/organise-wizard.tsx
@@ -1,0 +1,384 @@
+'use client';
+
+/**
+ * KAN-305 — Organise-event wizard client island.
+ *
+ * Steps: people → details → time → venue → create. Produces a draft gathering
+ * via createGatheringDraft, then routes to its detail page (where the host
+ * finalises a slot + venue and sends invites — KAN-306). Venue is advisory
+ * here (the draft has no venue until finalise); the wizard ranks the shared
+ * catalogue with the real scoreVenue engine.
+ */
+
+import { useState, useTransition } from 'react';
+import { useRouter } from 'next/navigation';
+import { createGatheringDraft, getHostBusyTimes, suggestVenues } from './actions';
+import {
+  GATHERING_TYPES,
+  GATHERING_TYPE_LABELS,
+  MAX_PROPOSED_SLOTS,
+  type BusyBlockView,
+  type ProposedSlotInput,
+  type VenueSuggestion,
+} from './organise-fields';
+import type { GatheringType } from '@/lib/recommend/convene/types';
+import type { WizardContact } from './page';
+
+const inputCls =
+  'w-full px-3 py-2 rounded-lg border border-[var(--color-border)] text-sm text-[var(--color-ink)] bg-white focus:outline-none focus:ring-1 focus:ring-[var(--color-sage)]';
+const primaryBtn =
+  'px-4 py-2 rounded-lg bg-[var(--color-sage)] text-white text-sm font-medium hover:opacity-90 disabled:opacity-50';
+const secondaryBtn =
+  'px-3 py-1.5 rounded-lg border border-[var(--color-border)] text-sm text-[var(--color-ink)] hover:bg-[var(--color-paper)] disabled:opacity-50';
+
+const STEPS = ['People', 'Details', 'Time', 'Venue', 'Create'];
+
+function localToISO(local: string): string | null {
+  if (!local) return null;
+  const d = new Date(local);
+  return Number.isNaN(d.getTime()) ? null : d.toISOString();
+}
+function fmt(iso: string): string {
+  return new Date(iso).toLocaleString('en-GB', { dateStyle: 'medium', timeStyle: 'short' });
+}
+
+interface SlotDraft {
+  start: string; // datetime-local
+  end: string;
+}
+
+export default function OrganiseWizard({
+  contacts,
+  preselectId,
+}: {
+  contacts: WizardContact[];
+  preselectId: string | null;
+}) {
+  const router = useRouter();
+  const [pending, startTransition] = useTransition();
+  const [step, setStep] = useState(0);
+  const [error, setError] = useState<string | null>(null);
+
+  // Step 1 — people
+  const [selected, setSelected] = useState<Set<string>>(
+    () => new Set(preselectId ? [preselectId] : [])
+  );
+
+  // Step 2 — details
+  const [title, setTitle] = useState('');
+  const [type, setType] = useState<GatheringType>('coffee');
+  const [description, setDescription] = useState('');
+  const [capacityMax, setCapacityMax] = useState('');
+  const [dietary, setDietary] = useState('');
+  const [notes, setNotes] = useState('');
+
+  // Step 3 — time
+  const [windowStart, setWindowStart] = useState('');
+  const [windowEnd, setWindowEnd] = useState('');
+  const [busy, setBusy] = useState<BusyBlockView[] | null>(null);
+  const [busyNote, setBusyNote] = useState<string | null>(null);
+  const [busyLoading, setBusyLoading] = useState(false);
+  const [slots, setSlots] = useState<SlotDraft[]>([{ start: '', end: '' }]);
+
+  // Step 4 — venue
+  const [venues, setVenues] = useState<VenueSuggestion[] | null>(null);
+  const [venueLoading, setVenueLoading] = useState(false);
+
+  function toggle(id: string) {
+    setSelected((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  }
+
+  async function checkCalendar() {
+    setError(null);
+    const s = localToISO(windowStart);
+    const e = localToISO(windowEnd);
+    if (!s || !e) {
+      setError('Pick a start and end for the window first.');
+      return;
+    }
+    setBusyLoading(true);
+    setBusy(null);
+    setBusyNote(null);
+    const res = await getHostBusyTimes(s, e);
+    setBusyLoading(false);
+    if (res.ok) {
+      setBusy(res.busy);
+      if (res.note) setBusyNote(res.note);
+    } else {
+      setError(res.error);
+    }
+  }
+
+  async function loadVenues() {
+    setError(null);
+    setVenueLoading(true);
+    const anchor = contacts.find((c) => selected.has(c.id))?.city ?? null;
+    const res = await suggestVenues({ intent: type, anchor, capacityRequired: selected.size });
+    setVenueLoading(false);
+    if (res.ok) setVenues(res.venues);
+    else setError(res.error);
+  }
+
+  function create() {
+    setError(null);
+    const proposed: ProposedSlotInput[] = [];
+    for (const s of slots) {
+      if (!s.start && !s.end) continue;
+      const startIso = localToISO(s.start);
+      const endIso = localToISO(s.end);
+      if (!startIso || !endIso) {
+        setError('One of your proposed times is incomplete.');
+        return;
+      }
+      proposed.push({ slot_start_iso: startIso, slot_end_iso: endIso });
+    }
+    startTransition(async () => {
+      const res = await createGatheringDraft({
+        title: title.trim(),
+        gathering_type: type,
+        description: description.trim() || undefined,
+        invitee_contact_ids: Array.from(selected),
+        proposed_slots: proposed.slice(0, MAX_PROPOSED_SLOTS),
+        target_window_start_iso: localToISO(windowStart) ?? undefined,
+        target_window_end_iso: localToISO(windowEnd) ?? undefined,
+        capacity_max: capacityMax ? Number(capacityMax) : undefined,
+        dietary_summary: dietary.trim() || undefined,
+        notes: notes.trim() || undefined,
+      });
+      if (res.ok) router.push(`/dashboard/convene/gatherings/${res.gatheringId}`);
+      else setError(res.error);
+    });
+  }
+
+  const canCreate = title.trim().length > 0;
+
+  return (
+    <div className="space-y-4">
+      <ol className="flex flex-wrap gap-2 text-xs">
+        {STEPS.map((label, i) => (
+          <li
+            key={label}
+            className={`px-2 py-1 rounded-md border ${
+              i === step
+                ? 'bg-[var(--color-sage)] text-white border-[var(--color-sage)]'
+                : 'border-[var(--color-border)] text-[var(--color-muted)]'
+            }`}
+          >
+            {i + 1}. {label}
+          </li>
+        ))}
+      </ol>
+
+      {error && (
+        <div className="bg-rose-50 border border-rose-200 rounded-lg px-4 py-3 text-sm text-rose-900">{error}</div>
+      )}
+
+      <div className="bg-white rounded-xl border border-[var(--color-border)] p-5 space-y-4">
+        {step === 0 && (
+          <div className="space-y-3">
+            <h2 className="font-medium text-[var(--color-ink)]">Who would you like to invite?</h2>
+            <ul className="space-y-2 max-h-80 overflow-auto">
+              {contacts.map((c) => (
+                <li key={c.id}>
+                  <label className="flex items-center gap-3 cursor-pointer">
+                    <input type="checkbox" checked={selected.has(c.id)} onChange={() => toggle(c.id)} />
+                    <span className="text-sm text-[var(--color-ink)]">{c.display_name}</span>
+                    {c.city && <span className="text-xs text-[var(--color-muted)]">· {c.city}</span>}
+                    {c.has_linked_profile && (
+                      <span className="text-xs text-[var(--color-muted)]">🔗</span>
+                    )}
+                  </label>
+                </li>
+              ))}
+            </ul>
+            <p className="text-xs text-[var(--color-muted)]">{selected.size} selected</p>
+          </div>
+        )}
+
+        {step === 1 && (
+          <div className="space-y-3">
+            <h2 className="font-medium text-[var(--color-ink)]">What’s the plan?</h2>
+            <div>
+              <label className="block text-sm text-[var(--color-muted)] mb-1">Title *</label>
+              <input className={inputCls} value={title} onChange={(e) => setTitle(e.target.value)} maxLength={200} />
+            </div>
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+              <div>
+                <label className="block text-sm text-[var(--color-muted)] mb-1">Type</label>
+                <select className={inputCls} value={type} onChange={(e) => setType(e.target.value as GatheringType)}>
+                  {GATHERING_TYPES.map((t) => (
+                    <option key={t} value={t}>
+                      {GATHERING_TYPE_LABELS[t]}
+                    </option>
+                  ))}
+                </select>
+              </div>
+              <div>
+                <label className="block text-sm text-[var(--color-muted)] mb-1">Max people (optional)</label>
+                <input
+                  className={inputCls}
+                  type="number"
+                  min={0}
+                  value={capacityMax}
+                  onChange={(e) => setCapacityMax(e.target.value)}
+                />
+              </div>
+            </div>
+            <div>
+              <label className="block text-sm text-[var(--color-muted)] mb-1">Description (optional)</label>
+              <textarea className={inputCls} rows={2} value={description} onChange={(e) => setDescription(e.target.value)} maxLength={2000} />
+            </div>
+            <div>
+              <label className="block text-sm text-[var(--color-muted)] mb-1">Dietary notes (optional)</label>
+              <input className={inputCls} value={dietary} onChange={(e) => setDietary(e.target.value)} maxLength={500} />
+            </div>
+            <div>
+              <label className="block text-sm text-[var(--color-muted)] mb-1">Private notes (optional)</label>
+              <textarea className={inputCls} rows={2} value={notes} onChange={(e) => setNotes(e.target.value)} maxLength={2000} />
+            </div>
+          </div>
+        )}
+
+        {step === 2 && (
+          <div className="space-y-3">
+            <h2 className="font-medium text-[var(--color-ink)]">When works?</h2>
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+              <div>
+                <label className="block text-sm text-[var(--color-muted)] mb-1">Window from</label>
+                <input className={inputCls} type="datetime-local" value={windowStart} onChange={(e) => setWindowStart(e.target.value)} />
+              </div>
+              <div>
+                <label className="block text-sm text-[var(--color-muted)] mb-1">Window to</label>
+                <input className={inputCls} type="datetime-local" value={windowEnd} onChange={(e) => setWindowEnd(e.target.value)} />
+              </div>
+            </div>
+            <button type="button" className={secondaryBtn} disabled={busyLoading} onClick={checkCalendar}>
+              {busyLoading ? 'Checking…' : 'Check my calendar'}
+            </button>
+            {busyNote && <p className="text-xs text-[var(--color-muted)]">{busyNote}</p>}
+            {busy && busy.length > 0 && (
+              <div className="text-xs text-[var(--color-muted)]">
+                <p className="mb-1">You’re busy during:</p>
+                <ul className="space-y-0.5">
+                  {busy.slice(0, 12).map((b, i) => (
+                    <li key={i}>
+                      {fmt(b.start)} – {fmt(b.end)}
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            )}
+            {busy && busy.length === 0 && <p className="text-xs text-[var(--color-muted)]">No busy times in that window.</p>}
+
+            <div className="space-y-2 pt-2 border-t border-[var(--color-border)]">
+              <p className="text-sm text-[var(--color-muted)]">Propose one or more times:</p>
+              {slots.map((s, i) => (
+                <div key={i} className="flex flex-wrap items-end gap-2">
+                  <input
+                    className={inputCls + ' max-w-[14rem]'}
+                    type="datetime-local"
+                    value={s.start}
+                    onChange={(e) => setSlots((prev) => prev.map((p, j) => (j === i ? { ...p, start: e.target.value } : p)))}
+                  />
+                  <span className="text-[var(--color-muted)]">→</span>
+                  <input
+                    className={inputCls + ' max-w-[14rem]'}
+                    type="datetime-local"
+                    value={s.end}
+                    onChange={(e) => setSlots((prev) => prev.map((p, j) => (j === i ? { ...p, end: e.target.value } : p)))}
+                  />
+                  {slots.length > 1 && (
+                    <button type="button" className={secondaryBtn} onClick={() => setSlots((prev) => prev.filter((_, j) => j !== i))}>
+                      Remove
+                    </button>
+                  )}
+                </div>
+              ))}
+              {slots.length < MAX_PROPOSED_SLOTS && (
+                <button type="button" className={secondaryBtn} onClick={() => setSlots((prev) => [...prev, { start: '', end: '' }])}>
+                  + Add another time
+                </button>
+              )}
+            </div>
+          </div>
+        )}
+
+        {step === 3 && (
+          <div className="space-y-3">
+            <h2 className="font-medium text-[var(--color-ink)]">Somewhere to meet?</h2>
+            <p className="text-xs text-[var(--color-muted)]">
+              Suggestions are ranked for a {GATHERING_TYPE_LABELS[type].toLowerCase()} near your guests. You’ll lock a
+              venue in when you finalise.
+            </p>
+            <button type="button" className={secondaryBtn} disabled={venueLoading} onClick={loadVenues}>
+              {venueLoading ? 'Finding venues…' : 'Suggest venues'}
+            </button>
+            {venues && venues.length === 0 && (
+              <p className="text-xs text-[var(--color-muted)]">
+                No venues in the catalogue yet — your agent can search Google Places via Convene, or you can add one when
+                finalising.
+              </p>
+            )}
+            {venues && venues.length > 0 && (
+              <ul className="space-y-2">
+                {venues.map((v) => (
+                  <li key={v.venueId} className="text-sm">
+                    <span className="text-[var(--color-ink)]">{v.name}</span>
+                    <span className="text-[var(--color-muted)]">
+                      {' '}· {v.venueType}
+                      {v.city ? ` · ${v.city}` : ''} · {Math.round(v.score * 100)}% fit
+                    </span>
+                    {v.reasons.length > 0 && (
+                      <span className="block text-xs text-[var(--color-muted)]">{v.reasons.join(' · ')}</span>
+                    )}
+                  </li>
+                ))}
+              </ul>
+            )}
+          </div>
+        )}
+
+        {step === 4 && (
+          <div className="space-y-3">
+            <h2 className="font-medium text-[var(--color-ink)]">Ready to create the draft?</h2>
+            <ul className="text-sm text-[var(--color-muted)] space-y-1">
+              <li>
+                <strong className="text-[var(--color-ink)]">{title.trim() || 'Untitled'}</strong> · {GATHERING_TYPE_LABELS[type]}
+              </li>
+              <li>{selected.size} {selected.size === 1 ? 'person' : 'people'} invited</li>
+              <li>{slots.filter((s) => s.start && s.end).length} proposed time(s)</li>
+            </ul>
+            <p className="text-xs text-[var(--color-muted)]">
+              We’ll create a draft you can review, finalise, and send invites from.
+            </p>
+          </div>
+        )}
+      </div>
+
+      <div className="flex justify-between">
+        <button type="button" className={secondaryBtn} disabled={step === 0 || pending} onClick={() => setStep((s) => Math.max(0, s - 1))}>
+          Back
+        </button>
+        {step < STEPS.length - 1 ? (
+          <button
+            type="button"
+            className={primaryBtn}
+            disabled={step === 1 && !title.trim()}
+            onClick={() => setStep((s) => Math.min(STEPS.length - 1, s + 1))}
+          >
+            Next
+          </button>
+        ) : (
+          <button type="button" className={primaryBtn} disabled={!canCreate || pending} onClick={create}>
+            {pending ? 'Creating…' : 'Create draft'}
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/app/dashboard/convene/organise/page.tsx
+++ b/src/app/dashboard/convene/organise/page.tsx
@@ -1,0 +1,99 @@
+import { createClient } from '@/lib/supabase-server';
+import { redirect } from 'next/navigation';
+import Link from 'next/link';
+import Image from 'next/image';
+import { isConveneEnabled } from '@/lib/convene/flags';
+import OrganiseWizard from './organise-wizard';
+
+export const metadata = {
+  title: 'Organise — Lyra',
+  description: 'Organise a gathering with the people in your life.',
+};
+
+export interface WizardContact {
+  id: string;
+  display_name: string;
+  city: string | null;
+  has_linked_profile: boolean;
+}
+
+function Shell({ children }: { children: React.ReactNode }) {
+  return (
+    <main className="min-h-screen bg-[var(--color-paper)]">
+      <header className="border-b border-[var(--color-border)] bg-white">
+        <div className="max-w-3xl mx-auto px-4 py-4 flex items-center justify-between">
+          <Link href="/dashboard" className="flex items-center">
+            <Image src="/lyra-logo.png" alt="Lyra" width={32} height={32} className="h-8 w-auto" />
+          </Link>
+          <span className="text-sm text-[var(--color-muted)]">Organise</span>
+        </div>
+      </header>
+      <div className="max-w-3xl mx-auto px-4 py-8 space-y-6">{children}</div>
+    </main>
+  );
+}
+
+export default async function OrganisePage({
+  searchParams,
+}: {
+  searchParams: Promise<{ contact?: string }>;
+}) {
+  if (!isConveneEnabled()) {
+    return (
+      <Shell>
+        <p className="text-[var(--color-muted)]">Convene is not enabled.</p>
+      </Shell>
+    );
+  }
+
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) redirect('/login?next=/dashboard/convene/organise');
+
+  const { data: rows } = await supabase
+    .from('contacts')
+    .select('id, display_name, city, linked_profile_id')
+    .eq('owner_user_id', user.id)
+    .is('deleted_at', null)
+    .order('display_name', { ascending: true });
+
+  const contacts: WizardContact[] = (rows ?? []).map((c) => ({
+    id: c.id as string,
+    display_name: c.display_name as string,
+    city: (c.city as string | null) ?? null,
+    has_linked_profile: !!(c.linked_profile_id as string | null),
+  }));
+
+  const sp = await searchParams;
+  const preselectId = sp.contact && contacts.some((c) => c.id === sp.contact) ? sp.contact : null;
+
+  return (
+    <Shell>
+      <div>
+        <h1 className="text-2xl font-medium text-[var(--color-ink)]">Organise a gathering</h1>
+        <p className="text-sm text-[var(--color-muted)] mt-1">
+          Choose who to invite, propose a few times, and we’ll create a draft you can finalise and send.
+        </p>
+      </div>
+
+      {contacts.length === 0 ? (
+        <div className="bg-white rounded-xl border border-[var(--color-border)] p-6 text-sm text-[var(--color-muted)]">
+          You don’t have any contacts yet.{' '}
+          <Link href="/dashboard/convene/contacts" className="text-[var(--color-sage)] hover:underline">
+            Add someone first →
+          </Link>
+        </div>
+      ) : (
+        <OrganiseWizard contacts={contacts} preselectId={preselectId} />
+      )}
+
+      <div className="pt-2">
+        <Link href="/dashboard/convene/contacts" className="text-sm text-[var(--color-sage)] hover:underline">
+          ← Back to people
+        </Link>
+      </div>
+    </Shell>
+  );
+}

--- a/tests/unit/convene/organise-actions.test.ts
+++ b/tests/unit/convene/organise-actions.test.ts
@@ -1,0 +1,260 @@
+/**
+ * KAN-305 — unit tests for the Organise-event wizard server actions.
+ *
+ * createGatheringDraft (ported insert), getHostBusyTimes (host free/busy), and
+ * suggestVenues (real scoreVenue over a mocked catalogue). The RLS client,
+ * service-role admin client, moderation, calendar adapter and oauth-connection
+ * lookup are mocked; scoreVenue runs for real.
+ */
+
+// ── Mutable mock state ─────────────────────────────────────
+let mockUserId: string | null = 'host-1';
+let ownedRows: { id: string }[] = [{ id: 'c1' }, { id: 'c2' }];
+let venuesData: Record<string, unknown>[] = [];
+let gatheringInsertResult: { data: { id: string } | null; error: unknown } = {
+  data: { id: 'g-1' },
+  error: null,
+};
+let moderationResult: { ok: true } | { ok: false; error: string } = { ok: true };
+let connResult: { id: string } | null = { id: 'conn-1' };
+let freeBusyResult: { start: string; end: string }[] = [{ start: '2026-07-01T10:00:00Z', end: '2026-07-01T11:00:00Z' }];
+
+const captured = {
+  gatheringInsert: [] as Record<string, unknown>[],
+  slotsInsert: [] as unknown[],
+  inviteesInsert: [] as unknown[],
+  eventsInsert: [] as Record<string, unknown>[],
+};
+
+function rlsChain(table: string) {
+  const chain: Record<string, unknown> = {};
+  for (const m of ['select', 'in', 'is', 'ilike', 'eq', 'order', 'limit']) chain[m] = () => chain;
+  chain.then = (res: (v: unknown) => unknown) =>
+    res(table === 'venues' ? { data: venuesData, error: null } : { data: ownedRows, error: null });
+  return chain;
+}
+
+jest.mock('@/lib/supabase-server', () => ({
+  createClient: jest.fn(async () => ({
+    auth: { getUser: jest.fn(async () => ({ data: { user: mockUserId ? { id: mockUserId } : null } })) },
+    from: jest.fn((t: string) => rlsChain(t)),
+  })),
+}));
+
+jest.mock('@supabase/supabase-js', () => ({
+  createClient: jest.fn(() => ({
+    from: (table: string) => ({
+      insert: (rows: Record<string, unknown> | Record<string, unknown>[]) => {
+        if (table === 'gatherings') {
+          captured.gatheringInsert.push(rows as Record<string, unknown>);
+          return { select: () => ({ single: async () => gatheringInsertResult }) };
+        }
+        if (table === 'gathering_proposed_slots') captured.slotsInsert.push(rows);
+        if (table === 'gathering_invitees') captured.inviteesInsert.push(rows);
+        if (table === 'gathering_events_log') captured.eventsInsert.push(rows as Record<string, unknown>);
+        return Promise.resolve({ error: null });
+      },
+    }),
+  })),
+}));
+
+jest.mock('@/lib/env', () => ({
+  env: {
+    supabaseUrl: () => 'http://localhost',
+    supabaseServiceRoleKey: () => 'service-role',
+    supabaseAnonKey: () => 'anon',
+  },
+}));
+
+const mockModerate = jest.fn();
+jest.mock('@/lib/moderation-audit', () => ({
+  moderateAndAudit: (...args: unknown[]) => mockModerate(...args),
+}));
+
+const mockGetConn = jest.fn();
+jest.mock('@/lib/convene/oauth-connections', () => ({
+  getConnectionForUser: (...args: unknown[]) => mockGetConn(...args),
+}));
+
+jest.mock('@/lib/convene/calendar', () => ({
+  adapterFor: () => ({ getFreeBusy: async () => freeBusyResult }),
+}));
+
+import { createGatheringDraft, getHostBusyTimes, suggestVenues } from '@/app/dashboard/convene/organise/actions';
+
+beforeEach(() => {
+  mockUserId = 'host-1';
+  ownedRows = [{ id: 'c1' }, { id: 'c2' }];
+  venuesData = [];
+  gatheringInsertResult = { data: { id: 'g-1' }, error: null };
+  moderationResult = { ok: true };
+  connResult = { id: 'conn-1' };
+  freeBusyResult = [{ start: '2026-07-01T10:00:00Z', end: '2026-07-01T11:00:00Z' }];
+  captured.gatheringInsert = [];
+  captured.slotsInsert = [];
+  captured.inviteesInsert = [];
+  captured.eventsInsert = [];
+  mockModerate.mockImplementation(async () => moderationResult);
+  mockGetConn.mockImplementation(async () => connResult);
+});
+
+describe('createGatheringDraft', () => {
+  const base = {
+    title: 'Coffee with the team',
+    gathering_type: 'coffee' as const,
+    invitee_contact_ids: ['c1', 'c2'],
+    proposed_slots: [{ slot_start_iso: '2026-07-02T10:00:00Z', slot_end_iso: '2026-07-02T11:00:00Z' }],
+  };
+
+  test('creates a draft stamped with host_user_id and writes slots/invitees/audit', async () => {
+    const res = await createGatheringDraft(base);
+    expect(res).toEqual({ ok: true, gatheringId: 'g-1' });
+    expect(captured.gatheringInsert[0].host_user_id).toBe('host-1');
+    expect(captured.gatheringInsert[0].status).toBe('draft');
+    expect(captured.gatheringInsert[0].title).toBe('Coffee with the team');
+    expect(captured.slotsInsert).toHaveLength(1);
+    expect(captured.inviteesInsert).toHaveLength(1);
+    expect(captured.eventsInsert[0].event_type).toBe('gathering_created');
+  });
+
+  test('rejects an empty title', async () => {
+    const res = await createGatheringDraft({ ...base, title: '  ' });
+    expect(res.ok).toBe(false);
+    expect(captured.gatheringInsert).toHaveLength(0);
+  });
+
+  test('rejects an invalid gathering type', async () => {
+    const res = await createGatheringDraft({ ...base, gathering_type: 'banquet' as never });
+    expect(res.ok).toBe(false);
+  });
+
+  test('rejects capacity_max < capacity_min', async () => {
+    const res = await createGatheringDraft({ ...base, capacity_min: 5, capacity_max: 2 });
+    expect(res.ok).toBe(false);
+  });
+
+  test('rejects a slot that ends before it starts', async () => {
+    const res = await createGatheringDraft({
+      ...base,
+      proposed_slots: [{ slot_start_iso: '2026-07-02T11:00:00Z', slot_end_iso: '2026-07-02T10:00:00Z' }],
+    });
+    expect(res.ok).toBe(false);
+  });
+
+  test('rejects when an invitee is not owned by the host', async () => {
+    ownedRows = [{ id: 'c1' }]; // c2 missing
+    const res = await createGatheringDraft(base);
+    expect(res.ok).toBe(false);
+    expect(captured.gatheringInsert).toHaveLength(0);
+  });
+
+  test('blocks on a moderation failure', async () => {
+    moderationResult = { ok: false, error: 'blocked text' };
+    const res = await createGatheringDraft(base);
+    expect(res.ok).toBe(false);
+    expect(captured.gatheringInsert).toHaveLength(0);
+  });
+
+  test('rejects unauthenticated callers', async () => {
+    mockUserId = null;
+    const res = await createGatheringDraft(base);
+    expect(res.ok).toBe(false);
+  });
+});
+
+describe('getHostBusyTimes', () => {
+  const win = ['2026-07-01T00:00:00Z', '2026-07-03T00:00:00Z'] as const;
+
+  test('returns busy blocks for a connected calendar', async () => {
+    const res = await getHostBusyTimes(win[0], win[1]);
+    expect(res).toEqual({ ok: true, connected: true, busy: freeBusyResult });
+  });
+
+  test('reports not-connected with a helpful note when no calendar is linked', async () => {
+    connResult = null;
+    const res = await getHostBusyTimes(win[0], win[1]);
+    expect(res.ok).toBe(true);
+    if (res.ok) {
+      expect(res.connected).toBe(false);
+      expect(res.note).toBeTruthy();
+    }
+  });
+
+  test('rejects an end before start', async () => {
+    const res = await getHostBusyTimes(win[1], win[0]);
+    expect(res.ok).toBe(false);
+  });
+
+  test('rejects a window longer than 14 days', async () => {
+    const res = await getHostBusyTimes('2026-07-01T00:00:00Z', '2026-08-01T00:00:00Z');
+    expect(res.ok).toBe(false);
+  });
+
+  test('rejects unauthenticated callers', async () => {
+    mockUserId = null;
+    const res = await getHostBusyTimes(win[0], win[1]);
+    expect(res.ok).toBe(false);
+  });
+});
+
+describe('suggestVenues', () => {
+  test('ranks the catalogue with the real scoreVenue engine', async () => {
+    venuesData = [
+      {
+        id: 'v1',
+        name: 'The Daily Grind',
+        venue_type: 'cafe',
+        city: 'Crawley',
+        postcode: 'RH10',
+        lat: '51.1',
+        lng: '-0.18',
+        price_tier: 1,
+        capacity_estimate: 20,
+        accessibility_flags: ['step_free'],
+        dietary_flags: ['vegan'],
+        external_rating: '4.5',
+      },
+      {
+        id: 'v2',
+        name: 'Tiny Room',
+        venue_type: 'cafe',
+        city: 'Crawley',
+        postcode: 'RH10',
+        lat: null,
+        lng: null,
+        price_tier: 2,
+        capacity_estimate: 2,
+        accessibility_flags: [],
+        dietary_flags: [],
+        external_rating: null,
+      },
+    ];
+    const res = await suggestVenues({ intent: 'coffee', anchor: 'Crawley', capacityRequired: 0 });
+    expect(res.ok).toBe(true);
+    if (res.ok) {
+      expect(Array.isArray(res.venues)).toBe(true);
+      expect(res.venues.map((v) => v.name)).toContain('The Daily Grind');
+      for (const v of res.venues) expect(v.score).toBeGreaterThanOrEqual(0);
+    }
+  });
+
+  test('hard-filters venues below the required capacity', async () => {
+    venuesData = [
+      { id: 'v2', name: 'Tiny Room', venue_type: 'cafe', city: 'Crawley', postcode: null, lat: null, lng: null, price_tier: 2, capacity_estimate: 2, accessibility_flags: [], dietary_flags: [], external_rating: null },
+    ];
+    const res = await suggestVenues({ intent: 'party', anchor: null, capacityRequired: 50 });
+    expect(res.ok).toBe(true);
+    if (res.ok) expect(res.venues).toHaveLength(0);
+  });
+
+  test('rejects an invalid intent', async () => {
+    const res = await suggestVenues({ intent: 'banquet' as never });
+    expect(res.ok).toBe(false);
+  });
+
+  test('rejects unauthenticated callers', async () => {
+    mockUserId = null;
+    const res = await suggestVenues({ intent: 'coffee' });
+    expect(res.ok).toBe(false);
+  });
+});

--- a/tests/unit/convene/organise-ui.test.ts
+++ b/tests/unit/convene/organise-ui.test.ts
@@ -1,0 +1,81 @@
+/**
+ * KAN-305 — Organise wizard UI structural tests.
+ */
+
+import fs from 'fs';
+import path from 'path';
+
+const ROOT = path.join(__dirname, '..', '..', '..');
+const base = 'src/app/dashboard/convene/organise';
+const pagePath = path.join(ROOT, base, 'page.tsx');
+const wizardPath = path.join(ROOT, base, 'organise-wizard.tsx');
+const actionsPath = path.join(ROOT, base, 'actions.ts');
+const fieldsPath = path.join(ROOT, base, 'organise-fields.ts');
+
+describe('Convene organise wizard UI (KAN-305)', () => {
+  test('all four files exist', () => {
+    expect(fs.existsSync(pagePath)).toBe(true);
+    expect(fs.existsSync(wizardPath)).toBe(true);
+    expect(fs.existsSync(actionsPath)).toBe(true);
+    expect(fs.existsSync(fieldsPath)).toBe(true);
+  });
+
+  describe('page', () => {
+    const src = fs.readFileSync(pagePath, 'utf8');
+    test('gates on isConveneEnabled', () => expect(src).toMatch(/isConveneEnabled\(\)/));
+    test('redirects unauthenticated users', () => expect(src).toMatch(/redirect\(['"]\/login\?next=\/dashboard\/convene\/organise/));
+    test('scopes contacts to the owner', () => expect(src).toMatch(/\.eq\(['"]owner_user_id['"],\s*user\.id\)/));
+    test('honours a ?contact= preselect', () => expect(src).toMatch(/sp\.contact/));
+  });
+
+  describe('server actions', () => {
+    const src = fs.readFileSync(actionsPath, 'utf8');
+    test("'use server' directive at top", () => expect(src).toMatch(/^['"]use server['"]/m));
+    test('exports the three actions', () => {
+      for (const fn of ['createGatheringDraft', 'getHostBusyTimes', 'suggestVenues']) {
+        expect(src).toMatch(new RegExp(`export async function ${fn}\\b`));
+      }
+    });
+    test('createGatheringDraft stamps host_user_id and starts as draft', () => {
+      expect(src).toMatch(/host_user_id:\s*userId/);
+      expect(src).toMatch(/status:\s*['"]draft['"]/);
+    });
+    test('verifies invitee contacts are owned by the host', () => {
+      expect(src).toMatch(/\.from\(['"]contacts['"]\)[\s\S]{0,160}\.in\(['"]id['"]/);
+    });
+    test('host-scoped writes carry ownership-ok comments', () => {
+      expect((src.match(/ownership-ok:/g) || []).length).toBeGreaterThanOrEqual(4);
+    });
+    test('moderates free-text before creating', () => expect(src).toMatch(/moderateAndAudit\(/));
+    test('appends a gathering_created audit row', () => expect(src).toMatch(/gathering_created/));
+    test('suggestVenues uses the scoreVenue engine over the venues catalogue', () => {
+      expect(src).toMatch(/scoreVenue\(/);
+      expect(src).toMatch(/\.from\(['"]venues['"]\)/);
+    });
+    test('getHostBusyTimes reads the host calendar via the adapter', () => {
+      expect(src).toMatch(/getConnectionForUser\(/);
+      expect(src).toMatch(/getFreeBusy\(/);
+    });
+    test('exports no non-async runtime values (Gotcha #18)', () => {
+      expect(src).not.toMatch(/export const /);
+      expect(src).not.toMatch(/export function (?!async)/);
+    });
+  });
+
+  describe('fields module', () => {
+    const src = fs.readFileSync(fieldsPath, 'utf8');
+    test('is not a use-server file', () => expect(src).not.toMatch(/^['"]use server['"]/m));
+    test('exports the gathering-type list + guard', () => {
+      expect(src).toMatch(/export const GATHERING_TYPES/);
+      expect(src).toMatch(/export function isGatheringType/);
+    });
+  });
+
+  describe('wizard island', () => {
+    const src = fs.readFileSync(wizardPath, 'utf8');
+    test("'use client' directive at top", () => expect(src).toMatch(/^['"]use client['"]/m));
+    test('imports the organise actions', () => expect(src).toMatch(/from ['"]\.\/actions['"]/));
+    test('routes to the new gathering detail page on success', () =>
+      expect(src).toMatch(/\/dashboard\/convene\/gatherings\/\$\{res\.gatheringId\}/));
+  });
+});


### PR DESCRIPTION
Part of epic **[KAN-302](https://checklyra.atlassian.net/browse/KAN-302)**. The core "click a contact → organise → draft" flow, reachable from each contact's **Organise →** button (KAN-304). Flag-gated on `isConveneEnabled()`.

## New `/dashboard/convene/organise`
A 5-step wizard — **people → details → time → venue → create** — that produces a **draft** gathering and routes to its detail page (where the host finalises a slot + venue and sends invites, KAN-306).

## Server actions (`actions.ts`)
- **`createGatheringDraft`** — ports the `lyra_create_gathering` insert sequence (gatherings → proposed_slots → invitees → events_log) into the web app, via the service-role client (like `gatherings/[id]/actions.ts`). Every write is host-scoped with `// ownership-ok:` comments; verifies the host owns every invitee contact; moderates free text (`moderateAndAudit`).
- **`getHostBusyTimes`** — the host's own Google free/busy via the calendar adapter, so the wizard can suggest a free slot. (Multi-attendee shared availability remains the consent-gated MCP path, `lyra_get_shared_availability` / **SEC-18**.)
- **`suggestVenues`** — ranks the shared `venues` catalogue with the existing **`scoreVenue`** engine.
- `organise-fields.ts` sibling holds consts/types (Gotcha #18).

## Tests
Behavioural action suite (incl. the real `scoreVenue`) + structural UI suite. Convene dir now **19 suites / 322 tests**, all green. `tsc` + `eslint` clean.

## MCP coverage (KAN-222 lockstep)
Agent equivalents already exist (`lyra_create_gathering`, `lyra_get_shared_availability`, `lyra_suggest_venues`, `lyra_propose_attendees`, `lyra_finalise_gathering`) — this is the web surface catching up. No new MCP tools required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[KAN-302]: https://checklyra.atlassian.net/browse/KAN-302?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ