### PR TITLE
feat(SEC-33): RS256 + JWKS OAuth token signing (web AS)

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -11,6 +11,12 @@ const nextConfig: NextConfig = {
         source: '/.well-known/oauth-authorization-server',
         destination: '/api/well-known/oauth-authorization-server',
       },
+      {
+        // SEC-33: canonical JWKS path → internal route (Next.js won't route a
+        // literal '.'-prefixed folder reliably).
+        source: '/.well-known/jwks.json',
+        destination: '/api/well-known/jwks',
+      },
     ];
   },
   async headers() {

--- a/src/app/api/well-known/jwks/route.ts
+++ b/src/app/api/well-known/jwks/route.ts
@@ -1,0 +1,52 @@
+/**
+ * /.well-known/jwks.json — OAuth JWKS (SEC-33).
+ *
+ * Publishes the AS's RS256 PUBLIC key(s) so resource servers verify access
+ * tokens with no shared secret. Only ever exposes public fields: we import the
+ * SPKI *public* PEM and explicitly construct the JWK from {kty,n,e} so private
+ * fields (d,p,q,dp,dq,qi) can never leak even if the env held a private key.
+ *
+ * Supports key rotation by publishing a NEXT key alongside the current one.
+ * Returns 500 (never an empty/placeholder key set) if the public key is missing.
+ */
+import { NextResponse } from 'next/server';
+import { importSPKI, exportJWK } from 'jose';
+
+export const dynamic = 'force-dynamic'; // env-driven — never cache at the framework layer
+
+const CORS = {
+  'Access-Control-Allow-Origin': '*',
+  'Cache-Control': 'public, max-age=300',
+};
+
+function pemFromB64(b64: string): string {
+  return Buffer.from(b64, 'base64').toString('utf8');
+}
+
+async function publicJwk(b64: string, kid: string) {
+  const key = await importSPKI(pemFromB64(b64), 'RS256');
+  const jwk = await exportJWK(key);
+  // Defence in depth: publish ONLY public RSA fields + metadata — never spread
+  // the raw jwk (which could carry private fields if a private key slipped in).
+  return { kty: jwk.kty, n: jwk.n, e: jwk.e, alg: 'RS256', use: 'sig', kid };
+}
+
+export async function GET() {
+  const b64 = process.env.OAUTH_JWT_PUBLIC_KEY_B64;
+  const kid = process.env.OAUTH_JWT_KID;
+  if (!b64 || !kid) {
+    // Loud failure, not a silent empty key set (workflow-integrity policy).
+    return NextResponse.json({ error: 'jwks_unavailable' }, { status: 500, headers: CORS });
+  }
+
+  const keys = [await publicJwk(b64, kid)];
+
+  // Rotation overlap: publish the next key too, so verifiers accept both kids.
+  const nextB64 = process.env.OAUTH_JWT_PUBLIC_KEY_B64_NEXT;
+  const nextKid = process.env.OAUTH_JWT_KID_NEXT;
+  if (nextB64 && nextKid) {
+    keys.push(await publicJwk(nextB64, nextKid));
+  }
+
+  return NextResponse.json({ keys }, { headers: CORS });
+}

--- a/src/app/api/well-known/oauth-authorization-server/route.ts
+++ b/src/app/api/well-known/oauth-authorization-server/route.ts
@@ -22,6 +22,8 @@ export async function GET() {
       token_endpoint: oauthConfig.tokenEndpoint(),
       registration_endpoint: oauthConfig.registrationEndpoint(),
       revocation_endpoint: oauthConfig.revocationEndpoint(),
+      jwks_uri: oauthConfig.jwksUri(), // SEC-33: RS256 public keys for token verification
+
       response_types_supported: ['code'],
       response_modes_supported: ['query'],
       grant_types_supported: ['authorization_code', 'refresh_token'],

--- a/src/lib/oauth/config.ts
+++ b/src/lib/oauth/config.ts
@@ -23,9 +23,9 @@ export const oauthConfig = {
   tokenEndpoint: () => `${siteUrl()}/oauth/token`,
   registrationEndpoint: () => `${siteUrl()}/oauth/register`,
   revocationEndpoint: () => `${siteUrl()}/oauth/revoke`,
-  // For MVP we don't expose JWKS — HS256 with shared secret. RS256 + JWKS
-  // is a follow-up. The AS metadata still has to omit the jwks_uri field
-  // gracefully so claude.ai doesn't reject us.
+  // SEC-33: RS256 + JWKS. The AS signs with an RS256 private key and publishes
+  // the public key here so resource servers verify with no shared secret.
+  jwksUri: () => `${siteUrl()}/.well-known/jwks.json`,
 
   // Scope catalogue. MVP = single 'lyra:full' scope. Granular scopes
   // (lyra:profile:read, lyra:convene:write, etc.) come later.

--- a/src/lib/oauth/jwt.ts
+++ b/src/lib/oauth/jwt.ts
@@ -1,39 +1,53 @@
 /**
- * JWT signing/verification for OAuth 2.1 access tokens — KAN-88 P4.
+ * JWT signing/verification for OAuth 2.1 access tokens — KAN-88 / SEC-33.
  *
- * HS256 with a shared secret (env: OAUTH_JWT_SIGNING_SECRET). The
- * secret MUST be the same on lyra (the AS — signs tokens here) and on
- * the MCP server (the RS — verifies tokens). Operationally, set the
- * same value on both Railway and Vercel.
+ * Signs **RS256** with an asymmetric private key (env OAUTH_JWT_PRIVATE_KEY_B64
+ * = base64 of a PKCS8 PEM; key id in OAUTH_JWT_KID) and publishes the matching
+ * public key at /.well-known/jwks.json, so resource servers (the MCP servers)
+ * verify with NO shared secret.
  *
- * Migration to RS256 + JWKS is a follow-up ticket. The shape is
- * deliberately RFC 7519-standard so we can swap algorithms without
- * breaking consumers.
+ * Migration safety: if no private key is configured, it falls back to the
+ * legacy **HS256** shared secret (OAUTH_JWT_SIGNING_SECRET). This lets the code
+ * deploy *before* the keypair is set without breaking token issuance — and the
+ * MCP verifiers accept both algorithms during the overlap. The HS256 path is
+ * removed once every environment has a keypair (SEC-33 teardown).
  *
- * Token shape (claims):
- *   iss: https://<this-deploy>            — AS URL
- *   sub: <user_id uuid>
- *   aud: <client_id>                      — the registered OAuth client
- *   exp: now + accessTokenTtlSeconds
- *   iat: now
- *   jti: <uuid>                           — for revocation tracking
- *   scope: 'lyra:full'
- *   client_id: <client_id>                — duplicates aud for compat
- *
- * The MCP server validates: signature, exp, iss, and (optionally)
- * looks up jti in oauth_access_tokens to honour revocations.
+ * Token shape (claims) is RFC 7519-standard and UNCHANGED by the alg switch:
+ *   iss, sub, aud, exp, iat, jti, scope, client_id.
  */
 
-import { SignJWT, jwtVerify } from 'jose';
+import { SignJWT, jwtVerify, importPKCS8, importSPKI } from 'jose';
 import { randomUUID } from 'crypto';
 import { oauthConfig } from './config';
 
-function secretKey(): Uint8Array {
+function pemFromB64(b64: string): string {
+  return Buffer.from(b64, 'base64').toString('utf8');
+}
+
+function hsSecret(): Uint8Array {
   const raw = process.env.OAUTH_JWT_SIGNING_SECRET;
   if (!raw || raw.length < 32) {
     throw new Error('OAUTH_JWT_SIGNING_SECRET must be set to at least 32 chars');
   }
   return new TextEncoder().encode(raw);
+}
+
+/** RS256 signing key (PKCS8), imported once. null when not configured → HS256. */
+let _privateKey: Promise<CryptoKey> | null = null;
+function privateKey(): Promise<CryptoKey> | null {
+  const b64 = process.env.OAUTH_JWT_PRIVATE_KEY_B64;
+  if (!b64) return null;
+  if (!_privateKey) _privateKey = importPKCS8(pemFromB64(b64), 'RS256');
+  return _privateKey;
+}
+
+/** RS256 public key (SPKI) for the AS self-check verify. null when not configured. */
+let _publicKey: Promise<CryptoKey> | null = null;
+function publicKey(): Promise<CryptoKey> | null {
+  const b64 = process.env.OAUTH_JWT_PUBLIC_KEY_B64;
+  if (!b64) return null;
+  if (!_publicKey) _publicKey = importSPKI(pemFromB64(b64), 'RS256');
+  return _publicKey;
 }
 
 export interface AccessTokenClaims {
@@ -78,25 +92,27 @@ export async function issueAccessToken(input: IssueAccessTokenInput): Promise<Is
     client_id: input.clientId,
   };
 
-  const jwt = await new SignJWT({
-    scope: input.scope,
-    client_id: input.clientId,
-  })
-    .setProtectedHeader({ alg: 'HS256', typ: 'JWT' })
+  const builder = new SignJWT({ scope: input.scope, client_id: input.clientId })
     .setIssuer(issuer)
     .setSubject(input.userId)
     .setAudience(input.clientId)
     .setJti(jti)
     .setIssuedAt(now)
-    .setExpirationTime(exp)
-    .sign(secretKey());
+    .setExpirationTime(exp);
 
-  return {
-    jwt,
-    jti,
-    expiresAt: new Date(exp * 1000),
-    claims,
-  };
+  const priv = privateKey();
+  let jwt: string;
+  if (priv) {
+    // Primary: RS256, kid lets verifiers select the key from the JWKS.
+    jwt = await builder
+      .setProtectedHeader({ alg: 'RS256', typ: 'JWT', kid: process.env.OAUTH_JWT_KID })
+      .sign(await priv);
+  } else {
+    // Legacy fallback: HS256 shared secret (no asymmetric key configured yet).
+    jwt = await builder.setProtectedHeader({ alg: 'HS256', typ: 'JWT' }).sign(hsSecret());
+  }
+
+  return { jwt, jti, expiresAt: new Date(exp * 1000), claims };
 }
 
 export interface VerifyOptions {
@@ -107,15 +123,21 @@ export interface VerifyOptions {
   issuer?: string;
 }
 
+/**
+ * AS-side self-check verifier (the load-bearing verification is the MCP resource
+ * server's). Verifies with whatever this AS is configured to sign: RS256 via the
+ * public key when configured, else legacy HS256.
+ */
 export async function verifyAccessToken(
   jwt: string,
   opts: VerifyOptions = {}
 ): Promise<{ ok: true; claims: AccessTokenClaims } | { ok: false; error: string }> {
   try {
-    const { payload } = await jwtVerify(jwt, secretKey(), {
-      issuer: opts.issuer ?? oauthConfig.issuer(),
-      algorithms: ['HS256'],
-    });
+    const issuer = opts.issuer ?? oauthConfig.issuer();
+    const pub = publicKey();
+    const { payload } = pub
+      ? await jwtVerify(jwt, await pub, { issuer, algorithms: ['RS256'] })
+      : await jwtVerify(jwt, hsSecret(), { issuer, algorithms: ['HS256'] });
     if (typeof payload.sub !== 'string') return { ok: false, error: 'missing sub' };
     if (typeof payload.jti !== 'string') return { ok: false, error: 'missing jti' };
     if (typeof payload.exp !== 'number') return { ok: false, error: 'missing exp' };

--- a/tests/unit/oauth/jwks-route.test.ts
+++ b/tests/unit/oauth/jwks-route.test.ts
@@ -1,0 +1,88 @@
+/**
+ * SEC-33 — JWKS route. Behavioural: publishes only public RSA fields, never
+ * leaks private material, 500s loudly when unconfigured, and a token signed by
+ * the private key verifies against the published JWK.
+ */
+import { GET } from '@/app/api/well-known/jwks/route';
+import { generateKeyPairSync } from 'crypto';
+import { SignJWT, importJWK, importPKCS8, jwtVerify } from 'jose';
+
+describe('GET /.well-known/jwks.json (SEC-33)', () => {
+  let PRIV_PEM: string;
+  let PUB_B64: string;
+
+  beforeAll(() => {
+    const { publicKey, privateKey } = generateKeyPairSync('rsa', {
+      modulusLength: 2048,
+      publicKeyEncoding: { type: 'spki', format: 'pem' },
+      privateKeyEncoding: { type: 'pkcs8', format: 'pem' },
+    });
+    PRIV_PEM = privateKey as string;
+    PUB_B64 = Buffer.from(publicKey as string).toString('base64');
+  });
+  afterEach(() => {
+    delete process.env.OAUTH_JWT_PUBLIC_KEY_B64;
+    delete process.env.OAUTH_JWT_KID;
+    delete process.env.OAUTH_JWT_PUBLIC_KEY_B64_NEXT;
+    delete process.env.OAUTH_JWT_KID_NEXT;
+  });
+
+  test('publishes the public JWK with kty/n/e/alg/use/kid', async () => {
+    process.env.OAUTH_JWT_PUBLIC_KEY_B64 = PUB_B64;
+    process.env.OAUTH_JWT_KID = 'kid-1';
+    const res = await GET();
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.keys).toHaveLength(1);
+    const k = body.keys[0];
+    expect(k.kty).toBe('RSA');
+    expect(typeof k.n).toBe('string');
+    expect(k.e).toBe('AQAB');
+    expect(k.alg).toBe('RS256');
+    expect(k.use).toBe('sig');
+    expect(k.kid).toBe('kid-1');
+  });
+
+  test('never leaks private key fields', async () => {
+    process.env.OAUTH_JWT_PUBLIC_KEY_B64 = PUB_B64;
+    process.env.OAUTH_JWT_KID = 'kid-1';
+    const k = (await (await GET()).json()).keys[0];
+    for (const f of ['d', 'p', 'q', 'dp', 'dq', 'qi']) {
+      expect(k[f]).toBeUndefined();
+    }
+  });
+
+  test('a token signed by the private key verifies against the published JWK', async () => {
+    process.env.OAUTH_JWT_PUBLIC_KEY_B64 = PUB_B64;
+    process.env.OAUTH_JWT_KID = 'kid-1';
+    const jwk = (await (await GET()).json()).keys[0];
+    const pub = await importJWK(jwk, 'RS256');
+    const priv = await importPKCS8(PRIV_PEM, 'RS256');
+    const token = await new SignJWT({ scope: 'lyra:full' })
+      .setProtectedHeader({ alg: 'RS256', kid: 'kid-1' })
+      .setIssuer('https://dev.checklyra.com')
+      .setSubject('user-x')
+      .setExpirationTime('1h')
+      .sign(priv);
+    const { payload } = await jwtVerify(token, pub, {
+      issuer: 'https://dev.checklyra.com',
+      algorithms: ['RS256'],
+    });
+    expect(payload.sub).toBe('user-x');
+  });
+
+  test('publishes a rotation NEXT key alongside the current one', async () => {
+    process.env.OAUTH_JWT_PUBLIC_KEY_B64 = PUB_B64;
+    process.env.OAUTH_JWT_KID = 'kid-1';
+    process.env.OAUTH_JWT_PUBLIC_KEY_B64_NEXT = PUB_B64;
+    process.env.OAUTH_JWT_KID_NEXT = 'kid-2';
+    const body = await (await GET()).json();
+    expect(body.keys.map((k: { kid: string }) => k.kid)).toEqual(['kid-1', 'kid-2']);
+  });
+
+  test('returns 500 jwks_unavailable when public key/kid missing (no silent empty set)', async () => {
+    const res = await GET();
+    expect(res.status).toBe(500);
+    expect((await res.json()).error).toBe('jwks_unavailable');
+  });
+});

--- a/tests/unit/oauth/jwt-pkce.test.ts
+++ b/tests/unit/oauth/jwt-pkce.test.ts
@@ -7,7 +7,7 @@
 
 import { issueAccessToken, verifyAccessToken } from '@/lib/oauth/jwt';
 import { verifyPkceS256 } from '@/lib/oauth/pkce';
-import { createHash } from 'crypto';
+import { createHash, generateKeyPairSync } from 'crypto';
 
 const TEST_SECRET = '0'.repeat(32);
 const ORIG_SECRET = process.env.OAUTH_JWT_SIGNING_SECRET;
@@ -109,5 +109,44 @@ describe('verifyPkceS256 (KAN-88 P4)', () => {
     // Both are valid base64url + same byte length, so the only path to
     // mismatch is the timingSafeEqual call returning false.
     expect(verifyPkceS256(verifier, wrong)).toBe(false);
+  });
+});
+
+describe('issueAccessToken RS256 + JWKS (SEC-33)', () => {
+  const userId = '00000000-0000-4000-8000-000000000000';
+  const clientId = 'lyra_oauth_test';
+
+  beforeAll(() => {
+    // Ephemeral keypair — proves RS256 signing end-to-end with no live keys.
+    const { publicKey, privateKey } = generateKeyPairSync('rsa', {
+      modulusLength: 2048,
+      publicKeyEncoding: { type: 'spki', format: 'pem' },
+      privateKeyEncoding: { type: 'pkcs8', format: 'pem' },
+    });
+    process.env.OAUTH_JWT_PRIVATE_KEY_B64 = Buffer.from(privateKey as string).toString('base64');
+    process.env.OAUTH_JWT_PUBLIC_KEY_B64 = Buffer.from(publicKey as string).toString('base64');
+    process.env.OAUTH_JWT_KID = 'test-kid-2026-06';
+  });
+  afterAll(() => {
+    // Clean up so other test files in the worker fall back to HS256.
+    delete process.env.OAUTH_JWT_PRIVATE_KEY_B64;
+    delete process.env.OAUTH_JWT_PUBLIC_KEY_B64;
+    delete process.env.OAUTH_JWT_KID;
+  });
+
+  test('signs RS256 with a kid when a private key is configured', async () => {
+    const issued = await issueAccessToken({ userId, clientId, scope: 'lyra:full' });
+    const header = JSON.parse(Buffer.from(issued.jwt.split('.')[0], 'base64url').toString('utf8'));
+    expect(header.alg).toBe('RS256');
+    expect(header.kid).toBe('test-kid-2026-06');
+  });
+
+  test('RS256 round-trips with correct claims (asymmetric, no shared secret)', async () => {
+    const issued = await issueAccessToken({ userId, clientId, scope: 'lyra:full' });
+    const v = await verifyAccessToken(issued.jwt);
+    if (!v.ok) throw new Error(`expected ok, got ${v.error}`);
+    expect(v.claims.sub).toBe(userId);
+    expect(v.claims.client_id).toBe(clientId);
+    expect(v.claims.scope).toBe('lyra:full');
   });
 });

--- a/tests/unit/oauth/metadata.test.ts
+++ b/tests/unit/oauth/metadata.test.ts
@@ -65,6 +65,13 @@ describe('GET /.well-known/oauth-authorization-server (KAN-88)', () => {
     expect(body.scopes_supported).toContain('lyra:full');
   });
 
+  test('advertises jwks_uri (SEC-33)', async () => {
+    process.env.NEXT_PUBLIC_SITE_URL = 'https://dev.checklyra.com';
+    const res = await GET();
+    const body = await res.json();
+    expect(body.jwks_uri).toBe('https://dev.checklyra.com/.well-known/jwks.json');
+  });
+
   test('uses VERCEL_URL fallback when NEXT_PUBLIC_SITE_URL absent', async () => {
     process.env.VERCEL_URL = 'lyra-abc123.vercel.app';
     const res = await GET();
@@ -84,6 +91,12 @@ describe('next.config.ts rewrite for /.well-known/oauth-authorization-server (KA
     const src = fs.readFileSync(path.join(ROOT, 'next.config.ts'), 'utf8');
     expect(src).toMatch(/source:\s*['"]\/\.well-known\/oauth-authorization-server['"]/);
     expect(src).toMatch(/destination:\s*['"]\/api\/well-known\/oauth-authorization-server['"]/);
+  });
+
+  test('jwks rewrite is configured (SEC-33)', () => {
+    const src = fs.readFileSync(path.join(ROOT, 'next.config.ts'), 'utf8');
+    expect(src).toMatch(/source:\s*['"]\/\.well-known\/jwks\.json['"]/);
+    expect(src).toMatch(/destination:\s*['"]\/api\/well-known\/jwks['"]/);
   });
 });
 


### PR DESCRIPTION
Part of **SEC-33** (HS256→RS256+JWKS), so OAuth works in every environment with **no shared secret on the MCP verifiers**. **Draft — do not merge until the coordinated rollout** (deploy MCP dual-accept verifiers FIRST, then this signer; needs per-env RS256 keypairs on Vercel).

- **Conditional signer** (`src/lib/oauth/jwt.ts`): RS256 when `OAUTH_JWT_PRIVATE_KEY_B64` is set, else legacy HS256 — safe to deploy before the keypair exists.
- **JWKS** (`/.well-known/jwks.json`): public-only ({kty,n,e,alg,use,kid}), no private-field leak, rotation NEXT key, 500-on-missing.
- Metadata advertises `jwks_uri`; next.config rewrite added.
- **99/99 oauth tests**, `tsc --noEmit` clean. Existing HS256 tests preserved (fallback). Behavioural RS256 + JWKS coverage via ephemeral keypair.

Pairs with MCP verifier PRs: [lyra-mcp-server#89](https://github.com/luisa-sys/lyra-mcp-server/pull/89), [lyra-admin-mcp-server#2](https://github.com/luisa-sys/lyra-admin-mcp-server/pull/2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)