### PR TITLE
feat(KAN-323): admin MCP health check in scheduled smoke tests

### DIFF
--- a/.github/workflows/health-check.yml
+++ b/.github/workflows/health-check.yml
@@ -19,6 +19,14 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - name: Run smoke tests (all environments)
+        # KAN-323: expose the admin-MCP health-check toggle (Actions variable) and the
+        # optional Cloudflare Access service-token (secrets) to the script. Unset values
+        # arrive as empty strings; the script degrades gracefully (the unauthenticated
+        # reachability/gating check still runs — no silent-skip of a real check).
+        env:
+          ADMIN_MCP_HEALTHCHECK_ENABLED: ${{ vars.ADMIN_MCP_HEALTHCHECK_ENABLED }}
+          CF_ACCESS_CLIENT_ID: ${{ secrets.CF_ACCESS_CLIENT_ID }}
+          CF_ACCESS_CLIENT_SECRET: ${{ secrets.CF_ACCESS_CLIENT_SECRET }}
         run: bash scripts/smoke-tests.sh all
       - name: Create issue on failure
         if: failure()

--- a/scripts/smoke-tests.sh
+++ b/scripts/smoke-tests.sh
@@ -152,8 +152,11 @@ run_admin_mcp() {
     -A "Mozilla/5.0 (compatible; LyraSmokeTest/1.0; +https://checklyra.com)" \
     "$HOST/health" 2>/dev/null || echo "000")
   case "$CODE" in
-    403)
-      echo -e "  ${GREEN}✓${NC} Admin MCP reachable + Cloudflare Access gating it (403)"
+    401|403|302)
+      # CF Access challenges an unauthenticated request with 401 (API/CLI clients),
+      # 403, or a 302 redirect to the team login page — all mean "reachable + Access
+      # is gating it", which is the healthy state from a CI runner without a token.
+      echo -e "  ${GREEN}✓${NC} Admin MCP reachable + Cloudflare Access gating it ($CODE)"
       ;;
     200)
       # 200 unauthenticated should never happen once CF Access is on. Distinguish

--- a/scripts/smoke-tests.sh
+++ b/scripts/smoke-tests.sh
@@ -106,11 +106,79 @@ run_mcp() {
   fi
 }
 
+# KAN-323 — Admin MCP (admin-mcp.checklyra.com). A SEPARATE, owner-gated deploy
+# behind Cloudflare Access, so the check is deliberately shaped for that:
+#   * OFF by default; only runs once ADMIN_MCP_HEALTHCHECK_ENABLED=1 is set (an
+#     Actions variable flipped at go-live). The admin MCP is intentionally not
+#     live until its SEC sign-off — a hard check before then would alert on a
+#     service that doesn't exist yet, not a real fault. A loud NOTICE is printed
+#     while it's off (never a silent green).
+#     # integrity-ok: deliberate opt-in for a not-yet-live, owner-gated service (KAN-323)
+#   * From a CI runner (no CF Access token) a HEALTHY admin MCP returns 403
+#     (Access challenge). A bare 200 means Access is NOT protecting the admin
+#     surface — a security failure. 000/4xx/5xx means it is down.
+#   * If CF Access service-token secrets are present, additionally verify true
+#     origin health through Access (/health -> {"status":"ok"}).
+run_admin_mcp() {
+  echo -e "${YELLOW}=== Admin MCP (admin-mcp.checklyra.com) ===${NC}"
+  local HOST="https://admin-mcp.checklyra.com"
+
+  if [ "${ADMIN_MCP_HEALTHCHECK_ENABLED:-}" != "1" ]; then
+    echo -e "  ${YELLOW}⚠ NOTICE${NC} Admin MCP health check is OFF — set ADMIN_MCP_HEALTHCHECK_ENABLED=1 once KAN-323 is deployed + SEC-signed-off. (Not yet live; nothing checked, not counted as pass.)"
+    return
+  fi
+
+  # Deep check through Cloudflare Access when a service token is configured.
+  if [ -n "${CF_ACCESS_CLIENT_ID:-}" ] && [ -n "${CF_ACCESS_CLIENT_SECRET:-}" ]; then
+    TOTAL=$((TOTAL + 1))
+    local BODY
+    BODY=$(curl -s --max-time 15 \
+      -H "CF-Access-Client-Id: ${CF_ACCESS_CLIENT_ID}" \
+      -H "CF-Access-Client-Secret: ${CF_ACCESS_CLIENT_SECRET}" \
+      "$HOST/health" 2>/dev/null || echo "")
+    if echo "$BODY" | grep -q '"status":"ok"'; then
+      echo -e "  ${GREEN}✓${NC} Admin MCP origin health (authenticated /health -> status:ok)"
+    else
+      echo -e "  ${RED}✗${NC} Admin MCP origin /health did not return status:ok through CF Access"
+      FAILURES=$((FAILURES + 1))
+    fi
+    return
+  fi
+
+  # Unauthenticated: assert reachable AND that Cloudflare Access is gating it.
+  TOTAL=$((TOTAL + 1))
+  local CODE
+  CODE=$(curl -so /dev/null -w "%{http_code}" --max-time 15 \
+    -A "Mozilla/5.0 (compatible; LyraSmokeTest/1.0; +https://checklyra.com)" \
+    "$HOST/health" 2>/dev/null || echo "000")
+  case "$CODE" in
+    403)
+      echo -e "  ${GREEN}✓${NC} Admin MCP reachable + Cloudflare Access gating it (403)"
+      ;;
+    200)
+      # 200 unauthenticated should never happen once CF Access is on. Distinguish
+      # "admin surface exposed" from "this domain points at the wrong service".
+      local WHO
+      WHO=$(curl -s --max-time 15 -A "Mozilla/5.0 (compatible; LyraSmokeTest/1.0; +https://checklyra.com)" "$HOST/health" 2>/dev/null || echo "")
+      if echo "$WHO" | grep -q 'lyra-admin-mcp-server'; then
+        echo -e "  ${RED}✗${NC} Admin MCP /health is PUBLIC (200) — Cloudflare Access is NOT protecting the admin surface!"
+      else
+        echo -e "  ${RED}✗${NC} admin-mcp.checklyra.com returns 200 but is NOT the admin server — domain points at the wrong service (got: $(echo "$WHO" | head -c 80))"
+      fi
+      FAILURES=$((FAILURES + 1))
+      ;;
+    *)
+      echo -e "  ${RED}✗${NC} Admin MCP unreachable/unhealthy (HTTP $CODE)"
+      FAILURES=$((FAILURES + 1))
+      ;;
+  esac
+}
+
 case "$ENV" in
-  production) run_production; run_mcp ;;
+  production) run_production; run_mcp; run_admin_mcp ;;
   staging) run_staging; run_mcp ;;
   dev) run_dev; run_mcp ;;
-  all) run_production; run_staging; run_dev; run_mcp ;;
+  all) run_production; run_staging; run_dev; run_mcp; run_admin_mcp ;;
   *) echo "Usage: $0 [dev|staging|production|all]"; exit 1 ;;
 esac
 


### PR DESCRIPTION
## Summary
[KAN-323](https://checklyra.atlassian.net/browse/KAN-323). Adds an admin-MCP health check to `scripts/smoke-tests.sh`, which the scheduled `health-check.yml` runs every 6h.

- `run_admin_mcp()` checks `admin-mcp.checklyra.com`, wired into the `production` + `all` runs.
- **OFF by default**, runs only when `ADMIN_MCP_HEALTHCHECK_ENABLED=1` (an Actions variable flipped at go-live) — the admin MCP is owner-gated/not-yet-live + pending SEC sign-off, so a hard check before then would alert on a non-existent service. Prints a loud NOTICE while off (no silent green). Justified inline per the Workflow Integrity Policy.
- **Healthy = 403** (behind Cloudflare Access). A **public 200 is a failure**, and the check distinguishes *admin surface exposed* from *domain mapped to the wrong service*. `000/4xx/5xx` = down.
- Optional **deep origin check** via a CF Access service token (`CF_ACCESS_CLIENT_ID`/`SECRET`) → asserts `/health` returns `status:ok`.

## Live finding (surfaced while fixing the Railway build)
`admin-mcp.checklyra.com` currently resolves to the **user-facing `lyra-mcp-server`**, not the new admin service — the custom domain is mapped to the wrong Railway service, and it answers publicly with no CF Access. Remap + CF Access needed (see RUNBOOK in `lyra-admin-mcp-server`).

## Notes
- Infra/ops change — not a user-facing feature (MCP-lockstep N/A).
- `bash -n` clean; ran both modes locally (NOTICE when off; correctly flags the current wrong-service 200).
- Reaches the live scheduled run (which runs from `main`) on the next promotion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[KAN-323]: https://checklyra.atlassian.net/browse/KAN-323?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ