### PR TITLE
feat(KAN-309): admin back-office — user console + bulk, moderation queue, monitoring

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -31,7 +31,7 @@ Lyra is a calm, structured public profile platform where users share preferences
 ### DNS & CDN
 - **Provider**: Cloudflare
 - **Domain**: checklyra.com
-- **Subdomains**: dev.checklyra.com, stage.checklyra.com, mcp.checklyra.com, mcp-dev.checklyra.com
+- **Subdomains**: dev.checklyra.com, stage.checklyra.com, mcp.checklyra.com, mcp-dev.checklyra.com, **admin.checklyra.com**
 
 ## Environments
 
@@ -42,8 +42,24 @@ Lyra is a calm, structured public profile platform where users share preferences
 | Development | dev.checklyra.com | develop | custom (develop) | ilprytcrnqyrsbsrfujj | Vercel SSO |
 | MCP Server | mcp.checklyra.com | main | Railway | llzkgprqewuwkiwclowi (prod) | Public |
 | MCP Dev | mcp-dev.checklyra.com | main | Railway | ilprytcrnqyrsbsrfujj (dev) | Public |
+| Admin (KAN-309) | admin.checklyra.com | main (prod deploy) | production | llzkgprqewuwkiwclowi (prod) | Cloudflare Access + `is_admin` |
 
 **Vercel Pro plan** — full environment separation. Each branch has its own custom environment with isolated env vars. No cross-environment contamination.
+
+### Admin back-office (`admin.checklyra.com`, KAN-309)
+
+The admin tools (`/admin/*`) are served on a private subdomain that points at the **same Production Vercel deployment** as `checklyra.com` (so it uses prod Supabase + prod env, and the shared `.checklyra.com` session cookie from KAN-274 works). Two gates: **Cloudflare Access** (allow-list of admin emails) in front, plus the existing `is_admin` DB check (`getCurrentAdmin`).
+
+Host routing lives in `src/middleware.ts` behind two env vars (set on the **prod** Vercel scope):
+
+| Env var | Default | Purpose |
+|---------|---------|---------|
+| `ADMIN_HOST` | `admin.checklyra.com` | The hostname that serves the admin tools |
+| `ADMIN_HOST_ENFORCED` | _(unset = off)_ | `true` rewrites the admin host → `/admin/*` and blocks `/admin` on other hosts. Leave **off** until the DNS record + Cloudflare Access app are live, then flip on (non-breaking rollout). |
+| `SENTRY_READ_TOKEN` | _(optional)_ | Reserved for live Sentry panels on `/admin/monitoring` |
+| `UPTIMEROBOT_API_KEY` | _(optional)_ | Lights up the UptimeRobot status on `/admin/monitoring` |
+
+**One-time setup (ops):** add `admin.checklyra.com` to the Lyra Vercel project (Production env) → Cloudflare DNS `CNAME admin → cname.vercel-dns.com` (proxied) → Cloudflare Access self-hosted app over `admin.checklyra.com/*` (admin allow-list) → set `ADMIN_HOST_ENFORCED=true` on prod and redeploy.
 
 ## CI/CD Pipeline
 

--- a/src/app/admin/beta-queue/page.tsx
+++ b/src/app/admin/beta-queue/page.tsx
@@ -1,89 +1,16 @@
 /**
- * KAN-277 (epic KAN-273): /admin/beta-queue — people awaiting beta approval.
+ * KAN-277 → KAN-311: the beta queue is now a filtered view of the unified
+ * user-management console. This route is kept as a permanent redirect so old
+ * links / bookmarks / the nav shortcut keep working.
  *
- * Admin-gated by the /admin layout (getCurrentAdmin → notFound for non-admins).
- * Lists profiles with beta_access_status='requested'; each row has an Approve
- * button wired to the approveBetaUser server action.
+ * The single-row `approveBetaUser` action (./actions) is retained — it remains a
+ * valid one-off approve path and is covered by its unit test — but day-to-day
+ * approvals now happen in the console with search + bulk select.
  */
-import { getAdminServiceClient } from '@/lib/admin';
-import { approveBetaUser } from './actions';
+import { redirect } from 'next/navigation';
 
 export const dynamic = 'force-dynamic';
 
-interface QueueRow {
-  id: string;
-  user_id: string;
-  display_name: string | null;
-  slug: string;
-  beta_requested_at: string | null;
-}
-
-async function listRequested(): Promise<QueueRow[]> {
-  const svc = getAdminServiceClient();
-  const { data } = await svc
-    .from('profiles')
-    .select('id, user_id, display_name, slug, beta_requested_at')
-    .eq('beta_access_status', 'requested')
-    .order('beta_requested_at', { ascending: true })
-    .limit(200);
-  return (data ?? []) as unknown as QueueRow[];
-}
-
-function formatRelative(iso: string | null): string {
-  if (!iso) return '—';
-  const diff = Date.now() - new Date(iso).getTime();
-  const mins = Math.floor(diff / 60000);
-  if (mins < 1) return 'just now';
-  if (mins < 60) return `${mins}m ago`;
-  const hrs = Math.floor(mins / 60);
-  if (hrs < 24) return `${hrs}h ago`;
-  return `${Math.floor(hrs / 24)}d ago`;
-}
-
-export default async function BetaQueuePage() {
-  const rows = await listRequested();
-
-  return (
-    <div className="max-w-6xl mx-auto px-6 py-8 space-y-6">
-      <header>
-        <h1 className="text-2xl font-medium text-[var(--color-ink)] font-[family-name:var(--font-serif)]">
-          Beta queue
-        </h1>
-        <p className="text-sm text-[var(--color-muted)] mt-1">
-          People who have requested access. Approving lets them into the beta and emails them a
-          &ldquo;you&rsquo;re in&rdquo; link.
-        </p>
-      </header>
-
-      <div className="rounded-xl border border-[var(--color-border)] bg-white divide-y divide-[var(--color-border)]">
-        {rows.length === 0 ? (
-          <p className="p-5 text-sm text-[var(--color-muted)]">No one is waiting for approval.</p>
-        ) : (
-          rows.map((r) => (
-            <div key={r.id} className="flex items-center justify-between gap-4 p-4">
-              <div className="min-w-0">
-                <p className="text-sm text-[var(--color-ink)] truncate">
-                  <span className="font-medium">{r.display_name ?? 'Unnamed'}</span>{' '}
-                  <span className="text-[var(--color-muted)]">(/{r.slug})</span>
-                </p>
-                <p className="text-xs text-[var(--color-muted)]">
-                  requested {formatRelative(r.beta_requested_at)}
-                </p>
-              </div>
-              <form action={approveBetaUser}>
-                <input type="hidden" name="profile_id" value={r.id} />
-                <input type="hidden" name="user_id" value={r.user_id} />
-                <button
-                  type="submit"
-                  className="text-xs font-medium px-4 py-2 rounded-full bg-[var(--color-sage)] text-white hover:opacity-90 transition-opacity shrink-0"
-                >
-                  Approve
-                </button>
-              </form>
-            </div>
-          ))
-        )}
-      </div>
-    </div>
-  );
+export default function BetaQueueRedirect() {
+  redirect('/admin/users?stage=waitlist');
 }

--- a/src/app/admin/layout.tsx
+++ b/src/app/admin/layout.tsx
@@ -47,22 +47,28 @@ export default async function AdminLayout({ children }: { children: React.ReactN
                 Overview
               </Link>
               <Link
-                href="/admin/reports"
-                className="text-sm text-[var(--color-muted)] hover:text-[var(--color-ink)] transition-colors"
-              >
-                Reports
-              </Link>
-              <Link
                 href="/admin/users"
                 className="text-sm text-[var(--color-muted)] hover:text-[var(--color-ink)] transition-colors"
               >
                 Users
               </Link>
               <Link
-                href="/admin/beta-queue"
+                href="/admin/moderation"
                 className="text-sm text-[var(--color-muted)] hover:text-[var(--color-ink)] transition-colors"
               >
-                Beta queue
+                Moderation
+              </Link>
+              <Link
+                href="/admin/reports"
+                className="text-sm text-[var(--color-muted)] hover:text-[var(--color-ink)] transition-colors"
+              >
+                Reports
+              </Link>
+              <Link
+                href="/admin/monitoring"
+                className="text-sm text-[var(--color-muted)] hover:text-[var(--color-ink)] transition-colors"
+              >
+                Monitoring
               </Link>
               <Link
                 href="/admin/audit"

--- a/src/app/admin/moderation/page.tsx
+++ b/src/app/admin/moderation/page.tsx
@@ -1,0 +1,186 @@
+/**
+ * KAN-309 / KAN-313: moderation review queue.
+ *
+ * One triage view over the two things the platform already captures:
+ *   1. Pending user `reports` (KAN-141) — link into the existing per-report
+ *      action page at /admin/reports/[id].
+ *   2. Recent `content_moderation_flags` (KAN-244) — the warn/block hits the
+ *      moderation library records on profile/Convene writes.
+ *
+ * v1 is read-only triage: flags have no review-state column yet (follow-up
+ * KAN-313), so each flag links through to the user where the admin acts with
+ * the existing suspend / delete tooling. `content_moderation_flags.profile_id`
+ * has no FK to profiles, so we resolve slugs in a second query and map.
+ */
+
+import Link from 'next/link';
+import { getAdminServiceClient } from '@/lib/admin';
+
+export const dynamic = 'force-dynamic';
+
+interface ReportRow {
+  id: string;
+  reason: string;
+  status: string;
+  note: string | null;
+  created_at: string;
+  profile: { slug: string; display_name: string } | null;
+}
+
+interface FlagRow {
+  id: string;
+  profile_id: string | null;
+  field: string;
+  severity: string;
+  flags: string[] | null;
+  content_snippet: string | null;
+  source: string | null;
+  created_at: string;
+}
+
+async function loadPendingReports(): Promise<ReportRow[]> {
+  const svc = getAdminServiceClient();
+  const { data } = await svc
+    .from('reports')
+    .select('id, reason, status, note, created_at, profile:profiles!reports_profile_id_fkey(slug, display_name)')
+    .eq('status', 'pending')
+    .order('created_at', { ascending: false })
+    .limit(100);
+  return ((data ?? []) as unknown as ReportRow[]).map((r) => {
+    const cand = r.profile as unknown;
+    const profile = Array.isArray(cand) ? (cand[0] ?? null) : cand;
+    return { ...r, profile: profile as ReportRow['profile'] };
+  });
+}
+
+async function loadFlags(): Promise<{ flags: FlagRow[]; slugById: Map<string, { slug: string; display_name: string }> }> {
+  const svc = getAdminServiceClient();
+  const { data } = await svc
+    .from('content_moderation_flags')
+    .select('id, profile_id, field, severity, flags, content_snippet, source, created_at')
+    .order('created_at', { ascending: false })
+    .limit(100);
+  const flags = (data ?? []) as FlagRow[];
+
+  const ids = Array.from(new Set(flags.map((f) => f.profile_id).filter((v): v is string => Boolean(v))));
+  const slugById = new Map<string, { slug: string; display_name: string }>();
+  if (ids.length > 0) {
+    const { data: profs } = await svc.from('profiles').select('id, slug, display_name').in('id', ids);
+    for (const p of (profs ?? []) as { id: string; slug: string; display_name: string }[]) {
+      slugById.set(p.id, { slug: p.slug, display_name: p.display_name });
+    }
+  }
+  return { flags, slugById };
+}
+
+function formatRelative(iso: string): string {
+  const diff = Math.max(0, Date.now() - new Date(iso).getTime());
+  const mins = Math.floor(diff / 60000);
+  if (mins < 1) return 'just now';
+  if (mins < 60) return `${mins}m ago`;
+  const hrs = Math.floor(mins / 60);
+  if (hrs < 24) return `${hrs}h ago`;
+  return `${Math.floor(hrs / 24)}d ago`;
+}
+
+export default async function ModerationQueuePage() {
+  const [reports, { flags, slugById }] = await Promise.all([loadPendingReports(), loadFlags()]);
+
+  return (
+    <div className="max-w-6xl mx-auto px-6 py-8 space-y-10">
+      <header>
+        <h1 className="text-2xl font-medium text-[var(--color-ink)] font-[family-name:var(--font-serif)]">
+          Moderation
+        </h1>
+        <p className="text-sm text-[var(--color-muted)] mt-1">
+          User reports awaiting review, and recent automated content flags. Open a report to action it, or
+          open a flagged profile to suspend or remove content.
+        </p>
+      </header>
+
+      <section aria-labelledby="reports-heading">
+        <h2 id="reports-heading" className="text-base font-medium text-[var(--color-ink)] mb-3">
+          Pending reports ({reports.length})
+        </h2>
+        <div className="rounded-xl border border-[var(--color-border)] bg-white divide-y divide-[var(--color-border)]">
+          {reports.length === 0 ? (
+            <p className="p-5 text-sm text-[var(--color-muted)]">No reports awaiting review.</p>
+          ) : (
+            reports.map((r) => (
+              <div key={r.id} className="p-4 flex items-center justify-between gap-4">
+                <div className="min-w-0">
+                  <p className="text-sm text-[var(--color-ink)] truncate">
+                    <span className="font-medium">{r.reason}</span>
+                    {' against '}
+                    {r.profile ? `${r.profile.display_name} (/${r.profile.slug})` : 'unknown profile'}
+                  </p>
+                  <p className="text-xs text-[var(--color-muted)] truncate">
+                    {r.note ? `“${r.note}” · ` : ''}{formatRelative(r.created_at)}
+                  </p>
+                </div>
+                <Link
+                  href={`/admin/reports/${r.id}`}
+                  className="text-xs font-medium px-4 py-2 rounded-full bg-[#f4efe7] text-[var(--color-ink)] hover:bg-[#ece7df] transition-colors shrink-0"
+                >
+                  Review →
+                </Link>
+              </div>
+            ))
+          )}
+        </div>
+      </section>
+
+      <section aria-labelledby="flags-heading">
+        <h2 id="flags-heading" className="text-base font-medium text-[var(--color-ink)] mb-3">
+          Recent content flags ({flags.length})
+        </h2>
+        <p className="text-xs text-[var(--color-muted)] mb-3">
+          Automated warn/block hits from the moderation library. Read-only triage — open the profile to act.
+        </p>
+        <div className="rounded-xl border border-[var(--color-border)] bg-white divide-y divide-[var(--color-border)]">
+          {flags.length === 0 ? (
+            <p className="p-5 text-sm text-[var(--color-muted)]">No content flags recorded.</p>
+          ) : (
+            flags.map((f) => {
+              const prof = f.profile_id ? slugById.get(f.profile_id) : undefined;
+              return (
+                <div key={f.id} className="p-4 flex items-start justify-between gap-4">
+                  <div className="min-w-0">
+                    <p className="text-sm text-[var(--color-ink)] truncate">
+                      <span
+                        className={
+                          'text-xs px-2 py-0.5 rounded-full mr-2 ' +
+                          (f.severity === 'block' ? 'bg-red-50 text-red-700' : 'bg-amber-50 text-amber-700')
+                        }
+                      >
+                        {f.severity}
+                      </span>
+                      <span className="font-medium">{f.field}</span>
+                      {f.source ? <span className="text-[var(--color-muted)]"> · {f.source}</span> : null}
+                    </p>
+                    {f.content_snippet && (
+                      <p className="text-xs text-[var(--color-muted)] mt-1 line-clamp-2">“{f.content_snippet}”</p>
+                    )}
+                    <p className="text-xs text-[var(--color-muted)] mt-1">
+                      {(f.flags ?? []).join(', ') || 'no tags'} · {formatRelative(f.created_at)}
+                    </p>
+                  </div>
+                  {prof ? (
+                    <Link
+                      href={`/admin/users/${prof.slug}`}
+                      className="text-xs font-medium px-4 py-2 rounded-full bg-[#f4efe7] text-[var(--color-ink)] hover:bg-[#ece7df] transition-colors shrink-0"
+                    >
+                      View profile →
+                    </Link>
+                  ) : (
+                    <span className="text-xs text-[var(--color-muted)] shrink-0">no profile</span>
+                  )}
+                </div>
+              );
+            })
+          )}
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/src/app/admin/monitoring/page.tsx
+++ b/src/app/admin/monitoring/page.tsx
@@ -1,0 +1,163 @@
+/**
+ * KAN-309 / KAN-314: monitoring / ops dashboard.
+ *
+ * Live in-app view for the operator:
+ *   - Activity metrics over 1h / 24h / 7d via the existing get_metrics_for_window
+ *     RPC (src/lib/metrics.ts).
+ *   - Operational counts (lifecycle stages, suspended, pending reports, recent
+ *     flags, admins) via the service-role client.
+ *   - External-tools panel: Sentry / UptimeRobot configured-or-not status + a
+ *     link out. Status is derived from env presence and labelled explicitly —
+ *     never a silent "looks fine" (Workflow Integrity policy).
+ */
+
+import Link from 'next/link';
+import { getAdminServiceClient } from '@/lib/admin';
+import { getAnomalyWindow, type AnomalyWindowKey, type MetricsSnapshot } from '@/lib/metrics';
+
+export const dynamic = 'force-dynamic';
+
+const WINDOWS: AnomalyWindowKey[] = ['1h', '24h', '7d'];
+
+async function safeWindow(key: AnomalyWindowKey): Promise<MetricsSnapshot | null> {
+  try {
+    return await getAnomalyWindow(key);
+  } catch (e) {
+    console.error(`[admin/monitoring] metrics ${key} failed`, e);
+    return null;
+  }
+}
+
+async function getCounts() {
+  const svc = getAdminServiceClient();
+  const sevenDaysAgo = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000).toISOString();
+  const [waitlist, beta, live, suspended, pendingReports, flags7d, admins, total] = await Promise.all([
+    svc.from('profiles').select('id', { count: 'exact', head: true }).eq('access_stage', 'waitlist'),
+    svc.from('profiles').select('id', { count: 'exact', head: true }).eq('access_stage', 'beta'),
+    svc.from('profiles').select('id', { count: 'exact', head: true }).eq('access_stage', 'live'),
+    svc.from('profiles').select('id', { count: 'exact', head: true }).eq('is_suspended', true),
+    svc.from('reports').select('id', { count: 'exact', head: true }).eq('status', 'pending'),
+    svc.from('content_moderation_flags').select('id', { count: 'exact', head: true }).gte('created_at', sevenDaysAgo),
+    svc.from('profiles').select('id', { count: 'exact', head: true }).eq('is_admin', true),
+    svc.from('profiles').select('id', { count: 'exact', head: true }),
+  ]);
+  return {
+    waitlist: waitlist.count ?? 0,
+    beta: beta.count ?? 0,
+    live: live.count ?? 0,
+    suspended: suspended.count ?? 0,
+    pendingReports: pendingReports.count ?? 0,
+    flags7d: flags7d.count ?? 0,
+    admins: admins.count ?? 0,
+    total: total.count ?? 0,
+  };
+}
+
+function StatCard({ label, value, href }: { label: string; value: number; href?: string }) {
+  const body = (
+    <div className="p-5 rounded-xl border border-[var(--color-border)] bg-white">
+      <p className="text-xs uppercase tracking-wider text-[var(--color-muted)] mb-2">{label}</p>
+      <p className="text-2xl font-semibold text-[var(--color-ink)]">{value.toLocaleString()}</p>
+    </div>
+  );
+  return href ? <Link href={href} className="block hover:shadow-sm transition-shadow">{body}</Link> : body;
+}
+
+function ExternalRow({ name, configured, href }: { name: string; configured: boolean; href: string }) {
+  return (
+    <div className="p-4 flex items-center justify-between gap-4">
+      <span className="text-sm text-[var(--color-ink)]">{name}</span>
+      <div className="flex items-center gap-3">
+        <span
+          className={
+            'text-xs px-2 py-0.5 rounded-full ' +
+            (configured ? 'bg-green-50 text-green-700' : 'bg-[#f4efe7] text-[var(--color-muted)]')
+          }
+        >
+          {configured ? 'configured' : 'not configured'}
+        </span>
+        <a href={href} target="_blank" rel="noopener noreferrer" className="text-xs text-[var(--color-muted)] hover:text-[var(--color-ink)]">
+          Open ↗
+        </a>
+      </div>
+    </div>
+  );
+}
+
+export default async function MonitoringPage() {
+  const [counts, windows] = await Promise.all([
+    getCounts(),
+    Promise.all(WINDOWS.map((w) => safeWindow(w))),
+  ]);
+
+  const sentryConfigured = Boolean(process.env.NEXT_PUBLIC_SENTRY_DSN);
+  const uptimeConfigured = Boolean(process.env.UPTIMEROBOT_API_KEY);
+
+  return (
+    <div className="max-w-6xl mx-auto px-6 py-8 space-y-10">
+      <header>
+        <h1 className="text-2xl font-medium text-[var(--color-ink)] font-[family-name:var(--font-serif)]">
+          Monitoring
+        </h1>
+        <p className="text-sm text-[var(--color-muted)] mt-1">Live activity and operational health.</p>
+      </header>
+
+      <section aria-label="Counts" className="grid grid-cols-2 sm:grid-cols-4 gap-4">
+        <StatCard label="Waitlist" value={counts.waitlist} href="/admin/users?stage=waitlist" />
+        <StatCard label="Beta" value={counts.beta} href="/admin/users?stage=beta" />
+        <StatCard label="Live" value={counts.live} href="/admin/users?stage=live" />
+        <StatCard label="Total signups" value={counts.total} href="/admin/users" />
+        <StatCard label="Suspended" value={counts.suspended} href="/admin/users?suspended=1" />
+        <StatCard label="Pending reports" value={counts.pendingReports} href="/admin/moderation" />
+        <StatCard label="Flags · 7d" value={counts.flags7d} href="/admin/moderation" />
+        <StatCard label="Admins" value={counts.admins} href="/admin/users?admin=1" />
+      </section>
+
+      <section aria-labelledby="activity-heading">
+        <h2 id="activity-heading" className="text-base font-medium text-[var(--color-ink)] mb-3">Activity</h2>
+        <div className="rounded-xl border border-[var(--color-border)] bg-white overflow-hidden">
+          <table className="w-full text-sm">
+            <thead className="bg-[#f4efe7]">
+              <tr>
+                <th className="text-left px-4 py-2 font-medium">Window</th>
+                <th className="text-right px-4 py-2 font-medium">Signups</th>
+                <th className="text-right px-4 py-2 font-medium">Publishes</th>
+                <th className="text-right px-4 py-2 font-medium">Items added</th>
+                <th className="text-right px-4 py-2 font-medium">Reports</th>
+              </tr>
+            </thead>
+            <tbody>
+              {WINDOWS.map((w, i) => {
+                const m = windows[i];
+                return (
+                  <tr key={w} className="border-t border-[var(--color-border)]">
+                    <td className="px-4 py-2 text-[var(--color-ink)]">Last {w}</td>
+                    {m === null ? (
+                      <td colSpan={4} className="px-4 py-2 text-right text-[var(--color-muted)]">data unavailable</td>
+                    ) : (
+                      <>
+                        <td className="px-4 py-2 text-right text-[var(--color-ink)]">{m.profile_signups}</td>
+                        <td className="px-4 py-2 text-right text-[var(--color-ink)]">{m.profile_publishes}</td>
+                        <td className="px-4 py-2 text-right text-[var(--color-ink)]">{m.profile_items_added}</td>
+                        <td className="px-4 py-2 text-right text-[var(--color-ink)]">{m.reports_filed}</td>
+                      </>
+                    )}
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+      </section>
+
+      <section aria-labelledby="external-heading">
+        <h2 id="external-heading" className="text-base font-medium text-[var(--color-ink)] mb-3">External monitoring</h2>
+        <div className="rounded-xl border border-[var(--color-border)] bg-white divide-y divide-[var(--color-border)]">
+          <ExternalRow name="Sentry (errors)" configured={sentryConfigured} href="https://sentry.io" />
+          <ExternalRow name="UptimeRobot (uptime)" configured={uptimeConfigured} href="https://dashboard.uptimerobot.com" />
+          <ExternalRow name="Public status page" configured href="https://checklyra.com/status" />
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/src/app/admin/users/BulkBar.tsx
+++ b/src/app/admin/users/BulkBar.tsx
@@ -1,0 +1,217 @@
+'use client';
+
+/**
+ * KAN-309 / KAN-311: bulk-select island for the user-management console.
+ *
+ * The admin pages are server components; multi-select needs client state, so
+ * this island renders BOTH the bulk toolbar AND the row checkboxes inside one
+ * <form action={bulkUserAction}>. Selected rows submit as `ids`; the
+ * "select all N matching this filter" toggle instead submits `selectAll=true`
+ * plus the current filter, and the server re-materialises the IDs itself.
+ *
+ * A confirm() dialog states the exact count + action before anything fires.
+ */
+
+import { useState } from 'react';
+import Link from 'next/link';
+import { bulkUserAction } from './actions';
+import { BULK_ACTIONS, type BulkActionConfig, type UserFilter } from './users-actions-shared';
+
+export interface BulkUserRow {
+  id: string;
+  user_id: string;
+  email: string | null;
+  display_name: string | null;
+  slug: string;
+  created_at: string;
+  access_stage: 'waitlist' | 'beta' | 'live';
+  early_access: boolean;
+  is_suspended: boolean;
+  is_admin: boolean;
+}
+
+const STAGE_BADGE: Record<string, string> = {
+  waitlist: 'bg-[#f4efe7] text-[var(--color-muted)]',
+  beta: 'bg-amber-50 text-amber-700',
+  live: 'bg-green-50 text-green-700',
+};
+
+function actionLabel(value: string): string {
+  return BULK_ACTIONS.find((a) => a.value === value)?.label ?? value;
+}
+
+export default function BulkBar({
+  rows,
+  total,
+  selfProfileId,
+  filter,
+}: {
+  rows: BulkUserRow[];
+  total: number;
+  selfProfileId: string;
+  filter: UserFilter;
+}) {
+  const selectable = rows.filter((r) => r.id !== selfProfileId);
+  const [selected, setSelected] = useState<Set<string>>(new Set());
+  const [selectAllMatching, setSelectAllMatching] = useState(false);
+  const [action, setAction] = useState<string>('');
+
+  const toggle = (id: string) => {
+    setSelected((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  };
+
+  const allPageSelected = selectable.length > 0 && selectable.every((r) => selected.has(r.id));
+  const togglePage = () => {
+    setSelected((prev) => {
+      if (selectable.every((r) => prev.has(r.id))) return new Set();
+      return new Set(selectable.map((r) => r.id));
+    });
+  };
+
+  const effectiveCount = selectAllMatching ? total : selected.size;
+  const cfg: BulkActionConfig | undefined = BULK_ACTIONS.find((a) => a.value === action);
+
+  const onSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+    if (!action) {
+      e.preventDefault();
+      alert('Choose an action first.');
+      return;
+    }
+    if (effectiveCount === 0) {
+      e.preventDefault();
+      alert('Select at least one user.');
+      return;
+    }
+    const reason = (e.currentTarget.elements.namedItem('reason') as HTMLInputElement | null)?.value?.trim();
+    if (cfg?.requiresReason && !reason) {
+      e.preventDefault();
+      alert(`A reason is required to ${actionLabel(action).toLowerCase()}.`);
+      return;
+    }
+    const ok = confirm(`${actionLabel(action)} — ${effectiveCount} user${effectiveCount === 1 ? '' : 's'}?`);
+    if (!ok) e.preventDefault();
+  };
+
+  return (
+    <form action={bulkUserAction} onSubmit={onSubmit} className="space-y-4">
+      {/* Toolbar */}
+      <div className="flex flex-wrap items-center gap-3 p-3 rounded-xl border border-[var(--color-border)] bg-white">
+        <label className="flex items-center gap-2 text-sm text-[var(--color-ink)]">
+          <input type="checkbox" checked={allPageSelected} onChange={togglePage} />
+          Select page
+        </label>
+
+        {total > selectable.length && (
+          <label className="flex items-center gap-2 text-sm text-[var(--color-ink)]">
+            <input
+              type="checkbox"
+              checked={selectAllMatching}
+              onChange={(e) => setSelectAllMatching(e.target.checked)}
+            />
+            Select all {total} matching
+          </label>
+        )}
+
+        <select
+          name="action"
+          value={action}
+          onChange={(e) => setAction(e.target.value)}
+          className="p-2 text-sm rounded-lg border border-[var(--color-border)] bg-white"
+        >
+          <option value="">Bulk action…</option>
+          {BULK_ACTIONS.map((a) => (
+            <option key={a.value} value={a.value}>{a.label}</option>
+          ))}
+        </select>
+
+        <input
+          name="reason"
+          type="text"
+          maxLength={500}
+          placeholder={cfg?.requiresReason ? 'Reason (required)' : 'Reason (optional)'}
+          className="flex-1 min-w-[180px] p-2 text-sm rounded-lg border border-[var(--color-border)] bg-white"
+        />
+
+        <button
+          type="submit"
+          disabled={!action || effectiveCount === 0}
+          className={
+            'px-4 py-2 rounded-full text-white text-sm font-medium transition-colors ' +
+            (cfg?.danger ? 'bg-red-600 hover:bg-red-700' : 'bg-[var(--color-sage)] hover:opacity-90') +
+            (!action || effectiveCount === 0 ? ' opacity-40 cursor-not-allowed' : '')
+          }
+        >
+          Apply{effectiveCount > 0 ? ` (${effectiveCount})` : ''}
+        </button>
+
+        {/* select-all + filter passthrough (read server-side only when selectAll=true) */}
+        {selectAllMatching && <input type="hidden" name="selectAll" value="true" />}
+        <input type="hidden" name="f_search" value={filter.search ?? ''} />
+        <input type="hidden" name="f_stage" value={filter.stage ?? ''} />
+        <input type="hidden" name="f_early" value={filter.early === null ? '' : String(filter.early)} />
+        <input type="hidden" name="f_suspended" value={filter.suspended === null ? '' : String(filter.suspended)} />
+        <input type="hidden" name="f_admin" value={filter.admin === null ? '' : String(filter.admin)} />
+      </div>
+
+      {/* Rows */}
+      <div className="rounded-xl border border-[var(--color-border)] bg-white divide-y divide-[var(--color-border)]">
+        {rows.length === 0 ? (
+          <p className="p-5 text-sm text-[var(--color-muted)]">No users match.</p>
+        ) : (
+          rows.map((u) => {
+            const isSelf = u.id === selfProfileId;
+            return (
+              <div key={u.id} className="flex items-center gap-3 p-4">
+                <input
+                  type="checkbox"
+                  name="ids"
+                  value={u.id}
+                  checked={selected.has(u.id)}
+                  onChange={() => toggle(u.id)}
+                  disabled={isSelf || selectAllMatching}
+                  aria-label={`Select ${u.display_name ?? u.slug}`}
+                  className={isSelf ? 'invisible' : ''}
+                />
+                <div className="min-w-0 flex-1">
+                  <p className="text-sm text-[var(--color-ink)] truncate">
+                    <span className="font-medium">{u.display_name ?? '(no name)'}</span>{' '}
+                    <span className="text-[var(--color-muted)]">/{u.slug}</span>
+                  </p>
+                  <p className="text-xs text-[var(--color-muted)] truncate">
+                    {u.email ?? '(no email)'} ·{' '}
+                    {new Date(u.created_at).toLocaleDateString('en-GB', { year: 'numeric', month: 'short', day: 'numeric' })}
+                  </p>
+                </div>
+                <div className="flex items-center gap-2 shrink-0">
+                  <span className={'text-xs px-2 py-0.5 rounded-full ' + (STAGE_BADGE[u.access_stage] ?? STAGE_BADGE.waitlist)}>
+                    {u.access_stage}
+                  </span>
+                  {u.early_access && (
+                    <span className="text-xs px-2 py-0.5 rounded-full bg-violet-50 text-violet-700">beta features</span>
+                  )}
+                  {u.is_admin && (
+                    <span className="text-xs px-2 py-0.5 rounded-full bg-blue-50 text-blue-700">admin</span>
+                  )}
+                  {u.is_suspended && (
+                    <span className="text-xs px-2 py-0.5 rounded-full bg-red-50 text-red-700">suspended</span>
+                  )}
+                  <Link
+                    href={`/admin/users/${u.slug}`}
+                    className="text-xs text-[var(--color-muted)] hover:text-[var(--color-ink)] transition-colors"
+                  >
+                    View →
+                  </Link>
+                </div>
+              </div>
+            );
+          })
+        )}
+      </div>
+    </form>
+  );
+}

--- a/src/app/admin/users/actions.ts
+++ b/src/app/admin/users/actions.ts
@@ -1,0 +1,146 @@
+'use server';
+
+/**
+ * KAN-309 / KAN-311: bulk user-management actions for the admin console.
+ *
+ * One server action (`bulkUserAction`) handles every bulk transition — enable /
+ * disable beta, promote to live (± early access), suspend / unsuspend — over a
+ * set of selected profiles. Contract, in order:
+ *
+ *   1. Re-check admin (never trust the client).
+ *   2. Resolve the target IDs. For "select all matching filter" the IDs are
+ *      re-materialised SERVER-SIDE from the filter via admin_filter_profile_ids
+ *      — a client-supplied ID list is never trusted for the select-all case.
+ *   3. De-dupe + exclude the admin's own profile (self-action guard), enforce cap.
+ *   4. Audit-first: one moderation_logs row per target (abort if it fails).
+ *   5. Apply the update via the service-role client (passes the admin-only
+ *      prevent_beta_self_elevation trigger).
+ *   6. Best-effort, bounded approval emails (never aborts the mutation).
+ */
+
+import { revalidatePath } from 'next/cache';
+import { createClient } from '@/lib/supabase-server';
+import { getCurrentAdmin, getAdminServiceClient, logModerationActionsBatch } from '@/lib/admin';
+import { sendBetaApprovedEmail } from '@/lib/beta-access/email';
+import {
+  BULK_MAX,
+  EMAIL_CAP,
+  computeAccessTransition,
+  isBulkAction,
+  type BulkAction,
+  type UserFilter,
+} from './users-actions-shared';
+
+function parseFilter(formData: FormData): UserFilter {
+  const str = (k: string): string | null => {
+    const v = String(formData.get(k) ?? '').trim();
+    return v.length ? v : null;
+  };
+  const tri = (k: string): boolean | null => {
+    const v = String(formData.get(k) ?? '').trim();
+    if (v === 'true') return true;
+    if (v === 'false') return false;
+    return null;
+  };
+  return {
+    search: str('f_search'),
+    stage: str('f_stage'),
+    early: tri('f_early'),
+    suspended: tri('f_suspended'),
+    admin: tri('f_admin'),
+  };
+}
+
+export async function bulkUserAction(formData: FormData): Promise<void> {
+  const admin = await getCurrentAdmin();
+  if (!admin) {
+    throw new Error('Not authorised');
+  }
+
+  const action = String(formData.get('action') ?? '').trim();
+  if (!isBulkAction(action)) {
+    throw new Error('Unknown action');
+  }
+  const reason = String(formData.get('reason') ?? '').trim();
+  if (action === 'suspend' && !reason) {
+    throw new Error('A reason is required to suspend');
+  }
+
+  // 1 + 2. Resolve target IDs.
+  let ids: string[];
+  if (String(formData.get('selectAll') ?? '') === 'true') {
+    const filter = parseFilter(formData);
+    const supabase = await createClient(); // cookie session → RPC admin check passes
+    const { data, error } = await supabase.rpc('admin_filter_profile_ids', {
+      p_search: filter.search,
+      p_stage: filter.stage,
+      p_early: filter.early,
+      p_suspended: filter.suspended,
+      p_admin: filter.admin,
+      p_cap: BULK_MAX,
+    });
+    if (error) {
+      throw new Error(`Could not resolve selection: ${error.message}`);
+    }
+    ids = (data as string[] | null) ?? [];
+  } else {
+    ids = formData.getAll('ids').map((v) => String(v)).filter(Boolean);
+  }
+
+  // 3. De-dupe + self-action guard + cap.
+  ids = Array.from(new Set(ids)).filter((id) => id !== admin.profileId);
+  if (ids.length === 0) {
+    throw new Error('No users selected');
+  }
+  if (ids.length > BULK_MAX) {
+    throw new Error(`Too many users (${ids.length}). Refine the filter; bulk is capped at ${BULK_MAX}.`);
+  }
+
+  const now = new Date().toISOString();
+  const transition = computeAccessTransition(action as BulkAction, { now, reason: reason || null });
+
+  // 4. Audit-first — abort the whole action if we can't record it.
+  await logModerationActionsBatch({
+    admin,
+    action: transition.moderationAction,
+    targetProfileIds: ids,
+    reason: reason || null,
+    metadata: { bulk: true, requested_action: action, count: ids.length },
+  });
+
+  // 5. Apply the change (service role passes the admin-only trigger).
+  const svc = getAdminServiceClient();
+  const { error: updErr } = await svc.from('profiles').update(transition.update).in('id', ids);
+  if (updErr) {
+    throw new Error(`Could not update users: ${updErr.message}`);
+  }
+
+  // 6. Best-effort approval emails, bounded — never roll back the mutation.
+  if (transition.sendApprovalEmail) {
+    const targets = ids.slice(0, EMAIL_CAP);
+    if (ids.length > EMAIL_CAP) {
+      console.warn(
+        `[admin] bulk ${action}: emailed first ${EMAIL_CAP} of ${ids.length}; remainder not emailed`,
+      );
+    }
+    try {
+      const { data: rows } = await svc.from('profiles').select('user_id').in('id', targets);
+      const userIds = (rows ?? [])
+        .map((r) => (r as { user_id?: string }).user_id)
+        .filter((v): v is string => Boolean(v));
+      for (const userId of userIds) {
+        try {
+          const { data: u } = await svc.auth.admin.getUserById(userId);
+          const email = u?.user?.email;
+          if (email) await sendBetaApprovedEmail({ to: email });
+        } catch (e) {
+          console.error('[admin] bulk approval email failed', e);
+        }
+      }
+    } catch (e) {
+      console.error('[admin] bulk approval email lookup failed', e);
+    }
+  }
+
+  revalidatePath('/admin/users');
+}

--- a/src/app/admin/users/page.tsx
+++ b/src/app/admin/users/page.tsx
@@ -1,59 +1,106 @@
 /**
- * KAN-141: /admin/users — list of profiles.
+ * KAN-309 / KAN-311: unified user-management console.
  *
- * Supports a `?filter=suspended` query to drill into the suspended set
- * (linked from the overview card) and a `?q=` text query for fuzzy name
- * / slug search. Pagination via `?page=` (10 per page) — the cursor is
- * created_at-keyed but offset is fine at the scale we're at.
+ * Lists ALL signups (not just the beta queue) with email, lifecycle stage and
+ * early-access state, plus search (email / name / slug) and filters
+ * (stage / suspended / admin). Bulk select + bulk actions live in the
+ * <BulkBar> client island. Data comes from the admin-only `admin_list_users`
+ * RPC (joins auth.users for email; admin-gated inside the function), called via
+ * the admin's cookie session.
  */
 
 import Link from 'next/link';
-import { getAdminServiceClient } from '@/lib/admin';
+import { getCurrentAdmin, getAdminServiceClient } from '@/lib/admin';
+import { createClient } from '@/lib/supabase-server';
+import BulkBar, { type BulkUserRow } from './BulkBar';
+import type { UserFilter } from './users-actions-shared';
 
 export const dynamic = 'force-dynamic';
 
 const PAGE_SIZE = 20;
+const STAGES = ['waitlist', 'beta', 'live'] as const;
 
-interface UserRow {
-  id: string;
-  display_name: string | null;
-  slug: string;
-  is_published: boolean;
-  is_suspended: boolean;
-  is_admin: boolean;
-  created_at: string;
+interface SearchParams {
+  q?: string;
+  stage?: string;
+  early?: string;
+  suspended?: string;
+  admin?: string;
+  filter?: string; // legacy links from the overview cards
+  page?: string;
 }
 
-async function listUsers(opts: { q?: string; filter?: string; page?: number }): Promise<{ rows: UserRow[]; total: number }> {
-  const supabase = getAdminServiceClient();
-  let q = supabase
-    .from('profiles')
-    .select('id, display_name, slug, is_published, is_suspended, is_admin, created_at', { count: 'exact' });
+function buildFilter(sp: SearchParams): UserFilter {
+  const stage = sp.stage && (STAGES as readonly string[]).includes(sp.stage) ? sp.stage : null;
+  const suspended = sp.suspended === '1' || sp.filter === 'suspended' ? true : null;
+  const admin = sp.admin === '1' || sp.filter === 'admin' ? true : null;
+  const early = sp.early === '1' ? true : null;
+  const search = sp.q && sp.q.trim().length ? sp.q.trim() : null;
+  return { search, stage, early, suspended, admin };
+}
 
-  if (opts.q && opts.q.trim().length > 0) {
-    const search = opts.q.trim().replace(/[%_]/g, '');
-    q = q.or(`display_name.ilike.%${search}%,slug.ilike.%${search}%`);
+async function listUsers(filter: UserFilter, page: number): Promise<{ rows: BulkUserRow[]; total: number; error: string | null }> {
+  const supabase = await createClient();
+  const { data, error } = await supabase.rpc('admin_list_users', {
+    p_search: filter.search,
+    p_stage: filter.stage,
+    p_early: filter.early,
+    p_suspended: filter.suspended,
+    p_admin: filter.admin,
+    p_limit: PAGE_SIZE,
+    p_offset: (page - 1) * PAGE_SIZE,
+  });
+  if (error) {
+    return { rows: [], total: 0, error: error.message };
   }
-  if (opts.filter === 'suspended') q = q.eq('is_suspended', true);
-  if (opts.filter === 'admin') q = q.eq('is_admin', true);
-
-  const page = Math.max(1, opts.page ?? 1);
-  q = q.order('created_at', { ascending: false })
-       .range((page - 1) * PAGE_SIZE, page * PAGE_SIZE - 1);
-
-  const { data, count } = await q;
-  return { rows: (data ?? []) as UserRow[], total: count ?? 0 };
+  const payload = (data ?? { rows: [], total: 0 }) as { rows: BulkUserRow[]; total: number };
+  return { rows: payload.rows ?? [], total: payload.total ?? 0, error: null };
 }
 
-export default async function UsersListPage({
+async function stageCounts(): Promise<{ waitlist: number; beta: number; live: number; suspended: number }> {
+  const svc = getAdminServiceClient();
+  const [waitlist, beta, live, suspended] = await Promise.all([
+    svc.from('profiles').select('id', { count: 'exact', head: true }).eq('access_stage', 'waitlist'),
+    svc.from('profiles').select('id', { count: 'exact', head: true }).eq('access_stage', 'beta'),
+    svc.from('profiles').select('id', { count: 'exact', head: true }).eq('access_stage', 'live'),
+    svc.from('profiles').select('id', { count: 'exact', head: true }).eq('is_suspended', true),
+  ]);
+  return {
+    waitlist: waitlist.count ?? 0,
+    beta: beta.count ?? 0,
+    live: live.count ?? 0,
+    suspended: suspended.count ?? 0,
+  };
+}
+
+function Chip({ href, label, active }: { href: string; label: string; active: boolean }) {
+  return (
+    <Link
+      href={href}
+      className={
+        'text-xs px-3 py-1.5 rounded-full transition-colors ' +
+        (active ? 'bg-[var(--color-ink)] text-white' : 'bg-[#f4efe7] text-[var(--color-muted)] hover:bg-[#ece7df]')
+      }
+    >
+      {label}
+    </Link>
+  );
+}
+
+export default async function UsersConsolePage({
   searchParams,
 }: {
-  searchParams: Promise<{ q?: string; filter?: string; page?: string }>;
+  searchParams: Promise<SearchParams>;
 }) {
   const sp = await searchParams;
+  const admin = (await getCurrentAdmin())!; // layout already gated
   const page = Math.max(1, Number(sp.page ?? '1') || 1);
-  const { rows, total } = await listUsers({ q: sp.q, filter: sp.filter, page });
+  const filter = buildFilter(sp);
+
+  const [{ rows, total, error }, counts] = await Promise.all([listUsers(filter, page), stageCounts()]);
   const totalPages = Math.max(1, Math.ceil(total / PAGE_SIZE));
+
+  const noFilter = !filter.stage && !filter.suspended && !filter.admin && !filter.early;
 
   return (
     <div className="max-w-6xl mx-auto px-6 py-8 space-y-6">
@@ -62,7 +109,7 @@ export default async function UsersListPage({
           Users
         </h1>
         <p className="text-sm text-[var(--color-muted)] mt-1">
-          {total} {total === 1 ? 'profile' : 'profiles'} {sp.filter ? `(${sp.filter})` : 'total'}.
+          {total} {total === 1 ? 'signup' : 'signups'} match. Waitlist {counts.waitlist} · Beta {counts.beta} · Live {counts.live} · Suspended {counts.suspended}.
         </p>
       </header>
 
@@ -70,93 +117,41 @@ export default async function UsersListPage({
         <input
           name="q"
           defaultValue={sp.q ?? ''}
-          placeholder="Search name or slug…"
-          className="flex-1 min-w-[200px] p-2 text-sm rounded-lg border border-[var(--color-border)] bg-white"
+          placeholder="Search email, name or slug…"
+          className="flex-1 min-w-[220px] p-2 text-sm rounded-lg border border-[var(--color-border)] bg-white"
         />
-        {sp.filter && <input type="hidden" name="filter" value={sp.filter} />}
+        {filter.stage && <input type="hidden" name="stage" value={filter.stage} />}
+        {filter.suspended && <input type="hidden" name="suspended" value="1" />}
+        {filter.admin && <input type="hidden" name="admin" value="1" />}
+        {filter.early && <input type="hidden" name="early" value="1" />}
         <button
           type="submit"
           className="px-4 py-2 rounded-full bg-[#f4efe7] text-[var(--color-ink)] text-sm font-medium hover:bg-[#ece7df] transition-colors"
         >
           Search
         </button>
-        <Link
-          href="/admin/users"
-          className="text-xs text-[var(--color-muted)] hover:text-[var(--color-ink)]"
-        >
+        <Link href="/admin/users" className="text-xs text-[var(--color-muted)] hover:text-[var(--color-ink)]">
           Clear
         </Link>
       </form>
 
-      <nav aria-label="Filter" className="flex gap-2">
-        <Link
-          href="/admin/users"
-          className={
-            'text-xs px-3 py-1.5 rounded-full transition-colors ' +
-            (!sp.filter
-              ? 'bg-[var(--color-ink)] text-white'
-              : 'bg-[#f4efe7] text-[var(--color-muted)] hover:bg-[#ece7df]')
-          }
-        >
-          All
-        </Link>
-        <Link
-          href="/admin/users?filter=suspended"
-          className={
-            'text-xs px-3 py-1.5 rounded-full transition-colors ' +
-            (sp.filter === 'suspended'
-              ? 'bg-[var(--color-ink)] text-white'
-              : 'bg-[#f4efe7] text-[var(--color-muted)] hover:bg-[#ece7df]')
-          }
-        >
-          Suspended
-        </Link>
-        <Link
-          href="/admin/users?filter=admin"
-          className={
-            'text-xs px-3 py-1.5 rounded-full transition-colors ' +
-            (sp.filter === 'admin'
-              ? 'bg-[var(--color-ink)] text-white'
-              : 'bg-[#f4efe7] text-[var(--color-muted)] hover:bg-[#ece7df]')
-          }
-        >
-          Admins
-        </Link>
+      <nav aria-label="Filter" className="flex flex-wrap gap-2">
+        <Chip href="/admin/users" label="All" active={noFilter && !filter.search} />
+        <Chip href="/admin/users?stage=waitlist" label="Waitlist" active={filter.stage === 'waitlist'} />
+        <Chip href="/admin/users?stage=beta" label="Beta" active={filter.stage === 'beta'} />
+        <Chip href="/admin/users?stage=live" label="Live" active={filter.stage === 'live'} />
+        <Chip href="/admin/users?early=1" label="Beta features" active={filter.early === true} />
+        <Chip href="/admin/users?suspended=1" label="Suspended" active={filter.suspended === true} />
+        <Chip href="/admin/users?admin=1" label="Admins" active={filter.admin === true} />
       </nav>
 
-      <div className="rounded-xl border border-[var(--color-border)] bg-white divide-y divide-[var(--color-border)]">
-        {rows.length === 0 ? (
-          <p className="p-5 text-sm text-[var(--color-muted)]">No users match.</p>
-        ) : rows.map((u) => (
-          <Link
-            key={u.id}
-            href={`/admin/users/${u.slug}`}
-            className="block p-4 hover:bg-[var(--color-paper)] transition-colors"
-          >
-            <div className="flex items-baseline justify-between gap-4 mb-1">
-              <p className="text-sm font-medium text-[var(--color-ink)] truncate">
-                {u.display_name ?? '(no name)'}{' '}
-                <span className="text-[var(--color-muted)]">/{u.slug}</span>
-              </p>
-              <div className="flex items-center gap-2 shrink-0">
-                {u.is_admin && (
-                  <span className="text-xs px-2 py-0.5 rounded-full bg-blue-50 text-blue-700">Admin</span>
-                )}
-                {u.is_suspended ? (
-                  <span className="text-xs px-2 py-0.5 rounded-full bg-red-50 text-red-700">Suspended</span>
-                ) : u.is_published ? (
-                  <span className="text-xs px-2 py-0.5 rounded-full bg-green-50 text-green-700">Published</span>
-                ) : (
-                  <span className="text-xs px-2 py-0.5 rounded-full bg-[#f4efe7] text-[var(--color-muted)]">Draft</span>
-                )}
-              </div>
-            </div>
-            <p className="text-xs text-[var(--color-muted)]">
-              Joined {new Date(u.created_at).toLocaleDateString('en-GB', { year: 'numeric', month: 'short', day: 'numeric' })}
-            </p>
-          </Link>
-        ))}
-      </div>
+      {error ? (
+        <p className="p-5 text-sm text-red-700 rounded-xl border border-red-200 bg-red-50">
+          Could not load users: {error}
+        </p>
+      ) : (
+        <BulkBar rows={rows} total={total} selfProfileId={admin.profileId} filter={filter} />
+      )}
 
       {totalPages > 1 && (
         <nav aria-label="Pagination" className="flex justify-between items-center text-sm">

--- a/src/app/admin/users/users-actions-shared.ts
+++ b/src/app/admin/users/users-actions-shared.ts
@@ -1,0 +1,148 @@
+/**
+ * KAN-309 (epic) / KAN-311: pure helpers + constants for the user-management
+ * console's bulk actions.
+ *
+ * This file is NOT 'use server' — it holds the runtime constants, types and the
+ * pure transition function so the action module (`actions.ts`) can stay
+ * async-only (BUGS-12: a 'use server' file may only export async functions).
+ *
+ * The transition matrix is the single source of truth for how each admin action
+ * maps onto the two-axis access model (access_stage + early_access) AND the
+ * legacy enforced gate (is_beta_eligible / beta_access_status). Keeping it pure
+ * makes it directly unit-testable without a DB.
+ */
+
+import type { ModerationAction } from '@/lib/admin';
+
+/** Hard ceiling on a single bulk action (server-enforced). */
+export const BULK_MAX = 500;
+
+/** Max approval emails to send per bulk action (best-effort, bounded). */
+export const EMAIL_CAP = 100;
+
+export interface BulkActionConfig {
+  value: string;
+  label: string;
+  requiresReason: boolean;
+  danger: boolean;
+}
+
+/** The bulk actions the console offers, in menu order. */
+export const BULK_ACTIONS = [
+  { value: 'enable_beta', label: 'Enable beta', requiresReason: false, danger: false },
+  { value: 'disable_beta', label: 'Disable beta', requiresReason: false, danger: true },
+  { value: 'promote_live_with_beta', label: 'Promote to live (with beta)', requiresReason: false, danger: false },
+  { value: 'promote_live_no_beta', label: 'Promote to live (no beta)', requiresReason: false, danger: false },
+  { value: 'suspend', label: 'Suspend', requiresReason: true, danger: true },
+  { value: 'unsuspend', label: 'Unsuspend', requiresReason: false, danger: false },
+] as const satisfies readonly BulkActionConfig[];
+
+export type BulkAction = (typeof BULK_ACTIONS)[number]['value'];
+
+const BULK_ACTION_VALUES = new Set<string>(BULK_ACTIONS.map((a) => a.value));
+
+export function isBulkAction(value: string): value is BulkAction {
+  return BULK_ACTION_VALUES.has(value);
+}
+
+export interface AccessTransition {
+  /** The partial `profiles` update to apply. */
+  update: Record<string, unknown>;
+  /** The moderation_logs action string to audit. */
+  moderationAction: ModerationAction;
+  /** Whether a "you're in" approval email is appropriate for this transition. */
+  sendApprovalEmail: boolean;
+}
+
+/**
+ * Map a bulk action onto the concrete column changes + audit action.
+ *
+ * Both axes (access_stage, early_access) are always written together with the
+ * derived enforced gate (is_beta_eligible / beta_access_status), so the model
+ * and the gate can never drift. `now` and `reason` are passed in to keep this
+ * function pure (no Date.now / no I/O).
+ */
+export function computeAccessTransition(
+  action: BulkAction,
+  opts: { now: string; reason?: string | null },
+): AccessTransition {
+  switch (action) {
+    case 'enable_beta':
+      return {
+        update: {
+          access_stage: 'beta',
+          early_access: true,
+          is_beta_eligible: true,
+          beta_access_status: 'approved',
+          beta_approved_at: opts.now,
+        },
+        moderationAction: 'enable_beta',
+        sendApprovalEmail: true,
+      };
+    case 'disable_beta':
+      return {
+        update: {
+          access_stage: 'waitlist',
+          early_access: false,
+          is_beta_eligible: false,
+          beta_access_status: 'none',
+          beta_approved_at: null,
+        },
+        moderationAction: 'disable_beta',
+        sendApprovalEmail: false,
+      };
+    case 'promote_live_with_beta':
+      return {
+        update: {
+          access_stage: 'live',
+          early_access: true,
+          is_beta_eligible: true,
+          beta_access_status: 'approved',
+        },
+        moderationAction: 'promote_live',
+        sendApprovalEmail: true,
+      };
+    case 'promote_live_no_beta':
+      return {
+        update: {
+          access_stage: 'live',
+          early_access: false,
+          // Still beta-eligible so the launched user passes the enforced gate;
+          // early_access=false is the "no experimental features" switch.
+          is_beta_eligible: true,
+          beta_access_status: 'approved',
+        },
+        moderationAction: 'promote_live',
+        sendApprovalEmail: false,
+      };
+    case 'suspend':
+      return {
+        update: {
+          is_suspended: true,
+          suspended_at: opts.now,
+          suspension_reason: opts.reason ?? null,
+        },
+        moderationAction: 'suspend',
+        sendApprovalEmail: false,
+      };
+    case 'unsuspend':
+      return {
+        update: {
+          is_suspended: false,
+          suspended_at: null,
+          suspension_reason: null,
+        },
+        moderationAction: 'unsuspend',
+        sendApprovalEmail: false,
+      };
+  }
+}
+
+/** Parsed shape of the filter posted by "select all matching filter". */
+export interface UserFilter {
+  search: string | null;
+  stage: string | null;
+  early: boolean | null;
+  suspended: boolean | null;
+  admin: boolean | null;
+}

--- a/src/lib/admin.ts
+++ b/src/lib/admin.ts
@@ -46,7 +46,11 @@ export type ModerationAction =
   | 'dismiss_report'
   | 'grant_admin'
   | 'revoke_admin'
-  | 'grant_beta_access'; // KAN-273: approve a queued user into the beta
+  | 'grant_beta_access' // KAN-273: approve a queued user into the beta
+  // KAN-309: two-axis access model transitions from the user-management console
+  | 'enable_beta' // waitlist -> beta (also sets is_beta_eligible=true)
+  | 'disable_beta' // beta -> waitlist (revokes is_beta_eligible)
+  | 'promote_live'; // promote to the launched product (± early_access)
 
 export interface AdminUser {
   userId: string;
@@ -133,4 +137,38 @@ export async function logModerationAction(input: LogModerationActionInput): Prom
     throw new Error(`Failed to write moderation_logs row: ${error?.message ?? 'unknown error'}`);
   }
   return data.id as string;
+}
+
+export interface LogModerationActionsBatchInput {
+  admin: AdminUser;
+  action: ModerationAction;
+  targetProfileIds: string[];
+  reason?: string | null;
+  metadata?: Record<string, unknown>;
+}
+
+/**
+ * KAN-309: audit a bulk admin action — one moderation_logs row per affected
+ * profile, written in a single insert. Used by the user-management console's
+ * bulk actions. Same audit-first contract as logModerationAction: throws if
+ * the insert fails so the caller aborts the mutation (a bulk action we
+ * couldn't audit is one we shouldn't commit).
+ */
+export async function logModerationActionsBatch(
+  input: LogModerationActionsBatchInput,
+): Promise<void> {
+  if (input.targetProfileIds.length === 0) return;
+  const client = getAdminServiceClient();
+  const rows = input.targetProfileIds.map((profileId) => ({
+    actor_user_id: input.admin.userId,
+    action: input.action,
+    target_profile_id: profileId,
+    target_item_id: null,
+    reason: input.reason ?? null,
+    metadata: input.metadata ?? {},
+  }));
+  const { error } = await client.from('moderation_logs').insert(rows);
+  if (error) {
+    throw new Error(`Failed to write ${rows.length} moderation_logs rows: ${error.message}`);
+  }
 }

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -15,6 +15,16 @@ function getClientIp(request: NextRequest): string {
 export async function middleware(request: NextRequest) {
   const pathname = request.nextUrl.pathname;
 
+  // KAN-309: admin.checklyra.com host routing. Enforced only when
+  // ADMIN_HOST_ENFORCED=true (set on prod once the DNS + Cloudflare Access app
+  // are live) — until then /admin keeps working on every host, so shipping this
+  // code is non-breaking.
+  const adminHost = process.env.ADMIN_HOST ?? 'admin.checklyra.com';
+  const adminHostEnforced = process.env.ADMIN_HOST_ENFORCED === 'true';
+  const requestHost =
+    request.headers.get('host') ?? request.headers.get('x-forwarded-host') ?? '';
+  const isAdminHost = requestHost === adminHost;
+
   // Supabase PKCE: redirect code param to /auth/callback for session exchange
   const code = request.nextUrl.searchParams.get('code');
   if (code && pathname === '/') {
@@ -77,6 +87,35 @@ export async function middleware(request: NextRequest) {
   const {
     data: { user },
   } = await supabase.auth.getUser();
+
+  // KAN-309: route the admin tools to the admin subdomain (once enforced).
+  if (adminHostEnforced) {
+    if (isAdminHost) {
+      // Let the auth/login flow, API routes and assets pass through unchanged.
+      const passthrough =
+        pathname === '/login' ||
+        pathname.startsWith('/auth/') ||
+        pathname.startsWith('/api/') ||
+        pathname.startsWith('/_next/');
+      if (!passthrough && !pathname.startsWith('/admin')) {
+        // admin.checklyra.com/users → /admin/users, carrying refreshed cookies.
+        const url = request.nextUrl.clone();
+        url.pathname = '/admin' + (pathname === '/' ? '' : pathname);
+        const rewrite = NextResponse.rewrite(url);
+        supabaseResponse.cookies.getAll().forEach((c) => rewrite.cookies.set(c));
+        return rewrite;
+      }
+      // Already an /admin path (or passthrough) — serve it, and crucially skip
+      // the beta gate below so an admin isn't bounced to /waitlist.
+      return supabaseResponse;
+    }
+    // Any non-admin host must never serve /admin — send it to the subdomain.
+    if (pathname.startsWith('/admin')) {
+      return NextResponse.redirect(
+        new URL(`https://${adminHost}${pathname}${request.nextUrl.search}`),
+      );
+    }
+  }
 
   // KAN-175: Beta gate. Only active on the beta deploy (IS_BETA_DEPLOY=true).
   // Authenticated users without is_beta_eligible=true get redirected to

--- a/supabase/migrations/20260622120000_two_axis_access_model.sql
+++ b/supabase/migrations/20260622120000_two_axis_access_model.sql
@@ -1,0 +1,239 @@
+-- KAN-309 / KAN-310 (+ SEC, see below): two-axis per-user access model for the
+-- admin back-office.
+--
+-- WHAT
+--   Adds two columns to public.profiles:
+--     - access_stage  enum('waitlist','beta','live')  default 'waitlist'
+--     - early_access  boolean                          default false
+--   so the admin console can model the full lifecycle the founder asked for:
+--     waitlisted signup -> enabled beta user -> launched ("live") user, with an
+--     orthogonal "early access" (beta/experimental features) switch.
+--     "Prod user WITH beta"    = access_stage='live' AND early_access=true
+--     "Prod user WITHOUT beta"  = access_stage='live' AND early_access=false
+--
+--   Plus two SECURITY DEFINER admin-only RPCs the console reads:
+--     - admin_list_users(...)        -> { rows: [...incl. auth.users.email], total }
+--     - admin_filter_profile_ids(...) -> uuid[]  (server-side "select all matching filter")
+--
+-- GATE STRATEGY (deliberate, low-risk)
+--   is_beta_eligible stays the single ENFORCED runtime gate (src/middleware.ts +
+--   resolveBetaAccess). The new model DRIVES it: every admin transition writes
+--   both new axes AND is_beta_eligible/beta_access_status together. No middleware
+--   refactor in this release.
+--
+-- SECURITY (SEC, child of SEC-1)
+--   The existing prevent_beta_self_elevation trigger only guarded the 4 legacy
+--   beta columns. This migration extends it to also reject user-context changes
+--   to access_stage / early_access, closing the same self-elevation class on the
+--   new columns. Service role (auth.uid() IS NULL) / migrations still bypass.
+--
+-- APPLIED TO
+--   dev (ilprytcrnqyrsbsrfujj): apply_migration 2026-06-22
+--   staging (uobmlkzrjkptwhttzmmi) / prod (llzkgprqewuwkiwclowi): user-gated promotion.
+--   NOTE: the beta-access columns + trigger are ALREADY live on all three envs
+--   (the 20260620120000/100 migration headers say "NOT YET" but are stale). This
+--   migration is additive on top of that live state.
+--
+-- ROLLBACK
+--   drop function if exists public.admin_filter_profile_ids(text,text,boolean,boolean,boolean,int);
+--   drop function if exists public.admin_list_users(text,text,boolean,boolean,boolean,int,int);
+--   drop index if exists public.profiles_access_stage_idx;
+--   alter table public.profiles drop column if exists early_access;
+--   alter table public.profiles drop column if exists access_stage;
+--   drop type if exists public.access_stage;
+--   -- and restore prevent_beta_self_elevation() to the 4-column version from
+--   -- 20260620120100_beta_access_lockdown.sql.
+
+-- 1. enum -------------------------------------------------------------------
+do $$
+begin
+  if not exists (select 1 from pg_type where typname = 'access_stage') then
+    create type public.access_stage as enum ('waitlist', 'beta', 'live');
+  end if;
+end $$;
+
+-- 2. columns (additive, safe defaults) -------------------------------------
+alter table public.profiles
+  add column if not exists access_stage public.access_stage not null default 'waitlist',
+  add column if not exists early_access boolean not null default false;
+
+-- 3. backfill from the existing flags ---------------------------------------
+-- Anyone already in the beta (legacy flag OR new status) -> beta + early access.
+update public.profiles
+   set access_stage = 'beta',
+       early_access = true
+ where access_stage = 'waitlist'
+   and (is_beta_eligible = true or beta_access_status = 'approved');
+
+-- Queued signups stay 'waitlist' (the default) — matches today's gate.
+-- 'none' / non-eligible rows also stay 'waitlist'.
+
+-- 4. index for the stage filter --------------------------------------------
+create index if not exists profiles_access_stage_idx on public.profiles (access_stage);
+
+-- 5. extend the self-elevation trigger to the new columns (SEC) -------------
+create or replace function public.prevent_beta_self_elevation()
+returns trigger
+language plpgsql
+security definer
+set search_path = public, pg_temp
+as $$
+begin
+  -- Service role / backend jobs / migrations run without a user JWT
+  -- (auth.uid() IS NULL) and ARE allowed to set the privileged columns.
+  if auth.uid() is null then
+    return new;
+  end if;
+
+  -- Any user-context request must NOT change the gate / access-model columns.
+  if new.is_beta_eligible   is distinct from old.is_beta_eligible
+  or new.beta_access_status is distinct from old.beta_access_status
+  or new.beta_requested_at  is distinct from old.beta_requested_at
+  or new.beta_approved_at   is distinct from old.beta_approved_at
+  or new.access_stage       is distinct from old.access_stage
+  or new.early_access       is distinct from old.early_access then
+    raise exception 'access-control columns are admin-only (KAN-273 / KAN-309)'
+      using errcode = '42501'; -- insufficient_privilege
+  end if;
+
+  return new;
+end;
+$$;
+
+drop trigger if exists profiles_prevent_beta_self_elevation on public.profiles;
+create trigger profiles_prevent_beta_self_elevation
+  before update on public.profiles
+  for each row execute function public.prevent_beta_self_elevation();
+
+-- 6. admin-only RPC: list signups with email + filters + pagination + count -
+-- SECURITY DEFINER so it can join auth.users; guarded by an internal is_admin
+-- check on auth.uid(). Called via the admin's COOKIE session (not service role),
+-- so auth.uid() resolves. Granted to `authenticated` only (revoked from anon).
+create or replace function public.admin_list_users(
+  p_search    text    default null,
+  p_stage     text    default null,
+  p_early     boolean default null,
+  p_suspended boolean default null,
+  p_admin     boolean default null,
+  p_limit     int     default 20,
+  p_offset    int     default 0
+)
+returns json
+language plpgsql
+security definer
+set search_path = public, pg_temp
+as $$
+declare
+  v_total  bigint;
+  v_rows   json;
+  v_limit  int  := least(greatest(coalesce(p_limit, 20), 1), 100);
+  v_offset int  := greatest(coalesce(p_offset, 0), 0);
+  v_search text := nullif(btrim(coalesce(p_search, '')), '');
+begin
+  if not exists (
+    select 1 from public.profiles
+     where user_id = auth.uid() and is_admin = true
+  ) then
+    raise exception 'admin only' using errcode = '42501';
+  end if;
+
+  select count(*) into v_total
+    from public.profiles p
+    join auth.users u on u.id = p.user_id
+   where (v_search is null
+          or u.email          ilike '%' || v_search || '%'
+          or p.display_name   ilike '%' || v_search || '%'
+          or p.slug           ilike '%' || v_search || '%')
+     and (p_stage     is null or p.access_stage::text = p_stage)
+     and (p_early     is null or p.early_access       = p_early)
+     and (p_suspended is null or p.is_suspended       = p_suspended)
+     and (p_admin     is null or p.is_admin           = p_admin);
+
+  select coalesce(json_agg(r), '[]'::json) into v_rows
+    from (
+      select p.id,
+             p.user_id,
+             u.email,
+             p.display_name,
+             p.slug,
+             p.created_at,
+             p.access_stage,
+             p.early_access,
+             p.is_beta_eligible,
+             p.beta_access_status,
+             p.beta_requested_at,
+             p.beta_approved_at,
+             p.is_suspended,
+             p.is_admin
+        from public.profiles p
+        join auth.users u on u.id = p.user_id
+       where (v_search is null
+              or u.email        ilike '%' || v_search || '%'
+              or p.display_name ilike '%' || v_search || '%'
+              or p.slug         ilike '%' || v_search || '%')
+         and (p_stage     is null or p.access_stage::text = p_stage)
+         and (p_early     is null or p.early_access       = p_early)
+         and (p_suspended is null or p.is_suspended       = p_suspended)
+         and (p_admin     is null or p.is_admin           = p_admin)
+       order by p.created_at desc
+       limit v_limit offset v_offset
+    ) r;
+
+  return json_build_object('rows', v_rows, 'total', v_total);
+end;
+$$;
+
+-- 7. admin-only RPC: resolve the IDs matching a filter, capped --------------
+-- Backs "select all N matching this filter" bulk actions: the IDs are
+-- re-materialized SERVER-SIDE from the filter, never trusted from the client.
+create or replace function public.admin_filter_profile_ids(
+  p_search    text    default null,
+  p_stage     text    default null,
+  p_early     boolean default null,
+  p_suspended boolean default null,
+  p_admin     boolean default null,
+  p_cap       int     default 500
+)
+returns uuid[]
+language plpgsql
+security definer
+set search_path = public, pg_temp
+as $$
+declare
+  v_ids    uuid[];
+  v_cap    int  := least(greatest(coalesce(p_cap, 500), 1), 1000);
+  v_search text := nullif(btrim(coalesce(p_search, '')), '');
+begin
+  if not exists (
+    select 1 from public.profiles
+     where user_id = auth.uid() and is_admin = true
+  ) then
+    raise exception 'admin only' using errcode = '42501';
+  end if;
+
+  select array_agg(id) into v_ids
+    from (
+      select p.id
+        from public.profiles p
+        join auth.users u on u.id = p.user_id
+       where (v_search is null
+              or u.email        ilike '%' || v_search || '%'
+              or p.display_name ilike '%' || v_search || '%'
+              or p.slug         ilike '%' || v_search || '%')
+         and (p_stage     is null or p.access_stage::text = p_stage)
+         and (p_early     is null or p.early_access       = p_early)
+         and (p_suspended is null or p.is_suspended       = p_suspended)
+         and (p_admin     is null or p.is_admin           = p_admin)
+       order by p.created_at desc
+       limit v_cap
+    ) s;
+
+  return coalesce(v_ids, array[]::uuid[]);
+end;
+$$;
+
+-- 8. grants: authenticated only (admins checked inside) ---------------------
+revoke all on function public.admin_list_users(text,text,boolean,boolean,boolean,int,int) from public;
+revoke all on function public.admin_filter_profile_ids(text,text,boolean,boolean,boolean,int) from public;
+grant execute on function public.admin_list_users(text,text,boolean,boolean,boolean,int,int) to authenticated;
+grant execute on function public.admin_filter_profile_ids(text,text,boolean,boolean,boolean,int) to authenticated;

--- a/tests/unit/access-model-transitions.test.ts
+++ b/tests/unit/access-model-transitions.test.ts
@@ -1,0 +1,101 @@
+/**
+ * KAN-309 / KAN-310: the two-axis access-model transition matrix is pure, so we
+ * test it directly — every action's exact column changes, the audited action
+ * string, and whether an approval email is appropriate.
+ */
+import {
+  computeAccessTransition,
+  isBulkAction,
+  BULK_ACTIONS,
+} from '@/app/admin/users/users-actions-shared';
+
+const NOW = '2026-06-22T00:00:00.000Z';
+
+describe('computeAccessTransition (KAN-309)', () => {
+  it('enable_beta sets both axes + the enforced gate + approved, and emails', () => {
+    const t = computeAccessTransition('enable_beta', { now: NOW });
+    expect(t.update).toMatchObject({
+      access_stage: 'beta',
+      early_access: true,
+      is_beta_eligible: true,
+      beta_access_status: 'approved',
+      beta_approved_at: NOW,
+    });
+    expect(t.moderationAction).toBe('enable_beta');
+    expect(t.sendApprovalEmail).toBe(true);
+  });
+
+  it('disable_beta revokes the gate, returns to waitlist, clears approval, no email', () => {
+    const t = computeAccessTransition('disable_beta', { now: NOW });
+    expect(t.update).toMatchObject({
+      access_stage: 'waitlist',
+      early_access: false,
+      is_beta_eligible: false,
+      beta_access_status: 'none',
+      beta_approved_at: null,
+    });
+    expect(t.moderationAction).toBe('disable_beta');
+    expect(t.sendApprovalEmail).toBe(false);
+  });
+
+  it('promote_live_with_beta → live, early access on, stays beta-eligible, emails', () => {
+    const t = computeAccessTransition('promote_live_with_beta', { now: NOW });
+    expect(t.update).toMatchObject({
+      access_stage: 'live',
+      early_access: true,
+      is_beta_eligible: true,
+      beta_access_status: 'approved',
+    });
+    expect(t.moderationAction).toBe('promote_live');
+    expect(t.sendApprovalEmail).toBe(true);
+  });
+
+  it('promote_live_no_beta → live, early access OFF, still beta-eligible, no email', () => {
+    const t = computeAccessTransition('promote_live_no_beta', { now: NOW });
+    expect(t.update).toMatchObject({
+      access_stage: 'live',
+      early_access: false,
+      is_beta_eligible: true,
+      beta_access_status: 'approved',
+    });
+    expect(t.moderationAction).toBe('promote_live');
+    expect(t.sendApprovalEmail).toBe(false);
+  });
+
+  it('suspend uses reason + now and does NOT touch the access axes', () => {
+    const t = computeAccessTransition('suspend', { now: NOW, reason: 'spam' });
+    expect(t.update).toMatchObject({
+      is_suspended: true,
+      suspended_at: NOW,
+      suspension_reason: 'spam',
+    });
+    expect(t.update.access_stage).toBeUndefined();
+    expect(t.update.is_beta_eligible).toBeUndefined();
+    expect(t.moderationAction).toBe('suspend');
+  });
+
+  it('unsuspend clears the suspension fields only', () => {
+    const t = computeAccessTransition('unsuspend', { now: NOW });
+    expect(t.update).toMatchObject({
+      is_suspended: false,
+      suspended_at: null,
+      suspension_reason: null,
+    });
+    expect(t.update.access_stage).toBeUndefined();
+    expect(t.moderationAction).toBe('unsuspend');
+  });
+
+  it('isBulkAction validates against the known set', () => {
+    for (const a of BULK_ACTIONS) {
+      expect(isBulkAction(a.value)).toBe(true);
+    }
+    expect(isBulkAction('grant_admin')).toBe(false);
+    expect(isBulkAction('')).toBe(false);
+    expect(isBulkAction('drop_table')).toBe(false);
+  });
+
+  it('only suspend requires a reason', () => {
+    expect(BULK_ACTIONS.find((a) => a.value === 'suspend')?.requiresReason).toBe(true);
+    expect(BULK_ACTIONS.filter((a) => a.requiresReason).map((a) => a.value)).toEqual(['suspend']);
+  });
+});

--- a/tests/unit/admin-host-routing.test.ts
+++ b/tests/unit/admin-host-routing.test.ts
@@ -1,0 +1,67 @@
+/**
+ * KAN-309 / KAN-312: middleware host routing for admin.checklyra.com.
+ *
+ * Verifies the three behaviours that keep the admin tools isolated to the
+ * subdomain WITHOUT breaking the main app — and that the whole thing is inert
+ * until ADMIN_HOST_ENFORCED=true (non-breaking rollout).
+ */
+
+process.env.NEXT_PUBLIC_SUPABASE_URL = 'https://test.supabase.co';
+process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY = 'anon-key';
+
+jest.mock('@supabase/ssr', () => ({
+  createServerClient: () => ({
+    auth: { getUser: async () => ({ data: { user: null } }) },
+    from: () => ({
+      select: () => ({ eq: () => ({ maybeSingle: async () => ({ data: null }) }) }),
+    }),
+  }),
+}));
+
+import { NextRequest } from 'next/server';
+import { middleware } from '@/middleware';
+
+function get(host: string, path: string): NextRequest {
+  return new NextRequest(new URL(`https://${host}${path}`), {
+    headers: { host },
+  });
+}
+
+describe('admin host routing (KAN-312)', () => {
+  afterEach(() => {
+    delete process.env.ADMIN_HOST_ENFORCED;
+    delete process.env.ADMIN_HOST;
+  });
+
+  it('is inert when enforcement is off (no rewrite of /admin on the admin host)', async () => {
+    const res = await middleware(get('admin.checklyra.com', '/users'));
+    expect(res.headers.get('x-middleware-rewrite')).toBeNull();
+    expect(res.headers.get('location')).toBeNull();
+  });
+
+  it('rewrites non-/admin paths to /admin/* on the admin host when enforced', async () => {
+    process.env.ADMIN_HOST_ENFORCED = 'true';
+    const res = await middleware(get('admin.checklyra.com', '/users'));
+    const rewrite = res.headers.get('x-middleware-rewrite');
+    expect(rewrite).not.toBeNull();
+    expect(new URL(rewrite as string).pathname).toBe('/admin/users');
+  });
+
+  it('rewrites the admin-host root to /admin when enforced', async () => {
+    process.env.ADMIN_HOST_ENFORCED = 'true';
+    const res = await middleware(get('admin.checklyra.com', '/'));
+    expect(new URL(res.headers.get('x-middleware-rewrite') as string).pathname).toBe('/admin');
+  });
+
+  it('redirects /admin on a non-admin host to the admin subdomain when enforced', async () => {
+    process.env.ADMIN_HOST_ENFORCED = 'true';
+    const res = await middleware(get('checklyra.com', '/admin/users'));
+    expect(res.status).toBe(307);
+    expect(res.headers.get('location')).toBe('https://admin.checklyra.com/admin/users');
+  });
+
+  it('does not block /admin on the main host when enforcement is off', async () => {
+    const res = await middleware(get('checklyra.com', '/admin/users'));
+    expect(res.headers.get('location')).toBeNull();
+  });
+});

--- a/tests/unit/users-bulk-actions.test.ts
+++ b/tests/unit/users-bulk-actions.test.ts
@@ -1,0 +1,137 @@
+/**
+ * KAN-309 / KAN-311: bulkUserAction — the privileged bulk mutation behind the
+ * user-management console. Covers the security-critical contract:
+ *   - non-admin rejected (no mutation, no audit)
+ *   - both axes + gate written per the matrix; audit one row per target
+ *   - the admin's own profile is excluded (self-action guard)
+ *   - "select all matching filter" re-materialises IDs SERVER-SIDE (client IDs
+ *     ignored)
+ *   - the BULK_MAX cap is enforced
+ *   - email failure does not abort the mutation
+ *   - a DB update error throws (no silent success)
+ */
+import { bulkUserAction } from '@/app/admin/users/actions';
+import { BULK_MAX } from '@/app/admin/users/users-actions-shared';
+
+jest.mock('next/cache', () => ({ revalidatePath: jest.fn() }));
+
+const mockGetCurrentAdmin = jest.fn();
+const mockUpdateIn = jest.fn();
+const mockSelectIn = jest.fn();
+const mockGetUserById = jest.fn();
+const mockLogBatch = jest.fn();
+const mockEmail = jest.fn();
+const mockRpc = jest.fn();
+
+jest.mock('@/lib/admin', () => ({
+  getCurrentAdmin: () => mockGetCurrentAdmin(),
+  getAdminServiceClient: () => ({
+    from: () => ({
+      update: () => ({ in: (...a: unknown[]) => mockUpdateIn(...a) }),
+      select: () => ({ in: (...a: unknown[]) => mockSelectIn(...a) }),
+    }),
+    auth: { admin: { getUserById: (...a: unknown[]) => mockGetUserById(...a) } },
+  }),
+  logModerationActionsBatch: (...a: unknown[]) => mockLogBatch(...a),
+}));
+
+jest.mock('@/lib/supabase-server', () => ({
+  createClient: jest.fn().mockResolvedValue({ rpc: (...a: unknown[]) => mockRpc(...a) }),
+}));
+
+jest.mock('@/lib/beta-access/email', () => ({
+  sendBetaApprovedEmail: (...a: unknown[]) => mockEmail(...a),
+}));
+
+const ADMIN = { userId: 'admin-user', profileId: 'admin-profile', email: 'a@a.com', displayName: 'A' };
+
+function fd(fields: Record<string, string | string[]>): FormData {
+  const f = new FormData();
+  for (const [k, v] of Object.entries(fields)) {
+    if (Array.isArray(v)) v.forEach((x) => f.append(k, x));
+    else f.set(k, v);
+  }
+  return f;
+}
+
+describe('bulkUserAction (KAN-311)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetCurrentAdmin.mockResolvedValue(ADMIN);
+    mockUpdateIn.mockResolvedValue({ error: null });
+    mockSelectIn.mockResolvedValue({ data: [{ user_id: 'u1' }, { user_id: 'u2' }] });
+    mockGetUserById.mockResolvedValue({ data: { user: { email: 'x@y.com' } } });
+    mockLogBatch.mockResolvedValue(undefined);
+    mockEmail.mockResolvedValue({ ok: true, messageId: 'm1' });
+    mockRpc.mockResolvedValue({ data: ['p1', 'p2'], error: null });
+  });
+
+  it('rejects non-admins with no mutation and no audit', async () => {
+    mockGetCurrentAdmin.mockResolvedValue(null);
+    await expect(bulkUserAction(fd({ action: 'enable_beta', ids: ['p1'] }))).rejects.toThrow('Not authorised');
+    expect(mockLogBatch).not.toHaveBeenCalled();
+    expect(mockUpdateIn).not.toHaveBeenCalled();
+  });
+
+  it('rejects an unknown action', async () => {
+    await expect(bulkUserAction(fd({ action: 'drop_table', ids: ['p1'] }))).rejects.toThrow('Unknown action');
+    expect(mockUpdateIn).not.toHaveBeenCalled();
+  });
+
+  it('requires a reason to suspend', async () => {
+    await expect(bulkUserAction(fd({ action: 'suspend', ids: ['p1'] }))).rejects.toThrow('reason is required');
+    expect(mockUpdateIn).not.toHaveBeenCalled();
+  });
+
+  it('enable_beta: audits per target then updates both axes + gate, and emails', async () => {
+    await bulkUserAction(fd({ action: 'enable_beta', ids: ['p1', 'p2'] }));
+    expect(mockLogBatch).toHaveBeenCalledWith(
+      expect.objectContaining({ action: 'enable_beta', targetProfileIds: ['p1', 'p2'] }),
+    );
+    expect(mockUpdateIn).toHaveBeenCalledWith('id', ['p1', 'p2']);
+    expect(mockEmail).toHaveBeenCalled();
+  });
+
+  it('excludes the admin\'s own profile from the batch', async () => {
+    await bulkUserAction(fd({ action: 'enable_beta', ids: ['p1', ADMIN.profileId, 'p2'] }));
+    expect(mockUpdateIn).toHaveBeenCalledWith('id', ['p1', 'p2']);
+  });
+
+  it('throws when only the admin selected themselves', async () => {
+    await expect(bulkUserAction(fd({ action: 'enable_beta', ids: [ADMIN.profileId] }))).rejects.toThrow(
+      'No users selected',
+    );
+    expect(mockUpdateIn).not.toHaveBeenCalled();
+  });
+
+  it('selectAll re-materialises IDs server-side and ignores client-sent IDs', async () => {
+    await bulkUserAction(
+      fd({ action: 'disable_beta', selectAll: 'true', f_stage: 'beta', ids: ['attacker-supplied'] }),
+    );
+    expect(mockRpc).toHaveBeenCalledWith('admin_filter_profile_ids', expect.objectContaining({ p_stage: 'beta' }));
+    expect(mockUpdateIn).toHaveBeenCalledWith('id', ['p1', 'p2']);
+  });
+
+  it('enforces the BULK_MAX cap', async () => {
+    const tooMany = Array.from({ length: BULK_MAX + 1 }, (_, i) => `id${i}`);
+    await expect(bulkUserAction(fd({ action: 'enable_beta', ids: tooMany }))).rejects.toThrow('Too many users');
+    expect(mockUpdateIn).not.toHaveBeenCalled();
+  });
+
+  it('does not send emails for non-approval transitions (disable_beta)', async () => {
+    await bulkUserAction(fd({ action: 'disable_beta', ids: ['p1'] }));
+    expect(mockUpdateIn).toHaveBeenCalledWith('id', ['p1']);
+    expect(mockEmail).not.toHaveBeenCalled();
+  });
+
+  it('still completes if the approval email step throws', async () => {
+    mockGetUserById.mockRejectedValue(new Error('auth down'));
+    await expect(bulkUserAction(fd({ action: 'enable_beta', ids: ['p1'] }))).resolves.toBeUndefined();
+    expect(mockUpdateIn).toHaveBeenCalled();
+  });
+
+  it('throws if the DB update fails (no silent success)', async () => {
+    mockUpdateIn.mockResolvedValue({ error: { message: 'db down' } });
+    await expect(bulkUserAction(fd({ action: 'enable_beta', ids: ['p1'] }))).rejects.toThrow('Could not update users');
+  });
+});


### PR DESCRIPTION
## Summary
Epic **[KAN-309](https://checklyra.atlassian.net/browse/KAN-309)** — a private admin back-office (`admin.checklyra.com`) over the existing `/admin` area (KAN-141), with the operator tools needed to run the beta and the launch.

The headline: one **user-management console** to see every signup, switch beta access **on and off**, promote testers to the launched product **with or without** early-access features, and suspend abusers — with **search, filters, and bulk select/edit**. Plus a moderation triage queue and a live monitoring dashboard.

## Access model (confirmed with Luisa)
Two axes per user: a lifecycle **`access_stage`** (`waitlist → beta → live`) plus an **`early_access`** switch.
- "Prod user **with** beta" = `live` + `early_access=true`
- "Prod user **without** beta" = `live` + `early_access=false`

`is_beta_eligible` stays the single **enforced** runtime gate; the new model *drives* it (no middleware-gate refactor this release).

## What's in here
- **[KAN-310](https://checklyra.atlassian.net/browse/KAN-310)** — migration `20260622120000_two_axis_access_model.sql`: `access_stage` enum + `early_access`, backfilled from the legacy beta flags; admin-only `SECURITY DEFINER` RPCs `admin_list_users` (joins `auth.users` for email + filters + pagination + count) and `admin_filter_profile_ids` (server-side "select all matching filter"). **Applied + validated on dev.**
- **[SEC-24](https://checklyra.atlassian.net/browse/SEC-24)** — extends `prevent_beta_self_elevation` to the new columns (closes the self-elevation hole on `access_stage`/`early_access`). Verified: user JWT blocked (42501), service role bypasses.
- **[KAN-311](https://checklyra.atlassian.net/browse/KAN-311)** — `/admin/users` unified console + `BulkBar` client island + `bulkUserAction`. Audit-first (one `moderation_logs` row per target), self-action guard, `BULK_MAX=500` cap, "select all" re-materialised server-side (never trusts client IDs), best-effort capped emails. `/admin/beta-queue` → redirect into the console.
- **[KAN-313](https://checklyra.atlassian.net/browse/KAN-313)** — `/admin/moderation` triage over `reports` + `content_moderation_flags` (v1 read-only, links into existing action surfaces).
- **[KAN-314](https://checklyra.atlassian.net/browse/KAN-314)** — `/admin/monitoring` live metrics (`get_metrics_for_window`) + ops counts + external-tool status.
- **[KAN-312](https://checklyra.atlassian.net/browse/KAN-312)** — `src/middleware.ts` host routing behind `ADMIN_HOST` / `ADMIN_HOST_ENFORCED`. **Default OFF** → `/admin` keeps working everywhere until DNS + Cloudflare Access are live, so this ships non-breaking.

## Verification
- `type-check` clean · `lint` clean · **`next build` clean** (all admin routes compiled) · server-action export guard passes.
- Unit: **+24 tests** (transition matrix, `bulkUserAction` security contract, middleware host routing). Full suite **1709 / 128 suites green**.
- DB on **dev** (`ilprytcrnqyrsbsrfujj`): backfill correct (0 misclassified); RPC rejects non-admins (42501) and returns rows + email search for an admin; trigger blocks user self-elevation, allows service role.

## Out-of-band ops (Luisa, before flipping enforcement)
Add `admin.checklyra.com` to Vercel (Production env) → Cloudflare DNS `CNAME admin → cname.vercel-dns.com` (proxied) → Cloudflare Access app (admin allow-list) → set `ADMIN_HOST_ENFORCED=true` on prod. Then promote the migration staging → prod. See `docs/ARCHITECTURE.md`.

MCP coverage: deferred — internal admin/ops tooling (CLAUDE.md KAN-222 exemption).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[KAN-309]: https://checklyra.atlassian.net/browse/KAN-309?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[KAN-310]: https://checklyra.atlassian.net/browse/KAN-310?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SEC-24]: https://checklyra.atlassian.net/browse/SEC-24?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ