### PR TITLE
feat: mirror prod waitlist front door on dev (LYRA_FORCE_WAITLIST)

### DIFF
--- a/src/app/(auth)/signup/page.tsx
+++ b/src/app/(auth)/signup/page.tsx
@@ -24,7 +24,9 @@ export default async function SignUpPage({
   // the gated beta app: signing up records a request and lands the user on the
   // waitlist. Frame the page as "join the waitlist". `?preview=waitlist`
   // renders this on any deploy so it can be verified before reaching prod.
-  const waitlist = isProdDeploy() || params.preview === 'waitlist';
+  // LYRA_FORCE_WAITLIST mirrors this framing on a non-prod env (e.g. dev) without
+  // flipping isProdDeploy() (which also drives auth routing). Framing only.
+  const waitlist = isProdDeploy() || process.env.LYRA_FORCE_WAITLIST === 'true' || params.preview === 'waitlist';
 
   return (
     <main className="min-h-screen flex items-center justify-center px-4">

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -205,8 +205,11 @@ export default async function Home({
 }) {
   // Prod (checklyra.com) is the public waitlist doorway. `?preview=waitlist`
   // renders it on any deploy so it can be verified before reaching prod.
+  // LYRA_FORCE_WAITLIST lets a non-prod env (e.g. dev) mirror the prod waitlist
+  // front door WITHOUT flipping isProdDeploy() (which also drives auth routing
+  // to beta.checklyra.com — see post-login-redirect.ts). Framing only.
   const sp = await searchParams;
-  if (isProdDeploy() || sp?.preview === "waitlist") {
+  if (isProdDeploy() || process.env.LYRA_FORCE_WAITLIST === "true" || sp?.preview === "waitlist") {
     return <WaitlistLanding />;
   }
 

--- a/tests/unit/homepage-content.test.js
+++ b/tests/unit/homepage-content.test.js
@@ -193,4 +193,11 @@ describe('KAN-273/287: Production waitlist front door', () => {
     expect(signup).toContain('Create your profile');
     expect(signup).toContain('Create account');
   });
+
+  test('dev mirrors the prod waitlist front door via LYRA_FORCE_WAITLIST (framing only)', () => {
+    // The override is applied to the public framing (homepage + signup), NOT to
+    // isProdDeploy()/auth routing — so dev keeps its own post-login redirects.
+    expect(home).toContain('LYRA_FORCE_WAITLIST');
+    expect(signup).toContain('LYRA_FORCE_WAITLIST');
+  });
 });


### PR DESCRIPTION
## What
Lets a non-prod env (dev) render prod's **"Join the waitlist" front door** on the homepage + signup, so dev's public entry matches production. Aligns dev to prod per founder request.

## Why
No code divergence existed — the framing keys off `isProdDeploy()` (prod-only by design, KAN-273/287) and `LYRA_INVITE_CODE` is set on dev (the "referral code" field). A non-prod env can't show the waitlist front door without faking `VERCEL_ENV`/`NEXT_PUBLIC_SITE_URL`, which would **also** wrongly flip auth post-login routing to `beta.checklyra.com`.

## Change
- Add a **framing-only** `LYRA_FORCE_WAITLIST` override to `src/app/page.tsx` and `src/app/(auth)/signup/page.tsx`, **alongside** `isProdDeploy()` — never replacing it. `src/lib/auth/post-login-redirect.ts` still uses `isProdDeploy()` for routing, so dev keeps its own same-origin redirects.
- Net-new test guard in `homepage-content.test.js` (both pages contain `LYRA_FORCE_WAITLIST`).

## Ops (after merge, dev scope only)
- Set `LYRA_FORCE_WAITLIST=true` on the dev (develop/Preview) Vercel scope.
- Remove `LYRA_INVITE_CODE` on dev.
- **Not** applied to beta (gated app keeps its product homepage).

## Safety
- **Prod unaffected**: `isProdDeploy()` already true on prod; flag unset on Production → no behaviour change.
- **Routing unaffected**: `isProdDeploy()` untouched; `post-login-redirect` routing test stays green.
- Affected suites: 35/35 pass; lint clean; changed files type-clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)