### PR TITLE
fix(SEC-40): share session cookie across an env's subdomains so the admin host can authenticate

### DIFF
--- a/src/lib/cookie-domain.ts
+++ b/src/lib/cookie-domain.ts
@@ -1,31 +1,57 @@
 /**
- * KAN-274 (epic KAN-273): cross-domain session-cookie scoping.
+ * KAN-274 (epic KAN-273) + SEC-40 (epic SEC-37): cross-subdomain session-cookie
+ * scoping.
  *
- * To let a checklyra.com (prod) session carry over to beta.checklyra.com
- * without a re-login, the Supabase auth cookies are scoped to the parent
- * domain `.checklyra.com` — but ONLY on prod + beta. dev (dev.checklyra.com)
- * and stage (stage.checklyra.com) use DIFFERENT Supabase projects and MUST
- * stay host-scoped, so a session can never be read across environments.
+ * Each environment runs an app host AND a sibling admin host on the same parent
+ * domain — `dev.checklyra.com` + `admin-dev.checklyra.com`, `checklyra.com` +
+ * `admin.checklyra.com`, etc. For a session established on the app host to be
+ * usable on the admin host (SEC-37), the Supabase auth cookie must be scoped to
+ * the shared parent `.checklyra.com`. We therefore scope to `.checklyra.com` on
+ * EVERY real checklyra.com environment (dev / stage / beta / prod) — not just
+ * prod + beta as originally (KAN-274). This is the same mechanism that already
+ * lets `checklyra.com -> admin.checklyra.com` work on prod.
  *
- * Detection (no new env vars — reuses existing wiring):
- *   - beta: IS_BETA_DEPLOY === 'true'
- *   - prod: NEXT_PUBLIC_SITE_URL === 'https://checklyra.com'
- *   - everything else (dev / stage / preview / local) → host-scoped (undefined).
+ * Cross-ENVIRONMENT isolation is preserved by the Supabase cookie NAME embedding
+ * the project ref (`sb-<ref>-auth-token`): a dev session cookie is now *sent* to
+ * prod/stage hosts, but each env's client only reads its own ref's cookie, so a
+ * session can never authenticate across environments. (KAN-274 additionally
+ * host-scoped dev/stage as belt-and-suspenders; the ref-in-name is the real
+ * guard, and the SEC-37 admin-subdomain requirement makes parent-scoping
+ * necessary — `admin-dev` is a *sibling* of `dev`, so the only shared parent is
+ * `.checklyra.com`.)
  *
- * Defence in depth: the Supabase cookie NAME embeds the project ref, so even a
- * misconfigured domain cannot let prod/beta (shared prod-lyra ref) collide with
- * dev/stage (different refs). SameSite + Secure are left as Supabase sets them
- * (Lax + Secure) — correct for a same-site top-level navigation between
- * checklyra.com and beta.checklyra.com.
+ * Detection (no new env vars): NEXT_PUBLIC_SITE_URL is set per env to that env's
+ * checklyra.com URL (dev/stage/beta/prod). Previews (`*.vercel.app`) leave it
+ * unset and local uses `localhost` — both stay host-scoped, because a
+ * `.checklyra.com` domain wouldn't match those hosts (the browser would drop the
+ * cookie). IS_BETA_DEPLOY stays as a defensive short-circuit. SameSite + Secure
+ * are left as Supabase sets them (Lax + Secure).
  */
 export const PROD_SITE_URL = 'https://checklyra.com';
 export const PARENT_COOKIE_DOMAIN = '.checklyra.com';
 
-/** The cookie `domain` to use, or undefined to stay host-scoped (dev/stage/local). */
+/** True when `host` is checklyra.com or any subdomain of it. */
+function isChecklyraHost(host: string): boolean {
+  return host === 'checklyra.com' || host.endsWith('.checklyra.com');
+}
+
+/**
+ * The cookie `domain` to use, or undefined to stay host-scoped (preview/local).
+ * Parent-scoped on every real checklyra.com env so the app host and its sibling
+ * admin host share one session (SEC-40 / SEC-37).
+ */
 export function parentCookieDomain(e: NodeJS.ProcessEnv = process.env): string | undefined {
-  const isBeta = e.IS_BETA_DEPLOY === 'true';
-  const isProd = e.NEXT_PUBLIC_SITE_URL === PROD_SITE_URL;
-  return isBeta || isProd ? PARENT_COOKIE_DOMAIN : undefined;
+  // Defensive: beta always shares, even if NEXT_PUBLIC_SITE_URL ever drifted.
+  if (e.IS_BETA_DEPLOY === 'true') return PARENT_COOKIE_DOMAIN;
+  const raw = e.NEXT_PUBLIC_SITE_URL;
+  if (!raw) return undefined;
+  let host: string;
+  try {
+    host = new URL(raw).hostname;
+  } catch {
+    return undefined;
+  }
+  return isChecklyraHost(host) ? PARENT_COOKIE_DOMAIN : undefined;
 }
 
 /**

--- a/tests/unit/cookie-domain.test.ts
+++ b/tests/unit/cookie-domain.test.ts
@@ -4,10 +4,12 @@ import {
   PARENT_COOKIE_DOMAIN,
 } from '@/lib/cookie-domain';
 
-// KAN-274 (epic KAN-273): the session cookie is scoped to the parent domain
-// `.checklyra.com` ONLY on prod + beta, so a checklyra.com session carries over
-// to beta.checklyra.com. dev/stage MUST stay host-scoped (different Supabase
-// projects), so their sessions can never be read cross-environment.
+// SEC-40 (epic SEC-37): the session cookie is scoped to the parent domain
+// `.checklyra.com` on EVERY real checklyra.com env (dev/stage/beta/prod) so the
+// app host and its sibling admin host (admin-dev.checklyra.com etc.) share one
+// session. Cross-ENVIRONMENT isolation is preserved by the Supabase cookie NAME
+// (it embeds the project ref). Previews (*.vercel.app) and local (localhost)
+// stay host-scoped — a `.checklyra.com` domain wouldn't match those hosts.
 
 const asEnv = (o: Record<string, string>) => o as unknown as NodeJS.ProcessEnv;
 
@@ -16,51 +18,80 @@ describe('parentCookieDomain', () => {
     expect(parentCookieDomain(asEnv({ IS_BETA_DEPLOY: 'true' }))).toBe(PARENT_COOKIE_DOMAIN);
   });
 
-  it('scopes to .checklyra.com on prod (NEXT_PUBLIC_SITE_URL=https://checklyra.com)', () => {
+  it('scopes to .checklyra.com on prod (https://checklyra.com)', () => {
     expect(parentCookieDomain(asEnv({ NEXT_PUBLIC_SITE_URL: 'https://checklyra.com' }))).toBe(
       PARENT_COOKIE_DOMAIN,
     );
   });
 
-  it('stays host-scoped on dev (dev.checklyra.com)', () => {
-    expect(
-      parentCookieDomain(asEnv({ NEXT_PUBLIC_SITE_URL: 'https://dev.checklyra.com' })),
-    ).toBeUndefined();
+  it('scopes to .checklyra.com on dev (https://dev.checklyra.com) — SEC-40', () => {
+    expect(parentCookieDomain(asEnv({ NEXT_PUBLIC_SITE_URL: 'https://dev.checklyra.com' }))).toBe(
+      PARENT_COOKIE_DOMAIN,
+    );
   });
 
-  it('stays host-scoped on stage (stage.checklyra.com)', () => {
-    expect(
-      parentCookieDomain(asEnv({ NEXT_PUBLIC_SITE_URL: 'https://stage.checklyra.com' })),
-    ).toBeUndefined();
+  it('scopes to .checklyra.com on stage (https://stage.checklyra.com) — SEC-40', () => {
+    expect(parentCookieDomain(asEnv({ NEXT_PUBLIC_SITE_URL: 'https://stage.checklyra.com' }))).toBe(
+      PARENT_COOKIE_DOMAIN,
+    );
   });
 
-  it('stays host-scoped with no env (local/preview)', () => {
+  it('stays host-scoped with no env (unset → PR preview)', () => {
     expect(parentCookieDomain(asEnv({}))).toBeUndefined();
   });
 
-  it('beta flag wins even if the site url looks like dev (defensive)', () => {
+  it('stays host-scoped on a *.vercel.app preview', () => {
     expect(
-      parentCookieDomain(
-        asEnv({ IS_BETA_DEPLOY: 'true', NEXT_PUBLIC_SITE_URL: 'https://dev.checklyra.com' }),
-      ),
-    ).toBe(PARENT_COOKIE_DOMAIN);
+      parentCookieDomain(asEnv({ NEXT_PUBLIC_SITE_URL: 'https://lyra-abc123.vercel.app' })),
+    ).toBeUndefined();
   });
 
-  it('does not scope when IS_BETA_DEPLOY is the string "false"', () => {
+  it('stays host-scoped on localhost', () => {
+    expect(
+      parentCookieDomain(asEnv({ NEXT_PUBLIC_SITE_URL: 'http://localhost:3000' })),
+    ).toBeUndefined();
+  });
+
+  it('does not scope when IS_BETA_DEPLOY is the string "false" and no site url', () => {
     expect(parentCookieDomain(asEnv({ IS_BETA_DEPLOY: 'false' }))).toBeUndefined();
+  });
+
+  it('rejects suffix-spoofing hostnames (defensive)', () => {
+    expect(
+      parentCookieDomain(asEnv({ NEXT_PUBLIC_SITE_URL: 'https://evilchecklyra.com' })),
+    ).toBeUndefined();
+    expect(
+      parentCookieDomain(asEnv({ NEXT_PUBLIC_SITE_URL: 'https://checklyra.com.evil.com' })),
+    ).toBeUndefined();
+  });
+
+  it('returns undefined for a malformed NEXT_PUBLIC_SITE_URL', () => {
+    expect(parentCookieDomain(asEnv({ NEXT_PUBLIC_SITE_URL: 'not a url' }))).toBeUndefined();
+  });
+
+  it('beta flag wins even with no NEXT_PUBLIC_SITE_URL (defensive short-circuit)', () => {
+    expect(
+      parentCookieDomain(asEnv({ IS_BETA_DEPLOY: 'true', NEXT_PUBLIC_SITE_URL: '' })),
+    ).toBe(PARENT_COOKIE_DOMAIN);
   });
 });
 
 describe('withParentCookieDomain', () => {
-  it('adds domain on prod/beta, preserving existing options', () => {
+  it('adds domain on a checklyra.com env, preserving existing options', () => {
     expect(
-      withParentCookieDomain({ path: '/', sameSite: 'lax', secure: true }, asEnv({ IS_BETA_DEPLOY: 'true' })),
+      withParentCookieDomain(
+        { path: '/', sameSite: 'lax', secure: true },
+        asEnv({ NEXT_PUBLIC_SITE_URL: 'https://dev.checklyra.com' }),
+      ),
     ).toEqual({ path: '/', sameSite: 'lax', secure: true, domain: PARENT_COOKIE_DOMAIN });
   });
 
-  it('returns the options untouched (no domain) on dev/stage', () => {
+  it('returns the options untouched (no domain) on preview/local', () => {
     const opts = { path: '/', sameSite: 'lax', secure: true };
-    const out = withParentCookieDomain(opts, asEnv({ NEXT_PUBLIC_SITE_URL: 'https://dev.checklyra.com' }));
+    const out = withParentCookieDomain(
+      opts,
+      asEnv({ NEXT_PUBLIC_SITE_URL: 'https://lyra-x.vercel.app' }),
+    );
     expect(out).toEqual(opts);
     expect('domain' in out).toBe(false);
   });


### PR DESCRIPTION
## SEC-40 — share the session cookie across an env's subdomains (epic SEC-37)

**Problem.** The SEC-37 admin console is served on a *sibling* subdomain per env (`admin-dev.checklyra.com` beside `dev.checklyra.com`). Session cookies were scoped to `.checklyra.com` only on prod/beta (KAN-274); dev/stage stayed host-scoped — so a dev login at `dev.checklyra.com` is never sent to `admin-dev.checklyra.com`, `getCurrentAdmin()` sees no session, and the dev admin console **404s for a real admin** (verified with an `is_admin=true` account).

**Fix.** Scope the Supabase auth cookie to `.checklyra.com` on every real checklyra.com env (detected via the per-env `NEXT_PUBLIC_SITE_URL` hostname), so the app host and its sibling admin host share one session — the same mechanism that already makes `checklyra.com → admin.checklyra.com` work on prod. `*.vercel.app` previews and `localhost` stay host-scoped (a `.checklyra.com` domain wouldn't match them).

**Why it's safe.** Cross-environment isolation is preserved by the Supabase cookie *name* embedding the project ref (`sb-<ref>-auth-token`): a dev cookie is now *sent* to prod hosts but prod's client reads only its own ref, so it can never authenticate across environments. `SameSite=Lax`/`Secure` unchanged. Relaxes KAN-274's host-scoping, which was belt-and-suspenders (the ref-in-name is the real guard).

**Tests.** `cookie-domain.test.ts` updated — dev/stage now `.checklyra.com`; prod/beta unchanged; `localhost`, `*.vercel.app`, unset, suffix-spoof (`evilchecklyra.com`, `checklyra.com.evil.com`), and malformed URLs all stay host-scoped. Full unit suite green (1739) + `tsc` clean.

Depends on SEC-34 (shipped). **Users on dev/stage must re-login after deploy** (cookie domain changes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)