### PR TITLE
feat(KAN-315): per-user feature entitlements — Convene/MCP/paid-links/uploads/discovery

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -58,6 +58,11 @@ Host routing lives in `src/middleware.ts` behind two env vars (set on the **prod
 | `ADMIN_HOST_ENFORCED` | _(unset = off)_ | `true` rewrites the admin host → `/admin/*` and blocks `/admin` on other hosts. Leave **off** until the DNS record + Cloudflare Access app are live, then flip on (non-breaking rollout). |
 | `SENTRY_READ_TOKEN` | _(optional)_ | Reserved for live Sentry panels on `/admin/monitoring` |
 | `UPTIMEROBOT_API_KEY` | _(optional)_ | Lights up the UptimeRobot status on `/admin/monitoring` |
+| `PAID_LINKS_COMPLIANCE_READY` | _(unset = off)_ | KAN-309: gates the `paid_gift_links` per-user entitlement. Monetised affiliate links are produced only when this is `true` (FTC/ASA/CMA disclosure KAN-192 + cookie/GDPR consent KAN-193 shipped) **and** the recipient is entitled **and** `SOVRN_API_KEY` is set. |
+
+### Per-user feature entitlements (KAN-309 follow-on)
+
+`feature_entitlements` (per `profile_id` × `feature_key`) lets the admin console switch beta features on/off per user. Keys: `mcp`, `convene`, `paid_gift_links`, `convene_paid_channels`, `media_uploads`, `discovery`. Effective gate everywhere is **per-env flag AND per-user entitlement** (env flag stays the master kill-switch). Defaults live in `src/lib/features/registry.ts` (`mcp`/`convene`/`paid_*` default off; `media_uploads`/`discovery` default on). Writes are service-role only (RLS + self-grant trigger). **MCP-server enforcement of `mcp`/`convene` ships as a follow-up** — until then the `mcp` toggle is recorded but not enforced over `mcp.checklyra.com`.
 
 **One-time setup (ops):** add `admin.checklyra.com` to the Lyra Vercel project (Production env) → Cloudflare DNS `CNAME admin → cname.vercel-dns.com` (proxied) → Cloudflare Access self-hosted app over `admin.checklyra.com/*` (admin allow-list) → set `ADMIN_HOST_ENFORCED=true` on prod and redeploy.
 

--- a/src/app/admin/users/[slug]/page.tsx
+++ b/src/app/admin/users/[slug]/page.tsx
@@ -10,6 +10,9 @@
 import { notFound, redirect } from 'next/navigation';
 import Link from 'next/link';
 import { getCurrentAdmin, getAdminServiceClient, logModerationAction } from '@/lib/admin';
+import { getProfileEntitlements } from '@/lib/features/entitlements-service';
+import { FEATURE_KEYS, FEATURE_CONFIG } from '@/lib/features/registry';
+import { setFeatureEntitlement } from '../actions';
 
 export const dynamic = 'force-dynamic';
 
@@ -140,6 +143,7 @@ export default async function UserDetailPage({
   const profile = await loadProfile(slug);
   if (!profile) notFound();
   const items = await loadItems(profile.id);
+  const entitlements = await getProfileEntitlements(profile.id);
   const isSelf = profile.id === admin.profileId;
 
   return (
@@ -232,6 +236,57 @@ export default async function UserDetailPage({
           )}
         </section>
       )}
+
+      <section className="p-5 rounded-xl border border-[var(--color-border)] bg-white">
+        <h2 className="text-base font-medium text-[var(--color-ink)]">Feature access</h2>
+        <p className="text-xs text-[var(--color-muted)] mt-1 mb-3">
+          Per-user beta features. Each also needs its environment switch on to take effect.
+        </p>
+        <div className="divide-y divide-[var(--color-border)]">
+          {FEATURE_KEYS.map((k) => {
+            const cfg = FEATURE_CONFIG[k];
+            const on = entitlements[k];
+            return (
+              <div key={k} className="py-3 flex items-center justify-between gap-3">
+                <div className="min-w-0">
+                  <p className="text-sm text-[var(--color-ink)]">
+                    <span className="font-medium">{cfg.label}</span>{' '}
+                    <span
+                      className={
+                        'text-xs px-2 py-0.5 rounded-full ' +
+                        (on ? 'bg-green-50 text-green-700' : 'bg-[#f4efe7] text-[var(--color-muted)]')
+                      }
+                    >
+                      {on ? 'on' : 'off'}
+                    </span>
+                  </p>
+                  <p className="text-xs text-[var(--color-muted)]">
+                    {cfg.description}
+                    {cfg.envPrerequisite ? ` · needs ${cfg.envPrerequisite}` : ''}
+                  </p>
+                </div>
+                <form action={setFeatureEntitlement} className="shrink-0">
+                  <input type="hidden" name="profileId" value={profile.id} />
+                  <input type="hidden" name="slug" value={profile.slug} />
+                  <input type="hidden" name="featureKey" value={k} />
+                  <input type="hidden" name="enabled" value={(!on).toString()} />
+                  <button
+                    type="submit"
+                    className={
+                      'text-xs font-medium px-4 py-2 rounded-full transition-colors ' +
+                      (on
+                        ? 'bg-[#f4efe7] text-red-700 hover:bg-red-50'
+                        : 'bg-[var(--color-sage)] text-white hover:opacity-90')
+                    }
+                  >
+                    {on ? 'Disable' : 'Enable'}
+                  </button>
+                </form>
+              </div>
+            );
+          })}
+        </div>
+      </section>
 
       <section className="p-5 rounded-xl border border-[var(--color-border)] bg-white">
         <h2 className="text-base font-medium text-[var(--color-ink)] mb-3">Items</h2>

--- a/src/app/admin/users/actions.ts
+++ b/src/app/admin/users/actions.ts
@@ -20,7 +20,7 @@
 
 import { revalidatePath } from 'next/cache';
 import { createClient } from '@/lib/supabase-server';
-import { getCurrentAdmin, getAdminServiceClient, logModerationActionsBatch } from '@/lib/admin';
+import { getCurrentAdmin, getAdminServiceClient, logModerationAction, logModerationActionsBatch } from '@/lib/admin';
 import { sendBetaApprovedEmail } from '@/lib/beta-access/email';
 import {
   BULK_MAX,
@@ -30,6 +30,7 @@ import {
   type BulkAction,
   type UserFilter,
 } from './users-actions-shared';
+import { isFeatureKey } from '@/lib/features/registry';
 
 function parseFilter(formData: FormData): UserFilter {
   const str = (k: string): string | null => {
@@ -142,5 +143,50 @@ export async function bulkUserAction(formData: FormData): Promise<void> {
     }
   }
 
+  revalidatePath('/admin/users');
+}
+
+/**
+ * KAN-309 follow-on: grant/revoke a single per-user feature entitlement
+ * (Convene, MCP, paid gift links, …). Audit-first; service-role upsert (passes
+ * the feature_entitlements self-grant trigger); stamps granted_by.
+ */
+export async function setFeatureEntitlement(formData: FormData): Promise<void> {
+  const admin = await getCurrentAdmin();
+  if (!admin) {
+    throw new Error('Not authorised');
+  }
+  const profileId = String(formData.get('profileId') ?? '').trim();
+  const featureKey = String(formData.get('featureKey') ?? '').trim();
+  const enabled = String(formData.get('enabled') ?? '') === 'true';
+  if (!profileId || !isFeatureKey(featureKey)) {
+    throw new Error('Invalid feature toggle');
+  }
+
+  await logModerationAction({
+    admin,
+    action: enabled ? 'enable_feature' : 'disable_feature',
+    targetProfileId: profileId,
+    metadata: { feature_key: featureKey },
+  });
+
+  const svc = getAdminServiceClient();
+  const { error } = await svc
+    .from('feature_entitlements')
+    .upsert(
+      {
+        profile_id: profileId,
+        feature_key: featureKey,
+        enabled,
+        granted_by: admin.profileId,
+        updated_at: new Date().toISOString(),
+      },
+      { onConflict: 'profile_id,feature_key' },
+    );
+  if (error) {
+    throw new Error(`Could not update feature: ${error.message}`);
+  }
+
+  revalidatePath(`/admin/users/${String(formData.get('slug') ?? '')}`);
   revalidatePath('/admin/users');
 }

--- a/src/app/dashboard/convene/connections/page.tsx
+++ b/src/app/dashboard/convene/connections/page.tsx
@@ -10,7 +10,7 @@ import { createClient } from '@/lib/supabase-server';
 import { redirect } from 'next/navigation';
 import Link from 'next/link';
 import Image from 'next/image';
-import { isConveneEnabled } from '@/lib/convene/flags';
+import { isConveneEnabledForCurrentUser } from '@/lib/convene/flags-user';
 import { ConnectionsClient } from './connections-client';
 import { AvailabilityToggle } from './availability-toggle';
 
@@ -34,7 +34,7 @@ export default async function ConnectionsPage({
 }: {
   searchParams: Promise<Record<string, string | undefined>>;
 }) {
-  if (!isConveneEnabled()) {
+  if (!(await isConveneEnabledForCurrentUser())) {
     return (
       <main className="min-h-screen bg-[var(--color-paper)] flex items-center justify-center">
         <div className="text-center">

--- a/src/app/dashboard/convene/contacts/page.tsx
+++ b/src/app/dashboard/convene/contacts/page.tsx
@@ -2,7 +2,7 @@ import { createClient } from '@/lib/supabase-server';
 import { redirect } from 'next/navigation';
 import Link from 'next/link';
 import Image from 'next/image';
-import { isConveneEnabled } from '@/lib/convene/flags';
+import { isConveneEnabledForCurrentUser } from '@/lib/convene/flags-user';
 import ContactsClient from './contacts-client';
 import type { ContactView } from './contacts-helpers';
 
@@ -40,7 +40,7 @@ interface ContactRow {
 }
 
 export default async function ContactsPage() {
-  if (!isConveneEnabled()) return <NotEnabled />;
+  if (!(await isConveneEnabledForCurrentUser())) return <NotEnabled />;
 
   const supabase = await createClient();
   const {

--- a/src/app/dashboard/convene/gatherings/[id]/page.tsx
+++ b/src/app/dashboard/convene/gatherings/[id]/page.tsx
@@ -12,7 +12,7 @@ import { createClient } from '@/lib/supabase-server';
 import { redirect, notFound } from 'next/navigation';
 import Link from 'next/link';
 import Image from 'next/image';
-import { isConveneEnabled } from '@/lib/convene/flags';
+import { isConveneEnabledForCurrentUser } from '@/lib/convene/flags-user';
 import {
   availableTransitions,
   type GatheringStatus,
@@ -65,7 +65,7 @@ const STATUS_LABELS: Record<string, { label: string; tone: string }> = {
 };
 
 export default async function GatheringDetailPage({ params }: { params: Promise<{ id: string }> }) {
-  if (!isConveneEnabled()) {
+  if (!(await isConveneEnabledForCurrentUser())) {
     return (
       <main className="min-h-screen bg-[var(--color-paper)] flex items-center justify-center">
         <p className="text-[var(--color-muted)]">Convene is not enabled.</p>

--- a/src/app/dashboard/convene/gatherings/page.tsx
+++ b/src/app/dashboard/convene/gatherings/page.tsx
@@ -9,7 +9,7 @@ import { createClient } from '@/lib/supabase-server';
 import { redirect } from 'next/navigation';
 import Link from 'next/link';
 import Image from 'next/image';
-import { isConveneEnabled } from '@/lib/convene/flags';
+import { isConveneEnabledForCurrentUser } from '@/lib/convene/flags-user';
 
 export const metadata = {
   title: 'Convene Gatherings — Lyra',
@@ -45,7 +45,7 @@ function formatDate(iso: string | null): string {
 }
 
 export default async function GatheringsListPage() {
-  if (!isConveneEnabled()) {
+  if (!(await isConveneEnabledForCurrentUser())) {
     return (
       <main className="min-h-screen bg-[var(--color-paper)] flex items-center justify-center">
         <p className="text-[var(--color-muted)]">Convene is not enabled.</p>

--- a/src/app/dashboard/convene/organise/page.tsx
+++ b/src/app/dashboard/convene/organise/page.tsx
@@ -2,7 +2,7 @@ import { createClient } from '@/lib/supabase-server';
 import { redirect } from 'next/navigation';
 import Link from 'next/link';
 import Image from 'next/image';
-import { isConveneEnabled } from '@/lib/convene/flags';
+import { isConveneEnabledForCurrentUser } from '@/lib/convene/flags-user';
 import OrganiseWizard from './organise-wizard';
 
 export const metadata = {
@@ -38,7 +38,7 @@ export default async function OrganisePage({
 }: {
   searchParams: Promise<{ contact?: string }>;
 }) {
-  if (!isConveneEnabled()) {
+  if (!(await isConveneEnabledForCurrentUser())) {
     return (
       <Shell>
         <p className="text-[var(--color-muted)]">Convene is not enabled.</p>

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -4,7 +4,7 @@ import Link from 'next/link';
 import Image from 'next/image';
 import { signOut } from '../(auth)/actions';
 import ShareProfile from './share-profile';
-import { isConveneEnabled } from '@/lib/convene/flags';
+import { isConveneEnabledForCurrentUser } from '@/lib/convene/flags-user';
 
 export const metadata = {
   title: 'Dashboard — Lyra',
@@ -28,7 +28,7 @@ export default async function DashboardPage() {
 
   // KAN-303 — Convene nav + landing card are gated on the feature flag so they
   // stay hidden until Convene is enabled (beta).
-  const conveneEnabled = isConveneEnabled();
+  const conveneEnabled = await isConveneEnabledForCurrentUser();
 
   return (
     <main className="min-h-screen">

--- a/src/app/dashboard/profile/actions.ts
+++ b/src/app/dashboard/profile/actions.ts
@@ -5,6 +5,7 @@ import { revalidatePath } from 'next/cache';
 import { sanitiseText, sanitiseUrl, type ActionResult } from '@/lib/sanitise';
 import { moderateAndAudit } from '@/lib/moderation-audit';
 import { checkProfileWriteRateLimit } from '@/lib/profile-rate-limit';
+import { getMyFeatureEntitlements } from '@/lib/features/entitlements';
 import { isAllowedProfileField } from './profile-fields';
 import { coerceVisibility } from './visibility';
 import { coerceAffiliationType } from './affiliation-fields';
@@ -488,6 +489,13 @@ const MAX_FILE_SIZE = 5 * 1024 * 1024; // 5MB
 export async function uploadAvatar(formData: FormData): Promise<ActionResult> {
   const { user, supabase, error: authError } = await getAuthenticatedUser();
   if (authError) return { success: false, error: authError };
+
+  // KAN-309 — per-user feature gate (media_uploads covers profile photos too;
+  // default on, an admin can revoke). Mirrors uploadProfileFile.
+  const features = await getMyFeatureEntitlements();
+  if (!features.media_uploads) {
+    return { success: false, error: 'Media uploads are not enabled for your account.' };
+  }
 
   // KAN-231 — profile-save rate limiting (avatars are user-driven writes too).
   const rl = await checkProfileWriteRateLimit(user!.id);

--- a/src/app/dashboard/profile/files-actions.ts
+++ b/src/app/dashboard/profile/files-actions.ts
@@ -11,6 +11,7 @@ import {
   extensionForMime,
   type AllowedMime,
 } from '@/lib/file-magic-bytes';
+import { getMyFeatureEntitlements } from '@/lib/features/entitlements';
 
 /**
  * KAN-142: server actions for the profile_files surface.
@@ -61,6 +62,12 @@ export async function uploadProfileFile(formData: FormData): Promise<ActionResul
   const authed = await getAuthedRequest();
   if ('error' in authed) return { success: false, error: authed.error };
   const { user, supabase, profileId } = authed;
+
+  // KAN-309 — per-user feature gate (default on; an admin can revoke).
+  const features = await getMyFeatureEntitlements();
+  if (!features.media_uploads) {
+    return { success: false, error: 'Media uploads are not enabled for your account.' };
+  }
 
   // KAN-231 — profile-save rate limiting (file uploads are expensive — cap them).
   const rl = await checkProfileWriteRateLimit(user.id);

--- a/src/app/dashboard/profile/page.tsx
+++ b/src/app/dashboard/profile/page.tsx
@@ -2,7 +2,7 @@ import { createClient } from '@/lib/supabase-server';
 import { redirect } from 'next/navigation';
 import { EditProfileForm } from './edit-profile-form';
 import type { ManualOfMe } from './manual-of-me-fields';
-import { isConveneEnabled } from '@/lib/convene/flags';
+import { isConveneEnabledForCurrentUser } from '@/lib/convene/flags-user';
 
 export const metadata = {
   title: 'Edit your profile — Lyra',
@@ -103,7 +103,7 @@ export default async function ProfilePage() {
       files={files || []}
       conversationPrompts={conversationPrompts || []}
       conversationAnswers={conversationAnswers}
-      conveneEnabled={isConveneEnabled()}
+      conveneEnabled={await isConveneEnabledForCurrentUser()}
     />
   );
 }

--- a/src/app/dashboard/settings/discoverability-actions.ts
+++ b/src/app/dashboard/settings/discoverability-actions.ts
@@ -41,6 +41,7 @@ import {
   hashPostcodeInput,
   SEARCH_RATE_LIMIT,
 } from './discoverability-helpers';
+import { getMyFeatureEntitlements } from '@/lib/features/entitlements';
 
 interface DiscoverabilityInput {
   phone?: boolean;
@@ -55,6 +56,15 @@ export async function setDiscoverability(input: DiscoverabilityInput): Promise<A
   const supabase = await createClient();
   const { data: { user } } = await supabase.auth.getUser();
   if (!user) return { success: false, error: 'Not authenticated' };
+
+  // KAN-309 — per-user feature gate (default on; an admin can revoke). Opting
+  // OUT is always allowed so a revoked user can still turn discovery off.
+  if (input.phone === true || input.postcode === true) {
+    const features = await getMyFeatureEntitlements();
+    if (!features.discovery) {
+      return { success: false, error: 'Discovery is not enabled for your account.' };
+    }
+  }
 
   // Read the current flags so we know which transitions to perform. We do
   // NOT read the hash columns (they are revoked from `authenticated` at

--- a/src/lib/admin.ts
+++ b/src/lib/admin.ts
@@ -50,7 +50,10 @@ export type ModerationAction =
   // KAN-309: two-axis access model transitions from the user-management console
   | 'enable_beta' // waitlist -> beta (also sets is_beta_eligible=true)
   | 'disable_beta' // beta -> waitlist (revokes is_beta_eligible)
-  | 'promote_live'; // promote to the launched product (± early_access)
+  | 'promote_live' // promote to the launched product (± early_access)
+  // KAN-309 follow-on: per-user feature entitlement toggles
+  | 'enable_feature'
+  | 'disable_feature';
 
 export interface AdminUser {
   userId: string;

--- a/src/lib/affiliate/link-service.ts
+++ b/src/lib/affiliate/link-service.ts
@@ -40,6 +40,7 @@ import {
   type AffiliateProvider,
 } from './types';
 import { detectMerchant } from './merchant-detector';
+import { isPaidLinksAllowedForRecipient } from '@/lib/features/entitlements-service';
 
 export type AffiliateLinkRequest = {
   /** The raw merchant product URL the recommender chose. */
@@ -58,6 +59,12 @@ export type AffiliateLinkRequest = {
   recommendationId?: string | null;
   /** Which surface initiated the call. */
   source: AffiliateClickSource;
+  /**
+   * KAN-309: precomputed paid-gift-links gate for the recipient (entitlement +
+   * disclosure compliance). When omitted, the service computes it from
+   * recipientId and FAILS CLOSED (no recipient → not allowed).
+   */
+  paidLinksEnabled?: boolean;
 };
 
 export type AffiliateLinkResult = {
@@ -93,6 +100,18 @@ export async function getAffiliateLink(
   const subId = buildSubId(clickId, req.source);
   const recipientCountry = req.recipientCountry ?? req.buyerCountry;
   const merchant = detectMerchant(req.rawUrl);
+
+  // KAN-309: paid links are a per-RECIPIENT entitlement (+ disclosure
+  // compliance gate). When not allowed, return the raw URL with NO click log —
+  // an opted-out profile's recommendations must neither monetise nor pollute
+  // attribution data. Callers (the V2 pipeline) precompute via
+  // req.paidLinksEnabled to avoid a per-candidate read; otherwise we fail
+  // closed off the recipient id.
+  const monetisationAllowed =
+    req.paidLinksEnabled ?? (await isPaidLinksAllowedForRecipient(req.recipientId));
+  if (!monetisationAllowed) {
+    return { url: req.rawUrl, clickId, provider: 'raw', monetised: false, merchant };
+  }
 
   // Provider chain. MVP: only Sovrn (currently stubbed) → raw fallback.
   // Phase 2 will insert Amazon-direct ahead of Sovrn here.

--- a/src/lib/convene/flags-user.ts
+++ b/src/lib/convene/flags-user.ts
@@ -1,0 +1,21 @@
+/**
+ * KAN-309 follow-on: per-user Convene gate.
+ *
+ * Effective rule (env = master kill-switch):
+ *   Convene is available to a user IFF  CONVENE_ENABLED  AND  the user is
+ *   entitled to the 'convene' feature.
+ *
+ * Kept in a separate module from the sync, dependency-free isConveneEnabled()
+ * (src/lib/convene/flags.ts) so cron/oauth/infra routes that have no user can
+ * keep using the env-only check without pulling in the server-only entitlement
+ * read (next/headers, service client).
+ */
+import { isConveneEnabled } from './flags';
+import { getMyFeatureEntitlements } from '@/lib/features/entitlements';
+
+/** True only if Convene is enabled in this env AND the current user is entitled. */
+export async function isConveneEnabledForCurrentUser(): Promise<boolean> {
+  if (!isConveneEnabled()) return false;
+  const entitlements = await getMyFeatureEntitlements();
+  return entitlements.convene === true;
+}

--- a/src/lib/convene/invites/dispatch.ts
+++ b/src/lib/convene/invites/dispatch.ts
@@ -24,6 +24,7 @@ import {
   renderInviteHtml,
 } from './templates';
 import { renderSmsBody } from './sms-templates';
+import { isFeatureEnabledByUserId } from '@/lib/features/entitlements-service';
 
 const SITE_URL = process.env.LYRA_SITE_URL ?? 'https://checklyra.com';
 const DEFAULT_BATCH_SIZE = 25;
@@ -67,6 +68,21 @@ function admin(): SupabaseClient {
   return createClient(env.supabaseUrl(), env.supabaseServiceRoleKey(), {
     auth: { persistSession: false },
   });
+}
+
+/**
+ * KAN-309: SMS/WhatsApp invites are a per-HOST paid entitlement
+ * (convene_paid_channels). Resolved at most once per host per dispatch run.
+ */
+async function hostHasPaidChannels(
+  hostUserId: string,
+  cache: Map<string, boolean>,
+): Promise<boolean> {
+  const hit = cache.get(hostUserId);
+  if (hit !== undefined) return hit;
+  const ok = await isFeatureEnabledByUserId(hostUserId, 'convene_paid_channels');
+  cache.set(hostUserId, ok);
+  return ok;
 }
 
 async function loadContext(
@@ -220,7 +236,8 @@ export function buildSmsBody(ctx: JoinedContext): string {
 async function processOne(
   sb: SupabaseClient,
   row: QueuedRow,
-  summary: DispatchSummary
+  summary: DispatchSummary,
+  paidChannelCache: Map<string, boolean>
 ): Promise<void> {
   const loaded = await loadContext(sb, row);
   if (!loaded.ok) {
@@ -248,6 +265,19 @@ async function processOne(
   let result: SendResult | TwilioSendResult;
   try {
     if (row.channel === 'sms' || row.channel === 'whatsapp') {
+      // KAN-309: paid channels require the host's convene_paid_channels entitlement.
+      if (!(await hostHasPaidChannels(ctx.hostUserId, paidChannelCache))) {
+        await sb
+          .from('gathering_invite_messages')
+          .update({
+            delivery_status: 'failed',
+            bounce_reason: 'convene_paid_channels not enabled for host',
+          })
+          .eq('id', row.id);
+        summary.failed++;
+        summary.errors.push(`${row.id}: convene_paid_channels not enabled`);
+        return;
+      }
       if (!ctx.recipientPhone) {
         await sb
           .from('gathering_invite_messages')
@@ -392,6 +422,10 @@ export async function dispatchQueuedInvites(
   const queue = [...queuedRows];
   summary.scanned = queue.length;
 
+  // KAN-309: per-host convene_paid_channels entitlement cache, shared across
+  // the concurrent workers for this run.
+  const paidChannelCache = new Map<string, boolean>();
+
   const workers: Promise<void>[] = [];
   for (let i = 0; i < concurrency; i++) {
     workers.push(
@@ -399,7 +433,7 @@ export async function dispatchQueuedInvites(
         while (queue.length > 0) {
           const row = queue.shift();
           if (!row) break;
-          await processOne(sb, row, summary);
+          await processOne(sb, row, summary, paidChannelCache);
         }
       })()
     );

--- a/src/lib/features/entitlements-service.ts
+++ b/src/lib/features/entitlements-service.ts
@@ -1,0 +1,80 @@
+/**
+ * KAN-309 follow-on: service-role entitlement reads (no next/headers).
+ *
+ * Kept separate from entitlements.ts (which imports the cookie client) so the
+ * affiliate link service and other service-role code paths can check
+ * entitlements without pulling request-scoped APIs into their module graph.
+ *
+ * SERVICE-ROLE — bypasses RLS. Use only for cross-user checks where the viewer
+ * is not the subject (paid gift links gate on the RECIPIENT; recommendation
+ * reads are anonymous) and from admin/server-only code.
+ */
+import { createClient as createServiceClient } from '@supabase/supabase-js';
+import { env } from '@/lib/env';
+import { resolveEntitlements, type FeatureKey } from './registry';
+
+function serviceClient() {
+  return createServiceClient(env.supabaseUrl(), env.supabaseServiceRoleKey(), {
+    auth: { persistSession: false },
+  });
+}
+
+/** Any profile's full entitlement map (service-role; bypasses RLS). */
+export async function getProfileEntitlements(
+  profileId: string,
+): Promise<Record<FeatureKey, boolean>> {
+  if (!profileId) return resolveEntitlements([]);
+  const svc = serviceClient();
+  const { data } = await svc
+    .from('feature_entitlements')
+    .select('feature_key, enabled')
+    .eq('profile_id', profileId);
+  return resolveEntitlements(data ?? []);
+}
+
+/** Cross-user single-feature check (service-role). */
+export async function isFeatureEnabledByProfile(
+  profileId: string,
+  key: FeatureKey,
+): Promise<boolean> {
+  return (await getProfileEntitlements(profileId))[key];
+}
+
+/** Single-feature check keyed by auth user id (resolves the profile first). */
+export async function isFeatureEnabledByUserId(
+  userId: string,
+  key: FeatureKey,
+): Promise<boolean> {
+  if (!userId) return false;
+  const svc = serviceClient();
+  const { data: profile } = await svc
+    .from('profiles')
+    .select('id')
+    .eq('user_id', userId)
+    .maybeSingle();
+  if (!profile?.id) return false;
+  return isFeatureEnabledByProfile(profile.id as string, key);
+}
+
+/**
+ * Compliance precondition for paid affiliate links (KAN-192 FTC/ASA/CMA
+ * disclosure + KAN-193 cookie/GDPR consent). Until disclosure ships, monetised
+ * links must not be produced even for entitled recipients. Default: NOT ready.
+ */
+export function isPaidLinksComplianceReady(): boolean {
+  return process.env.PAID_LINKS_COMPLIANCE_READY === 'true';
+}
+
+/**
+ * The full paid-gift-links gate for a recipient profile:
+ *   recipient entitled  AND  affiliate disclosure/consent shipped.
+ * (SOVRN_API_KEY — the network switch — is still checked deeper, in trySovrn.)
+ * Fail-closed: no recipient id → not allowed.
+ */
+export async function isPaidLinksAllowedForRecipient(
+  recipientId: string | null | undefined,
+): Promise<boolean> {
+  if (!recipientId) return false;
+  if (!isPaidLinksComplianceReady()) return false;
+  return isFeatureEnabledByProfile(recipientId, 'paid_gift_links');
+}

--- a/src/lib/features/entitlements.ts
+++ b/src/lib/features/entitlements.ts
@@ -1,0 +1,34 @@
+/**
+ * KAN-309 follow-on: the CURRENT user's own feature-entitlement read (web app).
+ *
+ * Cookie client (RLS owner-read) — least privilege. Used to gate the logged-in
+ * user's OWN features (Convene pages/nav, uploads, discovery). For cross-user
+ * checks (paid gift links on the recipient profile, admin tooling, MCP) use the
+ * service-role reads in entitlements-service.ts instead.
+ */
+import { createClient as createCookieClient } from '@/lib/supabase-server';
+import { resolveEntitlements, type FeatureKey } from './registry';
+
+/** The current (cookie-authenticated) user's full entitlement map. */
+export async function getMyFeatureEntitlements(): Promise<Record<FeatureKey, boolean>> {
+  const supabase = await createCookieClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) return resolveEntitlements([]);
+
+  // Resolve the caller's profile id and filter explicitly — an admin's
+  // RLS "read all" policy would otherwise return everyone's rows.
+  const { data: profile } = await supabase
+    .from('profiles')
+    .select('id')
+    .eq('user_id', user.id)
+    .maybeSingle();
+  if (!profile?.id) return resolveEntitlements([]);
+
+  const { data } = await supabase
+    .from('feature_entitlements')
+    .select('feature_key, enabled')
+    .eq('profile_id', profile.id);
+  return resolveEntitlements(data ?? []);
+}

--- a/src/lib/features/registry.ts
+++ b/src/lib/features/registry.ts
@@ -1,0 +1,103 @@
+/**
+ * KAN-309 follow-on: the per-user feature-entitlement registry.
+ *
+ * Single source of truth for the feature keys the admin back-office can toggle
+ * per user. Plain module (NOT 'use server') so the constants/types/pure helper
+ * can be imported by server components, server actions, the MCP server (mirror),
+ * and tests alike.
+ *
+ * Per-key `defaultEnabled` is what lets ONE table serve both:
+ *   - "opt-in beta" features (default OFF — need an explicit grant): convene,
+ *     paid_gift_links, mcp, convene_paid_channels
+ *   - "default-on, admin-revocable" features (default ON — only a revoke writes
+ *     a row): media_uploads, discovery
+ *
+ * The effective gate at every call site is ALWAYS: ENV_FLAG && isFeatureEnabled.
+ * The per-env flag named in `envPrerequisite` stays the master kill-switch.
+ */
+
+export const FEATURE_KEYS = [
+  'mcp',
+  'convene',
+  'paid_gift_links',
+  'convene_paid_channels',
+  'media_uploads',
+  'discovery',
+] as const;
+
+export type FeatureKey = (typeof FEATURE_KEYS)[number];
+
+export interface FeatureConfig {
+  key: FeatureKey;
+  label: string;
+  description: string;
+  /** Returned by isFeatureEnabled when the user has NO entitlement row. */
+  defaultEnabled: boolean;
+  /** Human-readable name of the per-env master switch, if any. */
+  envPrerequisite: string | null;
+}
+
+export const FEATURE_CONFIG: Record<FeatureKey, FeatureConfig> = {
+  mcp: {
+    key: 'mcp',
+    label: 'MCP access',
+    description: 'AI-assistant write tools via the MCP server.',
+    defaultEnabled: false, // backfilled true for existing API-key holders
+    envPrerequisite: null,
+  },
+  convene: {
+    key: 'convene',
+    label: 'Convene',
+    description: 'AI-orchestrated gatherings (host GUI + agent tools).',
+    defaultEnabled: false,
+    envPrerequisite: 'CONVENE_ENABLED',
+  },
+  paid_gift_links: {
+    key: 'paid_gift_links',
+    label: 'Paid gift links',
+    description: "Monetised affiliate links on this profile's gift recommendations.",
+    defaultEnabled: false,
+    envPrerequisite: 'SOVRN_API_KEY',
+  },
+  convene_paid_channels: {
+    key: 'convene_paid_channels',
+    label: 'Convene SMS / WhatsApp',
+    description: 'Paid invite channels (SMS/WhatsApp) for Convene.',
+    defaultEnabled: false,
+    envPrerequisite: 'CONVENE_ENABLED',
+  },
+  media_uploads: {
+    key: 'media_uploads',
+    label: 'Media uploads',
+    description: 'Profile photo & file/media uploads.',
+    defaultEnabled: true,
+    envPrerequisite: null,
+  },
+  discovery: {
+    key: 'discovery',
+    label: 'Discovery',
+    description: 'Be found by phone number / postcode.',
+    defaultEnabled: true,
+    envPrerequisite: null,
+  },
+};
+
+export function isFeatureKey(value: string): value is FeatureKey {
+  return (FEATURE_KEYS as readonly string[]).includes(value);
+}
+
+/**
+ * Pure: merge DB entitlement rows onto the per-key defaults to produce a full
+ * key→enabled map. A row always wins over the default; unknown keys are ignored.
+ * Kept pure (no I/O) so the precedence logic is directly unit-testable.
+ */
+export function resolveEntitlements(
+  rows: ReadonlyArray<{ feature_key: string; enabled: boolean }>,
+): Record<FeatureKey, boolean> {
+  const out = {} as Record<FeatureKey, boolean>;
+  for (const k of FEATURE_KEYS) out[k] = FEATURE_CONFIG[k].defaultEnabled;
+  for (const r of rows) {
+    if (isFeatureKey(r.feature_key)) out[r.feature_key] = r.enabled;
+  }
+  return out;
+}

--- a/src/lib/recommender/v2/pipeline.ts
+++ b/src/lib/recommender/v2/pipeline.ts
@@ -25,6 +25,7 @@ import { rankCandidates, type RankerContext } from './rank';
 import { composeRationale } from './explain';
 import { EVERGREEN_FALLBACK_CONCEPTS } from './evergreen';
 import { getAffiliateLink } from '@/lib/affiliate/link-service';
+import { isPaidLinksAllowedForRecipient } from '@/lib/features/entitlements-service';
 import type { PipelineRequest, PipelineResult, V2Recommendation } from './types';
 
 /**
@@ -86,7 +87,11 @@ export async function buildV2Recommendations(
   const ranked = rankCandidates(candidates, rankerCtx);
 
   // 4. Take the top N, then monetise each via the Affiliate Link Service.
+  //    KAN-309: paid links are a per-recipient entitlement (+ disclosure
+  //    compliance). Resolve it ONCE for the recipient and pass it down, so an
+  //    opted-out profile gets raw, un-logged links and we avoid N reads.
   const topN = ranked.slice(0, limit);
+  const paidLinksEnabled = await isPaidLinksAllowedForRecipient(req.recipientId ?? null);
   const monetised = await Promise.all(
     topN.map((cand) =>
       getAffiliateLink({
@@ -98,6 +103,7 @@ export async function buildV2Recommendations(
         recipientId: req.recipientId ?? null,
         recommendationId: req.recommendationId ?? null,
         source: req.source,
+        paidLinksEnabled,
       }),
     ),
   );

--- a/supabase/migrations/20260622140000_feature_entitlements.sql
+++ b/supabase/migrations/20260622140000_feature_entitlements.sql
@@ -1,0 +1,103 @@
+-- KAN-309 follow-on: per-user feature entitlements.
+--
+-- WHAT
+--   A per-user, per-feature on/off table so the admin back-office can switch
+--   beta features ON/OFF for individual users: Convene, MCP, paid gift links,
+--   Convene paid channels (SMS/WhatsApp), media uploads, discovery.
+--
+--   Effective gate at every call site is:  ENV_FLAG && isFeatureEnabled(user, key)
+--   The per-ENV flag (CONVENE_ENABLED, SOVRN_API_KEY, ...) stays the master
+--   kill-switch; this table is the per-user cohort. A flip here does NOTHING
+--   until the env flag is also on (keeps dormant features dormant).
+--
+--   Per-key DEFAULTS live in TS (src/lib/features/registry.ts), not here:
+--   isFeatureEnabled returns the row's `enabled` when a row exists, else the
+--   key's default. So "default-off beta" keys (convene/paid_gift_links/mcp/
+--   convene_paid_channels) need no row to be off, and "default-on revocable"
+--   keys (media_uploads/discovery) need no row to be on. Only explicit
+--   admin grants/revokes write rows.
+--
+-- SECURITY (mirrors SEC-24 / BUGS-28 — a paid_gift_links self-grant unlocks money)
+--   - writes are SERVICE-ROLE ONLY: REVOKE write privs + RLS (no write policy)
+--     + a BEFORE trigger that rejects any auth.uid()-context write (42501).
+--   - SELECT: a user reads only their own rows; admins read all.
+--
+-- APPLIED TO
+--   dev (ilprytcrnqyrsbsrfujj): apply_migration 2026-06-22.
+--   staging/prod: user-gated promotion. HARD PREREQUISITE: SEC-24
+--   (prevent_beta_self_elevation extension) must be live on staging+prod first.
+--
+-- ROLLBACK
+--   drop table if exists public.feature_entitlements cascade;
+--   drop function if exists public.prevent_feature_entitlement_self_grant();
+
+create table if not exists public.feature_entitlements (
+  id          uuid primary key default gen_random_uuid(),
+  profile_id  uuid not null references public.profiles(id) on delete cascade,
+  feature_key text not null,
+  enabled     boolean not null default true,
+  metadata    jsonb,
+  granted_by  uuid references public.profiles(id),
+  granted_at  timestamptz not null default now(),
+  updated_at  timestamptz not null default now(),
+  unique (profile_id, feature_key)
+);
+
+create index if not exists feature_entitlements_enabled_idx
+  on public.feature_entitlements (feature_key) where enabled;
+create index if not exists feature_entitlements_profile_idx
+  on public.feature_entitlements (profile_id);
+
+-- Backfill: keep existing MCP key holders working (mcp defaults OFF in the
+-- registry, so without this they'd lose write-tool access).
+insert into public.feature_entitlements (profile_id, feature_key, enabled)
+select distinct p.id, 'mcp', true
+  from public.profiles p
+ where exists (select 1 from public.api_keys k where k.user_id = p.user_id)
+on conflict (profile_id, feature_key) do nothing;
+
+-- Self-grant guard: only service-role / migrations (auth.uid() IS NULL) may write.
+create or replace function public.prevent_feature_entitlement_self_grant()
+returns trigger
+language plpgsql
+security definer
+set search_path = public, pg_temp
+as $$
+begin
+  if auth.uid() is not null then
+    raise exception 'feature_entitlements are admin-only (KAN-309)'
+      using errcode = '42501';
+  end if;
+  if tg_op = 'DELETE' then
+    return old;
+  end if;
+  return new;
+end;
+$$;
+
+drop trigger if exists feature_entitlements_no_self_grant on public.feature_entitlements;
+create trigger feature_entitlements_no_self_grant
+  before insert or update or delete on public.feature_entitlements
+  for each row execute function public.prevent_feature_entitlement_self_grant();
+
+-- RLS: owner-read + admin-read; NO write policy (writes are service-role only).
+alter table public.feature_entitlements enable row level security;
+
+drop policy if exists "owner reads own entitlements" on public.feature_entitlements;
+create policy "owner reads own entitlements"
+  on public.feature_entitlements for select to authenticated
+  using (exists (
+    select 1 from public.profiles p
+     where p.id = feature_entitlements.profile_id and p.user_id = auth.uid()
+  ));
+
+drop policy if exists "admins read all entitlements" on public.feature_entitlements;
+create policy "admins read all entitlements"
+  on public.feature_entitlements for select to authenticated
+  using (exists (
+    select 1 from public.profiles p
+     where p.user_id = auth.uid() and p.is_admin = true
+  ));
+
+-- Defense in depth: strip write privileges from the user-facing roles.
+revoke insert, update, delete on public.feature_entitlements from authenticated, anon;

--- a/tests/unit/convene/contacts-ui.test.ts
+++ b/tests/unit/convene/contacts-ui.test.ts
@@ -25,7 +25,7 @@ describe('Convene contacts UI (KAN-304)', () => {
 
   describe('page', () => {
     const src = fs.readFileSync(pagePath, 'utf8');
-    test('gates on isConveneEnabled', () => expect(src).toMatch(/isConveneEnabled\(\)/));
+    test('gates on the per-user convene gate', () => expect(src).toMatch(/isConveneEnabledForCurrentUser\(\)/));
     test('redirects unauthenticated users to /login with ?next', () =>
       expect(src).toMatch(/redirect\(['"]\/login\?next=\/dashboard\/convene\/contacts/));
     test('scopes the contacts query to owner_user_id', () =>

--- a/tests/unit/convene/convene-nav.test.ts
+++ b/tests/unit/convene/convene-nav.test.ts
@@ -16,10 +16,10 @@ const profilePagePath = path.join(ROOT, 'src/app/dashboard/profile/page.tsx');
 describe('Convene nav entry points (KAN-303)', () => {
   describe('dashboard page', () => {
     const src = fs.readFileSync(dashboardPath, 'utf8');
-    test('imports the convene flag', () =>
-      expect(src).toMatch(/import \{ isConveneEnabled \} from ['"]@\/lib\/convene\/flags['"]/));
-    test('computes conveneEnabled from the flag', () =>
-      expect(src).toMatch(/const conveneEnabled = isConveneEnabled\(\)/));
+    test('imports the per-user convene gate', () =>
+      expect(src).toMatch(/import \{ isConveneEnabledForCurrentUser \} from ['"]@\/lib\/convene\/flags-user['"]/));
+    test('computes conveneEnabled from the per-user gate', () =>
+      expect(src).toMatch(/const conveneEnabled = await isConveneEnabledForCurrentUser\(\)/));
     test('gates the header Convene link on the flag', () => {
       expect(src).toMatch(/conveneEnabled &&[\s\S]{0,200}\/dashboard\/convene\/gatherings/);
     });
@@ -42,7 +42,7 @@ describe('Convene nav entry points (KAN-303)', () => {
 
   describe('profile page wiring', () => {
     const src = fs.readFileSync(profilePagePath, 'utf8');
-    test('passes the live flag value into the editor', () =>
-      expect(src).toMatch(/conveneEnabled=\{isConveneEnabled\(\)\}/));
+    test('passes the live per-user gate value into the editor', () =>
+      expect(src).toMatch(/conveneEnabled=\{await isConveneEnabledForCurrentUser\(\)\}/));
   });
 });

--- a/tests/unit/convene/gathering-ui.test.ts
+++ b/tests/unit/convene/gathering-ui.test.ts
@@ -24,7 +24,7 @@ describe('Convene gatherings UI (KAN-236)', () => {
 
   describe('list page', () => {
     const src = fs.readFileSync(listPath, 'utf8');
-    test('gates on isConveneEnabled', () => expect(src).toMatch(/isConveneEnabled\(\)/));
+    test('gates on the per-user convene gate', () => expect(src).toMatch(/isConveneEnabledForCurrentUser\(\)/));
     test('redirects unauthenticated users to /login', () => expect(src).toMatch(/redirect\(['"]\/login/));
     test('filters by host_user_id', () => expect(src).toMatch(/\.eq\(['"]host_user_id['"],\s*user\.id\)/));
     test('soft-deleted gatherings excluded', () => expect(src).toMatch(/\.is\(['"]deleted_at['"],\s*null\)/));
@@ -32,7 +32,7 @@ describe('Convene gatherings UI (KAN-236)', () => {
 
   describe('detail page', () => {
     const src = fs.readFileSync(detailPath, 'utf8');
-    test('gates on isConveneEnabled', () => expect(src).toMatch(/isConveneEnabled\(\)/));
+    test('gates on the per-user convene gate', () => expect(src).toMatch(/isConveneEnabledForCurrentUser\(\)/));
     test('filters main gathering query by host_user_id', () => expect(src).toMatch(/\.eq\(['"]host_user_id['"],\s*user\.id\)/));
     test('returns 404 (notFound) on missing or non-owned gathering', () => expect(src).toMatch(/notFound\(\)/));
     test('uses state-machine availableTransitions to gate buttons', () => expect(src).toMatch(/availableTransitions/));

--- a/tests/unit/convene/organise-ui.test.ts
+++ b/tests/unit/convene/organise-ui.test.ts
@@ -22,7 +22,7 @@ describe('Convene organise wizard UI (KAN-305)', () => {
 
   describe('page', () => {
     const src = fs.readFileSync(pagePath, 'utf8');
-    test('gates on isConveneEnabled', () => expect(src).toMatch(/isConveneEnabled\(\)/));
+    test('gates on the per-user convene gate', () => expect(src).toMatch(/isConveneEnabledForCurrentUser\(\)/));
     test('redirects unauthenticated users', () => expect(src).toMatch(/redirect\(['"]\/login\?next=\/dashboard\/convene\/organise/));
     test('scopes contacts to the owner', () => expect(src).toMatch(/\.eq\(['"]owner_user_id['"],\s*user\.id\)/));
     test('honours a ?contact= preselect', () => expect(src).toMatch(/sp\.contact/));

--- a/tests/unit/discoverability-actions.test.ts
+++ b/tests/unit/discoverability-actions.test.ts
@@ -25,6 +25,13 @@ jest.mock('next/cache', () => ({
   revalidatePath: (...args: unknown[]) => mockRevalidatePath(...args),
 }));
 
+// KAN-309: setDiscoverability now checks the per-user 'discovery' entitlement
+// before an opt-in. Mock the new dependency as entitled (the default) so the
+// existing behavioural assertions exercise the same path as before.
+jest.mock('@/lib/features/entitlements', () => ({
+  getMyFeatureEntitlements: jest.fn(async () => ({ discovery: true })),
+}));
+
 // Capture supabase interactions.
 const mockUpdateCapture = jest.fn();
 const mockUpdateEq = jest.fn().mockResolvedValue({ error: null });

--- a/tests/unit/feature-entitlements.test.ts
+++ b/tests/unit/feature-entitlements.test.ts
@@ -1,0 +1,53 @@
+/**
+ * KAN-309 follow-on: feature-entitlement registry precedence (pure).
+ */
+import {
+  FEATURE_KEYS,
+  FEATURE_CONFIG,
+  isFeatureKey,
+  resolveEntitlements,
+} from '@/lib/features/registry';
+
+describe('feature registry (KAN-309)', () => {
+  it('isFeatureKey accepts known keys and rejects others', () => {
+    for (const k of FEATURE_KEYS) expect(isFeatureKey(k)).toBe(true);
+    expect(isFeatureKey('nope')).toBe(false);
+    expect(isFeatureKey('')).toBe(false);
+    expect(isFeatureKey('is_admin')).toBe(false);
+  });
+
+  it('the three owner-named beta features default OFF; uploads/discovery default ON', () => {
+    expect(FEATURE_CONFIG.mcp.defaultEnabled).toBe(false);
+    expect(FEATURE_CONFIG.convene.defaultEnabled).toBe(false);
+    expect(FEATURE_CONFIG.paid_gift_links.defaultEnabled).toBe(false);
+    expect(FEATURE_CONFIG.convene_paid_channels.defaultEnabled).toBe(false);
+    expect(FEATURE_CONFIG.media_uploads.defaultEnabled).toBe(true);
+    expect(FEATURE_CONFIG.discovery.defaultEnabled).toBe(true);
+  });
+
+  it('resolveEntitlements falls back to per-key defaults when no rows', () => {
+    const map = resolveEntitlements([]);
+    expect(map.convene).toBe(false);
+    expect(map.media_uploads).toBe(true);
+    expect(map.discovery).toBe(true);
+  });
+
+  it('an explicit row always wins over the default (both directions)', () => {
+    const map = resolveEntitlements([
+      { feature_key: 'convene', enabled: true }, // default off → on
+      { feature_key: 'media_uploads', enabled: false }, // default on → off
+    ]);
+    expect(map.convene).toBe(true);
+    expect(map.media_uploads).toBe(false);
+    // untouched keys keep defaults
+    expect(map.mcp).toBe(false);
+    expect(map.discovery).toBe(true);
+  });
+
+  it('ignores unknown feature keys in rows', () => {
+    const map = resolveEntitlements([
+      { feature_key: 'totally_made_up', enabled: true },
+    ]);
+    expect(Object.keys(map).sort()).toEqual([...FEATURE_KEYS].sort());
+  });
+});

--- a/tests/unit/feature-entitlements.test.ts
+++ b/tests/unit/feature-entitlements.test.ts
@@ -1,12 +1,16 @@
 /**
  * KAN-309 follow-on: feature-entitlement registry precedence (pure).
  */
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
 import {
   FEATURE_KEYS,
   FEATURE_CONFIG,
   isFeatureKey,
   resolveEntitlements,
 } from '@/lib/features/registry';
+
+const ROOT = resolve(__dirname, '../..');
 
 describe('feature registry (KAN-309)', () => {
   it('isFeatureKey accepts known keys and rejects others', () => {
@@ -49,5 +53,28 @@ describe('feature registry (KAN-309)', () => {
       { feature_key: 'totally_made_up', enabled: true },
     ]);
     expect(Object.keys(map).sort()).toEqual([...FEATURE_KEYS].sort());
+  });
+});
+
+describe('media_uploads gate covers BOTH upload entrypoints (KAN-309)', () => {
+  // media_uploads is scoped to "Profile photo & file/media uploads". Both the
+  // file uploader AND the avatar uploader must check it, or an admin's revoke
+  // is only partially effective.
+  it('uploadProfileFile gates on media_uploads', () => {
+    const src = readFileSync(resolve(ROOT, 'src/app/dashboard/profile/files-actions.ts'), 'utf-8');
+    expect(src).toMatch(/getMyFeatureEntitlements/);
+    expect(src).toMatch(/media_uploads/);
+  });
+  it('uploadAvatar gates on media_uploads', () => {
+    const src = readFileSync(resolve(ROOT, 'src/app/dashboard/profile/actions.ts'), 'utf-8');
+    // the gate must appear inside uploadAvatar, before the storage upload
+    const fn = src.slice(src.indexOf('export async function uploadAvatar'));
+    const gateIdx = fn.indexOf('features.media_uploads');
+    const uploadIdx = fn.indexOf("storage\n");
+    expect(gateIdx).toBeGreaterThan(-1);
+    expect(fn).toMatch(/getMyFeatureEntitlements/);
+    // gate precedes the profile-photos upload call
+    expect(gateIdx).toBeLessThan(fn.indexOf("from('profile-photos')"));
+    void uploadIdx;
   });
 });

--- a/tests/unit/paid-links-gate.test.ts
+++ b/tests/unit/paid-links-gate.test.ts
@@ -1,0 +1,53 @@
+/**
+ * KAN-309 follow-on: the paid-gift-links gate inside getAffiliateLink.
+ *
+ * Security-critical: a recipient who is NOT entitled to paid links must get a
+ * RAW url with monetised:false AND NO click logged (no attribution pollution).
+ * An entitled recipient still logs raw clicks today (Sovrn unset) — existing
+ * KAN-189 behaviour preserved.
+ */
+
+const mockInsert = jest.fn().mockResolvedValue({ error: null });
+
+jest.mock('@supabase/supabase-js', () => ({
+  createClient: () => ({
+    from: () => ({ insert: (...a: unknown[]) => mockInsert(...a) }),
+  }),
+}));
+
+jest.mock('@/lib/env', () => ({
+  env: {
+    supabaseUrl: () => 'http://localhost',
+    supabaseServiceRoleKey: () => 'service-key',
+  },
+}));
+
+import { getAffiliateLink } from '@/lib/affiliate/link-service';
+
+const BASE = {
+  rawUrl: 'https://amazon.co.uk/dp/B07XYZ',
+  buyerCountry: 'GB',
+  recipientId: 'recipient-profile-1',
+  source: 'web' as const,
+};
+
+describe('paid-gift-links gate (KAN-309)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    delete process.env.SOVRN_API_KEY;
+  });
+
+  it('not entitled → raw url, monetised:false, and NO click logged', async () => {
+    const r = await getAffiliateLink({ ...BASE, paidLinksEnabled: false });
+    expect(r.monetised).toBe(false);
+    expect(r.provider).toBe('raw');
+    expect(r.url).toBe(BASE.rawUrl);
+    expect(mockInsert).not.toHaveBeenCalled();
+  });
+
+  it('entitled (Sovrn unset) → raw url but the click IS logged (KAN-189 preserved)', async () => {
+    const r = await getAffiliateLink({ ...BASE, paidLinksEnabled: true });
+    expect(r.monetised).toBe(false); // no SOVRN_API_KEY → raw
+    expect(mockInsert).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/unit/set-feature-entitlement.test.ts
+++ b/tests/unit/set-feature-entitlement.test.ts
@@ -1,0 +1,77 @@
+/**
+ * KAN-309 follow-on: setFeatureEntitlement admin action contract.
+ */
+import { setFeatureEntitlement } from '@/app/admin/users/actions';
+
+jest.mock('next/cache', () => ({ revalidatePath: jest.fn() }));
+
+const mockGetCurrentAdmin = jest.fn();
+const mockUpsert = jest.fn();
+const mockLog = jest.fn();
+
+jest.mock('@/lib/admin', () => ({
+  getCurrentAdmin: () => mockGetCurrentAdmin(),
+  getAdminServiceClient: () => ({
+    from: () => ({ upsert: (...a: unknown[]) => mockUpsert(...a) }),
+  }),
+  logModerationAction: (...a: unknown[]) => mockLog(...a),
+  logModerationActionsBatch: jest.fn(),
+}));
+
+jest.mock('@/lib/supabase-server', () => ({ createClient: jest.fn() }));
+jest.mock('@/lib/beta-access/email', () => ({ sendBetaApprovedEmail: jest.fn() }));
+
+const ADMIN = { userId: 'admin-user', profileId: 'admin-profile', email: 'a@a.com', displayName: 'A' };
+
+function fd(obj: Record<string, string>): FormData {
+  const f = new FormData();
+  Object.entries(obj).forEach(([k, v]) => f.set(k, v));
+  return f;
+}
+
+describe('setFeatureEntitlement (KAN-309)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetCurrentAdmin.mockResolvedValue(ADMIN);
+    mockUpsert.mockResolvedValue({ error: null });
+    mockLog.mockResolvedValue('log-id');
+  });
+
+  it('rejects non-admins with no mutation', async () => {
+    mockGetCurrentAdmin.mockResolvedValue(null);
+    await expect(setFeatureEntitlement(fd({ profileId: 'p1', featureKey: 'convene', enabled: 'true' }))).rejects.toThrow('Not authorised');
+    expect(mockUpsert).not.toHaveBeenCalled();
+    expect(mockLog).not.toHaveBeenCalled();
+  });
+
+  it('rejects an unknown feature key', async () => {
+    await expect(setFeatureEntitlement(fd({ profileId: 'p1', featureKey: 'hack', enabled: 'true' }))).rejects.toThrow('Invalid feature toggle');
+    expect(mockUpsert).not.toHaveBeenCalled();
+    expect(mockLog).not.toHaveBeenCalled();
+  });
+
+  it('enable: audits enable_feature and upserts enabled=true with granted_by', async () => {
+    await setFeatureEntitlement(fd({ profileId: 'p1', featureKey: 'convene', enabled: 'true', slug: 'x' }));
+    expect(mockLog).toHaveBeenCalledWith(
+      expect.objectContaining({ action: 'enable_feature', targetProfileId: 'p1', metadata: { feature_key: 'convene' } }),
+    );
+    expect(mockUpsert).toHaveBeenCalledWith(
+      expect.objectContaining({ profile_id: 'p1', feature_key: 'convene', enabled: true, granted_by: ADMIN.profileId }),
+      { onConflict: 'profile_id,feature_key' },
+    );
+  });
+
+  it('disable: audits disable_feature and upserts enabled=false', async () => {
+    await setFeatureEntitlement(fd({ profileId: 'p1', featureKey: 'mcp', enabled: 'false', slug: 'x' }));
+    expect(mockLog).toHaveBeenCalledWith(expect.objectContaining({ action: 'disable_feature' }));
+    expect(mockUpsert).toHaveBeenCalledWith(
+      expect.objectContaining({ feature_key: 'mcp', enabled: false }),
+      { onConflict: 'profile_id,feature_key' },
+    );
+  });
+
+  it('throws if the upsert fails (no silent success)', async () => {
+    mockUpsert.mockResolvedValue({ error: { message: 'db down' } });
+    await expect(setFeatureEntitlement(fd({ profileId: 'p1', featureKey: 'convene', enabled: 'true' }))).rejects.toThrow('Could not update feature');
+  });
+});


### PR DESCRIPTION
## Summary
Epic **[KAN-315](https://checklyra.atlassian.net/browse/KAN-315)** ([KAN-316](https://checklyra.atlassian.net/browse/KAN-316)). Adds a per-user, per-feature **entitlement** layer so the admin back-office can switch beta features on/off per user. Stacked on **#351** (admin console) — base will retarget to `develop` once #351 merges.

**Effective gate everywhere = per-env flag AND per-user entitlement** (the env flag, e.g. `CONVENE_ENABLED`, stays the master kill-switch — a per-user flip does nothing until the env switch is also on).

## What's in here
- **Migration** `20260622140000_feature_entitlements.sql`: `feature_entitlements(profile_id × feature_key)`, service-role-only writes (RLS owner/admin-read + self-grant trigger raising 42501 + REVOKE), `mcp` backfilled for existing API-key holders. **Applied + verified on dev** (self-grant blocked; service-role upsert ok; backfill correct).
- **`src/lib/features/`**: registry (keys + per-key defaults + pure `resolveEntitlements`), `getMyFeatureEntitlements` (cookie/RLS, own rows), service-role `getProfileEntitlements`/`isFeatureEnabledByProfile`/`isPaidLinksAllowedForRecipient`.
- **Convene** — `isConveneEnabledForCurrentUser()` wired into ~9 user-facing surfaces (nav, profile header, all `dashboard/convene/*`).
- **Paid gift links** — gated on the **recipient profile** inside `getAffiliateLink` (the single chokepoint for web + the MCP recommend tool), **before** click logging (opted-out profiles get raw, un-logged links). Compliance gate `PAID_LINKS_COMPLIANCE_READY` (KAN-192/193) ANDed in.
- **Convene SMS/WhatsApp** — dispatch gated on the host's `convene_paid_channels` (cached per run).
- **media_uploads** gates `uploadProfileFile` **and** `uploadAvatar`; **discovery** gates the opt-in.
- **Admin** — per-user feature toggles on `/admin/users/[slug]` (audited, service-role upsert stamping `granted_by`); `ModerationAction += enable/disable_feature`.

## Verification
- type-check + lint clean; **`next build` clean**; full unit suite **1723 / 131 green** (+14 new).
- DB on dev: trigger blocks user self-grant (42501); service-role upsert ok; `mcp` backfill = API-key holders.
- **Adversarial multi-dimension review** run over the diff; the one confirmed finding (uploadAvatar bypass) is fixed in this PR with a guard test.

## Sequencing / follow-ups
- **MCP-server enforcement of `mcp`/`convene`** is a deferred follow-up ([KAN-317](https://checklyra.atlassian.net/browse/KAN-317)) — that repo has ~9 separate auth chokepoints + its own deploy; the table + backfill are already in place. Until it lands, the `mcp` toggle is recorded but not enforced over `mcp.checklyra.com` (noted in docs).
- Bulk feature toggles: [KAN-318](https://checklyra.atlassian.net/browse/KAN-318). Lockdown promotion to staging/prod: [SEC-26](https://checklyra.atlassian.net/browse/SEC-26).

MCP coverage: deferred — KAN-317 (follow-up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[KAN-315]: https://checklyra.atlassian.net/browse/KAN-315?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[KAN-316]: https://checklyra.atlassian.net/browse/KAN-316?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[KAN-317]: https://checklyra.atlassian.net/browse/KAN-317?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ