### PR TITLE
fix(SEC-23): backup-restore-test fails loudly on missing secret (no silent-skip)

### DIFF
--- a/.github/workflows/backup-restore-test.yml
+++ b/.github/workflows/backup-restore-test.yml
@@ -9,6 +9,9 @@ defaults:
   run:
     shell: bash
 
+permissions:
+  contents: read
+
 jobs:
   restore-test:
     runs-on: ubuntu-latest
@@ -29,8 +32,8 @@ jobs:
         run: |
           set -euo pipefail
           if [ -z "$SUPABASE_DB_URL" ]; then
-            echo "SUPABASE_DB_URL not configured — skipping"
-            exit 0
+            echo "::error::SUPABASE_DB_URL not configured — the restore test cannot run. Failing loudly (SEC-23: no silent-skip / false-green)."
+            exit 1
           fi
           pg_dump "$SUPABASE_DB_URL" --schema-only --schema=public --no-owner --no-privileges \
             > /tmp/prod-schema.sql 2>&1
@@ -42,8 +45,8 @@ jobs:
         run: |
           set -euo pipefail
           if [ -z "$SUPABASE_DB_URL" ]; then
-            echo "Skipping — no DB URL"
-            exit 0
+            echo "::error::SUPABASE_DB_URL not configured — cannot verify the restore. Failing loudly (SEC-23: no silent-skip / false-green)."
+            exit 1
           fi
 
           echo "## Backup Restore Test Results" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
Closes the **acute** SEC-23 item — the Backup Integrity Policy violation in `backup-restore-test.yml`: both steps had `if [ -z \"$SUPABASE_DB_URL\" ]; then echo skipping; exit 0`, so a missing secret produced a **green run that did nothing** (false-green). Both now emit `::error::` and `exit 1`. Also adds least-priv `permissions: contents: read`.

The rest of SEC-23 (Supabase **Storage**/Cloudflare **KV**/**Vault** backup jobs, daily-dump or **PITR** for ≤24h RPO, a timed **full-restore drill** for RTO, and confirming the Supabase plan) needs founder/infra decisions + credentials and stays open on the ticket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)