### PR TITLE
feat(SEC-4): public service status page at /status

### DIFF
--- a/scripts/lyra-maintenance-worker.js
+++ b/scripts/lyra-maintenance-worker.js
@@ -293,6 +293,9 @@ export default {
       '/partners',
       '/auth/',
       '/api/health',
+      // SEC-4: the public status page must be reachable while production shows
+      // the waitlist front door (the maintenance worker gates everything else).
+      '/status',
       // KAN-184: the affiliate recommendation API needs to be reachable
       // from outside the gate so the lyra-mcp-server (at mcp.checklyra.com)
       // can call it server-side. Without this allowlist entry, the MCP

--- a/src/app/status/page.tsx
+++ b/src/app/status/page.tsx
@@ -1,0 +1,76 @@
+/**
+ * SEC-4: public service status page.
+ *
+ * A lightweight, honest status page: it does live server-side health probes
+ * (no faked "all systems operational") and links to the deeper uptime history.
+ * Server-side probing avoids CORS and keeps the MCP health URL off the client.
+ *
+ * Public on every environment: exempted from the beta gate in middleware.ts and
+ * allow-listed in the Cloudflare maintenance worker so it's reachable even while
+ * production shows the waitlist front door.
+ */
+export const dynamic = 'force-dynamic';
+export const revalidate = 0;
+
+type Check = { name: string; ok: boolean; detail: string };
+
+async function probe(name: string, url: string): Promise<Check> {
+  try {
+    const res = await fetch(url, { signal: AbortSignal.timeout(5000), cache: 'no-store' });
+    return { name, ok: res.ok, detail: `HTTP ${res.status}` };
+  } catch (e) {
+    return { name, ok: false, detail: e instanceof Error ? e.message.slice(0, 80) : 'unreachable' };
+  }
+}
+
+export default async function StatusPage() {
+  const checkedAt = new Date().toISOString();
+
+  // The website is operational by virtue of serving this page. The MCP API is
+  // probed live. Add further components here as they gain health endpoints.
+  const checks: Check[] = [
+    { name: 'Website (checklyra.com)', ok: true, detail: 'Serving' },
+    await probe('Agent API (mcp.checklyra.com)', 'https://mcp.checklyra.com/health'),
+  ];
+
+  const allOk = checks.every((c) => c.ok);
+
+  return (
+    <main className="min-h-screen flex items-center justify-center bg-stone-50 px-6 py-16">
+      <div className="w-full max-w-xl">
+        <h1 className="text-2xl font-semibold text-stone-800">Lyra status</h1>
+        <div
+          className={`mt-4 rounded-xl border px-5 py-4 text-sm font-medium ${
+            allOk
+              ? 'border-emerald-200 bg-emerald-50 text-emerald-800'
+              : 'border-amber-200 bg-amber-50 text-amber-800'
+          }`}
+        >
+          {allOk ? 'All systems operational' : 'Some systems are degraded — see below'}
+        </div>
+
+        <ul className="mt-6 divide-y divide-stone-200 rounded-xl border border-stone-200 bg-white">
+          {checks.map((c) => (
+            <li key={c.name} className="flex items-center justify-between gap-4 px-5 py-3">
+              <span className="text-sm text-stone-700">{c.name}</span>
+              <span className="flex items-center gap-2">
+                <span className="text-xs text-stone-400">{c.detail}</span>
+                <span
+                  className={`inline-block h-2.5 w-2.5 rounded-full ${
+                    c.ok ? 'bg-emerald-500' : 'bg-amber-500'
+                  }`}
+                  aria-label={c.ok ? 'operational' : 'degraded'}
+                />
+              </span>
+            </li>
+          ))}
+        </ul>
+
+        <p className="mt-4 text-xs text-stone-400">
+          Checked {checkedAt}. Live probe — refresh to re-check. Detailed uptime history is tracked
+          in UptimeRobot; incident handling follows the Incident Response Runbook.
+        </p>
+      </div>
+    </main>
+  );
+}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -86,6 +86,7 @@ export async function middleware(request: NextRequest) {
   const isBetaDeploy = process.env.IS_BETA_DEPLOY === 'true';
   const exemptFromBetaGate =
     pathname === '/waitlist' ||
+    pathname === '/status' || // SEC-4: public status page is never beta-gated
     pathname === '/login' ||
     pathname === '/signup' ||
     pathname.startsWith('/auth/') ||

--- a/tests/unit/sec4-status-page.test.js
+++ b/tests/unit/sec4-status-page.test.js
@@ -1,0 +1,31 @@
+/**
+ * SEC-4 — public status page.
+ *
+ * Structural guards: the page does a LIVE probe (not a hard-coded "operational"),
+ * and it is reachable on every environment (exempt from the beta gate + allow-listed
+ * in the maintenance worker).
+ */
+const fs = require('fs');
+const path = require('path');
+
+const root = path.join(__dirname, '../..');
+const PAGE = fs.readFileSync(path.join(root, 'src/app/status/page.tsx'), 'utf8');
+const MW = fs.readFileSync(path.join(root, 'src/middleware.ts'), 'utf8');
+const WORKER = fs.readFileSync(path.join(root, 'scripts/lyra-maintenance-worker.js'), 'utf8');
+
+describe('SEC-4 status page', () => {
+  test('does a live MCP health probe, not a faked status', () => {
+    expect(PAGE).toMatch(/mcp\.checklyra\.com\/health/);
+    expect(PAGE).toMatch(/await fetch\(/);
+    // honest: derives overall status from the probe results
+    expect(PAGE).toMatch(/checks\.every/);
+  });
+
+  test('is exempt from the beta gate (public on beta)', () => {
+    expect(MW).toMatch(/pathname === '\/status'/);
+  });
+
+  test('is allow-listed in the maintenance worker (reachable on prod)', () => {
+    expect(WORKER).toMatch(/^\s*'\/status',\s*$/m);
+  });
+});


### PR DESCRIPTION
Closes the **status-page** item of SEC-4.

- New `/status` route — a lightweight, **honest** status page that does a **live server-side health probe** of the Agent API (`mcp.checklyra.com/health`) and shows the website as serving. No hard-coded 'all operational'.
- **Public on every environment:** exempted from the beta gate in `middleware.ts` (so logged-in ineligible beta users see it too) and added to the maintenance-worker allowlist (so it's reachable on prod behind the waitlist gate).
- +3 structural tests; existing worker/middleware tests still green (22/22 locally); ESLint clean.

**Deploy note:** the worker-allowlist line reaches prod via main + the manual two-step Cloudflare promote (Versions & Deployments → Promote). On dev/beta the route is reachable immediately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)