### PR TITLE
fix(SEC-21): HTML-escape signup email in maintenance-worker notification (F-23)

### DIFF
--- a/scripts/lyra-maintenance-worker.js
+++ b/scripts/lyra-maintenance-worker.js
@@ -248,6 +248,19 @@ function isValidEmail(email) {
   return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email);
 }
 
+// SEC-21 (F-23): escape HTML metacharacters before embedding user-supplied
+// input in the owner-notification email body. isValidEmail() allows `<` `>` `"`
+// (the local-part charset is `[^\s@]+`), so an address like `<b>x</b>@e.com`
+// passes validation yet would render/inject markup in the notification inbox.
+function escapeHtml(s) {
+  return String(s)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
 export default {
   async fetch(request, env) {
     const url = new URL(request.url);
@@ -363,7 +376,7 @@ export default {
                 to: ['luisa@checklyra.com'],
                 subject: `New Lyra interest signup: ${email}`,
                 html: `<p>Someone just signed up for Lyra launch notifications.</p>
-                       <p><strong>Email:</strong> ${email}</p>
+                       <p><strong>Email:</strong> ${escapeHtml(email)}</p>
                        <p><strong>Time:</strong> ${new Date().toISOString()}</p>
                        <p><strong>Source:</strong> Maintenance page (checklyra.com)</p>`,
               }),

--- a/tests/unit/maintenance-page.test.js
+++ b/tests/unit/maintenance-page.test.js
@@ -180,4 +180,15 @@ describe('KAN-129: Worker code file integrity', () => {
     const content = fs.readFileSync(workerPath, 'utf8');
     expect(content).toMatch(/allowedPaths\s*=\s*\[[\s\S]*?['"]\/api\/recommendations\/['"][\s\S]*?\]/);
   });
+
+  // SEC-21 (F-23): the signup email is user-supplied and isValidEmail() allows
+  // `<`/`>`/`"` (local-part charset is `[^\s@]+`), so it MUST be HTML-escaped
+  // before being embedded in the owner-notification email body — otherwise
+  // `<b>x</b>@e.com` passes validation yet injects markup into the inbox.
+  test('worker HTML-escapes the email in the notification body (SEC-21/F-23)', () => {
+    const content = fs.readFileSync(workerPath, 'utf8');
+    expect(content).toContain('function escapeHtml');
+    expect(content).toMatch(/Email:<\/strong>\s*\$\{escapeHtml\(email\)\}/);
+    expect(content).not.toMatch(/Email:<\/strong>\s*\$\{email\}/);
+  });
 });


### PR DESCRIPTION
Closes the **F-23** half of SEC-21. The maintenance worker embeds the user-supplied signup email into the owner-notification HTML; `isValidEmail()`'s `[^\s@]+` charset allows `<`/`>`/`"`, so `<b>x</b>@e.com` passes validation and would render/inject markup in the notification inbox. Adds `escapeHtml()` and escapes the email before embedding it.

- +1 structural test in `tests/unit/maintenance-page.test.js` (19/19 pass locally); worker `node --check` clean.
- Deploy note: the worker reaches prod via main + the **two-step Cloudflare promote** (Versions & Deployments → Promote) — that manual step is still required after this merges + promotes.
- **F-10** (rotate the dev Supabase service-role key) is the other half of SEC-21 and needs the Supabase dashboard — not in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)