### PR TITLE
KAN-326: admin status-model redesign + publish/age UX (dev-first)

### DIFF
--- a/src/app/admin/beta-queue/actions.ts
+++ b/src/app/admin/beta-queue/actions.ts
@@ -29,6 +29,8 @@ export async function approveBetaUser(formData: FormData): Promise<void> {
   const { error } = await svc
     .from('profiles')
     .update({
+      user_status: 'live',
+      access_tier: 'beta',
       beta_access_status: 'approved',
       is_beta_eligible: true,
       beta_approved_at: new Date().toISOString(),

--- a/src/app/admin/users/BulkBar.tsx
+++ b/src/app/admin/users/BulkBar.tsx
@@ -16,6 +16,7 @@ import { useState } from 'react';
 import Link from 'next/link';
 import { bulkUserAction } from './actions';
 import { BULK_ACTIONS, type BulkActionConfig, type UserFilter } from './users-actions-shared';
+import { userStatusBadge, accessBadge, publishBadge } from './status-badges';
 
 export interface BulkUserRow {
   id: string;
@@ -24,17 +25,17 @@ export interface BulkUserRow {
   display_name: string | null;
   slug: string;
   created_at: string;
-  access_stage: 'waitlist' | 'beta' | 'live';
-  early_access: boolean;
+  user_status: 'not_applied' | 'waitlist' | 'live';
+  access_tier: 'beta' | 'prod';
+  is_published: boolean;
+  age_status: string | null;
   is_suspended: boolean;
   is_admin: boolean;
+  has_revoked_ga_feature: boolean;
+  // legacy columns still returned during the transition; not rendered.
+  access_stage?: 'waitlist' | 'beta' | 'live';
+  early_access?: boolean;
 }
-
-const STAGE_BADGE: Record<string, string> = {
-  waitlist: 'bg-[#f4efe7] text-[var(--color-muted)]',
-  beta: 'bg-amber-50 text-amber-700',
-  live: 'bg-green-50 text-green-700',
-};
 
 function actionLabel(value: string): string {
   return BULK_ACTIONS.find((a) => a.value === value)?.label ?? value;
@@ -45,11 +46,13 @@ export default function BulkBar({
   total,
   selfProfileId,
   filter,
+  ageGateOn,
 }: {
   rows: BulkUserRow[];
   total: number;
   selfProfileId: string;
   filter: UserFilter;
+  ageGateOn: boolean;
 }) {
   const selectable = rows.filter((r) => r.id !== selfProfileId);
   const [selected, setSelected] = useState<Set<string>>(new Set());
@@ -165,6 +168,9 @@ export default function BulkBar({
         ) : (
           rows.map((u) => {
             const isSelf = u.id === selfProfileId;
+            const st = userStatusBadge(u);
+            const ac = accessBadge(u.access_tier);
+            const pb = publishBadge(u, ageGateOn);
             return (
               <div key={u.id} className="flex items-center gap-3 p-4">
                 <input
@@ -188,17 +194,20 @@ export default function BulkBar({
                   </p>
                 </div>
                 <div className="flex items-center gap-2 shrink-0">
-                  <span className={'text-xs px-2 py-0.5 rounded-full ' + (STAGE_BADGE[u.access_stage] ?? STAGE_BADGE.waitlist)}>
-                    {u.access_stage}
+                  {/* User status · Access · Publish — fixed-width so they line up as columns */}
+                  <span className={'w-24 text-center text-xs px-2 py-0.5 rounded-full ' + st.cls} title="User status">
+                    {st.label}
                   </span>
-                  {u.early_access && (
-                    <span className="text-xs px-2 py-0.5 rounded-full bg-violet-50 text-violet-700">beta features</span>
-                  )}
-                  {u.is_admin && (
-                    <span className="text-xs px-2 py-0.5 rounded-full bg-blue-50 text-blue-700">admin</span>
-                  )}
-                  {u.is_suspended && (
-                    <span className="text-xs px-2 py-0.5 rounded-full bg-red-50 text-red-700">suspended</span>
+                  <span className={'w-14 text-center text-xs px-2 py-0.5 rounded-full ' + ac.cls} title="Access tier">
+                    {ac.label}
+                  </span>
+                  <span className={'w-20 text-center text-xs px-2 py-0.5 rounded-full ' + pb.cls} title="Publish status">
+                    {pb.label}
+                  </span>
+                  {u.has_revoked_ga_feature && (
+                    <span className="text-xs px-2 py-0.5 rounded-full bg-orange-50 text-orange-700" title="A default-on feature is turned off for this user">
+                      features disabled
+                    </span>
                   )}
                   <Link
                     href={`/admin/users/${u.slug}`}

--- a/src/app/admin/users/[slug]/page.tsx
+++ b/src/app/admin/users/[slug]/page.tsx
@@ -11,8 +11,9 @@ import { notFound, redirect } from 'next/navigation';
 import Link from 'next/link';
 import { getCurrentAdmin, getAdminServiceClient, logModerationAction } from '@/lib/admin';
 import { getProfileEntitlements } from '@/lib/features/entitlements-service';
-import { FEATURE_KEYS, FEATURE_CONFIG } from '@/lib/features/registry';
+import { FEATURE_CONFIG, GA_FEATURE_KEYS, TEST_FEATURE_KEYS, type FeatureKey } from '@/lib/features/registry';
 import { setFeatureEntitlement } from '../actions';
+import { userStatusBadge, accessBadge, publishBadge } from '../status-badges';
 
 export const dynamic = 'force-dynamic';
 
@@ -26,6 +27,8 @@ interface ProfileFull {
   is_published: boolean;
   is_suspended: boolean;
   is_admin: boolean;
+  user_status: 'not_applied' | 'waitlist' | 'live';
+  access_tier: 'beta' | 'prod';
   suspended_at: string | null;
   suspension_reason: string | null;
   age_status: string;
@@ -45,7 +48,7 @@ async function loadProfile(slug: string): Promise<ProfileFull | null> {
   const supabase = getAdminServiceClient();
   const { data } = await supabase
     .from('profiles')
-    .select('id, user_id, display_name, slug, headline, bio_short, is_published, is_suspended, is_admin, suspended_at, suspension_reason, age_status, created_at')
+    .select('id, user_id, display_name, slug, headline, bio_short, is_published, is_suspended, is_admin, user_status, access_tier, suspended_at, suspension_reason, age_status, created_at')
     .eq('slug', slug)
     .maybeSingle();
   return (data ?? null) as ProfileFull | null;
@@ -223,6 +226,59 @@ export default async function UserDetailPage({
   const entitlements = await getProfileEntitlements(profile.id);
   const isSelf = profile.id === admin.profileId;
 
+  const ageGateOn = process.env.AGE_VERIFICATION_REQUIRED === 'true';
+  const st = userStatusBadge(profile);
+  const ac = accessBadge(profile.access_tier);
+  const pb = publishBadge(profile, ageGateOn);
+
+  const renderFeatureRow = (k: FeatureKey) => {
+    const cfg = FEATURE_CONFIG[k];
+    const on = entitlements[k];
+    const revokedDefault = cfg.tier === 'ga' && !on;
+    return (
+      <div key={k} className="py-3 flex items-center justify-between gap-3">
+        <div className="min-w-0">
+          <p className="text-sm text-[var(--color-ink)]">
+            <span className="font-medium">{cfg.label}</span>{' '}
+            <span
+              className={
+                'text-xs px-2 py-0.5 rounded-full ' +
+                (revokedDefault
+                  ? 'bg-orange-50 text-orange-700'
+                  : on
+                    ? 'bg-green-50 text-green-700'
+                    : 'bg-[#f4efe7] text-[var(--color-muted)]')
+              }
+            >
+              {revokedDefault ? 'disabled' : on ? 'on' : 'off'}
+            </span>
+          </p>
+          <p className="text-xs text-[var(--color-muted)]">
+            {cfg.description}
+            {cfg.envPrerequisite ? ` · needs ${cfg.envPrerequisite}` : ''}
+          </p>
+        </div>
+        <form action={setFeatureEntitlement} className="shrink-0">
+          <input type="hidden" name="profileId" value={profile.id} />
+          <input type="hidden" name="slug" value={profile.slug} />
+          <input type="hidden" name="featureKey" value={k} />
+          <input type="hidden" name="enabled" value={(!on).toString()} />
+          <button
+            type="submit"
+            className={
+              'text-xs font-medium px-4 py-2 rounded-full transition-colors ' +
+              (on
+                ? 'bg-[#f4efe7] text-red-700 hover:bg-red-50'
+                : 'bg-[var(--color-sage)] text-white hover:opacity-90')
+            }
+          >
+            {on ? 'Disable' : 'Enable'}
+          </button>
+        </form>
+      </div>
+    );
+  };
+
   return (
     <div className="max-w-4xl mx-auto px-6 py-8 space-y-8">
       <header>
@@ -240,29 +296,31 @@ export default async function UserDetailPage({
       </header>
 
       <section className="p-5 rounded-xl border border-[var(--color-border)] bg-white">
-        <dl className="grid grid-cols-1 sm:grid-cols-3 gap-x-6 gap-y-3 text-sm">
+        <dl className="grid grid-cols-2 sm:grid-cols-4 gap-x-6 gap-y-3 text-sm">
           <div>
-            <dt className="text-xs uppercase tracking-wider text-[var(--color-muted)]">Status</dt>
+            <dt className="text-xs uppercase tracking-wider text-[var(--color-muted)]">User status</dt>
             <dd className="mt-1">
-              {profile.is_suspended ? (
-                <span className="text-red-700">Suspended</span>
-              ) : profile.is_published ? (
-                <span className="text-green-700">Published</span>
-              ) : (
-                <span className="text-[var(--color-muted)]">Draft</span>
-              )}
+              <span className={'text-xs px-2 py-0.5 rounded-full ' + st.cls}>{st.label}</span>
             </dd>
           </div>
           <div>
-            <dt className="text-xs uppercase tracking-wider text-[var(--color-muted)]">Admin</dt>
-            <dd className="mt-1">{profile.is_admin ? 'Yes' : 'No'}</dd>
+            <dt className="text-xs uppercase tracking-wider text-[var(--color-muted)]">Access</dt>
+            <dd className="mt-1">
+              <span className={'text-xs px-2 py-0.5 rounded-full ' + ac.cls}>{ac.label}</span>
+            </dd>
+          </div>
+          <div>
+            <dt className="text-xs uppercase tracking-wider text-[var(--color-muted)]">Publish</dt>
+            <dd className="mt-1">
+              <span className={'text-xs px-2 py-0.5 rounded-full ' + pb.cls}>{pb.label}</span>
+            </dd>
           </div>
           <div>
             <dt className="text-xs uppercase tracking-wider text-[var(--color-muted)]">Items</dt>
             <dd className="mt-1">{items.length}</dd>
           </div>
           {profile.is_suspended && profile.suspension_reason && (
-            <div className="sm:col-span-3">
+            <div className="col-span-2 sm:col-span-4">
               <dt className="text-xs uppercase tracking-wider text-[var(--color-muted)]">Suspension reason</dt>
               <dd className="text-[var(--color-ink)] mt-1">{profile.suspension_reason}</dd>
             </div>
@@ -352,54 +410,27 @@ export default async function UserDetailPage({
         </section>
       )}
 
-      <section className="p-5 rounded-xl border border-[var(--color-border)] bg-white">
+      <section className="p-5 rounded-xl border border-[var(--color-border)] bg-white space-y-5">
         <h2 className="text-base font-medium text-[var(--color-ink)]">Feature access</h2>
-        <p className="text-xs text-[var(--color-muted)] mt-1 mb-3">
-          Per-user beta features. Each also needs its environment switch on to take effect.
-        </p>
-        <div className="divide-y divide-[var(--color-border)]">
-          {FEATURE_KEYS.map((k) => {
-            const cfg = FEATURE_CONFIG[k];
-            const on = entitlements[k];
-            return (
-              <div key={k} className="py-3 flex items-center justify-between gap-3">
-                <div className="min-w-0">
-                  <p className="text-sm text-[var(--color-ink)]">
-                    <span className="font-medium">{cfg.label}</span>{' '}
-                    <span
-                      className={
-                        'text-xs px-2 py-0.5 rounded-full ' +
-                        (on ? 'bg-green-50 text-green-700' : 'bg-[#f4efe7] text-[var(--color-muted)]')
-                      }
-                    >
-                      {on ? 'on' : 'off'}
-                    </span>
-                  </p>
-                  <p className="text-xs text-[var(--color-muted)]">
-                    {cfg.description}
-                    {cfg.envPrerequisite ? ` · needs ${cfg.envPrerequisite}` : ''}
-                  </p>
-                </div>
-                <form action={setFeatureEntitlement} className="shrink-0">
-                  <input type="hidden" name="profileId" value={profile.id} />
-                  <input type="hidden" name="slug" value={profile.slug} />
-                  <input type="hidden" name="featureKey" value={k} />
-                  <input type="hidden" name="enabled" value={(!on).toString()} />
-                  <button
-                    type="submit"
-                    className={
-                      'text-xs font-medium px-4 py-2 rounded-full transition-colors ' +
-                      (on
-                        ? 'bg-[#f4efe7] text-red-700 hover:bg-red-50'
-                        : 'bg-[var(--color-sage)] text-white hover:opacity-90')
-                    }
-                  >
-                    {on ? 'Disable' : 'Enable'}
-                  </button>
-                </form>
-              </div>
-            );
-          })}
+
+        <div>
+          <h3 className="text-sm font-medium text-[var(--color-ink)]">Test features</h3>
+          <p className="text-xs text-[var(--color-muted)] mt-0.5 mb-2">
+            Experimental, off by default — the set we trial with beta users. Each also needs its environment switch on to take effect.
+          </p>
+          <div className="divide-y divide-[var(--color-border)]">
+            {TEST_FEATURE_KEYS.map(renderFeatureRow)}
+          </div>
+        </div>
+
+        <div>
+          <h3 className="text-sm font-medium text-[var(--color-ink)]">Default-on features</h3>
+          <p className="text-xs text-[var(--color-muted)] mt-0.5 mb-2">
+            On for everyone. You can still turn one off for this user — they’ll then show a “features disabled” badge.
+          </p>
+          <div className="divide-y divide-[var(--color-border)]">
+            {GA_FEATURE_KEYS.map(renderFeatureRow)}
+          </div>
         </div>
       </section>
 

--- a/src/app/admin/users/page.tsx
+++ b/src/app/admin/users/page.tsx
@@ -96,6 +96,9 @@ export default async function UsersConsolePage({
   const admin = (await getCurrentAdmin())!; // layout already gated
   const page = Math.max(1, Number(sp.page ?? '1') || 1);
   const filter = buildFilter(sp);
+  // Age gate is a server env flag; the publish-status badge needs it to tell
+  // "age check" (blocked) from "private" (just unpublished).
+  const ageGateOn = process.env.AGE_VERIFICATION_REQUIRED === 'true';
 
   const [{ rows, total, error }, counts] = await Promise.all([listUsers(filter, page), stageCounts()]);
   const totalPages = Math.max(1, Math.ceil(total / PAGE_SIZE));
@@ -140,7 +143,7 @@ export default async function UsersConsolePage({
         <Chip href="/admin/users?stage=waitlist" label="Waitlist" active={filter.stage === 'waitlist'} />
         <Chip href="/admin/users?stage=beta" label="Beta" active={filter.stage === 'beta'} />
         <Chip href="/admin/users?stage=live" label="Live" active={filter.stage === 'live'} />
-        <Chip href="/admin/users?early=1" label="Beta features" active={filter.early === true} />
+        <Chip href="/admin/users?early=1" label="Test features" active={filter.early === true} />
         <Chip href="/admin/users?suspended=1" label="Suspended" active={filter.suspended === true} />
         <Chip href="/admin/users?admin=1" label="Admins" active={filter.admin === true} />
       </nav>
@@ -150,7 +153,7 @@ export default async function UsersConsolePage({
           Could not load users: {error}
         </p>
       ) : (
-        <BulkBar rows={rows} total={total} selfProfileId={admin.profileId} filter={filter} />
+        <BulkBar rows={rows} total={total} selfProfileId={admin.profileId} filter={filter} ageGateOn={ageGateOn} />
       )}
 
       {totalPages > 1 && (

--- a/src/app/admin/users/status-badges.ts
+++ b/src/app/admin/users/status-badges.ts
@@ -1,0 +1,44 @@
+/**
+ * KAN-326: shared badge logic for the admin user views, so the list (BulkBar,
+ * a client island) and the detail page (a server component) render the
+ * status / access / publish badges identically. Plain module — no
+ * 'use client' / 'use server' — so both surfaces can import it.
+ */
+
+export type Badge = { label: string; cls: string };
+
+/** User status (one badge): suspended > admin > lifecycle (live/waitlist/not_applied). */
+export function userStatusBadge(u: {
+  is_suspended: boolean;
+  is_admin: boolean;
+  user_status: 'not_applied' | 'waitlist' | 'live';
+}): Badge {
+  if (u.is_suspended) return { label: 'suspended', cls: 'bg-red-50 text-red-700' };
+  if (u.is_admin) return { label: 'admin', cls: 'bg-blue-50 text-blue-700' };
+  switch (u.user_status) {
+    case 'live':
+      return { label: 'live', cls: 'bg-green-50 text-green-700' };
+    case 'waitlist':
+      return { label: 'waitlist', cls: 'bg-amber-50 text-amber-700' };
+    default:
+      return { label: 'not applied', cls: 'bg-[#f4efe7] text-[var(--color-muted)]' };
+  }
+}
+
+/** Access tier — which site the user is routed to. */
+export function accessBadge(tier: 'beta' | 'prod'): Badge {
+  return tier === 'prod'
+    ? { label: 'prod', cls: 'bg-sky-50 text-sky-700' }
+    : { label: 'beta', cls: 'bg-violet-50 text-violet-700' };
+}
+
+/** Publish status (computed): public > age check > private. */
+export function publishBadge(
+  u: { is_published: boolean; age_status: string | null },
+  ageGateOn: boolean,
+): Badge {
+  if (u.is_published) return { label: 'public', cls: 'bg-green-50 text-green-700' };
+  if (ageGateOn && u.age_status !== 'passed')
+    return { label: 'age check', cls: 'bg-amber-50 text-amber-700' };
+  return { label: 'private', cls: 'bg-[#f4efe7] text-[var(--color-muted)]' };
+}

--- a/src/app/admin/users/users-actions-shared.ts
+++ b/src/app/admin/users/users-actions-shared.ts
@@ -57,10 +57,11 @@ export interface AccessTransition {
 /**
  * Map a bulk action onto the concrete column changes + audit action.
  *
- * Both axes (access_stage, early_access) are always written together with the
- * derived enforced gate (is_beta_eligible / beta_access_status), so the model
- * and the gate can never drift. `now` and `reason` are passed in to keep this
- * function pure (no Date.now / no I/O).
+ * KAN-326: the clean axes (user_status, access_tier) are the source of truth.
+ * The legacy columns (access_stage, early_access, is_beta_eligible,
+ * beta_access_status) are written together in lockstep until they're dropped in
+ * the follow-up migration, so the model and the gate can never drift. `now` and
+ * `reason` are passed in to keep this function pure (no Date.now / no I/O).
  */
 export function computeAccessTransition(
   action: BulkAction,
@@ -70,6 +71,8 @@ export function computeAccessTransition(
     case 'enable_beta':
       return {
         update: {
+          user_status: 'live',
+          access_tier: 'beta',
           access_stage: 'beta',
           early_access: true,
           is_beta_eligible: true,
@@ -82,6 +85,8 @@ export function computeAccessTransition(
     case 'disable_beta':
       return {
         update: {
+          user_status: 'waitlist',
+          access_tier: 'beta',
           access_stage: 'waitlist',
           early_access: false,
           is_beta_eligible: false,
@@ -94,6 +99,8 @@ export function computeAccessTransition(
     case 'promote_live_with_beta':
       return {
         update: {
+          user_status: 'live',
+          access_tier: 'prod',
           access_stage: 'live',
           early_access: true,
           is_beta_eligible: true,
@@ -105,6 +112,8 @@ export function computeAccessTransition(
     case 'promote_live_no_beta':
       return {
         update: {
+          user_status: 'live',
+          access_tier: 'prod',
           access_stage: 'live',
           early_access: false,
           // Still beta-eligible so the launched user passes the enforced gate;

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -5,6 +5,7 @@ import Image from 'next/image';
 import { signOut } from '../(auth)/actions';
 import ShareProfile from './share-profile';
 import { isConveneEnabledForCurrentUser } from '@/lib/convene/flags-user';
+import { canPublishWithAge } from '@/lib/age/gate';
 
 export const metadata = {
   title: 'Dashboard — Lyra',
@@ -29,14 +30,19 @@ export default async function DashboardPage() {
   // KAN-303 — Convene nav + landing card are gated on the feature flag so they
   // stay hidden until Convene is enabled (beta).
   const conveneEnabled = await isConveneEnabledForCurrentUser();
+  const isPublished = !!profile?.is_published;
+  // KAN-326: publish-status hub — show the age step only when the gate blocks publishing.
+  const needsAgeCheck = !canPublishWithAge(
+    (profile as { age_status?: string | null } | null)?.age_status,
+  );
 
   return (
     <main className="min-h-screen">
       <header className="border-b border-[var(--color-border)] bg-white">
         <div className="max-w-4xl mx-auto px-4 py-4 flex items-center justify-between">
-          <h1 className="flex items-center">
+          <Link href="/dashboard" className="flex items-center" aria-label="Lyra home">
             <Image src="/lyra-logo.png" alt="Lyra" width={32} height={32} className="h-8 w-auto" />
-          </h1>
+          </Link>
           <div className="flex items-center gap-4">
             <span className="text-sm text-[var(--color-muted)]">
               {user.email}
@@ -62,14 +68,54 @@ export default async function DashboardPage() {
       </header>
 
       <div className="max-w-4xl mx-auto px-4 py-8">
-        <h2 className="text-2xl font-medium text-[var(--color-ink)] mb-2">
-          Welcome{profile?.display_name ? `, ${profile.display_name}` : ''}
-        </h2>
-        <p className="text-[var(--color-muted)] mb-8">
-          {profile?.onboarding_complete
-            ? 'Manage your Lyra profile below.'
-            : 'Let\u2019s set up your profile so people in your life can get to know you better.'}
-        </p>
+        <div className="mb-6">
+          <h2 className="text-2xl font-medium text-[var(--color-ink)]">
+            Welcome{profile?.display_name ? `, ${profile.display_name}` : ''}
+          </h2>
+          <p className="text-[var(--color-muted)] mt-1">
+            {isPublished
+              ? 'Your profile is live — here’s your Lyra at a glance.'
+              : 'A few steps to get your profile live.'}
+          </p>
+        </div>
+
+        {/* KAN-326: next-steps hub — lead with what to do next while unpublished. */}
+        {!isPublished && (
+          <div className="bg-white rounded-xl border border-[var(--color-border)] p-6 mb-6">
+            <h3 className="text-lg font-medium text-[var(--color-ink)] mb-4">Get your profile live</h3>
+            <ol className="space-y-3">
+              <li className="flex items-center justify-between gap-3">
+                <span className="text-sm text-[var(--color-ink)]">
+                  <span className="font-medium">1. Build your profile</span>
+                  <span className="text-[var(--color-muted)]"> · {profile?.completion_score || 0}% complete</span>
+                </span>
+                <Link href="/dashboard/profile" className="shrink-0 px-4 py-2 rounded-lg bg-[var(--color-sage)] text-white text-sm font-medium hover:opacity-90 transition-opacity">
+                  Edit profile →
+                </Link>
+              </li>
+              {needsAgeCheck && (
+                <li className="flex items-center justify-between gap-3">
+                  <span className="text-sm text-[var(--color-ink)]">
+                    <span className="font-medium">2. Verify your age</span>
+                    <span className="text-[var(--color-muted)]"> · required before publishing</span>
+                  </span>
+                  <Link href="/verify-age" className="shrink-0 px-4 py-2 rounded-lg bg-[#f4efe7] text-[var(--color-ink)] text-sm font-medium hover:bg-[#ece7df] transition-colors">
+                    Verify age →
+                  </Link>
+                </li>
+              )}
+              <li className="flex items-center justify-between gap-3">
+                <span className="text-sm text-[var(--color-ink)]">
+                  <span className="font-medium">{needsAgeCheck ? '3' : '2'}. Publish</span>
+                  <span className="text-[var(--color-muted)]"> · make your profile public</span>
+                </span>
+                <Link href="/dashboard/profile" className="shrink-0 px-4 py-2 rounded-lg bg-[#f4efe7] text-[var(--color-ink)] text-sm font-medium hover:bg-[#ece7df] transition-colors">
+                  Open editor →
+                </Link>
+              </li>
+            </ol>
+          </div>
+        )}
 
         <div className="bg-white rounded-xl border border-[var(--color-border)] p-6">
           <h3 className="text-lg font-medium text-[var(--color-ink)] mb-4">
@@ -89,8 +135,8 @@ export default async function DashboardPage() {
             </div>
             <div className="flex justify-between">
               <span className="text-[var(--color-muted)]">Status</span>
-              <span className={profile?.is_published ? 'text-green-600' : 'text-amber-600'}>
-                {profile?.is_published ? 'Published' : 'Draft'}
+              <span className={isPublished ? 'text-green-600' : needsAgeCheck ? 'text-amber-600' : 'text-[var(--color-muted)]'}>
+                {isPublished ? 'Public' : needsAgeCheck ? 'Age check' : 'Private'}
               </span>
             </div>
             <div className="flex justify-between">
@@ -99,19 +145,9 @@ export default async function DashboardPage() {
             </div>
           </div>
 
-          {!profile?.onboarding_complete && (
-            <Link href="/dashboard/profile" className="mt-6 block w-full py-3 rounded-lg bg-[var(--color-sage)] text-white text-base font-medium hover:opacity-90 transition-opacity text-center">
-              Complete your profile →
-            </Link>
-          )}
-          {profile?.onboarding_complete && (
+          {isPublished && (
             <Link href="/dashboard/profile" className="mt-6 block w-full py-3 rounded-lg bg-[#f4efe7] text-[var(--color-ink)] text-base font-medium hover:bg-[#ece7df] transition-colors text-center">
               Edit your profile →
-            </Link>
-          )}
-          {!profile && (
-            <Link href="/dashboard/profile" className="mt-6 block w-full py-3 rounded-lg bg-[var(--color-sage)] text-white text-base font-medium hover:opacity-90 transition-opacity text-center">
-              Set up your profile →
             </Link>
           )}
 

--- a/src/app/dashboard/profile/edit-profile-form.tsx
+++ b/src/app/dashboard/profile/edit-profile-form.tsx
@@ -187,6 +187,7 @@ export function EditProfileForm({
   conversationPrompts,
   conversationAnswers,
   conveneEnabled = false,
+  needsAgeCheck = false,
 }: {
   profile: WizardProfile;
   items: WizardItem[];
@@ -197,9 +198,11 @@ export function EditProfileForm({
   conversationPrompts: ConversationPrompt[];
   conversationAnswers: ConversationAnswer[];
   conveneEnabled?: boolean;
+  needsAgeCheck?: boolean;
 }) {
   const router = useRouter();
   const [isPending, startTransition] = useTransition();
+  const [publishError, setPublishError] = useState<string | null>(null);
 
   // SSR-safe: all expanded by default (no flash on desktop). On mount,
   // matchMedia narrows to mobile and we collapse all but the first.
@@ -314,6 +317,16 @@ export function EditProfileForm({
 
         {/* Main column */}
         <div className="space-y-3">
+          {needsAgeCheck && (
+            <div className="rounded-[10px] border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-800 leading-relaxed flex items-start justify-between gap-3">
+              <span>
+                Verify your age to publish. You can keep editing meanwhile — your profile stays private until you do.
+              </span>
+              <Link href="/verify-age" className="shrink-0 underline font-medium hover:opacity-80">
+                Verify age →
+              </Link>
+            </div>
+          )}
           {/* KAN-266: one calm note — optionality stated once, not per field. */}
           <div className="rounded-[10px] border border-[#e3ece5] bg-[#e9efea] px-4 py-3 text-sm text-[var(--color-sage)] leading-relaxed">
             Everything here is optional — share whatever you&apos;d like people to know, and skip the rest.
@@ -438,23 +451,42 @@ export function EditProfileForm({
       {/* Sticky save bar */}
       <div className="fixed bottom-0 inset-x-0 bg-white border-t border-[#ece7df] px-4 py-3 z-10">
         <div className="max-w-5xl mx-auto flex items-center justify-between gap-4">
-          <p className="text-xs text-[var(--color-muted)] hidden sm:block">
-            Changes save automatically as you type.
-          </p>
-          <button
-            type="button"
-            onClick={() => {
-              startTransition(async () => {
-                await publishProfile();
-                router.refresh();
-                router.push('/dashboard');
-              });
-            }}
-            disabled={isPending}
-            className="px-5 py-2 rounded-lg bg-[var(--color-sage)] text-white text-sm font-medium hover:opacity-90 disabled:opacity-50 transition-opacity"
-          >
-            {profile.is_published ? 'Save & re-publish' : 'Save & publish'}
-          </button>
+          <div className="min-w-0">
+            <p className="text-xs text-[var(--color-muted)] hidden sm:block">
+              Changes save automatically as you type.
+            </p>
+            {publishError && (
+              <p className="text-xs text-red-700 mt-0.5">{publishError}</p>
+            )}
+          </div>
+          {needsAgeCheck ? (
+            <Link
+              href="/verify-age"
+              className="shrink-0 px-5 py-2 rounded-lg bg-[var(--color-sage)] text-white text-sm font-medium hover:opacity-90 transition-opacity"
+            >
+              Verify your age to publish →
+            </Link>
+          ) : (
+            <button
+              type="button"
+              onClick={() => {
+                setPublishError(null);
+                startTransition(async () => {
+                  const res = await publishProfile();
+                  if (res?.success) {
+                    router.refresh();
+                    router.push('/dashboard');
+                  } else {
+                    setPublishError(res?.error ?? 'Could not publish. Please try again.');
+                  }
+                });
+              }}
+              disabled={isPending}
+              className="shrink-0 px-5 py-2 rounded-lg bg-[var(--color-sage)] text-white text-sm font-medium hover:opacity-90 disabled:opacity-50 transition-opacity"
+            >
+              {profile.is_published ? 'Re-publish' : 'Publish'}
+            </button>
+          )}
         </div>
       </div>
     </main>

--- a/src/app/dashboard/profile/page.tsx
+++ b/src/app/dashboard/profile/page.tsx
@@ -3,6 +3,7 @@ import { redirect } from 'next/navigation';
 import { EditProfileForm } from './edit-profile-form';
 import type { ManualOfMe } from './manual-of-me-fields';
 import { isConveneEnabledForCurrentUser } from '@/lib/convene/flags-user';
+import { canPublishWithAge } from '@/lib/age/gate';
 
 export const metadata = {
   title: 'Edit your profile — Lyra',
@@ -93,6 +94,13 @@ export default async function ProfilePage() {
     };
   });
 
+  // KAN-326: when the age gate is on and the user isn't verified, the editor
+  // shows a "verify your age" banner + button instead of a (silently failing)
+  // publish action.
+  const needsAgeCheck = !canPublishWithAge(
+    (profile as { age_status?: string | null }).age_status,
+  );
+
   return (
     <EditProfileForm
       profile={profile}
@@ -104,6 +112,7 @@ export default async function ProfilePage() {
       conversationPrompts={conversationPrompts || []}
       conversationAnswers={conversationAnswers}
       conveneEnabled={await isConveneEnabledForCurrentUser()}
+      needsAgeCheck={needsAgeCheck}
     />
   );
 }

--- a/src/app/waitlist/page.tsx
+++ b/src/app/waitlist/page.tsx
@@ -31,11 +31,11 @@ export default async function WaitlistPage() {
   if (user) {
     const { data: profile } = await supabase
       .from('profiles')
-      .select('is_beta_eligible')
+      .select('user_status')
       .eq('user_id', user.id)
       .maybeSingle();
 
-    if (profile?.is_beta_eligible) {
+    if (profile?.user_status === 'live') {
       redirect('/dashboard');
     }
   }

--- a/src/lib/auth/post-login-redirect.ts
+++ b/src/lib/auth/post-login-redirect.ts
@@ -12,7 +12,7 @@
  * Extracted from /auth/callback so /auth/confirm reuses it verbatim (KAN-276/278).
  */
 import type { createClient } from '@/lib/supabase-server';
-import { resolveBetaAccess, betaRedirectUrl, isProdDeploy } from '@/lib/beta-access/flow';
+import { resolveBetaAccess, betaRedirectUrl, isProdFamily } from '@/lib/beta-access/flow';
 
 type ServerClient = Awaited<ReturnType<typeof createClient>>;
 
@@ -24,8 +24,19 @@ export async function resolvePostLoginRedirect(
   const {
     data: { user },
   } = await supabase.auth.getUser();
-  const approved = user
-    ? (await resolveBetaAccess({ id: user.id, email: user.email })).approved
-    : true;
-  return betaRedirectUrl({ origin, isProd: isProdDeploy(), approved, next });
+  if (!user) {
+    // No session (shouldn't happen post-login) — stay on the origin.
+    return betaRedirectUrl({
+      origin,
+      isProdFamily: false,
+      userStatus: 'live',
+      accessTier: 'prod',
+      next,
+    });
+  }
+  const { userStatus, accessTier } = await resolveBetaAccess({
+    id: user.id,
+    email: user.email,
+  });
+  return betaRedirectUrl({ origin, isProdFamily: isProdFamily(), userStatus, accessTier, next });
 }

--- a/src/lib/beta-access/flow.ts
+++ b/src/lib/beta-access/flow.ts
@@ -6,23 +6,38 @@
  *    requested) and notifies the admin ONCE (KAN-276); reports approval status.
  *    All writes go through the SERVICE ROLE so they pass the admin-only trigger
  *    from 20260620120100_beta_access_lockdown.sql.
- *  - betaRedirectUrl: pure — decides where to send the user (KAN-278). On prod
- *    (the public doorway) everyone is pushed to the beta app, carrying their
- *    session via the .checklyra.com cookie (KAN-274): approved -> beta dashboard,
- *    not-yet-approved -> beta waitlist. On beta the in-app middleware gate does
- *    the waitlist routing, and dev/stage stay on their own origin.
+ *  - betaRedirectUrl: pure — decides where to send the user (KAN-278 / KAN-326).
+ *    On the prod family (prod + beta share the .checklyra.com cookie, KAN-274)
+ *    it routes by access_tier: live+prod -> checklyra.com, live+beta ->
+ *    beta.checklyra.com, not-live -> the beta waitlist. Dev/stage stay on their
+ *    own origin and let the in-app middleware gate handle waitlisting.
  */
 import { createClient as createServiceRoleClient } from '@supabase/supabase-js';
 import { env } from '@/lib/env';
 import { sendBetaQueueNotice } from './email';
 
 const BETA_HOST = 'https://beta.checklyra.com';
+const PROD_HOST = 'https://checklyra.com';
 
-/** Pure: where to redirect after sign-in. `isProd` = the real production app. */
+export type UserStatus = 'not_applied' | 'waitlist' | 'live';
+export type AccessTier = 'beta' | 'prod';
+
+/**
+ * Pure: where to redirect after sign-in (KAN-326 — route by access tier).
+ *
+ * On the prod family (prod OR beta deploy — they share the prod-lyra Supabase
+ * and the .checklyra.com cookie, so a session carries across):
+ *   - not live  -> the beta waitlist page
+ *   - live+prod -> checklyra.com (the production product)
+ *   - live+beta -> beta.checklyra.com (the gated beta app)
+ * On dev/stage (single full env, host-scoped cookie) stay on the origin and let
+ * the in-app middleware gate handle waitlisting.
+ */
 export function betaRedirectUrl(opts: {
   origin: string;
-  isProd: boolean;
-  approved: boolean;
+  isProdFamily: boolean;
+  userStatus: UserStatus;
+  accessTier: AccessTier;
   next: string;
 }): string {
   // Guard against open redirects (SEC-07 + SEC-19/F-12): accept only a same-origin
@@ -37,18 +52,29 @@ export function betaRedirectUrl(opts: {
     !opts.next.startsWith('/\\')
       ? opts.next
       : '/dashboard';
-  if (opts.isProd) {
-    // Prod is a doorway into the gated beta app.
-    return opts.approved ? `${BETA_HOST}${path}` : `${BETA_HOST}/waitlist`;
+  if (opts.isProdFamily) {
+    if (opts.userStatus !== 'live') {
+      return `${BETA_HOST}/waitlist`;
+    }
+    return opts.accessTier === 'prod' ? `${PROD_HOST}${path}` : `${BETA_HOST}${path}`;
   }
-  // Beta: the IS_BETA_DEPLOY middleware routes ineligible users to /waitlist.
-  // Dev/stage: open — land on the requested page.
+  // Dev/stage: open — land on the requested page (middleware gates if needed).
   return `${opts.origin}${path}`;
 }
 
 /** True only on the real production deployment (not beta/dev/stage/local). */
 export function isProdDeploy(e: NodeJS.ProcessEnv = process.env): boolean {
   return e.NEXT_PUBLIC_SITE_URL === 'https://checklyra.com' && e.VERCEL_ENV === 'production';
+}
+
+/**
+ * The "prod family" = the real production deploy OR the beta deploy. Both share
+ * the prod-lyra Supabase project and the .checklyra.com parent cookie, so they
+ * form a two-site pair that routes by access_tier. Dev and stage are separate
+ * single-env deployments and are NOT part of this family.
+ */
+export function isProdFamily(e: NodeJS.ProcessEnv = process.env): boolean {
+  return isProdDeploy(e) || e.IS_BETA_DEPLOY === 'true';
 }
 
 /**
@@ -59,26 +85,33 @@ export function isProdDeploy(e: NodeJS.ProcessEnv = process.env): boolean {
 export async function resolveBetaAccess(user: {
   id: string;
   email?: string | null;
-}): Promise<{ approved: boolean }> {
+}): Promise<{ userStatus: UserStatus; accessTier: AccessTier }> {
   try {
     const svc = createServiceRoleClient(env.supabaseUrl(), env.supabaseServiceRoleKey());
 
     const { data: profile } = await svc
       .from('profiles')
-      .select('beta_access_status, is_beta_eligible, display_name')
+      .select('user_status, access_tier, beta_access_status, display_name')
       .eq('user_id', user.id)
       .maybeSingle();
 
-    const status = profile?.beta_access_status as string | undefined;
-    if (profile?.is_beta_eligible === true || status === 'approved') {
-      return { approved: true };
+    const userStatus = (profile?.user_status as UserStatus | undefined) ?? 'waitlist';
+    const accessTier = (profile?.access_tier as AccessTier | undefined) ?? 'beta';
+
+    // Already an active user — nothing to record.
+    if (userStatus === 'live') {
+      return { userStatus, accessTier };
     }
 
-    // Brand-new signup: record the request once + notify the admin.
-    if (status === undefined || status === 'none') {
+    // Brand-new signup: record the request once + notify the admin. We key the
+    // idempotent transition + the one-shot notice off the legacy
+    // beta_access_status (kept in sync until the legacy columns are dropped).
+    const legacyStatus = profile?.beta_access_status as string | undefined;
+    if (legacyStatus === undefined || legacyStatus === 'none') {
       const { data: updated } = await svc
         .from('profiles')
         .update({
+          user_status: 'waitlist',
           beta_access_status: 'requested',
           beta_requested_at: new Date().toISOString(),
         })
@@ -92,10 +125,12 @@ export async function resolveBetaAccess(user: {
           displayName: (profile?.display_name as string | undefined) ?? null,
         });
       }
+      return { userStatus: 'waitlist', accessTier };
     }
-    return { approved: false };
+
+    return { userStatus, accessTier };
   } catch (e) {
     console.error('[beta-access] resolveBetaAccess failed', e);
-    return { approved: false };
+    return { userStatus: 'waitlist', accessTier: 'beta' };
   }
 }

--- a/src/lib/features/registry.ts
+++ b/src/lib/features/registry.ts
@@ -27,12 +27,24 @@ export const FEATURE_KEYS = [
 
 export type FeatureKey = (typeof FEATURE_KEYS)[number];
 
+/**
+ * KAN-326: every feature has a `tier`:
+ *   - 'ga'   = generally available — ON for everyone, admin-revocable. Turning
+ *              it off for a user shows a "features disabled" badge.
+ *   - 'test' = experimental ("test features", was "beta features") — the opt-in
+ *              set. Promoting a feature from 'test' to 'ga' makes it on-by-default
+ *              while staying per-user revocable.
+ */
+export type FeatureTier = 'ga' | 'test';
+
 export interface FeatureConfig {
   key: FeatureKey;
   label: string;
   description: string;
   /** Returned by isFeatureEnabled when the user has NO entitlement row. */
   defaultEnabled: boolean;
+  /** GA (on for everyone, revocable) vs test (experimental opt-in). */
+  tier: FeatureTier;
   /** Human-readable name of the per-env master switch, if any. */
   envPrerequisite: string | null;
 }
@@ -43,6 +55,7 @@ export const FEATURE_CONFIG: Record<FeatureKey, FeatureConfig> = {
     label: 'MCP access',
     description: 'AI-assistant write tools via the MCP server.',
     defaultEnabled: false, // backfilled true for existing API-key holders
+    tier: 'test',
     envPrerequisite: null,
   },
   convene: {
@@ -50,6 +63,7 @@ export const FEATURE_CONFIG: Record<FeatureKey, FeatureConfig> = {
     label: 'Convene',
     description: 'AI-orchestrated gatherings (host GUI + agent tools).',
     defaultEnabled: false,
+    tier: 'test',
     envPrerequisite: 'CONVENE_ENABLED',
   },
   paid_gift_links: {
@@ -57,6 +71,7 @@ export const FEATURE_CONFIG: Record<FeatureKey, FeatureConfig> = {
     label: 'Paid gift links',
     description: "Monetised affiliate links on this profile's gift recommendations.",
     defaultEnabled: false,
+    tier: 'test',
     envPrerequisite: 'SOVRN_API_KEY',
   },
   convene_paid_channels: {
@@ -64,6 +79,7 @@ export const FEATURE_CONFIG: Record<FeatureKey, FeatureConfig> = {
     label: 'Convene SMS / WhatsApp',
     description: 'Paid invite channels (SMS/WhatsApp) for Convene.',
     defaultEnabled: false,
+    tier: 'test',
     envPrerequisite: 'CONVENE_ENABLED',
   },
   media_uploads: {
@@ -71,6 +87,7 @@ export const FEATURE_CONFIG: Record<FeatureKey, FeatureConfig> = {
     label: 'Media uploads',
     description: 'Profile photo & file/media uploads.',
     defaultEnabled: true,
+    tier: 'ga',
     envPrerequisite: null,
   },
   discovery: {
@@ -78,9 +95,18 @@ export const FEATURE_CONFIG: Record<FeatureKey, FeatureConfig> = {
     label: 'Discovery',
     description: 'Be found by phone number / postcode.',
     defaultEnabled: true,
+    tier: 'ga',
     envPrerequisite: null,
   },
 };
+
+/** GA features (on for everyone, revocable) and test features (experimental opt-in). */
+export const GA_FEATURE_KEYS: FeatureKey[] = FEATURE_KEYS.filter(
+  (k) => FEATURE_CONFIG[k].tier === 'ga',
+);
+export const TEST_FEATURE_KEYS: FeatureKey[] = FEATURE_KEYS.filter(
+  (k) => FEATURE_CONFIG[k].tier === 'test',
+);
 
 export function isFeatureKey(value: string): value is FeatureKey {
   return (FEATURE_KEYS as readonly string[]).includes(value);

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -151,12 +151,24 @@ export async function middleware(request: NextRequest) {
     }
   }
 
-  // KAN-175: Beta gate. Only active on the beta deploy (IS_BETA_DEPLOY=true).
-  // Authenticated users without is_beta_eligible=true get redirected to
-  // /waitlist. The /waitlist page itself is exempt so the redirect doesn't
-  // loop. Auth pages and the auth callback are also exempt so users can
-  // complete sign-in before the gate evaluates them.
+  // KAN-326: tier-aware access gate. Active on the "prod family" — the beta
+  // deploy (IS_BETA_DEPLOY=true, tier 'beta') and the real production deploy
+  // (checklyra.com, tier 'prod'). Dev/stage are single full envs (deployTier
+  // null) and are not gated here. An authenticated user is:
+  //   - not live          -> sent to /waitlist
+  //   - live, wrong tier  -> sent to their tier's site (beta <-> prod), so a
+  //                          promoted user always lands on the right site
+  //                          (sessions carry via the shared .checklyra.com cookie).
+  // The /waitlist page itself + auth pages are exempt to avoid redirect loops.
   const isBetaDeploy = process.env.IS_BETA_DEPLOY === 'true';
+  const isProdSite =
+    process.env.NEXT_PUBLIC_SITE_URL === 'https://checklyra.com' &&
+    process.env.VERCEL_ENV === 'production';
+  const deployTier: 'beta' | 'prod' | null = isBetaDeploy
+    ? 'beta'
+    : isProdSite
+      ? 'prod'
+      : null;
   const exemptFromBetaGate =
     pathname === '/waitlist' ||
     pathname === '/suspended' || // KAN-319: suspended users land here, not /waitlist
@@ -167,18 +179,28 @@ export async function middleware(request: NextRequest) {
     pathname.startsWith('/_next/') ||
     pathname === '/favicon.ico';
 
-  if (isBetaDeploy && user && !exemptFromBetaGate) {
+  if (deployTier && user && !exemptFromBetaGate) {
     const { data: profile } = await supabase
       .from('profiles')
-      .select('is_beta_eligible')
+      .select('user_status, access_tier')
       .eq('user_id', user.id)
       .maybeSingle();
 
-    if (!profile?.is_beta_eligible) {
+    if (profile?.user_status !== 'live') {
       const url = request.nextUrl.clone();
       url.pathname = '/waitlist';
       url.search = '';
       return NextResponse.redirect(url);
+    }
+    if (profile.access_tier !== deployTier) {
+      // Live user on the wrong site — move them to their tier's host, keeping path.
+      const targetHost =
+        profile.access_tier === 'prod'
+          ? 'https://checklyra.com'
+          : 'https://beta.checklyra.com';
+      return NextResponse.redirect(
+        new URL(`${targetHost}${pathname}${request.nextUrl.search}`),
+      );
     }
   }
 

--- a/supabase/migrations/20260624120000_clean_access_model_user_status_access_tier.sql
+++ b/supabase/migrations/20260624120000_clean_access_model_user_status_access_tier.sql
@@ -1,0 +1,58 @@
+-- KAN-326 / KAN-327: Clean access model — add user_status + access_tier (additive, backfilled).
+-- Collapses the overlapping lifecycle fields into two clear axes:
+--   user_status: not_applied -> waitlist -> live   (was: beta_access_status none/requested/approved)
+--   access_tier: beta | prod                       (was: access_stage live-vs-beta split)
+-- Legacy columns (is_beta_eligible, beta_access_status, access_stage, early_access) are KEPT for
+-- the transition and dropped in a follow-up migration once all code reads/writes the new columns.
+
+create type public.user_status as enum ('not_applied', 'waitlist', 'live');
+create type public.access_tier as enum ('beta', 'prod');
+
+alter table public.profiles
+  add column user_status public.user_status not null default 'waitlist',
+  add column access_tier public.access_tier not null default 'beta';
+
+-- One-time backfill from legacy fields
+update public.profiles set
+  user_status = case beta_access_status
+    when 'approved'  then 'live'::public.user_status
+    when 'requested' then 'waitlist'::public.user_status
+    when 'none'      then 'not_applied'::public.user_status
+    else 'waitlist'::public.user_status
+  end,
+  access_tier = case
+    when access_stage = 'live' then 'prod'::public.access_tier
+    else 'beta'::public.access_tier
+  end;
+
+-- Extend the self-elevation guard to cover the new admin-only columns
+create or replace function public.prevent_beta_self_elevation()
+ returns trigger
+ language plpgsql
+ security definer
+ set search_path to 'public', 'pg_temp'
+as $function$
+begin
+  if auth.uid() is null then
+    return new;
+  end if;
+
+  if new.is_beta_eligible   is distinct from old.is_beta_eligible
+  or new.beta_access_status is distinct from old.beta_access_status
+  or new.beta_requested_at  is distinct from old.beta_requested_at
+  or new.beta_approved_at   is distinct from old.beta_approved_at
+  or new.access_stage       is distinct from old.access_stage
+  or new.early_access       is distinct from old.early_access
+  or new.user_status        is distinct from old.user_status
+  or new.access_tier        is distinct from old.access_tier
+  or new.age_status         is distinct from old.age_status then
+    raise exception 'access-control columns are admin-only (KAN-273 / KAN-309 / KAN-319 / status-model)'
+      using errcode = '42501';
+  end if;
+
+  return new;
+end;
+$function$;
+
+comment on column public.profiles.user_status is 'Lifecycle: not_applied -> waitlist -> live. Replaces beta_access_status. Admin-only (trigger-guarded).';
+comment on column public.profiles.access_tier is 'Which site + test-feature default: beta or prod. Replaces the live/beta split of access_stage. Admin-only (trigger-guarded).';

--- a/supabase/migrations/20260624130000_admin_list_users_status_fields.sql
+++ b/supabase/migrations/20260624130000_admin_list_users_status_fields.sql
@@ -1,0 +1,94 @@
+-- KAN-326 / KAN-329: surface the clean status model in the admin user list.
+-- admin_list_users now also returns user_status, access_tier, is_published,
+-- age_status (for the computed publish-status badge) and has_revoked_ga_feature
+-- (any GA/default-on feature turned off -> "features disabled" badge).
+--
+-- Same signature as 20260622120000 -> CREATE OR REPLACE just swaps the body
+-- (no new overload, grants unchanged). Filters still key off the legacy columns,
+-- which are kept in sync until the legacy-drop migration.
+--
+-- ROLLBACK: restore the admin_list_users body from 20260622120000.
+
+create or replace function public.admin_list_users(
+  p_search    text    default null,
+  p_stage     text    default null,
+  p_early     boolean default null,
+  p_suspended boolean default null,
+  p_admin     boolean default null,
+  p_limit     int     default 20,
+  p_offset    int     default 0
+)
+returns json
+language plpgsql
+security definer
+set search_path = public, pg_temp
+as $$
+declare
+  v_total  bigint;
+  v_rows   json;
+  v_limit  int  := least(greatest(coalesce(p_limit, 20), 1), 100);
+  v_offset int  := greatest(coalesce(p_offset, 0), 0);
+  v_search text := nullif(btrim(coalesce(p_search, '')), '');
+begin
+  if not exists (
+    select 1 from public.profiles
+     where user_id = auth.uid() and is_admin = true
+  ) then
+    raise exception 'admin only' using errcode = '42501';
+  end if;
+
+  select count(*) into v_total
+    from public.profiles p
+    join auth.users u on u.id = p.user_id
+   where (v_search is null
+          or u.email          ilike '%' || v_search || '%'
+          or p.display_name   ilike '%' || v_search || '%'
+          or p.slug           ilike '%' || v_search || '%')
+     and (p_stage     is null or p.access_stage::text = p_stage)
+     and (p_early     is null or p.early_access       = p_early)
+     and (p_suspended is null or p.is_suspended       = p_suspended)
+     and (p_admin     is null or p.is_admin           = p_admin);
+
+  select coalesce(json_agg(r), '[]'::json) into v_rows
+    from (
+      select p.id,
+             p.user_id,
+             u.email,
+             p.display_name,
+             p.slug,
+             p.created_at,
+             p.user_status,
+             p.access_tier,
+             p.is_published,
+             p.age_status,
+             p.access_stage,
+             p.early_access,
+             p.is_beta_eligible,
+             p.beta_access_status,
+             p.beta_requested_at,
+             p.beta_approved_at,
+             p.is_suspended,
+             p.is_admin,
+             exists (
+               select 1 from public.feature_entitlements fe
+                where fe.profile_id = p.id
+                  and fe.enabled = false
+                  and fe.feature_key in ('media_uploads', 'discovery') -- GA (tier='ga') keys; see src/lib/features/registry.ts
+             ) as has_revoked_ga_feature
+        from public.profiles p
+        join auth.users u on u.id = p.user_id
+       where (v_search is null
+              or u.email        ilike '%' || v_search || '%'
+              or p.display_name ilike '%' || v_search || '%'
+              or p.slug         ilike '%' || v_search || '%')
+         and (p_stage     is null or p.access_stage::text = p_stage)
+         and (p_early     is null or p.early_access       = p_early)
+         and (p_suspended is null or p.is_suspended       = p_suspended)
+         and (p_admin     is null or p.is_admin           = p_admin)
+       order by p.created_at desc
+       limit v_limit offset v_offset
+    ) r;
+
+  return json_build_object('rows', v_rows, 'total', v_total);
+end;
+$$;

--- a/tests/unit/access-model-transitions.test.ts
+++ b/tests/unit/access-model-transitions.test.ts
@@ -15,6 +15,8 @@ describe('computeAccessTransition (KAN-309)', () => {
   it('enable_beta sets both axes + the enforced gate + approved, and emails', () => {
     const t = computeAccessTransition('enable_beta', { now: NOW });
     expect(t.update).toMatchObject({
+      user_status: 'live',
+      access_tier: 'beta',
       access_stage: 'beta',
       early_access: true,
       is_beta_eligible: true,
@@ -28,6 +30,8 @@ describe('computeAccessTransition (KAN-309)', () => {
   it('disable_beta revokes the gate, returns to waitlist, clears approval, no email', () => {
     const t = computeAccessTransition('disable_beta', { now: NOW });
     expect(t.update).toMatchObject({
+      user_status: 'waitlist',
+      access_tier: 'beta',
       access_stage: 'waitlist',
       early_access: false,
       is_beta_eligible: false,
@@ -41,6 +45,8 @@ describe('computeAccessTransition (KAN-309)', () => {
   it('promote_live_with_beta → live, early access on, stays beta-eligible, emails', () => {
     const t = computeAccessTransition('promote_live_with_beta', { now: NOW });
     expect(t.update).toMatchObject({
+      user_status: 'live',
+      access_tier: 'prod',
       access_stage: 'live',
       early_access: true,
       is_beta_eligible: true,
@@ -53,6 +59,8 @@ describe('computeAccessTransition (KAN-309)', () => {
   it('promote_live_no_beta → live, early access OFF, still beta-eligible, no email', () => {
     const t = computeAccessTransition('promote_live_no_beta', { now: NOW });
     expect(t.update).toMatchObject({
+      user_status: 'live',
+      access_tier: 'prod',
       access_stage: 'live',
       early_access: false,
       is_beta_eligible: true,
@@ -71,6 +79,8 @@ describe('computeAccessTransition (KAN-309)', () => {
     });
     expect(t.update.access_stage).toBeUndefined();
     expect(t.update.is_beta_eligible).toBeUndefined();
+    expect(t.update.user_status).toBeUndefined();
+    expect(t.update.access_tier).toBeUndefined();
     expect(t.moderationAction).toBe('suspend');
   });
 
@@ -82,6 +92,8 @@ describe('computeAccessTransition (KAN-309)', () => {
       suspension_reason: null,
     });
     expect(t.update.access_stage).toBeUndefined();
+    expect(t.update.user_status).toBeUndefined();
+    expect(t.update.access_tier).toBeUndefined();
     expect(t.moderationAction).toBe('unsuspend');
   });
 

--- a/tests/unit/admin-status-badges.test.ts
+++ b/tests/unit/admin-status-badges.test.ts
@@ -1,0 +1,75 @@
+/**
+ * KAN-326: feature tiers + the shared admin status/access/publish badge logic.
+ */
+import { userStatusBadge, accessBadge, publishBadge } from '@/app/admin/users/status-badges';
+import {
+  GA_FEATURE_KEYS,
+  TEST_FEATURE_KEYS,
+  FEATURE_KEYS,
+  FEATURE_CONFIG,
+} from '@/lib/features/registry';
+
+describe('feature tiers', () => {
+  it('GA = media_uploads + discovery; test = the opt-in set', () => {
+    expect(new Set(GA_FEATURE_KEYS)).toEqual(new Set(['media_uploads', 'discovery']));
+    expect(new Set(TEST_FEATURE_KEYS)).toEqual(
+      new Set(['mcp', 'convene', 'paid_gift_links', 'convene_paid_channels']),
+    );
+  });
+
+  it('every feature has a tier and the two tiers partition all keys', () => {
+    for (const k of FEATURE_KEYS) {
+      expect(['ga', 'test']).toContain(FEATURE_CONFIG[k].tier);
+    }
+    expect(GA_FEATURE_KEYS.length + TEST_FEATURE_KEYS.length).toBe(FEATURE_KEYS.length);
+  });
+
+  it('GA features default on, test features default off', () => {
+    for (const k of GA_FEATURE_KEYS) expect(FEATURE_CONFIG[k].defaultEnabled).toBe(true);
+    for (const k of TEST_FEATURE_KEYS) expect(FEATURE_CONFIG[k].defaultEnabled).toBe(false);
+  });
+});
+
+describe('userStatusBadge (priority: suspended > admin > lifecycle)', () => {
+  const base = { is_suspended: false, is_admin: false, user_status: 'live' as const };
+
+  it('suspended wins over everything', () => {
+    expect(userStatusBadge({ ...base, is_suspended: true, is_admin: true }).label).toBe('suspended');
+  });
+
+  it('admin wins over lifecycle when not suspended', () => {
+    expect(userStatusBadge({ ...base, is_admin: true }).label).toBe('admin');
+  });
+
+  it('lifecycle otherwise', () => {
+    expect(userStatusBadge({ ...base, user_status: 'live' }).label).toBe('live');
+    expect(userStatusBadge({ ...base, user_status: 'waitlist' }).label).toBe('waitlist');
+    expect(userStatusBadge({ ...base, user_status: 'not_applied' }).label).toBe('not applied');
+  });
+});
+
+describe('accessBadge', () => {
+  it('prod / beta', () => {
+    expect(accessBadge('prod').label).toBe('prod');
+    expect(accessBadge('beta').label).toBe('beta');
+  });
+});
+
+describe('publishBadge (public > age check > private)', () => {
+  it('published -> public regardless of age', () => {
+    expect(publishBadge({ is_published: true, age_status: 'none' }, true).label).toBe('public');
+  });
+
+  it('unpublished + gate on + not passed -> age check', () => {
+    expect(publishBadge({ is_published: false, age_status: 'none' }, true).label).toBe('age check');
+    expect(publishBadge({ is_published: false, age_status: 'pending' }, true).label).toBe('age check');
+  });
+
+  it('unpublished + gate on + passed -> private', () => {
+    expect(publishBadge({ is_published: false, age_status: 'passed' }, true).label).toBe('private');
+  });
+
+  it('unpublished + gate off -> private (age irrelevant)', () => {
+    expect(publishBadge({ is_published: false, age_status: 'none' }, false).label).toBe('private');
+  });
+});

--- a/tests/unit/beta-access-flow.test.ts
+++ b/tests/unit/beta-access-flow.test.ts
@@ -1,62 +1,140 @@
-import { betaRedirectUrl, isProdDeploy } from '@/lib/beta-access/flow';
+import { betaRedirectUrl, isProdDeploy, isProdFamily } from '@/lib/beta-access/flow';
 
 const asEnv = (o: Record<string, string>) => o as unknown as NodeJS.ProcessEnv;
 
-// KAN-278: where a user lands after sign-in.
+// KAN-326: where a user lands after sign-in — routed by access tier on the prod family.
 describe('betaRedirectUrl', () => {
-  it('prod + approved -> beta dashboard', () => {
+  // --- prod family: live users route to their own tier's site ---
+  it('prod family + live + prod tier -> production site', () => {
     expect(
-      betaRedirectUrl({ origin: 'https://checklyra.com', isProd: true, approved: true, next: '/dashboard' }),
+      betaRedirectUrl({
+        origin: 'https://checklyra.com',
+        isProdFamily: true,
+        userStatus: 'live',
+        accessTier: 'prod',
+        next: '/dashboard',
+      }),
+    ).toBe('https://checklyra.com/dashboard');
+  });
+
+  it('prod family + live + beta tier -> beta site', () => {
+    expect(
+      betaRedirectUrl({
+        origin: 'https://checklyra.com',
+        isProdFamily: true,
+        userStatus: 'live',
+        accessTier: 'beta',
+        next: '/dashboard',
+      }),
     ).toBe('https://beta.checklyra.com/dashboard');
   });
 
-  it('prod + not approved -> beta waitlist', () => {
-    expect(
-      betaRedirectUrl({ origin: 'https://checklyra.com', isProd: true, approved: false, next: '/dashboard' }),
-    ).toBe('https://beta.checklyra.com/waitlist');
+  it('prod family + not-live -> beta waitlist (regardless of tier)', () => {
+    for (const userStatus of ['waitlist', 'not_applied'] as const) {
+      for (const accessTier of ['beta', 'prod'] as const) {
+        expect(
+          betaRedirectUrl({
+            origin: 'https://checklyra.com',
+            isProdFamily: true,
+            userStatus,
+            accessTier,
+            next: '/dashboard',
+          }),
+        ).toBe('https://beta.checklyra.com/waitlist');
+      }
+    }
   });
 
-  it('prod preserves a safe nested next path', () => {
+  it('prod family preserves a safe nested next path on the resolved tier host', () => {
     expect(
-      betaRedirectUrl({ origin: 'https://checklyra.com', isProd: true, approved: true, next: '/dashboard/profile' }),
+      betaRedirectUrl({
+        origin: 'https://checklyra.com',
+        isProdFamily: true,
+        userStatus: 'live',
+        accessTier: 'prod',
+        next: '/dashboard/profile',
+      }),
+    ).toBe('https://checklyra.com/dashboard/profile');
+    expect(
+      betaRedirectUrl({
+        origin: 'https://beta.checklyra.com',
+        isProdFamily: true,
+        userStatus: 'live',
+        accessTier: 'beta',
+        next: '/dashboard/profile',
+      }),
     ).toBe('https://beta.checklyra.com/dashboard/profile');
   });
 
-  it('non-prod (beta/dev) stays on the same origin', () => {
+  // --- dev/stage: single full env, stay on the origin ---
+  it('non-prod-family (dev/stage) stays on the same origin', () => {
     expect(
-      betaRedirectUrl({ origin: 'https://beta.checklyra.com', isProd: false, approved: false, next: '/dashboard' }),
+      betaRedirectUrl({
+        origin: 'https://beta.checklyra.com',
+        isProdFamily: false,
+        userStatus: 'waitlist',
+        accessTier: 'beta',
+        next: '/dashboard',
+      }),
     ).toBe('https://beta.checklyra.com/dashboard');
     expect(
-      betaRedirectUrl({ origin: 'https://dev.checklyra.com', isProd: false, approved: true, next: '/dashboard' }),
+      betaRedirectUrl({
+        origin: 'https://dev.checklyra.com',
+        isProdFamily: false,
+        userStatus: 'live',
+        accessTier: 'prod',
+        next: '/dashboard',
+      }),
     ).toBe('https://dev.checklyra.com/dashboard');
   });
 
-  it('rejects open-redirect next values (protocol-relative / absolute / userinfo / backslash)', () => {
+  // --- open-redirect safety preserved (SEC-07 + SEC-19/F-12) ---
+  it('rejects open-redirect next values -> safe /dashboard on the resolved host', () => {
     // SEC-19/F-12 — all must fall back to the safe default, never an off-site host.
-    for (const next of ['//evil.com', 'https://evil.com', '@evil.com', '/\\evil.com']) {
+    for (const next of [
+      '//evil.com',
+      'https://evil.com',
+      '@evil.com',
+      '/\\evil.com',
+      '/\\/evil.com',
+      '.evil.com',
+      '\\evil.com',
+    ]) {
+      // prod tier -> production host, never the off-site host
       expect(
-        betaRedirectUrl({ origin: 'https://checklyra.com', isProd: true, approved: true, next }),
-      ).toBe('https://beta.checklyra.com/dashboard');
+        betaRedirectUrl({
+          origin: 'https://checklyra.com',
+          isProdFamily: true,
+          userStatus: 'live',
+          accessTier: 'prod',
+          next,
+        }),
+      ).toBe('https://checklyra.com/dashboard');
+      // dev/stage -> origin, never the off-site host
+      expect(
+        betaRedirectUrl({
+          origin: 'https://dev.checklyra.com',
+          isProdFamily: false,
+          userStatus: 'live',
+          accessTier: 'beta',
+          next,
+        }),
+      ).toBe('https://dev.checklyra.com/dashboard');
     }
-    // A genuine relative path is still honoured.
+    // A genuine relative path is still honoured (beta tier).
     expect(
-      betaRedirectUrl({ origin: 'https://checklyra.com', isProd: true, approved: true, next: '/dashboard/profile' }),
+      betaRedirectUrl({
+        origin: 'https://checklyra.com',
+        isProdFamily: true,
+        userStatus: 'live',
+        accessTier: 'beta',
+        next: '/dashboard/profile',
+      }),
     ).toBe('https://beta.checklyra.com/dashboard/profile');
-  });
-
-  it('rejects backslash and userinfo open-redirect tricks (SEC-07)', () => {
-    // `/\evil.com` and `/\/evil.com` start with a single "/" so a naive guard
-    // would let them through; some browsers normalise "\" to "/" → "//evil.com".
-    // `@evil.com` / `.evil.com` would escape the origin via `${origin}${next}`.
-    for (const evil of ['/\\evil.com', '/\\/evil.com', '@evil.com', '.evil.com', '\\evil.com']) {
-      expect(
-        betaRedirectUrl({ origin: 'https://checklyra.com', isProd: true, approved: true, next: evil }),
-      ).toBe('https://beta.checklyra.com/dashboard');
-    }
   });
 });
 
-// KAN-278: only the real production deploy hops users to beta.
+// KAN-278: only the real production deploy is "prod".
 describe('isProdDeploy', () => {
   it('true only on prod URL + VERCEL_ENV=production', () => {
     expect(isProdDeploy(asEnv({ NEXT_PUBLIC_SITE_URL: 'https://checklyra.com', VERCEL_ENV: 'production' }))).toBe(true);
@@ -74,5 +152,26 @@ describe('isProdDeploy', () => {
 
   it('false on dev', () => {
     expect(isProdDeploy(asEnv({ NEXT_PUBLIC_SITE_URL: 'https://dev.checklyra.com', VERCEL_ENV: 'preview' }))).toBe(false);
+  });
+});
+
+// KAN-326: the "prod family" = real production OR the beta deploy (shared Supabase + .checklyra.com cookie).
+describe('isProdFamily', () => {
+  it('true on real production', () => {
+    expect(isProdFamily(asEnv({ NEXT_PUBLIC_SITE_URL: 'https://checklyra.com', VERCEL_ENV: 'production' }))).toBe(true);
+  });
+
+  it('true on the beta deploy', () => {
+    expect(
+      isProdFamily(asEnv({ NEXT_PUBLIC_SITE_URL: 'https://beta.checklyra.com', VERCEL_ENV: 'production', IS_BETA_DEPLOY: 'true' })),
+    ).toBe(true);
+  });
+
+  it('false on dev', () => {
+    expect(isProdFamily(asEnv({ NEXT_PUBLIC_SITE_URL: 'https://dev.checklyra.com', VERCEL_ENV: 'preview' }))).toBe(false);
+  });
+
+  it('false on stage', () => {
+    expect(isProdFamily(asEnv({ NEXT_PUBLIC_SITE_URL: 'https://stage.checklyra.com', VERCEL_ENV: 'preview' }))).toBe(false);
   });
 });

--- a/tests/unit/post-login-redirect.test.ts
+++ b/tests/unit/post-login-redirect.test.ts
@@ -1,11 +1,11 @@
 /**
- * BUGS-50 — resolvePostLoginRedirect shared helper.
+ * BUGS-50 / KAN-326 — resolvePostLoginRedirect shared helper.
  *
  * Both /auth/confirm (token-hash) and /auth/callback (OAuth) call this after a
  * session is established. It must: read the user, record beta-access, and feed
- * the resulting approval into betaRedirectUrl. The beta-access/flow module is
- * mocked so we assert the wiring deterministically (the routing matrix itself
- * is covered by beta-access-flow.test.ts).
+ * the resulting {userStatus, accessTier} into betaRedirectUrl. The
+ * beta-access/flow module is mocked so we assert the wiring deterministically
+ * (the routing matrix itself is covered by beta-access-flow.test.ts).
  */
 
 const mockResolveBetaAccess = jest.fn();
@@ -13,12 +13,12 @@ const mockBetaRedirectUrl = jest.fn((opts?: unknown) => {
   void opts; // accept (and ignore) the opts arg; assertions use toHaveBeenCalledWith
   return 'REDIRECT_RESULT';
 });
-const mockIsProdDeploy = jest.fn(() => false);
+const mockIsProdFamily = jest.fn(() => false);
 
 jest.mock('@/lib/beta-access/flow', () => ({
   resolveBetaAccess: (u: unknown) => mockResolveBetaAccess(u),
   betaRedirectUrl: (o: unknown) => mockBetaRedirectUrl(o),
-  isProdDeploy: () => mockIsProdDeploy(),
+  isProdFamily: () => mockIsProdFamily(),
 }));
 
 import { resolvePostLoginRedirect } from '@/lib/auth/post-login-redirect';
@@ -33,45 +33,48 @@ beforeEach(() => {
   mockResolveBetaAccess.mockReset();
   mockBetaRedirectUrl.mockClear();
   mockBetaRedirectUrl.mockReturnValue('REDIRECT_RESULT');
-  mockIsProdDeploy.mockReturnValue(false);
+  mockIsProdFamily.mockReset();
+  mockIsProdFamily.mockReturnValue(false);
 });
 
 describe('resolvePostLoginRedirect', () => {
-  test('records beta access for the signed-in user and returns betaRedirectUrl result', async () => {
-    mockResolveBetaAccess.mockResolvedValue({ approved: true });
+  test('records beta access for the signed-in user and feeds the tier into betaRedirectUrl', async () => {
+    mockResolveBetaAccess.mockResolvedValue({ userStatus: 'live', accessTier: 'prod' });
+    mockIsProdFamily.mockReturnValue(true);
     const supabase = fakeSupabase({ id: 'user-1', email: 'ben@example.com' });
 
-    const url = await resolvePostLoginRedirect(supabase, 'https://dev.checklyra.com', '/dashboard');
+    const url = await resolvePostLoginRedirect(supabase, 'https://checklyra.com', '/dashboard');
 
     expect(mockResolveBetaAccess).toHaveBeenCalledWith({ id: 'user-1', email: 'ben@example.com' });
     expect(mockBetaRedirectUrl).toHaveBeenCalledWith({
-      origin: 'https://dev.checklyra.com',
-      isProd: false,
-      approved: true,
+      origin: 'https://checklyra.com',
+      isProdFamily: true,
+      userStatus: 'live',
+      accessTier: 'prod',
       next: '/dashboard',
     });
     expect(url).toBe('REDIRECT_RESULT');
   });
 
-  test('passes approved:false through to betaRedirectUrl (waitlist routing)', async () => {
-    mockResolveBetaAccess.mockResolvedValue({ approved: false });
+  test('passes a not-live status through to betaRedirectUrl (waitlist routing)', async () => {
+    mockResolveBetaAccess.mockResolvedValue({ userStatus: 'waitlist', accessTier: 'beta' });
     const supabase = fakeSupabase({ id: 'user-2', email: null });
 
     await resolvePostLoginRedirect(supabase, 'https://checklyra.com', '/dashboard');
 
     expect(mockBetaRedirectUrl).toHaveBeenCalledWith(
-      expect.objectContaining({ approved: false }),
+      expect.objectContaining({ userStatus: 'waitlist', accessTier: 'beta' }),
     );
   });
 
-  test('no user: skips beta-access lookup and treats as approved (defensive)', async () => {
+  test('no user: skips beta-access lookup and stays on origin (defensive)', async () => {
     const supabase = fakeSupabase(null);
 
     await resolvePostLoginRedirect(supabase, 'https://dev.checklyra.com', '/dashboard');
 
     expect(mockResolveBetaAccess).not.toHaveBeenCalled();
     expect(mockBetaRedirectUrl).toHaveBeenCalledWith(
-      expect.objectContaining({ approved: true }),
+      expect.objectContaining({ isProdFamily: false, userStatus: 'live' }),
     );
   });
 });


### PR DESCRIPTION
Collapses the overlapping access fields into a clean model and makes age verification visible. Founder-driven; dev-first.

## Changes
- **Model + routing** (`7b5fc1a`): `user_status` (not_applied/waitlist/live) + `access_tier` (beta/prod) on profiles, backfilled. Routing now sends live users to their tier's site (prod→checklyra.com, beta→beta.checklyra.com); not-live → waitlist. Legacy columns (`is_beta_eligible`/`beta_access_status`/`access_stage`/`early_access`) kept in sync; dropped in a follow-up.
- **Admin redesign** (`513d7cd`): single User-status badge (suspended > admin > live/waitlist/not_applied), Access badge (beta/prod), computed Publish badge (public/age check/private), "features disabled" badge. Feature registry gains a tier (`ga`/`test`); `admin_list_users` RPC extended.
- **Publish/age UX** (`b69904d`): age banner + "Verify age" button; **fixed the silently-swallowed publish error**; "Save & publish" → "Publish" (autosave already saves).
- **Dashboard** (`4759f6d`): next-steps hub when unpublished + clickable logo.

## Migrations (applied to dev)
- `20260624120000_clean_access_model_user_status_access_tier.sql`
- `20260624130000_admin_list_users_status_fields.sql`

## Tests
tsc clean; **1757 unit tests green**. The betaRedirectUrl + post-login suites were updated to the new tier-routing contract with founder sign-off (open-redirect/security assertions preserved); net-new tier/badge/routing/family coverage added.

## MCP coverage
KAN-328 (lyra-mcp-server, parallel agent) aligns MCP capability to the new model. The legacy-column DROP (Phase C) is gated on KAN-328 landing first.

## Deferred (walkthrough decisions / follow-ups)
- Login → /search vs the new /dashboard hub; age-check-at-signup prompt.
- Phase C (drop legacy columns); dev/stage mirror; bulk "enable/disable test features" admin action.

Epic: KAN-326 · KAN-327 (migration) · KAN-328 (MCP) · KAN-329 (admin RPC).

🤖 Generated with [Claude Code](https://claude.com/claude-code)