### PR TITLE
feat(SEC-34): app-layer Cloudflare Access verification for the admin console

### DIFF
--- a/src/lib/cf-access.ts
+++ b/src/lib/cf-access.ts
@@ -1,0 +1,78 @@
+/**
+ * SEC-34 / SEC-37 — app-layer Cloudflare Access verification for the admin
+ * console (defence in depth). Mirrors `lyra-admin-mcp-server/src/cf-access.ts`,
+ * adapted for the Next.js **edge** middleware (jose only — Web Crypto, edge-safe).
+ *
+ * Cloudflare Access, in front of the admin host, stamps every request that
+ * passes its policy with a signed `Cf-Access-Jwt-Assertion` JWT. Verifying that
+ * JWT *inside the app* means a request that reaches the Vercel origin WITHOUT
+ * transiting the CF edge — a leaked `*.vercel.app` preview URL, a spoofed `Host`
+ * header straight to the origin, or `/admin` on the public domain — is rejected
+ * even though CF Access only fronts the admin hostname. Without this, the edge
+ * gate is bypassable and therefore theatre (see SEC-37).
+ *
+ * INERT until configured: with `CF_ACCESS_TEAM_DOMAIN` + `CF_ACCESS_AUD` unset
+ * the verifier allows everything, so local dev and any env without the CF app
+ * keep working and shipping this is non-breaking. Once both are set it enforces.
+ * Env is read at call-time (not module-load) so per-env config + tests work.
+ */
+import { createRemoteJWKSet, jwtVerify } from 'jose';
+
+function rawTeam(): string | undefined {
+  return process.env.CF_ACCESS_TEAM_DOMAIN;
+}
+function audience(): string | undefined {
+  return process.env.CF_ACCESS_AUD;
+}
+
+/** True iff both CF Access env vars are present → verification is enforced. */
+export function cfAccessEnabled(): boolean {
+  return Boolean(rawTeam() && audience());
+}
+
+/** Accept either "yourteam" or a full "yourteam.cloudflareaccess.com". */
+function teamDomain(): string {
+  const t = rawTeam()!;
+  return t.includes('.') ? t : `${t}.cloudflareaccess.com`;
+}
+
+// Cache the remote JWKS per team domain so we don't rebuild/re-fetch it on every
+// request; jose keeps the keys warm and refreshes them in the background.
+let cachedJwks: ReturnType<typeof createRemoteJWKSet> | null = null;
+let cachedFor: string | null = null;
+function getJwks() {
+  const td = teamDomain();
+  if (!cachedJwks || cachedFor !== td) {
+    cachedJwks = createRemoteJWKSet(new URL(`https://${td}/cdn-cgi/access/certs`));
+    cachedFor = td;
+  }
+  return cachedJwks;
+}
+
+/**
+ * Verify a `Cf-Access-Jwt-Assertion` header value.
+ * - Returns `true` (allow) when CF Access is not configured — inert.
+ * - Returns `false` when configured but the token is missing, malformed,
+ *   expired, or fails issuer/audience/signature checks.
+ */
+export async function verifyCfAccessToken(
+  token: string | null | undefined,
+): Promise<boolean> {
+  if (!cfAccessEnabled()) return true; // inert until configured
+  if (!token) return false;
+  try {
+    await jwtVerify(token, getJwks(), {
+      issuer: `https://${teamDomain()}`,
+      audience: audience(),
+    });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/** Test-only: drop the cached JWKS so a test can swap the mocked key set. */
+export function __resetCfAccessJwksCacheForTests(): void {
+  cachedJwks = null;
+  cachedFor = null;
+}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -2,6 +2,7 @@ import { createServerClient } from '@supabase/ssr';
 import { NextResponse, type NextRequest } from 'next/server';
 import { rateLimit, RATE_LIMITS } from '@/lib/rate-limit';
 import { withParentCookieDomain } from '@/lib/cookie-domain';
+import { cfAccessEnabled, verifyCfAccessToken } from '@/lib/cf-access';
 
 function getClientIp(request: NextRequest): string {
   return (
@@ -24,6 +25,9 @@ export async function middleware(request: NextRequest) {
   const requestHost =
     request.headers.get('host') ?? request.headers.get('x-forwarded-host') ?? '';
   const isAdminHost = requestHost === adminHost;
+  // SEC-34/SEC-37: app-layer Cloudflare Access verification is enforced once
+  // CF_ACCESS_TEAM_DOMAIN + CF_ACCESS_AUD are set (inert before that).
+  const cfEnabled = cfAccessEnabled();
 
   // Supabase PKCE: redirect code param to /auth/callback for session exchange
   const code = request.nextUrl.searchParams.get('code');
@@ -88,9 +92,24 @@ export async function middleware(request: NextRequest) {
     data: { user },
   } = await supabase.auth.getUser();
 
-  // KAN-309: route the admin tools to the admin subdomain (once enforced).
-  if (adminHostEnforced) {
+  // KAN-309 / SEC-37: route the admin tools to the admin subdomain, and verify
+  // Cloudflare Access on the admin host. Isolation applies when
+  // ADMIN_HOST_ENFORCED=true OR CF Access is configured — so enabling CF Access
+  // can never leave /admin reachable on a public host by forgetting a flag.
+  if (adminHostEnforced || cfEnabled) {
     if (isAdminHost) {
+      // SEC-34/SEC-37: every request reaching the admin host must carry a valid
+      // Cloudflare Access JWT — this rejects anything that hit the origin
+      // without transiting the CF edge (leaked preview URL, spoofed Host,
+      // direct origin). Inert (allows all) until CF_ACCESS_* are configured.
+      if (
+        cfEnabled &&
+        !(await verifyCfAccessToken(request.headers.get('cf-access-jwt-assertion')))
+      ) {
+        return new NextResponse('Forbidden: Cloudflare Access required.', {
+          status: 403,
+        });
+      }
       // Let the auth/login flow, API routes and assets pass through unchanged.
       const passthrough =
         pathname === '/login' ||

--- a/tests/unit/admin/cf-access.test.ts
+++ b/tests/unit/admin/cf-access.test.ts
@@ -1,0 +1,121 @@
+/**
+ * SEC-34 — app-layer Cloudflare Access verification (`src/lib/cf-access.ts`).
+ *
+ * Only the remote JWKS fetch is mocked: we swap `createRemoteJWKSet` for a local
+ * key set built from an ephemeral RSA keypair, so the real jose signature /
+ * issuer / audience / expiry checks are exercised end-to-end.
+ */
+import { generateKeyPairSync } from 'crypto';
+
+jest.mock('jose', () => {
+  const actual = jest.requireActual('jose');
+  return { ...actual, createRemoteJWKSet: jest.fn() };
+});
+
+import {
+  createRemoteJWKSet,
+  SignJWT,
+  importPKCS8,
+  importSPKI,
+  exportJWK,
+  createLocalJWKSet,
+} from 'jose';
+import {
+  cfAccessEnabled,
+  verifyCfAccessToken,
+  __resetCfAccessJwksCacheForTests,
+} from '@/lib/cf-access';
+
+const TEAM = 'lyra-test';
+const ISS = `https://${TEAM}.cloudflareaccess.com`;
+const AUD = 'test-aud-abc123';
+const ORIG = { ...process.env };
+
+let signKey: Awaited<ReturnType<typeof importPKCS8>>;
+
+beforeAll(async () => {
+  const { publicKey, privateKey } = generateKeyPairSync('rsa', {
+    modulusLength: 2048,
+    publicKeyEncoding: { type: 'spki', format: 'pem' },
+    privateKeyEncoding: { type: 'pkcs8', format: 'pem' },
+  });
+  signKey = await importPKCS8(privateKey as string, 'RS256');
+  const pub = await importSPKI(publicKey as string, 'RS256');
+  const jwk = await exportJWK(pub);
+  jwk.kid = 'cf-test';
+  jwk.alg = 'RS256';
+  // Every createRemoteJWKSet() call returns a local resolver over our test key.
+  (createRemoteJWKSet as jest.Mock).mockReturnValue(createLocalJWKSet({ keys: [jwk] }));
+});
+
+afterEach(() => {
+  process.env = { ...ORIG };
+  __resetCfAccessJwksCacheForTests();
+});
+
+function enable() {
+  process.env.CF_ACCESS_TEAM_DOMAIN = TEAM;
+  process.env.CF_ACCESS_AUD = AUD;
+}
+
+function signCf(opts: { iss?: string; aud?: string } = {}): Promise<string> {
+  return new SignJWT({ email: 'admin@checklyra.com' })
+    .setProtectedHeader({ alg: 'RS256', kid: 'cf-test' })
+    .setIssuer(opts.iss ?? ISS)
+    .setAudience(opts.aud ?? AUD)
+    .setExpirationTime('1h')
+    .sign(signKey);
+}
+
+describe('cfAccessEnabled (SEC-34)', () => {
+  test('false when both env vars unset', () => {
+    delete process.env.CF_ACCESS_TEAM_DOMAIN;
+    delete process.env.CF_ACCESS_AUD;
+    expect(cfAccessEnabled()).toBe(false);
+  });
+  test('false when only one is set', () => {
+    process.env.CF_ACCESS_TEAM_DOMAIN = TEAM;
+    delete process.env.CF_ACCESS_AUD;
+    expect(cfAccessEnabled()).toBe(false);
+  });
+  test('true when both set', () => {
+    enable();
+    expect(cfAccessEnabled()).toBe(true);
+  });
+});
+
+describe('verifyCfAccessToken (SEC-34)', () => {
+  test('INERT: allows everything when unconfigured (even with no token)', async () => {
+    delete process.env.CF_ACCESS_TEAM_DOMAIN;
+    delete process.env.CF_ACCESS_AUD;
+    expect(await verifyCfAccessToken(null)).toBe(true);
+    expect(await verifyCfAccessToken('whatever')).toBe(true);
+  });
+
+  test('configured + missing/empty token → false (the origin-bypass block)', async () => {
+    enable();
+    expect(await verifyCfAccessToken(null)).toBe(false);
+    expect(await verifyCfAccessToken(undefined)).toBe(false);
+    expect(await verifyCfAccessToken('')).toBe(false);
+  });
+
+  test('configured + valid CF Access token → true', async () => {
+    enable();
+    expect(await verifyCfAccessToken(await signCf())).toBe(true);
+  });
+
+  test('configured + wrong audience → false', async () => {
+    enable();
+    expect(await verifyCfAccessToken(await signCf({ aud: 'some-other-access-app' }))).toBe(false);
+  });
+
+  test('configured + wrong issuer → false', async () => {
+    enable();
+    expect(await verifyCfAccessToken(await signCf({ iss: 'https://evil.cloudflareaccess.com' }))).toBe(false);
+  });
+
+  test('configured + malformed token → false', async () => {
+    enable();
+    expect(await verifyCfAccessToken('not.a.jwt')).toBe(false);
+  });
+});


### PR DESCRIPTION
Code half of **SEC-34** (epic [SEC-37](https://checklyra.atlassian.net/browse/SEC-37)) — defence-in-depth so an accidental `is_admin` can't reach the admin console without also passing Cloudflare Access.

**What:** verify the `Cf-Access-Jwt-Assertion` header **inside the edge middleware** for the admin host. This closes the bypass that edge-only CF Access leaves open — the `/admin` routes are in the shared Next.js app and are otherwise reachable on `checklyra.com`, every `*.vercel.app` preview URL, and the raw Vercel origin.

- `src/lib/cf-access.ts` (new) — edge-safe (jose) verifier mirroring `lyra-admin-mcp-server/src/cf-access.ts`. **INERT until `CF_ACCESS_TEAM_DOMAIN` + `CF_ACCESS_AUD` are set.**
- `src/middleware.ts` — 403 on the admin host without a valid CF JWT; host isolation now triggers on `ADMIN_HOST_ENFORCED=true` **or** CF being configured.
- `tests/unit/admin/cf-access.test.ts` (new) — 9 tests via ephemeral keypair + local JWKS.

**Safety:** non-breaking — inert until the env vars are set. tsc clean; full unit suite **1784 green**.

**Activated by** the provisioning in [SEC-38](https://checklyra.atlassian.net/browse/SEC-38) (DNS / Vercel domains / CF Access apps / per-env env vars). Pairs with the dev admin MCP [SEC-39](https://checklyra.atlassian.net/browse/SEC-39).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[SEC-37]: https://checklyra.atlassian.net/browse/SEC-37?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SEC-38]: https://checklyra.atlassian.net/browse/SEC-38?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ