### PR TITLE
feat(KAN-306): Convene initiate (finalise + send invites) + RSVP surface

### DIFF
--- a/src/app/dashboard/convene/gatherings/[id]/actions.ts
+++ b/src/app/dashboard/convene/gatherings/[id]/actions.ts
@@ -19,8 +19,11 @@ import { env } from '@/lib/env';
 import { applyTransition, type GatheringStatus } from '@/lib/convene/gatherings/state-machine';
 import { adapterFor } from '@/lib/convene/calendar';
 import { getConnectionForUser } from '@/lib/convene/oauth-connections';
+import { generateRsvpToken, persistQueuedInvite, setInviteeRsvpToken } from '@/lib/convene/invites/repository';
+import { dispatchQueuedInvites } from '@/lib/convene/invites/dispatch';
 
 type Result = { ok: true } | { ok: false; error: string };
+type SendSummary = { queued: number; sent: number; blocked_by_allowlist: number; failed: number };
 
 function admin() {
   return createSupabaseAdmin(env.supabaseUrl(), env.supabaseServiceRoleKey(), {
@@ -141,5 +144,212 @@ export async function cancelGathering(gatheringId: string): Promise<Result> {
     to_status: nextStatus,
   });
 
+  return { ok: true };
+}
+
+/**
+ * KAN-306 — finalise a draft gathering (draft → live) by locking a slot (and an
+ * optional venue). This is the web equivalent of lyra_finalise_gathering, and
+ * the precursor to sending invites.
+ */
+export async function finaliseGathering(
+  gatheringId: string,
+  slotStartISO: string,
+  slotEndISO: string,
+  venueId?: string | null
+): Promise<Result> {
+  const a = await authedUser();
+  if ('error' in a) return { ok: false, error: a.error };
+  const userId = a.userId;
+
+  const start = new Date(slotStartISO);
+  const end = new Date(slotEndISO);
+  if (Number.isNaN(start.getTime()) || Number.isNaN(end.getTime())) return { ok: false, error: 'Pick a valid time' };
+  if (end <= start) return { ok: false, error: 'The end time must be after the start time' };
+
+  const sb = admin();
+  // ownership-ok: host_user_id filter (KAN-306)
+  const { data: g, error: gErr } = await sb
+    .from('gatherings')
+    .select('id, status')
+    .eq('id', gatheringId)
+    .eq('host_user_id', userId)
+    .is('deleted_at', null)
+    .maybeSingle();
+  if (gErr || !g) return { ok: false, error: 'Gathering not found' };
+
+  let nextStatus: GatheringStatus;
+  try {
+    nextStatus = applyTransition(g.status as GatheringStatus, 'finalise');
+  } catch (e) {
+    return { ok: false, error: e instanceof Error ? e.message : 'Cannot finalise from this state' };
+  }
+
+  if (venueId) {
+    const { data: venue } = await sb.from('venues').select('id').eq('id', venueId).maybeSingle();
+    if (!venue) return { ok: false, error: 'That venue could not be found' };
+  }
+
+  // ownership-ok: explicit host_user_id filter (KAN-306)
+  const { error: upErr } = await sb
+    .from('gatherings')
+    .update({
+      status: nextStatus,
+      finalised_slot_start: slotStartISO,
+      finalised_slot_end: slotEndISO,
+      venue_id: venueId ?? null,
+    })
+    .eq('id', gatheringId)
+    .eq('host_user_id', userId);
+  if (upErr) return { ok: false, error: upErr.message };
+
+  await appendEvent(gatheringId, userId, 'gathering_finalised', {
+    from_status: g.status,
+    to_status: nextStatus,
+    slot_start: slotStartISO,
+    slot_end: slotEndISO,
+    venue_id: venueId ?? null,
+  });
+  return { ok: true };
+}
+
+/**
+ * KAN-306 — queue + send invites for a finalised gathering, then drain the
+ * queue synchronously (Vercel cron does not fire on preview branches, CLAUDE.md
+ * Gotcha #21). Per-recipient dedup: invitees that already have a queued/sent
+ * message are skipped. Allowlist + sender verification are env gates (KAN-308);
+ * blocked sends stay queued and surface in the summary.
+ */
+export async function sendInvites(
+  gatheringId: string
+): Promise<{ ok: true; summary: SendSummary } | { ok: false; error: string }> {
+  const a = await authedUser();
+  if ('error' in a) return { ok: false, error: a.error };
+  const userId = a.userId;
+
+  const sb = admin();
+  // ownership-ok: host_user_id filter (KAN-306)
+  const { data: g } = await sb
+    .from('gatherings')
+    .select('id, status, finalised_slot_start')
+    .eq('id', gatheringId)
+    .eq('host_user_id', userId)
+    .is('deleted_at', null)
+    .maybeSingle();
+  if (!g) return { ok: false, error: 'Gathering not found' };
+  if (!g.finalised_slot_start) return { ok: false, error: 'Finalise a time before sending invites' };
+  if (g.status === 'cancelled' || g.status === 'completed') {
+    return { ok: false, error: `Cannot send invites for a ${g.status} gathering` };
+  }
+
+  // ownership-ok: invitees scoped to the host's verified gathering (KAN-306)
+  const { data: invitees } = await sb
+    .from('gathering_invitees')
+    .select('id, status')
+    .eq('gathering_id', gatheringId);
+  const active = (invitees ?? []).filter((i) => i.status !== 'cancelled');
+  if (active.length === 0) return { ok: false, error: 'There is no one to invite yet' };
+
+  // Dedup: skip invitees that already have a live (queued/sent/...) message.
+  // ownership-ok: messages scoped to the host's verified gathering (KAN-306)
+  const { data: msgs } = await sb
+    .from('gathering_invite_messages')
+    .select('invitee_id, delivery_status')
+    .eq('gathering_id', gatheringId);
+  const alreadyLive = new Set(
+    (msgs ?? [])
+      .filter((m) => ['queued', 'sent', 'delivered', 'opened', 'clicked'].includes(m.delivery_status as string))
+      .map((m) => m.invitee_id)
+  );
+
+  let queued = 0;
+  for (const inv of active) {
+    if (alreadyLive.has(inv.id)) continue;
+    const token = generateRsvpToken();
+    await setInviteeRsvpToken(inv.id, token);
+    await persistQueuedInvite({ gatheringId, inviteeId: inv.id, channel: 'email', templateName: 'convene-invite' });
+    queued++;
+  }
+
+  await appendEvent(gatheringId, userId, 'gathering_invite_sent', { queued, source: 'web' });
+
+  const summary = await dispatchQueuedInvites({ hostUserId: userId });
+  return {
+    ok: true,
+    summary: {
+      queued,
+      sent: summary.sent,
+      blocked_by_allowlist: summary.blocked_by_allowlist,
+      failed: summary.failed,
+    },
+  };
+}
+
+/** KAN-306 — re-queue a single invitee (rotates the RSVP token) and drain. */
+export async function resendInvite(inviteeId: string): Promise<Result> {
+  const a = await authedUser();
+  if ('error' in a) return { ok: false, error: a.error };
+  const userId = a.userId;
+
+  const sb = admin();
+  const { data: inv } = await sb
+    .from('gathering_invitees')
+    .select('id, gathering_id, status')
+    .eq('id', inviteeId)
+    .maybeSingle();
+  if (!inv) return { ok: false, error: 'Invite not found' };
+  if (inv.status === 'cancelled') return { ok: false, error: 'That invite was cancelled' };
+
+  // ownership-ok: verify the parent gathering is owned by the host (KAN-306)
+  const { data: g } = await sb
+    .from('gatherings')
+    .select('id, finalised_slot_start')
+    .eq('id', inv.gathering_id)
+    .eq('host_user_id', userId)
+    .is('deleted_at', null)
+    .maybeSingle();
+  if (!g) return { ok: false, error: 'Gathering not found' };
+  if (!g.finalised_slot_start) return { ok: false, error: 'Finalise a time before sending invites' };
+
+  const token = generateRsvpToken();
+  await setInviteeRsvpToken(inviteeId, token);
+  await persistQueuedInvite({ gatheringId: inv.gathering_id, inviteeId, channel: 'email', templateName: 'convene-invite' });
+  await appendEvent(inv.gathering_id, userId, 'gathering_invite_sent', { invitee_id: inviteeId, resend: true, source: 'web' });
+  await dispatchQueuedInvites({ hostUserId: userId });
+  return { ok: true };
+}
+
+/** KAN-306 — cancel a single invite: mark the invitee cancelled + invalidate its RSVP token. */
+export async function cancelInvite(inviteeId: string): Promise<Result> {
+  const a = await authedUser();
+  if ('error' in a) return { ok: false, error: a.error };
+  const userId = a.userId;
+
+  const sb = admin();
+  const { data: inv } = await sb
+    .from('gathering_invitees')
+    .select('id, gathering_id')
+    .eq('id', inviteeId)
+    .maybeSingle();
+  if (!inv) return { ok: false, error: 'Invite not found' };
+
+  // ownership-ok: verify the parent gathering is owned by the host (KAN-306)
+  const { data: g } = await sb
+    .from('gatherings')
+    .select('id')
+    .eq('id', inv.gathering_id)
+    .eq('host_user_id', userId)
+    .is('deleted_at', null)
+    .maybeSingle();
+  if (!g) return { ok: false, error: 'Gathering not found' };
+
+  // ownership-ok: update invitee on the host's verified gathering (KAN-306)
+  const { error } = await sb
+    .from('gathering_invitees')
+    .update({ status: 'cancelled', rsvp_token: null, rsvp_token_expires_at: null })
+    .eq('id', inviteeId);
+  if (error) return { ok: false, error: 'Could not cancel the invite' };
+
+  await appendEvent(inv.gathering_id, userId, 'invitee_cancelled', { invitee_id: inviteeId });
   return { ok: true };
 }

--- a/src/app/dashboard/convene/gatherings/[id]/invite-actions.tsx
+++ b/src/app/dashboard/convene/gatherings/[id]/invite-actions.tsx
@@ -1,0 +1,207 @@
+'use client';
+
+/**
+ * KAN-306 — finalise + invite-management client island for the gathering
+ * detail page.
+ *
+ *   FinalisePanel — pick one of the proposed slots and lock the gathering
+ *     (draft → live) via finaliseGathering.
+ *   InviteManager — "Send invites" (queues + drains, shows a summary) plus a
+ *     per-invitee surface (RSVP status, delivery status, resend, cancel).
+ *
+ * Mutations call the server actions in ./actions and router.refresh()
+ * (the established convene convention).
+ */
+
+import { useState, useTransition } from 'react';
+import { useRouter } from 'next/navigation';
+import { finaliseGathering, sendInvites, resendInvite, cancelInvite } from './actions';
+
+const primaryBtn =
+  'px-4 py-2 rounded-lg bg-[var(--color-sage)] text-white text-sm font-medium hover:opacity-90 disabled:opacity-50';
+const secondaryBtn =
+  'px-3 py-1.5 rounded-lg border border-[var(--color-border)] text-sm text-[var(--color-ink)] hover:bg-[var(--color-paper)] disabled:opacity-50';
+const dangerBtn =
+  'px-3 py-1.5 rounded-lg border border-rose-300 text-rose-700 text-sm hover:bg-rose-50 disabled:opacity-50';
+
+function fmt(iso: string): string {
+  return new Date(iso).toLocaleString('en-GB', { dateStyle: 'medium', timeStyle: 'short' });
+}
+
+export interface ProposedSlot {
+  id: string;
+  slot_start: string;
+  slot_end: string;
+}
+
+export function FinalisePanel({ gatheringId, slots }: { gatheringId: string; slots: ProposedSlot[] }) {
+  const router = useRouter();
+  const [pending, startTransition] = useTransition();
+  const [selected, setSelected] = useState<string>(slots[0]?.id ?? '');
+  const [error, setError] = useState<string | null>(null);
+
+  function finalise() {
+    const slot = slots.find((s) => s.id === selected);
+    if (!slot) {
+      setError('Pick a time to lock in.');
+      return;
+    }
+    setError(null);
+    startTransition(async () => {
+      const res = await finaliseGathering(gatheringId, slot.slot_start, slot.slot_end);
+      if (res.ok) router.refresh();
+      else setError(res.error);
+    });
+  }
+
+  return (
+    <div className="bg-white rounded-xl border border-[var(--color-border)] p-6">
+      <h2 className="text-lg font-medium text-[var(--color-ink)] mb-1">Lock in a time</h2>
+      <p className="text-sm text-[var(--color-muted)] mb-3">
+        Choose one of your proposed times to finalise this gathering. You can then send invites.
+      </p>
+      {error && (
+        <div className="mb-3 bg-rose-50 border border-rose-200 rounded-lg px-3 py-2 text-sm text-rose-900">{error}</div>
+      )}
+      <div className="flex flex-wrap items-center gap-2">
+        <select
+          className="px-3 py-2 rounded-lg border border-[var(--color-border)] text-sm bg-white"
+          value={selected}
+          onChange={(e) => setSelected(e.target.value)}
+        >
+          {slots.map((s) => (
+            <option key={s.id} value={s.id}>
+              {fmt(s.slot_start)} → {new Date(s.slot_end).toLocaleTimeString('en-GB', { hour: '2-digit', minute: '2-digit' })}
+            </option>
+          ))}
+        </select>
+        <button type="button" className={primaryBtn} disabled={pending || !selected} onClick={finalise}>
+          {pending ? 'Finalising…' : 'Finalise'}
+        </button>
+      </div>
+    </div>
+  );
+}
+
+export interface InviteeView {
+  id: string;
+  displayName: string;
+  city: string | null;
+  status: string;
+  deliveryStatus: string | null;
+}
+
+const RSVP_TONE: Record<string, string> = {
+  accepted: 'text-emerald-700',
+  declined: 'text-rose-700',
+  tentative: 'text-amber-700',
+  cancelled: 'text-[var(--color-muted)]',
+};
+
+export function InviteManager({
+  gatheringId,
+  canSend,
+  invitees,
+}: {
+  gatheringId: string;
+  canSend: boolean;
+  invitees: InviteeView[];
+}) {
+  const router = useRouter();
+  const [pending, startTransition] = useTransition();
+  const [error, setError] = useState<string | null>(null);
+  const [notice, setNotice] = useState<string | null>(null);
+
+  function run(fn: () => Promise<{ ok: true } | { ok: false; error: string }>, onOk?: () => void) {
+    setError(null);
+    setNotice(null);
+    startTransition(async () => {
+      const res = await fn();
+      if (res.ok) {
+        onOk?.();
+        router.refresh();
+      } else {
+        setError(res.error);
+      }
+    });
+  }
+
+  function send() {
+    setError(null);
+    setNotice(null);
+    startTransition(async () => {
+      const res = await sendInvites(gatheringId);
+      if (!res.ok) {
+        setError(res.error);
+        return;
+      }
+      const s = res.summary;
+      const parts = [`Queued ${s.queued}`, `sent ${s.sent}`];
+      if (s.blocked_by_allowlist > 0) parts.push(`${s.blocked_by_allowlist} held by the invite allow-list`);
+      if (s.failed > 0) parts.push(`${s.failed} failed`);
+      setNotice(parts.join(' · '));
+      router.refresh();
+    });
+  }
+
+  return (
+    <div className="bg-white rounded-xl border border-[var(--color-border)] p-6">
+      <div className="flex items-center justify-between mb-3 gap-3">
+        <h2 className="text-lg font-medium text-[var(--color-ink)]">Invitees ({invitees.length})</h2>
+        {canSend && (
+          <button type="button" className={primaryBtn} disabled={pending} onClick={send}>
+            {pending ? 'Sending…' : 'Send invites'}
+          </button>
+        )}
+      </div>
+
+      {!canSend && (
+        <p className="text-xs text-[var(--color-muted)] mb-3">
+          Finalise a time (above) to enable sending invites.
+        </p>
+      )}
+      {error && (
+        <div className="mb-3 bg-rose-50 border border-rose-200 rounded-lg px-3 py-2 text-sm text-rose-900">{error}</div>
+      )}
+      {notice && (
+        <div className="mb-3 bg-emerald-50 border border-emerald-200 rounded-lg px-3 py-2 text-sm text-emerald-900">
+          {notice}
+        </div>
+      )}
+
+      <ul className="space-y-2">
+        {invitees.map((i) => (
+          <li key={i.id} className="flex flex-wrap items-center justify-between gap-2 text-sm">
+            <span className="text-[var(--color-ink)]">
+              {i.displayName}
+              {i.city && <span className="text-[var(--color-muted)]"> — {i.city}</span>}
+            </span>
+            <div className="flex items-center gap-3">
+              <span className={`text-xs ${RSVP_TONE[i.status] ?? 'text-[var(--color-muted)]'}`}>{i.status}</span>
+              {i.deliveryStatus && (
+                <span className="text-xs text-[var(--color-muted)]">· {i.deliveryStatus}</span>
+              )}
+              {i.status !== 'cancelled' && (
+                <>
+                  <button type="button" className={secondaryBtn} disabled={pending || !canSend} onClick={() => run(() => resendInvite(i.id))}>
+                    Resend
+                  </button>
+                  <button
+                    type="button"
+                    className={dangerBtn}
+                    disabled={pending}
+                    onClick={() => {
+                      if (confirm(`Cancel the invite for ${i.displayName}?`)) run(() => cancelInvite(i.id));
+                    }}
+                  >
+                    Cancel
+                  </button>
+                </>
+              )}
+            </div>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/src/app/dashboard/convene/gatherings/[id]/page.tsx
+++ b/src/app/dashboard/convene/gatherings/[id]/page.tsx
@@ -18,6 +18,7 @@ import {
   type GatheringStatus,
 } from '@/lib/convene/gatherings/state-machine';
 import { GatheringActions } from './gathering-actions';
+import { FinalisePanel, InviteManager } from './invite-actions';
 
 interface InviteeRow {
   id: string;
@@ -86,7 +87,7 @@ export default async function GatheringDetailPage({ params }: { params: Promise<
     .maybeSingle();
   if (!g) notFound();
 
-  const [invitees, slots, events, venue, calendarAdded] = await Promise.all([
+  const [invitees, slots, events, venue, calendarAdded, messages] = await Promise.all([
     supabase
       .from('gathering_invitees')
       .select('id, status, invited_at, responded_at, contact:contacts(display_name, city)')
@@ -116,7 +117,28 @@ export default async function GatheringDetailPage({ params }: { params: Promise<
       .eq('event_type', 'calendar_event_added')
       .limit(1)
       .then((r) => (r.data?.length ?? 0) > 0),
+    supabase
+      .from('gathering_invite_messages')
+      .select('invitee_id, delivery_status, created_at')
+      .eq('gathering_id', id)
+      .order('created_at', { ascending: false })
+      .then((r) => (r.data as { invitee_id: string; delivery_status: string; created_at: string }[]) ?? []),
   ]);
+
+  // Latest delivery status per invitee (messages are ordered newest-first).
+  const deliveryByInvitee = new Map<string, string>();
+  for (const m of messages) {
+    if (!deliveryByInvitee.has(m.invitee_id)) deliveryByInvitee.set(m.invitee_id, m.delivery_status);
+  }
+  const finalised = !!g.finalised_slot_start;
+  const canSend = finalised && g.status !== 'cancelled' && g.status !== 'completed';
+  const inviteeViews = invitees.map((i) => ({
+    id: i.id,
+    displayName: i.contact?.display_name ?? '(unknown)',
+    city: i.contact?.city ?? null,
+    status: i.status,
+    deliveryStatus: deliveryByInvitee.get(i.id) ?? null,
+  }));
 
   const tone = STATUS_LABELS[g.status as string] ?? { label: g.status, tone: 'bg-[#f4efe7]' };
   const transitions = availableTransitions(g.status as GatheringStatus);
@@ -191,22 +213,9 @@ export default async function GatheringDetailPage({ params }: { params: Promise<
           calendarAdded={calendarAdded}
         />
 
-        {invitees.length > 0 && (
-          <div className="bg-white rounded-xl border border-[var(--color-border)] p-6">
-            <h2 className="text-lg font-medium text-[var(--color-ink)] mb-3">Invitees ({invitees.length})</h2>
-            <ul className="space-y-2">
-              {invitees.map((i) => (
-                <li key={i.id} className="flex items-center justify-between text-sm">
-                  <span className="text-[var(--color-ink)]">
-                    {i.contact?.display_name ?? '(unknown)'}
-                    {i.contact?.city && <span className="text-[var(--color-muted)]"> — {i.contact.city}</span>}
-                  </span>
-                  <span className="text-xs text-[var(--color-muted)]">{i.status}</span>
-                </li>
-              ))}
-            </ul>
-          </div>
-        )}
+        {g.status === 'draft' && slots.length > 0 && <FinalisePanel gatheringId={id} slots={slots} />}
+
+        {invitees.length > 0 && <InviteManager gatheringId={id} canSend={canSend} invitees={inviteeViews} />}
 
         {slots.length > 0 && g.status === 'draft' && (
           <div className="bg-white rounded-xl border border-[var(--color-border)] p-6">

--- a/tests/unit/convene/invites-actions.test.ts
+++ b/tests/unit/convene/invites-actions.test.ts
@@ -1,0 +1,279 @@
+/**
+ * KAN-306 — unit tests for the gathering "initiate" server actions:
+ * finaliseGathering, sendInvites (queue + dedup + drain), resendInvite,
+ * cancelInvite. The admin client, RLS session, invite repository and the
+ * dispatcher are mocked; applyTransition runs for real.
+ */
+
+// ── Mutable mock state ─────────────────────────────────────
+let mockUserId: string | null = 'host-1';
+let gatheringRow: Record<string, unknown> | null = {
+  id: 'g1',
+  status: 'draft',
+  finalised_slot_start: null as string | null,
+};
+let inviteeRows: { id: string; status: string }[] = [
+  { id: 'i1', status: 'invited' },
+  { id: 'i2', status: 'invited' },
+];
+let inviteeSingle: Record<string, unknown> | null = { id: 'i1', gathering_id: 'g1', status: 'invited' };
+let messageRows: { invitee_id: string; delivery_status: string }[] = [];
+let venueRow: { id: string } | null = { id: 'v1' };
+let updateError: unknown = null;
+
+const captured = {
+  gatheringUpdate: [] as Record<string, unknown>[],
+  inviteeUpdate: [] as Record<string, unknown>[],
+  events: [] as Record<string, unknown>[],
+};
+
+function adminFrom(table: string) {
+  if (table === 'gatherings') {
+    return {
+      select: () => {
+        const c: Record<string, unknown> = {};
+        c.eq = () => c;
+        c.is = () => c;
+        c.maybeSingle = async () => ({ data: gatheringRow, error: null });
+        c.single = async () => ({ data: gatheringRow, error: null });
+        return c;
+      },
+      update: (vals: Record<string, unknown>) => {
+        captured.gatheringUpdate.push(vals);
+        const c: Record<string, unknown> = {};
+        c.eq = () => c;
+        c.then = (r: (v: unknown) => unknown) => r({ error: updateError });
+        return c;
+      },
+    };
+  }
+  if (table === 'venues') {
+    return {
+      select: () => {
+        const c: Record<string, unknown> = {};
+        c.eq = () => c;
+        c.maybeSingle = async () => ({ data: venueRow, error: null });
+        return c;
+      },
+    };
+  }
+  if (table === 'gathering_invitees') {
+    return {
+      select: () => {
+        const c: Record<string, unknown> = {};
+        c.eq = () => c;
+        c.maybeSingle = async () => ({ data: inviteeSingle, error: null });
+        c.then = (r: (v: unknown) => unknown) => r({ data: inviteeRows, error: null });
+        return c;
+      },
+      update: (vals: Record<string, unknown>) => {
+        captured.inviteeUpdate.push(vals);
+        const c: Record<string, unknown> = {};
+        c.eq = () => c;
+        c.then = (r: (v: unknown) => unknown) => r({ error: updateError });
+        return c;
+      },
+    };
+  }
+  if (table === 'gathering_invite_messages') {
+    return {
+      select: () => {
+        const c: Record<string, unknown> = {};
+        c.eq = () => c;
+        c.then = (r: (v: unknown) => unknown) => r({ data: messageRows, error: null });
+        return c;
+      },
+    };
+  }
+  if (table === 'gathering_events_log') {
+    return { insert: (row: Record<string, unknown>) => (captured.events.push(row), Promise.resolve({ error: null })) };
+  }
+  return { select: () => ({ then: (r: (v: unknown) => unknown) => r({ data: [], error: null }) }) };
+}
+
+jest.mock('@/lib/supabase-server', () => ({
+  createClient: jest.fn(async () => ({
+    auth: { getUser: jest.fn(async () => ({ data: { user: mockUserId ? { id: mockUserId } : null } })) },
+  })),
+}));
+
+jest.mock('@supabase/supabase-js', () => ({
+  createClient: jest.fn(() => ({ from: (t: string) => adminFrom(t) })),
+}));
+
+jest.mock('@/lib/env', () => ({
+  env: { supabaseUrl: () => 'http://localhost', supabaseServiceRoleKey: () => 'svc', supabaseAnonKey: () => 'anon' },
+}));
+
+const mockPersist = jest.fn(async () => ({ id: 'm1' }));
+const mockSetToken = jest.fn(async () => undefined);
+jest.mock('@/lib/convene/invites/repository', () => ({
+  generateRsvpToken: () => 'tok',
+  persistQueuedInvite: (...a: unknown[]) => mockPersist(...(a as [])),
+  setInviteeRsvpToken: (...a: unknown[]) => mockSetToken(...(a as [])),
+}));
+
+const mockDispatch = jest.fn(async () => ({
+  scanned: 2,
+  sent: 0,
+  blocked_by_allowlist: 2,
+  failed: 0,
+  skipped_unfinalised: 0,
+  errors: [] as string[],
+}));
+jest.mock('@/lib/convene/invites/dispatch', () => ({ dispatchQueuedInvites: (...a: unknown[]) => mockDispatch(...(a as [])) }));
+
+jest.mock('@/lib/convene/calendar', () => ({
+  adapterFor: () => ({ getFreeBusy: async () => [], createEvent: async () => ({ providerEventId: 'x' }) }),
+}));
+jest.mock('@/lib/convene/oauth-connections', () => ({ getConnectionForUser: async () => null }));
+
+import {
+  finaliseGathering,
+  sendInvites,
+  resendInvite,
+  cancelInvite,
+} from '@/app/dashboard/convene/gatherings/[id]/actions';
+
+beforeEach(() => {
+  mockUserId = 'host-1';
+  gatheringRow = { id: 'g1', status: 'draft', finalised_slot_start: null };
+  inviteeRows = [
+    { id: 'i1', status: 'invited' },
+    { id: 'i2', status: 'invited' },
+  ];
+  inviteeSingle = { id: 'i1', gathering_id: 'g1', status: 'invited' };
+  messageRows = [];
+  venueRow = { id: 'v1' };
+  updateError = null;
+  captured.gatheringUpdate = [];
+  captured.inviteeUpdate = [];
+  captured.events = [];
+  mockPersist.mockClear();
+  mockSetToken.mockClear();
+  mockDispatch.mockClear();
+});
+
+describe('finaliseGathering', () => {
+  const start = '2026-07-02T10:00:00Z';
+  const end = '2026-07-02T11:00:00Z';
+
+  test('locks a draft to live with the chosen slot', async () => {
+    const res = await finaliseGathering('g1', start, end);
+    expect(res).toEqual({ ok: true });
+    expect(captured.gatheringUpdate[0].status).toBe('live');
+    expect(captured.gatheringUpdate[0].finalised_slot_start).toBe(start);
+    expect(captured.events[0].event_type).toBe('gathering_finalised');
+  });
+
+  test('rejects an end before start', async () => {
+    const res = await finaliseGathering('g1', end, start);
+    expect(res.ok).toBe(false);
+    expect(captured.gatheringUpdate).toHaveLength(0);
+  });
+
+  test('rejects finalise from a non-draft state', async () => {
+    gatheringRow = { id: 'g1', status: 'live', finalised_slot_start: start };
+    const res = await finaliseGathering('g1', start, end);
+    expect(res.ok).toBe(false);
+  });
+
+  test('rejects unauthenticated callers', async () => {
+    mockUserId = null;
+    const res = await finaliseGathering('g1', start, end);
+    expect(res.ok).toBe(false);
+  });
+});
+
+describe('sendInvites', () => {
+  beforeEach(() => {
+    gatheringRow = { id: 'g1', status: 'live', finalised_slot_start: '2026-07-02T10:00:00Z' };
+  });
+
+  test('queues every active invitee then drains, returning a summary', async () => {
+    const res = await sendInvites('g1');
+    expect(res.ok).toBe(true);
+    if (res.ok) {
+      expect(res.summary.queued).toBe(2);
+      expect(res.summary.blocked_by_allowlist).toBe(2);
+    }
+    expect(mockPersist).toHaveBeenCalledTimes(2);
+    expect(mockDispatch).toHaveBeenCalledTimes(1);
+  });
+
+  test('dedups invitees that already have a live message', async () => {
+    messageRows = [{ invitee_id: 'i1', delivery_status: 'sent' }];
+    const res = await sendInvites('g1');
+    expect(res.ok).toBe(true);
+    if (res.ok) expect(res.summary.queued).toBe(1);
+    expect(mockPersist).toHaveBeenCalledTimes(1);
+  });
+
+  test('refuses to send before the gathering is finalised', async () => {
+    gatheringRow = { id: 'g1', status: 'draft', finalised_slot_start: null };
+    const res = await sendInvites('g1');
+    expect(res.ok).toBe(false);
+    expect(mockPersist).not.toHaveBeenCalled();
+  });
+
+  test('errors when there is no one left to invite', async () => {
+    inviteeRows = [{ id: 'i1', status: 'cancelled' }];
+    const res = await sendInvites('g1');
+    expect(res.ok).toBe(false);
+  });
+
+  test('rejects unauthenticated callers', async () => {
+    mockUserId = null;
+    const res = await sendInvites('g1');
+    expect(res.ok).toBe(false);
+  });
+});
+
+describe('resendInvite', () => {
+  beforeEach(() => {
+    gatheringRow = { id: 'g1', status: 'live', finalised_slot_start: '2026-07-02T10:00:00Z' };
+  });
+
+  test('re-queues a single invitee and drains', async () => {
+    const res = await resendInvite('i1');
+    expect(res).toEqual({ ok: true });
+    expect(mockPersist).toHaveBeenCalledTimes(1);
+    expect(mockDispatch).toHaveBeenCalledTimes(1);
+  });
+
+  test('refuses to resend a cancelled invite', async () => {
+    inviteeSingle = { id: 'i1', gathering_id: 'g1', status: 'cancelled' };
+    const res = await resendInvite('i1');
+    expect(res.ok).toBe(false);
+    expect(mockPersist).not.toHaveBeenCalled();
+  });
+
+  test('rejects unauthenticated callers', async () => {
+    mockUserId = null;
+    const res = await resendInvite('i1');
+    expect(res.ok).toBe(false);
+  });
+});
+
+describe('cancelInvite', () => {
+  test('marks the invitee cancelled and clears its token', async () => {
+    const res = await cancelInvite('i1');
+    expect(res).toEqual({ ok: true });
+    expect(captured.inviteeUpdate[0].status).toBe('cancelled');
+    expect(captured.inviteeUpdate[0].rsvp_token).toBeNull();
+    expect(captured.events[0].event_type).toBe('invitee_cancelled');
+  });
+
+  test('errors when the invite is not found', async () => {
+    inviteeSingle = null;
+    const res = await cancelInvite('ghost');
+    expect(res.ok).toBe(false);
+    expect(captured.inviteeUpdate).toHaveLength(0);
+  });
+
+  test('rejects unauthenticated callers', async () => {
+    mockUserId = null;
+    const res = await cancelInvite('i1');
+    expect(res.ok).toBe(false);
+  });
+});

--- a/tests/unit/convene/invites-ui.test.ts
+++ b/tests/unit/convene/invites-ui.test.ts
@@ -1,0 +1,65 @@
+/**
+ * KAN-306 — initiate (send invites) + RSVP surface UI structural tests.
+ */
+
+import fs from 'fs';
+import path from 'path';
+
+const ROOT = path.join(__dirname, '..', '..', '..');
+const base = 'src/app/dashboard/convene/gatherings/[id]';
+const actionsPath = path.join(ROOT, base, 'actions.ts');
+const islandPath = path.join(ROOT, base, 'invite-actions.tsx');
+const pagePath = path.join(ROOT, base, 'page.tsx');
+
+describe('Convene initiate + RSVP surface (KAN-306)', () => {
+  describe('server actions', () => {
+    const src = fs.readFileSync(actionsPath, 'utf8');
+    test('exports the four initiate actions', () => {
+      for (const fn of ['finaliseGathering', 'sendInvites', 'resendInvite', 'cancelInvite']) {
+        expect(src).toMatch(new RegExp(`export async function ${fn}\\b`));
+      }
+    });
+    test('sendInvites requires a finalised gathering', () =>
+      expect(src).toMatch(/Finalise a time before sending invites/));
+    test('dedups against existing queued/sent messages', () => {
+      expect(src).toMatch(/\.from\(['"]gathering_invite_messages['"]\)/);
+      expect(src).toMatch(/alreadyLive/);
+    });
+    test('queues via the repository helpers and drains via the dispatcher', () => {
+      expect(src).toMatch(/persistQueuedInvite\(/);
+      expect(src).toMatch(/setInviteeRsvpToken\(/);
+      expect(src).toMatch(/dispatchQueuedInvites\(\{\s*hostUserId/);
+    });
+    test('finalise uses the state machine', () => expect(src).toMatch(/applyTransition\([^,]+,\s*['"]finalise['"]/));
+    test('cancelInvite invalidates the RSVP token', () =>
+      expect(src).toMatch(/rsvp_token:\s*null/));
+    test('host-scoped reads/writes carry ownership-ok comments', () => {
+      expect((src.match(/ownership-ok:/g) || []).length).toBeGreaterThanOrEqual(8);
+    });
+    test('every initiate path filters by host_user_id', () =>
+      expect((src.match(/\.eq\(['"]host_user_id['"],\s*userId\)/g) || []).length).toBeGreaterThanOrEqual(4));
+  });
+
+  describe('client island', () => {
+    const src = fs.readFileSync(islandPath, 'utf8');
+    test("'use client' directive at top", () => expect(src).toMatch(/^['"]use client['"]/m));
+    test('exports FinalisePanel + InviteManager', () => {
+      expect(src).toMatch(/export function FinalisePanel\(/);
+      expect(src).toMatch(/export function InviteManager\(/);
+    });
+    test('wires the initiate actions', () => {
+      expect(src).toMatch(/finaliseGathering|sendInvites|resendInvite|cancelInvite/);
+    });
+    test('confirms before cancelling an invite', () => expect(src).toMatch(/confirm\(/));
+  });
+
+  describe('detail page', () => {
+    const src = fs.readFileSync(pagePath, 'utf8');
+    test('reads per-invitee delivery status from gathering_invite_messages', () =>
+      expect(src).toMatch(/\.from\(['"]gathering_invite_messages['"]\)/));
+    test('renders the finalise panel for a draft with proposed slots', () =>
+      expect(src).toMatch(/FinalisePanel/));
+    test('renders the interactive invite manager', () => expect(src).toMatch(/InviteManager/));
+    test('computes canSend from the finalised state', () => expect(src).toMatch(/const canSend =/));
+  });
+});


### PR DESCRIPTION
Part of epic **[KAN-302](https://checklyra.atlassian.net/browse/KAN-302)**. Completes the host web flow end-to-end on the gathering detail page so a host can finalise and send entirely from the GUI.

## What's new (`gatherings/[id]/`)
- **`finaliseGathering`** — web equivalent of `lyra_finalise_gathering` (draft → live), via the new **FinalisePanel** (pick a proposed slot). This was the missing bridge between the wizard's draft and sending.
- **`sendInvites`** — queues each active invitee (the existing `repository.ts` helpers, previously unused by the web) with **per-recipient dedup**, then drains synchronously via `dispatchQueuedInvites({ hostUserId })` (Vercel cron doesn't fire on preview — Gotcha #21). Returns a summary that surfaces `blocked_by_allowlist` so empty-allowlist behaviour is legible (the `CONVENE_INVITE_ALLOWLIST` gate is part of KAN-308).
- **`resendInvite` / `cancelInvite`** — per-invitee; rotate / invalidate the RSVP token.
- **InviteManager** — renders each invitee's RSVP status + delivery status (joined from `gathering_invite_messages`) with resend/cancel.

All host-scoped reads/writes filter `.eq('host_user_id', userId)` and carry `// ownership-ok:` comments.

The public RSVP page `/r/<token>` already existed (KAN-209) — unchanged.

## Tests
Behavioural action suite (finalise / send + dedup / resend / cancel) + structural UI suite. `tsc` + `eslint` clean; convene dir green.

## MCP coverage (KAN-222 lockstep)
`lyra_finalise_gathering`, `lyra_send_invite`, `lyra_record_rsvp`, `lyra_drain_invite_queue` already exist — no new MCP tools.

> Note: actual email delivery on beta depends on `CONVENE_INVITE_ALLOWLIST` + `RESEND_API_KEY` + a verified `CONVENE_INVITE_FROM_EMAIL` sender — the KAN-308 enablement step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[KAN-302]: https://checklyra.atlassian.net/browse/KAN-302?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ