### PR TITLE
fix(SEC-20): CI/CD hardening — least-priv permissions, env-bind inputs, SHA-pin actions

### DIFF
--- a/.github/workflows/affiliate-link-smoke.yml
+++ b/.github/workflows/affiliate-link-smoke.yml
@@ -26,16 +26,19 @@ defaults:
   run:
     shell: bash
 
+permissions:
+  contents: read
+
 jobs:
   smoke:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: '20'
           cache: 'npm'
@@ -57,7 +60,7 @@ jobs:
         # Always upload, even on failure — that's the whole point of
         # keeping the artifact when the workflow fails.
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: smoke-results-${{ github.run_id }}
           path: smoke-results.json

--- a/.github/workflows/auto-fix-known-failures.yml
+++ b/.github/workflows/auto-fix-known-failures.yml
@@ -58,12 +58,12 @@ jobs:
       github.event.workflow_run.conclusion == 'failure'
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           fetch-depth: 1
 
       - name: Setup Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: "3.12"
 
@@ -76,15 +76,23 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}
+          # SEC-20/F-17: bind event + dispatch inputs to env so no untrusted
+          # value is interpolated directly into the run: shell.
+          EVENT_NAME: ${{ github.event_name }}
+          INPUT_RUN_ID: ${{ inputs.run_id }}
+          INPUT_WORKFLOW_NAME: ${{ inputs.workflow_name }}
+          INPUT_DRY_RUN: ${{ inputs.dry_run }}
+          WORKFLOW_RUN_ID: ${{ github.event.workflow_run.id }}
+          WORKFLOW_RUN_NAME: ${{ github.event.workflow_run.name }}
         run: |
           set -euo pipefail
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            RUN_ID="${{ inputs.run_id }}"
-            WF_NAME="${{ inputs.workflow_name }}"
-            DRY="${{ inputs.dry_run }}"
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            RUN_ID="$INPUT_RUN_ID"
+            WF_NAME="$INPUT_WORKFLOW_NAME"
+            DRY="$INPUT_DRY_RUN"
           else
-            RUN_ID="${{ github.event.workflow_run.id }}"
-            WF_NAME="${{ github.event.workflow_run.name }}"
+            RUN_ID="$WORKFLOW_RUN_ID"
+            WF_NAME="$WORKFLOW_RUN_NAME"
             DRY="false"
           fi
 

--- a/.github/workflows/backup-database.yml
+++ b/.github/workflows/backup-database.yml
@@ -27,6 +27,9 @@ env:
   # See KAN-125 (launch tracking) and KAN-167 (this policy work).
   EXPECTED_MIN_ROWS: '0'
 
+permissions:
+  contents: read
+
 jobs:
   backup:
     runs-on: ubuntu-latest

--- a/.github/workflows/backup-platform.yml
+++ b/.github/workflows/backup-platform.yml
@@ -14,6 +14,9 @@ defaults:
 env:
   BACKUP_DIR: ./platform-backup
 
+permissions:
+  contents: read
+
 jobs:
   backup:
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy-beta.yml
+++ b/.github/workflows/deploy-beta.yml
@@ -17,6 +17,9 @@ defaults:
   run:
     shell: bash
 
+permissions:
+  contents: read
+
 jobs:
   lint-and-unit-tests:
     name: Lint & Unit Tests

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -10,6 +10,9 @@ defaults:
   run:
     shell: bash
 
+permissions:
+  contents: read
+
 jobs:
   lint-and-test:
     name: Lint & Unit Tests

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -5,6 +5,9 @@ on:
 env:
   VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
   VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+permissions:
+  contents: read
+
 jobs:
   lint-and-unit-tests:
     name: Lint & Unit Tests

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -5,6 +5,9 @@ on:
 env:
   VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
   VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+permissions:
+  contents: read
+
 jobs:
   lint-and-unit-tests:
     name: Lint & Unit Tests
@@ -283,7 +286,7 @@ jobs:
           npx playwright test
       - name: Upload Playwright report on failure
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: playwright-report
           path: playwright-report/

--- a/.github/workflows/mutation-testing.yml
+++ b/.github/workflows/mutation-testing.yml
@@ -9,6 +9,9 @@ defaults:
   run:
     shell: bash
 
+permissions:
+  contents: read
+
 jobs:
   mutation-test:
     runs-on: ubuntu-latest

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -8,6 +8,9 @@ defaults:
   run:
     shell: bash
 
+permissions:
+  contents: read
+
 jobs:
   checks:
     name: PR Quality Gate

--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -9,6 +9,9 @@ defaults:
   run:
     shell: bash
 
+permissions:
+  contents: read
+
 jobs:
   audit:
     runs-on: ubuntu-latest

--- a/.github/workflows/weekly-report.yml
+++ b/.github/workflows/weekly-report.yml
@@ -17,6 +17,10 @@ defaults:
   run:
     shell: bash
 
+permissions:
+  contents: read
+  actions: read
+
 jobs:
   report:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Hardens GitHub Actions per the red-team audit (SEC-20). **No app change.**

- **F-17** — `auto-fix-known-failures.yml` now binds `github.event.workflow_run.*` and the workflow_dispatch inputs to `env:` and dereferences them in the shell, so no untrusted value is interpolated into a `run:` block.
- **F-19** — added least-privilege top-level `permissions:` to the **11** workflows that lacked one (`contents: read`; `weekly-report` also gets `actions: read` for `gh run`). Verified none use `GITHUB_TOKEN` for writes — deploy/backup use external tokens / the backup PAT.
- **F-22** — SHA-pinned the 6 remaining floating-tag `actions/*` uses (with `# v4`/`# v5` comments).
- **F-20** (fine-grain/rotate `LYRA_RELEASE_PAT` + confirm the `production` Environment reviewers) is an owner/GitHub-settings action — **not** in this PR; tracked on the ticket (overlaps SEC-3 / KAN-170).

Verified: `check-workflow-integrity.sh` green, all workflow YAML parses, no floating tags or raw event interpolation remain. (Separate tiny PR will add `permissions:` to the mcp `test.yml`.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)