### PR TITLE
fix(SEC-18): busy-time consent gate + HMAC contact-discovery hashes

### DIFF
--- a/src/app/dashboard/convene/connections/availability-actions.ts
+++ b/src/app/dashboard/convene/connections/availability-actions.ts
@@ -1,0 +1,32 @@
+'use server';
+
+/**
+ * SEC-18 (F-07) — opt-in toggle for sharing calendar busy-times with contacts.
+ *
+ * Default is OFF (deny). When a user turns this on, hosts who have them as a
+ * linked contact can see their busy/free windows (never event details) when
+ * organising. The MCP availability tool reads
+ * profiles.share_availability_with_contacts (paired SEC-18 change).
+ */
+
+import { createClient } from '@/lib/supabase-server';
+import { revalidatePath } from 'next/cache';
+
+export async function setAvailabilitySharing(
+  enabled: boolean
+): Promise<{ ok: true } | { ok: false; error: string }> {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) return { ok: false, error: 'Not authenticated' };
+
+  const { error } = await supabase
+    .from('profiles')
+    .update({ share_availability_with_contacts: enabled })
+    .eq('user_id', user.id);
+  if (error) return { ok: false, error: 'Could not update your sharing preference' };
+
+  revalidatePath('/dashboard/convene/connections');
+  return { ok: true };
+}

--- a/src/app/dashboard/convene/connections/availability-toggle.tsx
+++ b/src/app/dashboard/convene/connections/availability-toggle.tsx
@@ -1,0 +1,62 @@
+'use client';
+
+/**
+ * SEC-18 (F-07) — calendar busy-time sharing opt-in toggle.
+ */
+
+import { useState, useTransition } from 'react';
+import { useRouter } from 'next/navigation';
+import { setAvailabilitySharing } from './availability-actions';
+
+export function AvailabilityToggle({ enabled }: { enabled: boolean }) {
+  const router = useRouter();
+  const [on, setOn] = useState(enabled);
+  const [pending, startTransition] = useTransition();
+  const [error, setError] = useState<string | null>(null);
+
+  function toggle() {
+    const next = !on;
+    setError(null);
+    startTransition(async () => {
+      const res = await setAvailabilitySharing(next);
+      if (res.ok) {
+        setOn(next);
+        router.refresh();
+      } else {
+        setError(res.error);
+      }
+    });
+  }
+
+  return (
+    <div className="bg-white rounded-xl border border-[var(--color-border)] p-6">
+      <div className="flex items-start justify-between gap-4">
+        <div>
+          <h2 className="text-lg font-medium text-[var(--color-ink)]">Share my availability</h2>
+          <p className="text-sm text-[var(--color-muted)] mt-1">
+            When on, people who’ve added you as a contact can see your <strong>busy/free</strong> windows
+            (never event details) while organising — so they can pick a time that works. Off by default.
+          </p>
+        </div>
+        <button
+          type="button"
+          role="switch"
+          aria-checked={on}
+          aria-label="Share my availability with contacts"
+          disabled={pending}
+          onClick={toggle}
+          className={`shrink-0 mt-1 inline-flex h-6 w-11 items-center rounded-full transition-colors disabled:opacity-50 ${
+            on ? 'bg-[var(--color-sage)]' : 'bg-[var(--color-border)]'
+          }`}
+        >
+          <span
+            className={`inline-block h-5 w-5 transform rounded-full bg-white transition-transform ${
+              on ? 'translate-x-5' : 'translate-x-0.5'
+            }`}
+          />
+        </button>
+      </div>
+      {error && <p className="mt-3 text-sm text-rose-700">{error}</p>}
+    </div>
+  );
+}

--- a/src/app/dashboard/convene/connections/page.tsx
+++ b/src/app/dashboard/convene/connections/page.tsx
@@ -12,6 +12,7 @@ import Link from 'next/link';
 import Image from 'next/image';
 import { isConveneEnabled } from '@/lib/convene/flags';
 import { ConnectionsClient } from './connections-client';
+import { AvailabilityToggle } from './availability-toggle';
 
 export const metadata = {
   title: 'Calendar Connections — Lyra Convene',
@@ -57,6 +58,14 @@ export default async function ConnectionsPage({
     .is('deleted_at', null)
     .order('created_at', { ascending: false });
 
+  // SEC-18 — the user's busy-time sharing opt-in (default off).
+  const { data: profileRow } = await supabase
+    .from('profiles')
+    .select('share_availability_with_contacts')
+    .eq('user_id', user.id)
+    .maybeSingle();
+  const sharingEnabled = !!profileRow?.share_availability_with_contacts;
+
   const sp = await searchParams;
   const flash = sp.convene_oauth;
   const provider = sp.provider;
@@ -93,6 +102,8 @@ export default async function ConnectionsPage({
         )}
 
         <ConnectionsClient connections={(connections ?? []) as ConnectionRow[]} />
+
+        <AvailabilityToggle enabled={sharingEnabled} />
 
         <div className="bg-white rounded-xl border border-[var(--color-border)] p-6">
           <h2 className="text-lg font-medium text-[var(--color-ink)] mb-2">What Lyra does with this</h2>

--- a/src/app/dashboard/settings/discoverability-helpers.ts
+++ b/src/app/dashboard/settings/discoverability-helpers.ts
@@ -17,7 +17,7 @@
  *     mount a rainbow-table attack against any unpeppered hashes that
  *     accidentally got persisted).
  */
-import { createHash } from 'crypto';
+import { createHmac } from 'crypto';
 
 /** What kind of contact value is being hashed. */
 export type ContactKind = 'phone' | 'postcode';
@@ -40,6 +40,19 @@ export function getSearchPepper(): string {
     );
   }
   return pepper;
+}
+
+/**
+ * SEC-18 (F-04 part 2): the HMAC key for contact-discovery hashes. Prefers the
+ * dedicated `CONTACT_SEARCH_HMAC_KEY`; falls back to `LYRA_SEARCH_PEPPER` so the
+ * SHA-256 → HMAC switch is non-breaking before the dedicated key is provisioned
+ * on a given environment. Never included in error messages.
+ */
+export function getContactSearchHmacKey(): string {
+  const key = process.env.CONTACT_SEARCH_HMAC_KEY;
+  if (key && key.length >= 16) return key;
+  // getSearchPepper() still hard-fails if NEITHER secret is configured.
+  return getSearchPepper();
 }
 
 /**
@@ -105,25 +118,25 @@ export function normalisePostcode(input: string): string | null {
 }
 
 /**
- * Deterministic peppered SHA-256 hash. Hex digest.
+ * Deterministic HMAC-SHA-256 hash, hex digest (SEC-18, F-04 part 2).
  *
- * Format: SHA-256(pepper || ':' || kind || ':' || value)
- *   - Including the `kind` prevents a phone hash from ever colliding with
- *     a postcode hash, even if a user accidentally entered a postcode in
- *     the phone field at some point.
- *   - The pepper is prepended; the separator avoids ambiguity between
- *     short pepper + long value vs. long pepper + short value.
+ * Format: HMAC-SHA-256(key, kind || ':' || value)
+ *   - HMAC-keying (rather than the old SHA-256(pepper || …) construction)
+ *     means a stored hash can't be brute-forced with a precomputed rainbow
+ *     table even if the algorithm and value space are known — an authenticated
+ *     attacker can no longer enumerate members by guessing.
+ *   - Including the `kind` inside the message keeps a phone hash from ever
+ *     colliding with a postcode hash.
+ *   - `key` is the server secret from getContactSearchHmacKey().
  *
  * This function does not validate the input — callers must normalise
  * first and refuse to call this with a null/empty value.
  */
-export function hashContact(kind: ContactKind, value: string, pepper: string): string {
+export function hashContact(kind: ContactKind, value: string, key: string): string {
   if (!value) {
     throw new Error('hashContact called with empty value (programmer error)');
   }
-  return createHash('sha256')
-    .update(pepper)
-    .update(':')
+  return createHmac('sha256', key)
     .update(kind)
     .update(':')
     .update(value)
@@ -139,13 +152,13 @@ export function hashContact(kind: ContactKind, value: string, pepper: string): s
 export function hashPhoneInput(input: string): string | null {
   const normalised = normalisePhone(input);
   if (!normalised) return null;
-  return hashContact('phone', normalised, getSearchPepper());
+  return hashContact('phone', normalised, getContactSearchHmacKey());
 }
 
 export function hashPostcodeInput(input: string): string | null {
   const normalised = normalisePostcode(input);
   if (!normalised) return null;
-  return hashContact('postcode', normalised, getSearchPepper());
+  return hashContact('postcode', normalised, getContactSearchHmacKey());
 }
 
 /**

--- a/supabase/migrations/20260621140000_sec18_availability_consent.sql
+++ b/supabase/migrations/20260621140000_sec18_availability_consent.sql
@@ -1,0 +1,30 @@
+-- SEC-18 (F-07): opt-in consent gate for sharing calendar busy-times.
+--
+-- Problem
+-- -------
+-- lyra_get_shared_availability fans out a linked Lyra profile's Google
+-- free/busy to any host who has that profile as a `contacts.linked_profile_id`,
+-- with the only target-side filter being `is_suspended = false`. The OAuth
+-- consent the target gave was "share my calendar with Lyra for my own use", not
+-- "fan it out to other users' availability queries". This is a cross-user
+-- availability disclosure (IDOR-adjacent).
+--
+-- Fix
+-- ---
+-- Add a per-user opt-in flag, default FALSE (deny). The MCP availability tool
+-- only includes a linked profile's busy-times when this is TRUE; otherwise the
+-- attendee falls through to `requires_manual_confirm`. Paired change in
+-- lyra-mcp-server/src/convene-availability-tool.ts (MCP-main lockstep, KAN-222).
+--
+-- Non-destructive, additive. Default false means existing users are deny until
+-- they opt in via the Convene calendar-connections settings.
+--
+-- Apply order: dev -> staging -> prod (Supabase Migration Rules).
+-- Rollback (drop column — requires sign-off per CLAUDE.md):
+--   alter table public.profiles drop column if exists share_availability_with_contacts;
+
+alter table public.profiles
+  add column if not exists share_availability_with_contacts boolean not null default false;
+
+comment on column public.profiles.share_availability_with_contacts is
+  'SEC-18 — when true, this user consents to their calendar busy-times being shared with hosts who have them as a linked contact (Convene shared availability). Default false (deny).';

--- a/tests/unit/convene/availability-actions.test.ts
+++ b/tests/unit/convene/availability-actions.test.ts
@@ -1,0 +1,62 @@
+/**
+ * SEC-18 (F-07) — tests for the busy-time sharing opt-in action.
+ */
+
+const mockRevalidatePath = jest.fn();
+jest.mock('next/cache', () => ({ revalidatePath: (...a: unknown[]) => mockRevalidatePath(...a) }));
+
+let mockUserId: string | null = 'u1';
+let updateError: unknown = null;
+const captured = { updates: [] as Record<string, unknown>[] };
+
+jest.mock('@/lib/supabase-server', () => ({
+  createClient: jest.fn(async () => ({
+    auth: { getUser: jest.fn(async () => ({ data: { user: mockUserId ? { id: mockUserId } : null } })) },
+    from: jest.fn(() => ({
+      update: (vals: Record<string, unknown>) => {
+        captured.updates.push(vals);
+        const c: Record<string, unknown> = {};
+        c.eq = () => c;
+        c.then = (r: (v: unknown) => unknown) => r({ error: updateError });
+        return c;
+      },
+    })),
+  })),
+}));
+
+import { setAvailabilitySharing } from '@/app/dashboard/convene/connections/availability-actions';
+
+beforeEach(() => {
+  mockUserId = 'u1';
+  updateError = null;
+  captured.updates = [];
+  mockRevalidatePath.mockClear();
+});
+
+describe('setAvailabilitySharing', () => {
+  test('opting in writes the flag true and revalidates', async () => {
+    const res = await setAvailabilitySharing(true);
+    expect(res).toEqual({ ok: true });
+    expect(captured.updates[0].share_availability_with_contacts).toBe(true);
+    expect(mockRevalidatePath).toHaveBeenCalledWith('/dashboard/convene/connections');
+  });
+
+  test('opting out writes the flag false', async () => {
+    const res = await setAvailabilitySharing(false);
+    expect(res).toEqual({ ok: true });
+    expect(captured.updates[0].share_availability_with_contacts).toBe(false);
+  });
+
+  test('rejects unauthenticated callers', async () => {
+    mockUserId = null;
+    const res = await setAvailabilitySharing(true);
+    expect(res.ok).toBe(false);
+    expect(captured.updates).toHaveLength(0);
+  });
+
+  test('surfaces a generic error on db failure', async () => {
+    updateError = { message: 'boom' };
+    const res = await setAvailabilitySharing(true);
+    expect(res.ok).toBe(false);
+  });
+});

--- a/tests/unit/convene/sec18-availability-migration.test.ts
+++ b/tests/unit/convene/sec18-availability-migration.test.ts
@@ -1,0 +1,38 @@
+/**
+ * SEC-18 (F-07) — regression guard for the availability-consent column
+ * migration. Applied live across dev/staging/prod via the Supabase MCP on
+ * 2026-06-21; this pins the column shape (opt-in, default false = deny).
+ */
+
+import fs from 'fs';
+import path from 'path';
+
+const MIGRATION = path.join(
+  __dirname,
+  '..',
+  '..',
+  '..',
+  'supabase',
+  'migrations',
+  '20260621140000_sec18_availability_consent.sql'
+);
+
+describe('SEC-18 availability-consent migration', () => {
+  test('migration file exists', () => {
+    expect(fs.existsSync(MIGRATION)).toBe(true);
+  });
+
+  const sql = fs.existsSync(MIGRATION) ? fs.readFileSync(MIGRATION, 'utf8') : '';
+
+  test('adds share_availability_with_contacts as NOT NULL DEFAULT false (deny)', () => {
+    expect(sql).toMatch(
+      /add column if not exists share_availability_with_contacts boolean not null default false/i
+    );
+  });
+
+  test('is additive/idempotent (no destructive DROP in the forward migration)', () => {
+    // The forward migration must not drop anything; rollback is documented in a comment.
+    const body = sql.replace(/--.*$/gm, '');
+    expect(body).not.toMatch(/drop\s+(table|column)/i);
+  });
+});

--- a/tests/unit/convene/sec18-hmac-hash.test.ts
+++ b/tests/unit/convene/sec18-hmac-hash.test.ts
@@ -1,0 +1,72 @@
+/**
+ * SEC-18 (F-04 part 2) — contact-discovery hashes are HMAC-keyed.
+ *
+ * The old construction was SHA-256(key || ':' || kind || ':' || value), which
+ * an authenticated attacker could rainbow-table to enumerate members. We now
+ * HMAC-key the message. These tests pin that, and that getContactSearchHmacKey
+ * prefers the dedicated key but falls back to the pepper (non-breaking rollout).
+ */
+
+process.env.LYRA_SEARCH_PEPPER = 'unit-test-pepper-long-enough-here';
+
+import { createHash, createHmac } from 'crypto';
+import {
+  hashContact,
+  getContactSearchHmacKey,
+  hashPhoneInput,
+} from '@/app/dashboard/settings/discoverability-helpers';
+
+const KEY = 'a-test-key-at-least-16-chars';
+
+describe('SEC-18 HMAC contact hashing', () => {
+  test('hashContact is HMAC-SHA256, not the old SHA256(key||…) construction', () => {
+    const got = hashContact('phone', '+447700900000', KEY);
+    const hmac = createHmac('sha256', KEY).update('phone').update(':').update('+447700900000').digest('hex');
+    const oldSha = createHash('sha256')
+      .update(KEY)
+      .update(':')
+      .update('phone')
+      .update(':')
+      .update('+447700900000')
+      .digest('hex');
+    expect(got).toBe(hmac);
+    expect(got).not.toBe(oldSha); // algorithm genuinely changed
+    expect(got).toMatch(/^[a-f0-9]{64}$/);
+  });
+
+  test('stable per key; different key → different hash', () => {
+    const a = hashContact('phone', '+447700900000', KEY);
+    const b = hashContact('phone', '+447700900000', KEY);
+    const c = hashContact('phone', '+447700900000', 'another-key-16-chars-ok');
+    expect(a).toBe(b);
+    expect(a).not.toBe(c);
+  });
+
+  test('kind namespacing holds under HMAC', () => {
+    expect(hashContact('phone', 'SAMEVALUE', KEY)).not.toBe(hashContact('postcode', 'SAMEVALUE', KEY));
+  });
+
+  test('getContactSearchHmacKey prefers CONTACT_SEARCH_HMAC_KEY, falls back to the pepper', () => {
+    const orig = process.env.CONTACT_SEARCH_HMAC_KEY;
+    process.env.CONTACT_SEARCH_HMAC_KEY = 'dedicated-hmac-key-16chars+';
+    expect(getContactSearchHmacKey()).toBe('dedicated-hmac-key-16chars+');
+    delete process.env.CONTACT_SEARCH_HMAC_KEY;
+    expect(getContactSearchHmacKey()).toBe(process.env.LYRA_SEARCH_PEPPER);
+    if (orig === undefined) delete process.env.CONTACT_SEARCH_HMAC_KEY;
+    else process.env.CONTACT_SEARCH_HMAC_KEY = orig;
+  });
+
+  test('hashPhoneInput end-to-end no longer matches a plain-SHA256 guess', () => {
+    const h = hashPhoneInput('07700 900000'); // falls back to pepper as key
+    const pepper = process.env.LYRA_SEARCH_PEPPER as string;
+    const oldSha = createHash('sha256')
+      .update(pepper)
+      .update(':')
+      .update('phone')
+      .update(':')
+      .update('+447700900000')
+      .digest('hex');
+    expect(h).not.toBe(oldSha);
+    expect(h).toMatch(/^[a-f0-9]{64}$/);
+  });
+});


### PR DESCRIPTION
**[SEC-18](https://checklyra.atlassian.net/browse/SEC-18)** — Convene pre-prod privacy gate; a KAN-308 blocker. Two findings:

### F-07 — busy-time consent
- Migration `20260621140000_sec18_availability_consent.sql` adds `profiles.share_availability_with_contacts` (**NOT NULL DEFAULT false = deny**); already applied dev→staging→prod via Supabase MCP.
- Opt-in **toggle** on the Convene calendar-connections page (+ `setAvailabilitySharing` action). The paired MCP change ([lyra-mcp-server#78](https://github.com/luisa-sys/lyra-mcp-server/pull/78), merged + deployed) gates `lyra_get_shared_availability` on this flag — non-consenting profiles fall through to `requires_manual_confirm`.

### F-04 part 2 — member-enumeration oracle
- `hashContact` switched from `SHA-256(key||kind||value)` to **`HMAC-SHA256(key, kind:value)`** so stored phone/postcode discovery hashes can't be rainbow-tabled by an authenticated attacker.
- New `getContactSearchHmacKey()` prefers a dedicated **`CONTACT_SEARCH_HMAC_KEY`** but **falls back to `LYRA_SEARCH_PEPPER`**, so the rollout is non-breaking before the dedicated key is provisioned. (The discoverability columns aren't on prod yet, so there's zero real-user impact.)

> **Env follow-up (non-blocking):** generate + set `CONTACT_SEARCH_HMAC_KEY` (≥16 chars) on dev/staging/prod for the dedicated-key benefit. Until then the pepper is used. Captured in the KAN-308 enablement runbook.

## Tests
Existing discoverability suites stay green (their assertions are behavioural — HMAC satisfies determinism / 64-hex / key-sensitivity). New SEC-18 tests: HMAC hashing (proves it's no longer plain-SHA), the consent action, and a migration guard. convene dir **23 suites / 341 tests** green. `tsc` + `eslint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[SEC-18]: https://checklyra.atlassian.net/browse/SEC-18?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ