### PR TITLE
feat(KAN-282): Didit facial age-estimation flow (hosted session + webhook)

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -59,6 +59,11 @@ Host routing lives in `src/middleware.ts` behind two env vars (set on the **prod
 | `SENTRY_READ_TOKEN` | _(optional)_ | Reserved for live Sentry panels on `/admin/monitoring` |
 | `UPTIMEROBOT_API_KEY` | _(optional)_ | Lights up the UptimeRobot status on `/admin/monitoring` |
 | `PAID_LINKS_COMPLIANCE_READY` | _(unset = off)_ | KAN-309: gates the `paid_gift_links` per-user entitlement. Monetised affiliate links are produced only when this is `true` (FTC/ASA/CMA disclosure KAN-192 + cookie/GDPR consent KAN-193 shipped) **and** the recipient is entitled **and** `SOVRN_API_KEY` is set. |
+| `AGE_VERIFICATION_REQUIRED` | _(unset = off)_ | KAN-319: env-wide age-gate switch. When `true`, a profile can publish only if `age_status='passed'`. |
+| `DIDIT_API_KEY` | _(unset = dormant)_ | KAN-282: Didit age-estimation API key. With this + `DIDIT_WORKFLOW_ID` set, `/verify-age` runs the real hosted selfie flow; unset → the page shows "coming soon" (feature inert). |
+| `DIDIT_WORKFLOW_ID` | _(unset)_ | KAN-282: the Didit workflow (age estimation + ID fallback). |
+| `DIDIT_WEBHOOK_SECRET` | _(unset)_ | KAN-282: HMAC secret for verifying the `/api/age/didit/webhook` signature. Without it the webhook rejects all calls (fail-closed). |
+| `DIDIT_API_BASE` | `https://verification.didit.me` | KAN-282: override the Didit API base if needed. |
 
 ### Per-user feature entitlements (KAN-309 follow-on)
 

--- a/src/app/api/age/didit/webhook/route.ts
+++ b/src/app/api/age/didit/webhook/route.ts
@@ -1,0 +1,59 @@
+/**
+ * KAN-282: Didit age-verification webhook.
+ *
+ * Didit POSTs the verification decision here (signed). We verify the HMAC
+ * signature, map the decision to an age_status, and persist it (service-role).
+ * Idempotent: re-delivery for the same session just re-writes the same status.
+ *
+ * No selfie/biometric is received or stored — only the status + session ref.
+ */
+import { NextRequest, NextResponse } from 'next/server';
+import {
+  verifyWebhookSignature,
+  normaliseDecision,
+  mapDecisionToAgeStatus,
+} from '@/lib/age/didit';
+import { setProfileAgeStatus, profileExists } from '@/lib/age/age-service';
+
+export const dynamic = 'force-dynamic';
+
+export async function POST(req: NextRequest) {
+  const raw = await req.text();
+  const sig =
+    req.headers.get('x-signature') ??
+    req.headers.get('x-didit-signature') ??
+    req.headers.get('x-hub-signature-256');
+
+  if (!verifyWebhookSignature(raw, sig)) {
+    return NextResponse.json({ error: 'invalid signature' }, { status: 401 });
+  }
+
+  let body: Record<string, unknown>;
+  try {
+    body = JSON.parse(raw) as Record<string, unknown>;
+  } catch {
+    return NextResponse.json({ error: 'invalid json' }, { status: 400 });
+  }
+
+  // vendor_data is the profile id we set when creating the session.
+  const profileId = String(body.vendor_data ?? body.vendorData ?? '').trim();
+  const sessionId = String(body.session_id ?? body.id ?? '').trim() || null;
+  if (!profileId || !(await profileExists(profileId))) {
+    // 200 so the provider doesn't retry forever on an unknown ref; logged for ops.
+    console.warn('[didit-webhook] unknown or missing vendor_data profile id');
+    return NextResponse.json({ ok: true, ignored: 'unknown profile' });
+  }
+
+  const status = mapDecisionToAgeStatus(normaliseDecision(body.decision ?? body));
+  // 'pending' is not a terminal outcome — don't overwrite with it from a webhook.
+  if (status === 'pending') {
+    return NextResponse.json({ ok: true, status });
+  }
+
+  const result = await setProfileAgeStatus(profileId, status, sessionId);
+  if (!result.ok) {
+    console.error('[didit-webhook] failed to persist age_status:', result.error);
+    return NextResponse.json({ error: 'persist failed' }, { status: 500 });
+  }
+  return NextResponse.json({ ok: true, status });
+}

--- a/src/app/how-we-check-your-age/page.tsx
+++ b/src/app/how-we-check-your-age/page.tsx
@@ -1,0 +1,86 @@
+/**
+ * KAN-282: public "How we check your age" summary.
+ *
+ * Ofcom's Highly Effective Age Assurance guidance requires a service that
+ * restricts access to adults to publish an easy-to-find, plain-English summary
+ * of its age-assurance process. This is that page. (Copy is provisional and
+ * should be reviewed/signed off by Luisa before age checks are switched on.)
+ */
+import Link from 'next/link';
+import Image from 'next/image';
+
+export const metadata = {
+  title: 'How we check your age — Lyra',
+  description: 'How Lyra confirms that members are over 18, and what data we keep.',
+};
+
+export default function HowWeCheckYourAgePage() {
+  return (
+    <main className="min-h-screen bg-[var(--color-paper)]">
+      <header className="border-b border-[var(--color-border)] bg-white">
+        <div className="max-w-3xl mx-auto px-4 py-4 flex items-center">
+          <Link href="/" className="flex items-center" aria-label="Lyra">
+            <Image src="/lyra-logo.png" alt="Lyra" width={32} height={32} className="h-8 w-auto" />
+          </Link>
+        </div>
+      </header>
+
+      <article className="max-w-2xl mx-auto px-4 py-12 space-y-6 text-[var(--color-ink)]">
+        <h1 className="text-2xl font-medium font-[family-name:var(--font-serif)]">How we check your age</h1>
+
+        <p className="text-sm text-[var(--color-muted)] leading-relaxed">
+          Lyra is an adults-only (18+) service. Before a profile can be published, we confirm the
+          member is over 18 using a privacy-preserving age check. This page explains how it works
+          and what we keep.
+        </p>
+
+        <section className="space-y-2">
+          <h2 className="text-base font-medium">The method</h2>
+          <p className="text-sm text-[var(--color-muted)] leading-relaxed">
+            We use <strong>facial age estimation</strong> provided by our age-assurance partner,
+            Didit. You take a short selfie in their secure flow; their system estimates your age.
+            A simple date-of-birth box or tick-box is not enough on its own, so we don&rsquo;t rely
+            on one.
+          </p>
+        </section>
+
+        <section className="space-y-2">
+          <h2 className="text-base font-medium">What we store</h2>
+          <p className="text-sm text-[var(--color-muted)] leading-relaxed">
+            We store only a <strong>yes/no age result</strong>, the date of the check, and a
+            reference number from the provider. We do <strong>not</strong> store your selfie, your
+            image, or your date of birth — the photo is processed by the provider and deleted after
+            the estimate.
+          </p>
+        </section>
+
+        <section className="space-y-2">
+          <h2 className="text-base font-medium">If the estimate is borderline</h2>
+          <p className="text-sm text-[var(--color-muted)] leading-relaxed">
+            To be confident at the 18 boundary, anyone whose estimate is close to 18 is asked to
+            complete a stronger check (for example a document check) rather than being passed or
+            refused on a near-18 guess. If a check can&rsquo;t confirm you&rsquo;re over 18, your
+            profile stays private and you can contact us to review it.
+          </p>
+        </section>
+
+        <section className="space-y-2">
+          <h2 className="text-base font-medium">Accessibility & alternatives</h2>
+          <p className="text-sm text-[var(--color-muted)] leading-relaxed">
+            If you can&rsquo;t or would prefer not to take a selfie, an alternative check is
+            available. If you have any difficulty, email{' '}
+            <a href="mailto:hello@checklyra.com" className="underline hover:text-[var(--color-sage)]">
+              hello@checklyra.com
+            </a>.
+          </p>
+        </section>
+
+        <p className="text-xs text-[var(--color-muted)]">
+          See also our{' '}
+          <Link href="/privacy" className="underline hover:text-[var(--color-sage)]">privacy policy</Link>
+          {' '}for the legal basis and retention details.
+        </p>
+      </article>
+    </main>
+  );
+}

--- a/src/app/verify-age/actions.ts
+++ b/src/app/verify-age/actions.ts
@@ -1,0 +1,36 @@
+'use server';
+
+/**
+ * KAN-282: start a Didit age-verification session and hand off to the hosted
+ * selfie flow. Marks the profile 'pending', then redirects to Didit's URL. The
+ * outcome arrives via the signed webhook (authoritative) and/or the callback
+ * route (immediate UX). No biometric is handled here.
+ */
+import { redirect } from 'next/navigation';
+import { createClient } from '@/lib/supabase-server';
+import { env } from '@/lib/env';
+import { createAgeSession } from '@/lib/age/didit';
+import { profileIdForUser, setProfileAgeStatus } from '@/lib/age/age-service';
+
+export async function startAgeVerification(): Promise<void> {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) redirect('/login?next=/verify-age');
+
+  const profileId = await profileIdForUser(user.id);
+  if (!profileId) redirect('/verify-age?e=no_profile');
+
+  const session = await createAgeSession({
+    vendorData: profileId,
+    callbackUrl: `${env.siteUrl()}/verify-age/callback`,
+  });
+  if (!session.ok) {
+    redirect(`/verify-age?e=${session.reason}`);
+  }
+
+  // Mark in-flight; the webhook/callback will resolve to passed/failed/manual_review.
+  await setProfileAgeStatus(profileId, 'pending', session.sessionId);
+  redirect(session.url);
+}

--- a/src/app/verify-age/callback/route.ts
+++ b/src/app/verify-age/callback/route.ts
@@ -1,0 +1,39 @@
+/**
+ * KAN-282: Didit returns the user here after the hosted selfie flow. We confirm
+ * the decision server-side and persist age_status (the webhook is the
+ * authoritative async path; this gives immediate UX). No biometric is received.
+ */
+import { NextRequest, NextResponse } from 'next/server';
+import { createClient } from '@/lib/supabase-server';
+import { env } from '@/lib/env';
+import { fetchAgeDecision, normaliseDecision, mapDecisionToAgeStatus } from '@/lib/age/didit';
+import { profileIdForUser, setProfileAgeStatus } from '@/lib/age/age-service';
+
+export const dynamic = 'force-dynamic';
+
+export async function GET(req: NextRequest) {
+  const base = env.siteUrl();
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) return NextResponse.redirect(`${base}/login?next=/verify-age`);
+
+  const profileId = await profileIdForUser(user.id);
+  const sessionId =
+    req.nextUrl.searchParams.get('session_id') ?? req.nextUrl.searchParams.get('sessionId');
+
+  if (profileId && sessionId) {
+    const decision = await fetchAgeDecision(sessionId);
+    if (decision) {
+      const status = mapDecisionToAgeStatus(normaliseDecision(decision));
+      if (status !== 'pending') {
+        await setProfileAgeStatus(profileId, status, sessionId);
+      }
+      if (status === 'passed') {
+        return NextResponse.redirect(`${base}/dashboard/profile`);
+      }
+    }
+  }
+  return NextResponse.redirect(`${base}/verify-age`);
+}

--- a/src/app/verify-age/page.tsx
+++ b/src/app/verify-age/page.tsx
@@ -12,6 +12,8 @@ import Image from 'next/image';
 import { createClient } from '@/lib/supabase-server';
 import { redirect } from 'next/navigation';
 import { isAgeVerificationRequired } from '@/lib/age/gate';
+import { isDiditConfigured } from '@/lib/age/didit';
+import { startAgeVerification } from './actions';
 
 export const metadata = {
   title: 'Verify your age — Lyra',
@@ -58,11 +60,30 @@ export default async function VerifyAgePage() {
           <p className="text-sm text-[var(--color-muted)]">
             {status === 'failed'
               ? 'Our last check could not confirm you are over 18. Please contact us if you think this is a mistake.'
-              : 'Age checks are being switched on shortly. We never store your photo or date of birth — only a yes/no age result.'}
+              : status === 'manual_review'
+              ? 'Your check needs a closer look — we may ask for a quick document check. We never store your photo or date of birth, only a yes/no age result.'
+              : 'We never store your photo or date of birth — only a yes/no age result.'}
           </p>
+
+          {isDiditConfigured() ? (
+            <form action={startAgeVerification}>
+              <button
+                type="submit"
+                className="px-6 py-2.5 rounded-full bg-[var(--color-sage)] text-white text-sm font-medium hover:opacity-90 transition-opacity"
+              >
+                {status === 'pending' ? 'Continue age check' : 'Start age check'}
+              </button>
+            </form>
+          ) : (
+            <p className="text-sm text-[var(--color-muted)]">
+              Age checks are being switched on shortly.
+            </p>
+          )}
+
           <p className="text-xs text-[var(--color-muted)]">
-            A plain-English &ldquo;How we check your age&rdquo; summary will be published here
-            when checks go live.
+            <Link href="/how-we-check-your-age" className="underline hover:text-[var(--color-sage)]">
+              How we check your age
+            </Link>
           </p>
         </div>
       </div>

--- a/src/lib/age/age-service.ts
+++ b/src/lib/age/age-service.ts
@@ -1,0 +1,53 @@
+/**
+ * KAN-282: service-role writes for age verification.
+ *
+ * age_status is admin/service-role-only (the prevent_beta_self_elevation trigger
+ * blocks user-context writes), so the Didit webhook + callback persist results
+ * through the service client. We store ONLY the status + provider reference +
+ * timestamp — never a DOB, selfie, or raw biometric.
+ */
+import { createClient } from '@supabase/supabase-js';
+import { env } from '@/lib/env';
+import type { AgeStatusResult } from './didit';
+
+function serviceClient() {
+  return createClient(env.supabaseUrl(), env.supabaseServiceRoleKey(), {
+    auth: { persistSession: false },
+  });
+}
+
+/** Persist a verification outcome onto a profile (idempotent for a given session). */
+export async function setProfileAgeStatus(
+  profileId: string,
+  status: AgeStatusResult,
+  sessionRef: string | null,
+): Promise<{ ok: boolean; error?: string }> {
+  if (!profileId) return { ok: false, error: 'missing profile id' };
+  const svc = serviceClient();
+  const { error } = await svc
+    .from('profiles')
+    .update({
+      age_status: status,
+      age_checked_at: new Date().toISOString(),
+      age_provider: 'didit',
+      age_provider_ref: sessionRef,
+    })
+    .eq('id', profileId);
+  return error ? { ok: false, error: error.message } : { ok: true };
+}
+
+/** Resolve the current user's profile id (service-role; used by the verify flow). */
+export async function profileIdForUser(userId: string): Promise<string | null> {
+  if (!userId) return null;
+  const svc = serviceClient();
+  const { data } = await svc.from('profiles').select('id').eq('user_id', userId).maybeSingle();
+  return (data as { id?: string } | null)?.id ?? null;
+}
+
+/** Confirm a vendor_data value is a real profile id (webhook safety). */
+export async function profileExists(profileId: string): Promise<boolean> {
+  if (!profileId) return false;
+  const svc = serviceClient();
+  const { data } = await svc.from('profiles').select('id').eq('id', profileId).maybeSingle();
+  return Boolean((data as { id?: string } | null)?.id);
+}

--- a/src/lib/age/didit.ts
+++ b/src/lib/age/didit.ts
@@ -1,0 +1,168 @@
+/**
+ * KAN-282: Didit facial-age-estimation client + decision mapping.
+ *
+ * Hosted session flow (privacy-by-design — the selfie/biometric never touches
+ * Lyra; we store only an age signal + the provider session reference):
+ *   1. createAgeSession() → POST /v3/session/ → returns { id, url }
+ *   2. redirect the user to session.url (Didit hosts the selfie capture)
+ *   3. Didit calls our webhook (signed) AND redirects back to /verify-age/callback
+ *   4. we read the decision (webhook payload or GET /v3/session/{id}/decision/)
+ *      and map it to age_status via mapDecisionToAgeStatus().
+ *
+ * GRACEFUL DEGRADATION: with DIDIT_API_KEY / DIDIT_WORKFLOW_ID unset the feature
+ * is inert — createAgeSession returns { ok:false, reason:'not_configured' } and
+ * the /verify-age page shows "checks coming soon". So this ships dormant and is
+ * switched on by setting the env vars (mirrors the Sovrn affiliate pattern).
+ *
+ * Challenge age: we treat an estimate >= CHALLENGE_AGE (23) as a confident adult
+ * pass; below it (but not clearly under 18) routes to manual_review / the ID
+ * fallback rather than admitting on a near-18 guess (Ofcom HEAA expectation).
+ */
+import crypto from 'node:crypto';
+
+const DIDIT_BASE = process.env.DIDIT_API_BASE ?? 'https://verification.didit.me';
+export const CHALLENGE_AGE = 23;
+
+export type AgeStatusResult = 'passed' | 'failed' | 'manual_review' | 'pending';
+
+export function isDiditConfigured(): boolean {
+  return Boolean(process.env.DIDIT_API_KEY && process.env.DIDIT_WORKFLOW_ID);
+}
+
+export type CreateSessionResult =
+  | { ok: true; sessionId: string; url: string }
+  | { ok: false; reason: 'not_configured' | 'create_failed'; detail?: string };
+
+/**
+ * Create a hosted verification session. `vendorData` is our opaque reference
+ * (the user/profile id) echoed back in the webhook; `callbackUrl` is where Didit
+ * returns the user after capture.
+ */
+export async function createAgeSession(opts: {
+  vendorData: string;
+  callbackUrl: string;
+}): Promise<CreateSessionResult> {
+  const apiKey = process.env.DIDIT_API_KEY;
+  const workflowId = process.env.DIDIT_WORKFLOW_ID;
+  if (!apiKey || !workflowId) {
+    return { ok: false, reason: 'not_configured' };
+  }
+  try {
+    const res = await fetch(`${DIDIT_BASE}/v3/session/`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', 'x-api-key': apiKey },
+      body: JSON.stringify({
+        workflow_id: workflowId,
+        vendor_data: opts.vendorData,
+        callback: opts.callbackUrl,
+      }),
+    });
+    if (!res.ok) {
+      const detail = await res.text().catch(() => '');
+      return { ok: false, reason: 'create_failed', detail: detail.slice(0, 300) };
+    }
+    const data = (await res.json().catch(() => ({}))) as { session_id?: string; id?: string; url?: string };
+    const sessionId = data.session_id ?? data.id;
+    if (!sessionId || !data.url) {
+      return { ok: false, reason: 'create_failed', detail: 'missing session id/url in response' };
+    }
+    return { ok: true, sessionId, url: data.url };
+  } catch (e) {
+    return { ok: false, reason: 'create_failed', detail: e instanceof Error ? e.message : 'unknown' };
+  }
+}
+
+/** Fetch a session decision (server-side confirm after the callback). */
+export async function fetchAgeDecision(sessionId: string): Promise<unknown | null> {
+  const apiKey = process.env.DIDIT_API_KEY;
+  if (!apiKey || !sessionId) return null;
+  try {
+    const res = await fetch(`${DIDIT_BASE}/v3/session/${encodeURIComponent(sessionId)}/decision/`, {
+      headers: { 'x-api-key': apiKey },
+    });
+    if (!res.ok) return null;
+    return await res.json().catch(() => null);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Normalised decision input. We keep parsing the raw Didit payload separate from
+ * the policy so the policy is pure + unit-testable.
+ */
+export interface NormalisedDecision {
+  /** Provider's high-level status, lower-cased (e.g. 'approved','declined','in_review'). */
+  status?: string | null;
+  /** Estimated age, if the provider returned one. */
+  estimatedAge?: number | null;
+}
+
+/** Pull the bits we need out of Didit's decision payload (defensive). */
+export function normaliseDecision(raw: unknown): NormalisedDecision {
+  const d = (raw ?? {}) as Record<string, unknown>;
+  const ageEst = (d.age_estimation ?? d.age_estimate ?? {}) as Record<string, unknown>;
+  const statusRaw =
+    (typeof d.status === 'string' && d.status) ||
+    (typeof (d.decision as Record<string, unknown> | undefined)?.status === 'string'
+      ? ((d.decision as Record<string, unknown>).status as string)
+      : undefined) ||
+    (typeof ageEst.status === 'string' ? (ageEst.status as string) : undefined);
+  const ageRaw =
+    (typeof ageEst.age === 'number' && ageEst.age) ||
+    (typeof ageEst.estimated_age === 'number' && ageEst.estimated_age) ||
+    (typeof d.age === 'number' ? (d.age as number) : undefined);
+  return {
+    status: statusRaw ? String(statusRaw).toLowerCase() : null,
+    estimatedAge: typeof ageRaw === 'number' ? ageRaw : null,
+  };
+}
+
+/**
+ * Map a normalised decision to an age_status. Pure.
+ *  - explicit decline / clearly-under-18 → failed
+ *  - confident adult (estimate >= challengeAge, or provider 'approved') → passed
+ *  - borderline / in-review / no estimate → manual_review (→ ID fallback)
+ */
+export function mapDecisionToAgeStatus(
+  decision: NormalisedDecision,
+  challengeAge: number = CHALLENGE_AGE,
+): AgeStatusResult {
+  const { status, estimatedAge } = decision;
+
+  if (status === 'declined' || status === 'rejected' || status === 'failed') {
+    return 'failed';
+  }
+  if (typeof estimatedAge === 'number') {
+    if (estimatedAge < 18) return 'failed';
+    if (estimatedAge >= challengeAge) return 'passed';
+    // 18..challengeAge: not confident enough on a near-18 estimate.
+    return 'manual_review';
+  }
+  if (status === 'approved' || status === 'verified' || status === 'passed') {
+    return 'passed';
+  }
+  if (status === 'in_review' || status === 'pending' || status === 'in_progress') {
+    return 'pending';
+  }
+  return 'manual_review';
+}
+
+/**
+ * Verify a Didit webhook HMAC-SHA256 signature (timing-safe). Returns false on
+ * any mismatch / missing secret / malformed header.
+ */
+export function verifyWebhookSignature(
+  rawBody: string,
+  signatureHeader: string | null,
+  secret: string | undefined = process.env.DIDIT_WEBHOOK_SECRET,
+): boolean {
+  if (!secret || !signatureHeader) return false;
+  const expected = crypto.createHmac('sha256', secret).update(rawBody, 'utf8').digest('hex');
+  // header may be raw hex or prefixed (e.g. "sha256=...")
+  const provided = signatureHeader.includes('=') ? signatureHeader.split('=').pop()! : signatureHeader;
+  const a = Buffer.from(expected, 'hex');
+  const b = Buffer.from(provided.trim(), 'hex');
+  if (a.length !== b.length || a.length === 0) return false;
+  return crypto.timingSafeEqual(a, b);
+}

--- a/tests/unit/didit-age.test.ts
+++ b/tests/unit/didit-age.test.ts
@@ -1,0 +1,70 @@
+/**
+ * KAN-282: Didit age-verification client core — decision mapping, normalisation,
+ * and webhook signature verification (the security-critical, pure pieces).
+ */
+import crypto from 'node:crypto';
+import {
+  mapDecisionToAgeStatus,
+  normaliseDecision,
+  verifyWebhookSignature,
+  CHALLENGE_AGE,
+} from '@/lib/age/didit';
+
+describe('mapDecisionToAgeStatus (KAN-282)', () => {
+  it('explicit decline → failed', () => {
+    expect(mapDecisionToAgeStatus({ status: 'declined' })).toBe('failed');
+    expect(mapDecisionToAgeStatus({ status: 'rejected' })).toBe('failed');
+    expect(mapDecisionToAgeStatus({ status: 'failed' })).toBe('failed');
+  });
+  it('estimate under 18 → failed (even if status looks ok)', () => {
+    expect(mapDecisionToAgeStatus({ status: 'approved', estimatedAge: 16 })).toBe('failed');
+  });
+  it('estimate >= challenge age (23) → passed', () => {
+    expect(mapDecisionToAgeStatus({ estimatedAge: CHALLENGE_AGE })).toBe('passed');
+    expect(mapDecisionToAgeStatus({ estimatedAge: 40 })).toBe('passed');
+  });
+  it('estimate 18..<23 → manual_review (no near-18 auto-pass)', () => {
+    expect(mapDecisionToAgeStatus({ estimatedAge: 18 })).toBe('manual_review');
+    expect(mapDecisionToAgeStatus({ estimatedAge: 22 })).toBe('manual_review');
+  });
+  it('approved with no estimate → passed; in_review → pending; empty → manual_review', () => {
+    expect(mapDecisionToAgeStatus({ status: 'approved' })).toBe('passed');
+    expect(mapDecisionToAgeStatus({ status: 'in_review' })).toBe('pending');
+    expect(mapDecisionToAgeStatus({})).toBe('manual_review');
+  });
+});
+
+describe('normaliseDecision (KAN-282)', () => {
+  it('extracts status + age from nested age_estimation', () => {
+    expect(normaliseDecision({ age_estimation: { age: 30, status: 'Approved' } })).toEqual({
+      status: 'approved',
+      estimatedAge: 30,
+    });
+  });
+  it('handles top-level status + missing age', () => {
+    expect(normaliseDecision({ status: 'DECLINED' })).toEqual({ status: 'declined', estimatedAge: null });
+  });
+  it('handles empty/garbage defensively', () => {
+    expect(normaliseDecision(null)).toEqual({ status: null, estimatedAge: null });
+    expect(normaliseDecision('nonsense')).toEqual({ status: null, estimatedAge: null });
+  });
+});
+
+describe('verifyWebhookSignature (KAN-282)', () => {
+  const secret = 'whsec_test_secret';
+  const body = JSON.stringify({ vendor_data: 'p1', decision: { age_estimation: { age: 30 } } });
+  const good = crypto.createHmac('sha256', secret).update(body, 'utf8').digest('hex');
+
+  it('accepts a valid signature (raw + prefixed)', () => {
+    expect(verifyWebhookSignature(body, good, secret)).toBe(true);
+    expect(verifyWebhookSignature(body, `sha256=${good}`, secret)).toBe(true);
+  });
+  it('rejects a wrong/tampered signature', () => {
+    expect(verifyWebhookSignature(body, good.replace(/.$/, '0'), secret)).toBe(false);
+    expect(verifyWebhookSignature(body + 'x', good, secret)).toBe(false);
+  });
+  it('rejects when secret or header is missing', () => {
+    expect(verifyWebhookSignature(body, good, undefined)).toBe(false);
+    expect(verifyWebhookSignature(body, null, secret)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
Epic [KAN-282](https://checklyra.atlassian.net/browse/KAN-282) / [KAN-319](https://checklyra.atlassian.net/browse/KAN-319). The real age-verification flow that moves a user to `age_status='passed'` — the path the age-gate framework (shipped in v0.1.75) was waiting for.

**Ships DORMANT.** Inert until `DIDIT_API_KEY` + `DIDIT_WORKFLOW_ID` are set (Sovrn-style graceful degradation) — `/verify-age` shows "coming soon" without them. Safe to land + promote; switched on by setting the env vars (+ DPIA/copy sign-off).

## What's in here
- **`src/lib/age/didit.ts`** — hosted-session create (`POST /v3/session/`), decision fetch, a **pure decision mapper** (challenge age **23**: estimate ≥23 → passed, <18 → failed, 18–22 → `manual_review`/ID-fallback; never a near-18 auto-pass — Ofcom HEAA), and **HMAC-SHA256 webhook signature** verification (timing-safe). Privacy-by-design: no DOB/selfie stored.
- **`/api/age/didit/webhook`** — signature-verified, idempotent; maps the decision → `age_status` via the service role.
- **`/verify-age`** — "Start age check" creates a session, marks `pending`, redirects to Didit's hosted selfie; **`/verify-age/callback`** confirms server-side on return.
- **`/how-we-check-your-age`** — Ofcom-required plain-English summary (copy provisional, pending sign-off).
- **`src/lib/age/age-service.ts`** — service-role `age_status` writes (status + provider ref + timestamp only). `age_status` remains admin/service-only (the self-elevation trigger blocks users).
- **+11 unit tests** (decision mapping, normalisation, webhook signature).

Uses the `age_status`/`age_provider` columns already live on all envs (v0.1.75) — **no new migration**. Full suite **1749/135 green**; `next build` clean.

## To switch on (Luisa)
Set `DIDIT_API_KEY`, `DIDIT_WORKFLOW_ID`, `DIDIT_WEBHOOK_SECRET` on the Vercel scope; configure the Didit workflow (passive liveness on, challenge age 23, ID fallback) with the callback `…/verify-age/callback` and webhook `…/api/age/didit/webhook`; complete the DPIA + sign off the "How we check your age" copy. Then set `AGE_VERIFICATION_REQUIRED=true` to enforce.

MCP coverage: deferred — age gate over the MCP publish tool folds into KAN-317.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[KAN-282]: https://checklyra.atlassian.net/browse/KAN-282?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[KAN-319]: https://checklyra.atlassian.net/browse/KAN-319?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ