### PR TITLE
chore(legal): add proprietary LICENSE (SEC-3)

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,16 @@
+Copyright (c) 2026 CheckLyra Ltd. All rights reserved.
+
+CheckLyra Ltd (company no. 16351012, registered in England & Wales) is the sole
+owner of this software and its source code. The code is published in a public
+repository for transparency only.
+
+No licence or right is granted to any person to use, copy, modify, merge,
+publish, distribute, sublicense, or sell any part of this software, or to create
+derivative works from it, without the prior written permission of CheckLyra Ltd.
+All rights not expressly granted are reserved.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+
+For licensing enquiries, contact CheckLyra Ltd.


### PR DESCRIPTION
Adds an explicit proprietary/all-rights-reserved LICENSE (CheckLyra Ltd, co. 16351012). lyra previously had **no** LICENSE — code was all-rights-reserved by default but ambiguous. **Wording is a draft — please confirm with legal.** Related: mcp is currently MIT-licensed (gives commercial code away) and should likely be switched too — flagged on SEC-3 but not changed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)