### PR TITLE
fix(SEC-27): block is_admin/is_suspended self-elevation on profiles (CRITICAL)

### DIFF
--- a/docs/DAILY_SECURITY_CHECK.md
+++ b/docs/DAILY_SECURITY_CHECK.md
@@ -187,15 +187,17 @@ Run all SQL probes via Supabase MCP `execute_sql` (read-only SELECT) against **p
 - **FAIL:** owner predicate missing or anon list returns other users' objects → 🔴 **SEC-03 reproduced** → BUGS-25.
 
 ### B6 — 🟠 Self-privilege-escalation columns are write-protected (regression for the beta/admin privesc class)
-- **Threat:** `profiles.is_beta_eligible`/`beta_access_status` were self-settable via the "update own profile" RLS policy until `20260620120100_beta_access_lockdown.sql` added `prevent_beta_self_elevation()`. Same risk shape for `is_admin`.
-- **Check:** confirm the trigger exists and is promoted to **prod**:
+- **Threat:** `profiles.is_beta_eligible`/`beta_access_status` were self-settable via the "update own profile" RLS policy until the beta-access lockdown added `prevent_beta_self_elevation()`. The **same shape applied to `is_admin`/`is_suspended`** (full admin privesc + self-unsuspend) — **fixed by SEC-27** (`20260622061545_sec27_block_admin_is_suspended_self_set.sql`, `profiles_block_admin_is_suspended_self_set` trigger, live on all envs 2026-06-22).
+- **Check:** confirm **both** privesc-guard triggers exist and are enabled on **prod**:
   ```sql
   SELECT tgname, tgenabled FROM pg_trigger
-  WHERE tgname IN ('prevent_beta_self_elevation','profiles_block_admin_self_set');
-  SELECT count(*) FROM supabase_migrations.schema_migrations WHERE version='20260620120100';
+  WHERE tgname IN ('prevent_beta_self_elevation','profiles_block_admin_is_suspended_self_set');
+  -- Expect 2 rows, both tgenabled = 'O'. Trigger presence is the source of truth:
+  -- schema_migrations.version is unreliable here because apply_migration assigns its
+  -- own timestamp (beta lockdown recorded 20260620200641, SEC-27 recorded 20260622061545).
   ```
-- **PASS:** trigger present + enabled on prod; migration applied. No authenticated UPDATE path to `is_admin`/beta columns.
-- **FAIL:** trigger missing on prod (migration drift — see OPS-04) → 🟠 promote the migration; until then privesc is live.
+- **PASS:** both triggers present + enabled on prod → no authenticated/anon UPDATE path to `is_admin`/`is_suspended`/beta columns (each raises 42501; service-role writes still pass).
+- **FAIL:** either trigger missing or disabled on prod (migration drift — see OPS-04) → 🔴 privesc is live; re-apply the migration immediately.
 
 ### B7 — 🟡 RPC SQL-injection surface
 - **Threat:** any `SECURITY DEFINER` function using `EXECUTE` with string concatenation = full-DB SQLi.

--- a/supabase/migrations/20260622061545_sec27_block_admin_is_suspended_self_set.sql
+++ b/supabase/migrations/20260622061545_sec27_block_admin_is_suspended_self_set.sql
@@ -1,0 +1,53 @@
+-- SEC-27 (CRITICAL): block authenticated/anon self-elevation of is_admin and
+-- self-unsuspension of is_suspended on public.profiles.
+--
+-- Root cause: the "Update own profile" RLS policy (auth.uid() = user_id) allows a
+-- user to UPDATE *any* column of their own row, and prevent_beta_self_elevation
+-- only guarded the beta columns. Both `authenticated` and `anon` also hold a
+-- column-level UPDATE grant on is_admin/is_suspended. Net effect: any signed-in
+-- user could PATCH {"is_admin": true} (full admin privesc) or {"is_suspended":
+-- false} (self-unsuspend) via PostgREST. Discovered by the daily security check
+-- (B6) on 2026-06-22; the expected blocking trigger had never been created in any
+-- environment.
+--
+-- Fix: a BEFORE UPDATE trigger that raises 42501 if a JWT-bearing caller
+-- (auth.uid() IS NOT NULL) changes either column. Service-role / backend callers
+-- (auth.uid() IS NULL) are unaffected, so the admin console's service-role writes
+-- (see src/app/admin/users/actions.ts — "service role passes the admin-only
+-- trigger") and the beta/suspension approval flows continue to work.
+--
+-- Applied live (idempotent) to dev/staging/prod via the Supabase MCP on
+-- 2026-06-22 and verified on all three: an authenticated UPDATE of either column
+-- raises 42501, a service-role UPDATE still succeeds.
+--
+-- Rollback:
+--   DROP TRIGGER IF EXISTS profiles_block_admin_is_suspended_self_set ON public.profiles;
+--   DROP FUNCTION IF EXISTS public.block_admin_is_suspended_self_set();
+
+CREATE OR REPLACE FUNCTION public.block_admin_is_suspended_self_set()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+BEGIN
+  -- Service role / backend (no JWT subject): allow.
+  IF auth.uid() IS NULL THEN
+    RETURN NEW;
+  END IF;
+  -- JWT-bearing (authenticated/anon) caller: is_admin and is_suspended are
+  -- admin-only columns — reject any attempt to change them.
+  IF NEW.is_admin IS DISTINCT FROM OLD.is_admin
+  OR NEW.is_suspended IS DISTINCT FROM OLD.is_suspended THEN
+    RAISE EXCEPTION 'is_admin and is_suspended are admin-only columns'
+      USING errcode = '42501';
+  END IF;
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS profiles_block_admin_is_suspended_self_set ON public.profiles;
+CREATE TRIGGER profiles_block_admin_is_suspended_self_set
+  BEFORE UPDATE ON public.profiles
+  FOR EACH ROW
+  EXECUTE FUNCTION public.block_admin_is_suspended_self_set();

--- a/tests/unit/sec27-block-admin-self-set-migration.test.ts
+++ b/tests/unit/sec27-block-admin-self-set-migration.test.ts
@@ -1,0 +1,66 @@
+/**
+ * SEC-27 (CRITICAL) — regression guard for the is_admin / is_suspended
+ * self-elevation lockdown migration.
+ *
+ * Any signed-in user could PATCH their own profile row with {"is_admin": true}
+ * (full admin privilege escalation) or {"is_suspended": false} (self-unsuspend)
+ * because the "Update own profile" RLS policy carried no column restriction and
+ * the expected blocking trigger had never been created. The migration installs a
+ * BEFORE UPDATE trigger that raises 42501 when a JWT-bearing caller changes
+ * either column, while leaving service-role (auth.uid() IS NULL) writes — the
+ * admin console + approval flows — untouched.
+ *
+ * This test pins the migration's content so the protection can't be silently
+ * weakened or deleted. (Applied live across dev/staging/prod via the Supabase MCP
+ * on 2026-06-22; trigger byte-identical across all three.)
+ */
+
+import fs from 'fs';
+import path from 'path';
+
+const MIGRATION = path.join(
+  __dirname,
+  '..',
+  '..',
+  'supabase',
+  'migrations',
+  '20260622061545_sec27_block_admin_is_suspended_self_set.sql'
+);
+
+describe('SEC-27 is_admin / is_suspended self-elevation guard', () => {
+  test('migration file exists', () => {
+    expect(fs.existsSync(MIGRATION)).toBe(true);
+  });
+
+  const sql = fs.existsSync(MIGRATION) ? fs.readFileSync(MIGRATION, 'utf8') : '';
+
+  test('defines the guard function with a pinned search_path', () => {
+    expect(sql).toMatch(/create or replace function public\.block_admin_is_suspended_self_set/i);
+    expect(sql).toMatch(/set search_path = public, pg_temp/i);
+    expect(sql).toMatch(/security definer/i);
+  });
+
+  test('exempts the service-role / backend caller (auth.uid() IS NULL)', () => {
+    expect(sql).toMatch(/if auth\.uid\(\) is null then/i);
+  });
+
+  test('blocks changing is_admin and is_suspended', () => {
+    expect(sql).toMatch(/new\.is_admin is distinct from old\.is_admin/i);
+    expect(sql).toMatch(/new\.is_suspended is distinct from old\.is_suspended/i);
+  });
+
+  test('raises an insufficient_privilege (42501) error on violation', () => {
+    expect(sql).toMatch(/raise exception/i);
+    expect(sql).toMatch(/errcode = '42501'/i);
+  });
+
+  test('wires the guard as a BEFORE UPDATE row trigger on public.profiles', () => {
+    expect(sql).toMatch(
+      /create trigger profiles_block_admin_is_suspended_self_set\s+before update on public\.profiles\s+for each row/i
+    );
+  });
+
+  test('documents a rollback path', () => {
+    expect(sql).toMatch(/drop trigger if exists profiles_block_admin_is_suspended_self_set/i);
+  });
+});


### PR DESCRIPTION
## CRITICAL privilege-escalation — fixed + verified live on all 3 envs

Any signed-in user could `PATCH /rest/v1/profiles` their own row with `{"is_admin": true}` (full admin privesc — admin dashboard, user list, moderation, suspension powers) or `{"is_suspended": false}` (self-unsuspend). The "Update own profile" RLS policy carried **no column restriction**, `authenticated`/`anon` held column-level `UPDATE` on both columns, and the `profiles_block_admin_self_set` trigger the B6 daily probe expected **had never been created** in any environment. Found by the daily security check (B6) 2026-06-22.

### Fix
`profiles_block_admin_is_suspended_self_set` — a `BEFORE UPDATE` trigger that raises **42501** when a JWT-bearing caller (`auth.uid() IS NOT NULL`) changes `is_admin` or `is_suspended`. Service-role / backend callers (`auth.uid() IS NULL`) are unaffected, so the admin console's service-role writes (see `src/app/admin/users/actions.ts` — *"service role passes the admin-only trigger"*) and the beta/suspension approval flows keep working.

### Applied + verified (Supabase MCP, 2026-06-22)
Live (idempotent) on **dev + staging + prod**. Rolled-back verification on each returned `admin_blocked=t susp_blocked=t svc_ok=t` — i.e. authenticated UPDATE of either column → 42501, service-role UPDATE still succeeds. Migration filename matches the live recorded version `20260622061545`.

### This PR (source-of-truth + regression guards)
- the migration file (already applied live)
- `tests/unit/sec27-block-admin-self-set-migration.test.ts` — pins the trigger/function/42501/rollback so it can't be silently weakened
- `docs/DAILY_SECURITY_CHECK.md` B6 — updated to look for the new trigger (keyed off trigger presence, not the brittle `schema_migrations.version`)

Supersedes the daily-routine's **BUGS-52**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)