### PR TITLE
docs(KAN-286): Google Sign-In OAuth In production / brand-verified

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -25,7 +25,7 @@ Lyra is a calm, structured public profile platform where users share preferences
 - **Region**: EU West (Ireland)
 - **Tables**: profiles, profile_items, external_links, school_affiliations, api_keys
 - **Auth**: Supabase Auth (email/password, Google OAuth, email confirmation). Apple Sign-In deferred.
-- **Google OAuth**: Client ID 381290542304-46avld4uoubqd259nrf8ssp8pj2h73kn (same across all 3 projects, Testing mode)
+- **Google OAuth**: Client ID 381290542304-46avld4uoubqd259nrf8ssp8pj2h73kn (same across all 3 projects, **In production / brand-verified 2026-06-28**, basic scopes openid/email/profile)
 - **Security**: Row Level Security on all tables
 
 ### DNS & CDN
@@ -249,12 +249,12 @@ All operations run via GitHub Actions — no local machine needed:
 - **PR quality gate**: Scans for eslint-disable/ts-ignore without Jira reference
 
 ### OAuth Security — partially configured
-- **Google OAuth**: Client ID 381290542304-* shared across 3 Supabase projects. Consent screen in **Testing mode** — only allow-listed emails can sign in. **Must move to Production mode before beta launch (KAN-125), which is itself gated by removing Cloudflare lockdown on prod so the Google verifier can reach the consent screen URLs.** Google verification takes days/weeks — submit early.
+- **Google OAuth**: Client ID 381290542304-* shared across 3 Supabase projects. Consent screen **published 'In production' (External) and brand-verified 2026-06-28 (KAN-286 / KAN-125)** on **basic scopes** (openid/email/profile) → unlimited public Google Sign-In, no 'unverified app' warning, no 100-test-user cap. ⚠️ Convene's Google **Calendar** integration uses a **separate** OAuth client with **sensitive** scopes (calendar.readonly/events) that still needs its **own** Google sensitive-scope verification before public Calendar use — not covered by the basic-scope brand verification.
 - **Apple Sign-In**: Deferred (no Apple Developer account)
 - **Audit checklist (KAN-90)**: see `docs/CYBER_LOCKDOWN.md` — quarterly verification of redirect URIs, JavaScript origins, scopes, 2FA on owning Google account, consent screen branding, test users allow-list, IAM members. Re-run the Google Cloud Console section of that doc before each beta/prod launch.
 
 ### Known gaps — tracked in Jira
-- Google OAuth consent screen in Testing mode — **beta blocker** (KAN-125)
+- ✅ Google OAuth consent screen **In production / brand-verified** (KAN-286 / KAN-125) — beta blocker **RESOLVED 2026-06-28**
 - MCP server has no rate limiting or CORS (KAN-118) — **DONE 29 Mar 2026**
 - Token rotation schedule documented (KAN-119) — **DONE 29 Mar 2026**
 - Prompt injection defence for user-generated profile data read by AI (KAN-120) — **DONE 29 Mar 2026**

--- a/docs/SECURITY_ROTATION.md
+++ b/docs/SECURITY_ROTATION.md
@@ -59,6 +59,8 @@
 6. Test Google Sign-In on dev environment
 7. Promote to staging and production
 
+> **Note (2026-06-28):** Rotating the client *secret* does NOT re-trigger Google's consent-screen / brand verification — verification is tied to the app (authorised domains, homepage, privacy policy, app name), not the secret. Google Sign-In stays "In production / verified" (KAN-286) across secret rotations. Re-verification is only needed if you change authorised domains, the app name/logo, or add sensitive/restricted scopes.
+
 ### Rotating LYRA_RELEASE_PAT
 
 ⚠️ **All three scopes below are required.** Earlier versions of this doc said only `Contents` was needed; that was outdated and caused multiple production-promotion failures (BUGS-8, BUGS-15, plus the 2026-05-27 incident where a rotation dropped scopes). Always set all three.


### PR DESCRIPTION
Reflects the **Google brand verification for checklyra.com (approved 2026-06-28)** in the docs.

- `ARCHITECTURE.md` — Google OAuth: "Testing mode" → **"In production / brand-verified"** (basic scopes openid/email/profile); the *Known gaps* line "consent screen in Testing mode — beta blocker" marked **RESOLVED**. Added a flag that Convene's Google **Calendar** OAuth client uses **sensitive** scopes and needs its **own** sensitive-scope verification before public use.
- `SECURITY_ROTATION.md` — note that rotating the client **secret** does not re-trigger consent-screen/brand verification.

Docs-only. (KAN-286 brand verification + KAN-125.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)