### PR TITLE
feat(KAN-336): optional sign-up code that skips the waitlist and grants beta

### DIFF
--- a/src/app/(auth)/actions.ts
+++ b/src/app/(auth)/actions.ts
@@ -20,29 +20,27 @@ export async function signUp(formData: FormData) {
     return redirect('/signup?error=' + encodeURIComponent('Your name and email are required'));
   }
 
-  // KAN-258 — invite-only phase. When an invite code is configured, a new
-  // account can only be created with the correct code. This check sits
-  // BEFORE any account creation, so no auth.users row (and therefore no
-  // profile, via the handle_new_user trigger) is ever created without it.
-  const requiredInvite = env.inviteCode();
-  if (requiredInvite) {
-    const code = ((formData.get('invite_code') as string | null) ?? '').trim();
-    if (code !== requiredInvite) {
-      return redirect(
-        '/signup?error=' +
-          encodeURIComponent(
-            "That invite code isn't right. Lyra is invite-only while we're in private testing.",
-          ),
-      );
-    }
+  // KAN-336 — OPTIONAL sign-up code (formerly the KAN-258 hard invite gate). A
+  // configured LYRA_INVITE_CODE no longer blocks signup; entering the CORRECT
+  // code fast-tracks the user into beta (skipping the waitlist). We validate
+  // here for instant UX feedback, but the AUTHORITATIVE grant is re-checked
+  // server-side in resolveBetaAccess at link-confirm time (user_metadata is
+  // user-settable). Wrong non-empty code => rejected; empty => waitlist signup.
+  const configuredCode = env.inviteCode();
+  const submittedCode = ((formData.get('invite_code') as string | null) ?? '').trim();
+  if (configuredCode && submittedCode && submittedCode !== configuredCode) {
+    return redirect(
+      '/signup?error=' +
+        encodeURIComponent("That code isn't right. Leave it blank to join the waitlist instead."),
+    );
   }
+  const codeMatches = !!configuredCode && submittedCode === configuredCode;
 
   const siteUrl = getSiteUrl();
 
-  // KAN-258 — passwordless sign-up. We email a magic link instead of asking
-  // for a password. shouldCreateUser:true so an invited person gets an
-  // account on first click; the handle_new_user trigger reads full_name
-  // from the user metadata we pass here.
+  // KAN-258/KAN-336 — passwordless sign-up via magic link. shouldCreateUser:true
+  // creates the account on first click; handle_new_user reads full_name from the
+  // metadata, and resolveBetaAccess reads invite_code to decide waitlist vs beta.
   const { error } = await supabase.auth.signInWithOtp({
     email,
     options: {
@@ -50,6 +48,7 @@ export async function signUp(formData: FormData) {
       shouldCreateUser: true,
       data: {
         full_name: fullName,
+        ...(codeMatches ? { invite_code: configuredCode } : {}),
       },
     },
   });

--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -2,7 +2,6 @@ import Link from 'next/link';
 import Image from 'next/image';
 import { signIn } from '../actions';
 import { SocialLoginButtons } from '../social-login-buttons';
-import { env } from '@/lib/env';
 
 export const metadata = {
   title: 'Sign in to Lyra',
@@ -15,9 +14,6 @@ export default async function LoginPage({
   searchParams: Promise<{ error?: string; message?: string }>;
 }) {
   const params = await searchParams;
-  // KAN-258 — hide third-party sign-in during the invite-only phase
-  // (Google sign-in would otherwise create an un-gated account).
-  const inviteOnly = !!env.inviteCode();
 
   return (
     <main className="min-h-screen flex items-center justify-center px-4">
@@ -48,17 +44,13 @@ export default async function LoginPage({
           </div>
         )}
 
-        {!inviteOnly && (
-          <>
-            <SocialLoginButtons />
+        <SocialLoginButtons />
 
-            <div className="flex items-center gap-3 my-6">
-              <div className="flex-1 h-px bg-[#ece7df]" />
-              <span className="text-xs text-[var(--color-muted)]">or</span>
-              <div className="flex-1 h-px bg-[#ece7df]" />
-            </div>
-          </>
-        )}
+        <div className="flex items-center gap-3 my-6">
+          <div className="flex-1 h-px bg-[#ece7df]" />
+          <span className="text-xs text-[var(--color-muted)]">or</span>
+          <div className="flex-1 h-px bg-[#ece7df]" />
+        </div>
 
         <form className="space-y-4">
           <div>

--- a/src/app/(auth)/signup/page.tsx
+++ b/src/app/(auth)/signup/page.tsx
@@ -16,10 +16,10 @@ export default async function SignUpPage({
   searchParams: Promise<{ error?: string; message?: string; preview?: string }>;
 }) {
   const params = await searchParams;
-  // KAN-258 — during the private phase, account creation needs an invite
-  // code and third-party sign-in is hidden, so the only way in is the
-  // gated email form.
-  const inviteOnly = !!env.inviteCode();
+  // KAN-336 — when a sign-up code is configured, offer it as an OPTIONAL field:
+  // entering the correct code skips the waitlist and grants beta directly. No
+  // code = a normal waitlist signup. Social sign-in stays available either way.
+  const hasInviteCode = !!env.inviteCode();
   // KAN-273/KAN-287 — on the public production deploy, prod is the doorway into
   // the gated beta app: signing up records a request and lands the user on the
   // waitlist. Frame the page as "join the waitlist". `?preview=waitlist`
@@ -65,35 +65,30 @@ export default async function SignUpPage({
           </div>
         )}
 
-        {!inviteOnly && (
-          <>
-            <SocialLoginButtons />
+        <SocialLoginButtons />
 
-            <div className="flex items-center gap-3 my-6">
-              <div className="flex-1 h-px bg-[#ece7df]" />
-              <span className="text-xs text-[var(--color-muted)]">or sign up with email</span>
-              <div className="flex-1 h-px bg-[#ece7df]" />
-            </div>
-          </>
-        )}
+        <div className="flex items-center gap-3 my-6">
+          <div className="flex-1 h-px bg-[#ece7df]" />
+          <span className="text-xs text-[var(--color-muted)]">or sign up with email</span>
+          <div className="flex-1 h-px bg-[#ece7df]" />
+        </div>
 
         <form className="space-y-4">
-          {inviteOnly && (
+          {hasInviteCode && (
             <div>
               <label htmlFor="invite_code" className="block text-sm font-medium text-[var(--color-ink)] mb-1">
-                Invite code
+                Invite code <span className="font-normal text-[var(--color-muted)]">(optional)</span>
               </label>
               <input
                 id="invite_code"
                 name="invite_code"
                 type="text"
-                required
                 autoComplete="off"
                 className="w-full px-3 py-2 rounded-lg border border-[var(--color-border)] bg-white text-[var(--color-ink)] text-sm focus:outline-none focus:ring-2 focus:ring-[var(--color-sage)] focus:border-transparent"
-                placeholder="From your invitation"
+                placeholder="Skip the waitlist"
               />
               <p className="mt-1 text-xs text-[var(--color-muted)]">
-                Lyra is invite-only while we&apos;re in private testing.
+                Have a code? Enter it to skip the waitlist and go straight in.
               </p>
             </div>
           )}

--- a/src/lib/beta-access/flow.ts
+++ b/src/lib/beta-access/flow.ts
@@ -15,6 +15,7 @@
 import { createClient as createServiceRoleClient } from '@supabase/supabase-js';
 import { env } from '@/lib/env';
 import { sendBetaQueueNotice } from './email';
+import { computeAccessTransition } from '@/app/admin/users/users-actions-shared';
 
 const BETA_HOST = 'https://beta.checklyra.com';
 const PROD_HOST = 'https://checklyra.com';
@@ -101,6 +102,25 @@ export async function resolveBetaAccess(user: {
     // Already an active user — nothing to record.
     if (userStatus === 'live') {
       return { userStatus, accessTier };
+    }
+
+    // KAN-336 — fast-track: if this signup carried a valid invite code, grant
+    // beta directly (skip the waitlist). user_metadata is user-settable, so we
+    // re-validate the SECRET VALUE here, server-side, against env.inviteCode().
+    // Possessing the correct code IS the authorisation. Only runs when a code is
+    // configured, so it adds no work on envs without the feature.
+    const configuredCode = env.inviteCode();
+    if (configuredCode) {
+      const { data: authData } = await svc.auth.admin.getUserById(user.id);
+      const carried =
+        (authData?.user?.user_metadata?.invite_code as string | undefined) ?? '';
+      if (carried && carried === configuredCode) {
+        const { update } = computeAccessTransition('enable_beta', {
+          now: new Date().toISOString(),
+        });
+        await svc.from('profiles').update(update).eq('user_id', user.id);
+        return { userStatus: 'live', accessTier: 'beta' };
+      }
     }
 
     // Brand-new signup: record the request once + notify the admin. We key the

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -23,9 +23,10 @@ export const env = {
   supabaseAnonKey: () => requireEnv('NEXT_PUBLIC_SUPABASE_ANON_KEY'),
   supabaseServiceRoleKey: () => requireEnv('SUPABASE_SERVICE_ROLE_KEY'),
   siteUrl: () => optionalEnv('NEXT_PUBLIC_SITE_URL', 'https://checklyra.com'),
-  // KAN-258 — shared invite code for the private (invite-only) phase.
-  // When set, creating an account requires this code and third-party
-  // sign-in is hidden. Empty string = gate off (open signup).
+  // KAN-336 (was KAN-258) — shared OPTIONAL sign-up code. When set, entering it
+  // on /signup skips the waitlist and grants beta directly (re-validated
+  // server-side in resolveBetaAccess). No code = normal waitlist signup; empty
+  // string = feature off (no code field shown).
   inviteCode: () => optionalEnv('LYRA_INVITE_CODE', ''),
 };
 // Force rebuild 20260329011858

--- a/tests/unit/auth-actions.test.ts
+++ b/tests/unit/auth-actions.test.ts
@@ -86,7 +86,7 @@ describe('KAN-258: signUp action (passwordless)', () => {
   });
 });
 
-describe('KAN-258: invite-only signup gate', () => {
+describe('KAN-336: invite code (optional, skip-waitlist)', () => {
   test('with no invite code configured, signup is NOT gated (back-compat)', async () => {
     mockSignInWithOtp.mockResolvedValue({ error: null });
     const fd = makeFormData({ email: 'a@b.com', full_name: 'A' });
@@ -94,13 +94,17 @@ describe('KAN-258: invite-only signup gate', () => {
     expect(mockSignInWithOtp).toHaveBeenCalled();
   });
 
-  test('rejects signup when an invite code is required but missing', async () => {
+  test('a missing code (with a code configured) now proceeds to a normal waitlist signup', async () => {
+    // KAN-336: the code is OPTIONAL — a missing code is no longer a hard block
+    // (was the old KAN-258 invite-only behaviour). The signup proceeds and the
+    // user joins the waitlist; no invite_code is carried into the OTP metadata.
     mockInviteCode = 'LET-ME-IN';
+    mockSignInWithOtp.mockResolvedValue({ error: null });
     const fd = makeFormData({ email: 'a@b.com', full_name: 'A' });
     await expect(signUp(fd)).rejects.toThrow('REDIRECT');
-    expect(mockSignInWithOtp).not.toHaveBeenCalled();
-    expect(mockRedirect.mock.calls[0][0]).toContain('/signup?error=');
-    expect(mockRedirect.mock.calls[0][0]).toContain('invite-only');
+    expect(mockSignInWithOtp).toHaveBeenCalled();
+    expect(mockSignInWithOtp.mock.calls[0][0].options.data).toEqual({ full_name: 'A' });
+    expect(mockRedirect.mock.calls[0][0]).toContain('/signup?message=');
   });
 
   test('rejects signup when the invite code is wrong', async () => {
@@ -125,6 +129,56 @@ describe('KAN-258: invite-only signup gate', () => {
     const fd = makeFormData({ email: 'a@b.com', full_name: 'A', invite_code: '  LET-ME-IN  ' });
     await expect(signUp(fd)).rejects.toThrow('REDIRECT');
     expect(mockSignInWithOtp).toHaveBeenCalled();
+  });
+});
+
+describe('KAN-336: optional skip-waitlist code', () => {
+  test('missing code (with a code configured) proceeds to a normal signup — no invite_code carried', async () => {
+    mockInviteCode = 'LET-ME-IN';
+    mockSignInWithOtp.mockResolvedValue({ error: null });
+    const fd = makeFormData({ email: 'a@b.com', full_name: 'A' }); // no invite_code
+    await expect(signUp(fd)).rejects.toThrow('REDIRECT');
+    expect(mockSignInWithOtp).toHaveBeenCalled();
+    expect(mockSignInWithOtp.mock.calls[0][0].options.data).toEqual({ full_name: 'A' });
+    expect(mockRedirect.mock.calls[0][0]).toContain('/signup?message=');
+  });
+
+  test('the correct code carries invite_code in the OTP metadata', async () => {
+    mockInviteCode = 'LET-ME-IN';
+    mockSignInWithOtp.mockResolvedValue({ error: null });
+    const fd = makeFormData({ email: 'a@b.com', full_name: 'A', invite_code: 'LET-ME-IN' });
+    await expect(signUp(fd)).rejects.toThrow('REDIRECT');
+    expect(mockSignInWithOtp.mock.calls[0][0].options.data).toEqual({
+      full_name: 'A',
+      invite_code: 'LET-ME-IN',
+    });
+  });
+
+  test('a wrong non-empty code is rejected (no account created)', async () => {
+    mockInviteCode = 'LET-ME-IN';
+    const fd = makeFormData({ email: 'a@b.com', full_name: 'A', invite_code: 'nope' });
+    await expect(signUp(fd)).rejects.toThrow('REDIRECT');
+    expect(mockSignInWithOtp).not.toHaveBeenCalled();
+    expect(mockRedirect.mock.calls[0][0]).toContain('/signup?error=');
+  });
+
+  test('trims whitespace and carries the matched code', async () => {
+    mockInviteCode = 'LET-ME-IN';
+    mockSignInWithOtp.mockResolvedValue({ error: null });
+    const fd = makeFormData({ email: 'a@b.com', full_name: 'A', invite_code: '  LET-ME-IN  ' });
+    await expect(signUp(fd)).rejects.toThrow('REDIRECT');
+    expect(mockSignInWithOtp.mock.calls[0][0].options.data).toEqual({
+      full_name: 'A',
+      invite_code: 'LET-ME-IN',
+    });
+  });
+
+  test('no code configured: invite_code is never carried even if submitted (back-compat)', async () => {
+    mockInviteCode = '';
+    mockSignInWithOtp.mockResolvedValue({ error: null });
+    const fd = makeFormData({ email: 'a@b.com', full_name: 'A', invite_code: 'anything' });
+    await expect(signUp(fd)).rejects.toThrow('REDIRECT');
+    expect(mockSignInWithOtp.mock.calls[0][0].options.data).toEqual({ full_name: 'A' });
   });
 });
 

--- a/tests/unit/beta-access-resolve.test.ts
+++ b/tests/unit/beta-access-resolve.test.ts
@@ -1,0 +1,134 @@
+/**
+ * KAN-336: resolveBetaAccess — server-side invite-code grant.
+ *
+ * The grant goes through the service-role client (admin-only trigger). We mock
+ * @supabase/supabase-js's createClient and verify that a carried invite code in
+ * user_metadata, re-validated against env.inviteCode(), fast-tracks the user
+ * into beta via the canonical enable_beta transition; otherwise they waitlist.
+ */
+
+let mockInviteCode = '';
+let mockProfile: Record<string, unknown> | null = null;
+let mockUserMetadata: Record<string, unknown> = {};
+let mockWaitlistUpdated: Array<{ user_id: string }> = [{ user_id: 'u1' }];
+const updateSpy = jest.fn();
+const getUserByIdSpy = jest.fn();
+const mockSendBetaQueueNotice = jest.fn();
+
+jest.mock('@/lib/env', () => ({
+  env: {
+    supabaseUrl: () => 'https://x.supabase.co',
+    supabaseServiceRoleKey: () => 'svc-key',
+    inviteCode: () => mockInviteCode,
+  },
+}));
+
+jest.mock('@/lib/beta-access/email', () => ({
+  sendBetaQueueNotice: (...args: unknown[]) => mockSendBetaQueueNotice(...args),
+}));
+
+jest.mock('@supabase/supabase-js', () => ({
+  createClient: () => ({
+    from: () => ({
+      select: () => ({
+        eq: () => ({ maybeSingle: () => Promise.resolve({ data: mockProfile }) }),
+      }),
+      update: (payload: Record<string, unknown>) => {
+        updateSpy(payload);
+        return {
+          eq: () => ({
+            // grant path: `await svc.from().update().eq()` resolves here
+            then: (resolve: (v: unknown) => void) => resolve({ data: null }),
+            // waitlist path: `.eq().eq().select()`
+            eq: () => ({ select: () => Promise.resolve({ data: mockWaitlistUpdated }) }),
+          }),
+        };
+      },
+    }),
+    auth: {
+      admin: {
+        getUserById: (id: string) => {
+          getUserByIdSpy(id);
+          return Promise.resolve({ data: { user: { user_metadata: mockUserMetadata } } });
+        },
+      },
+    },
+  }),
+}));
+
+import { resolveBetaAccess } from '@/lib/beta-access/flow';
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockInviteCode = '';
+  mockProfile = {
+    user_status: 'waitlist',
+    access_tier: 'beta',
+    beta_access_status: 'none',
+    display_name: 'A',
+  };
+  mockUserMetadata = {};
+  mockWaitlistUpdated = [{ user_id: 'u1' }];
+});
+
+describe('KAN-336: resolveBetaAccess invite-code grant', () => {
+  it('grants beta when the carried code matches the configured code', async () => {
+    mockInviteCode = 'SECRET-123';
+    mockUserMetadata = { full_name: 'A', invite_code: 'SECRET-123' };
+
+    const result = await resolveBetaAccess({ id: 'u1', email: 'a@b.com' });
+
+    expect(result).toEqual({ userStatus: 'live', accessTier: 'beta' });
+    expect(getUserByIdSpy).toHaveBeenCalledWith('u1');
+    // The canonical enable_beta column set was applied (real computeAccessTransition).
+    expect(updateSpy).toHaveBeenCalledTimes(1);
+    expect(updateSpy.mock.calls[0][0]).toMatchObject({
+      user_status: 'live',
+      access_tier: 'beta',
+      access_stage: 'beta',
+      early_access: true,
+      is_beta_eligible: true,
+      beta_access_status: 'approved',
+    });
+    // No waitlist queue notice for a self-redeemed code.
+    expect(mockSendBetaQueueNotice).not.toHaveBeenCalled();
+  });
+
+  it('does NOT grant when the carried code is wrong — falls back to the waitlist', async () => {
+    mockInviteCode = 'SECRET-123';
+    mockUserMetadata = { invite_code: 'WRONG' };
+
+    const result = await resolveBetaAccess({ id: 'u1', email: 'a@b.com' });
+
+    expect(result).toEqual({ userStatus: 'waitlist', accessTier: 'beta' });
+    expect(updateSpy).toHaveBeenCalledTimes(1);
+    expect(updateSpy.mock.calls[0][0]).toMatchObject({
+      user_status: 'waitlist',
+      beta_access_status: 'requested',
+    });
+    expect(mockSendBetaQueueNotice).toHaveBeenCalled();
+  });
+
+  it('does NOT grant when no code is configured (getUserById skipped) — waitlist', async () => {
+    mockInviteCode = '';
+    mockUserMetadata = { invite_code: 'SECRET-123' }; // present, but feature is off
+
+    const result = await resolveBetaAccess({ id: 'u1', email: 'a@b.com' });
+
+    expect(result).toEqual({ userStatus: 'waitlist', accessTier: 'beta' });
+    expect(getUserByIdSpy).not.toHaveBeenCalled();
+    expect(updateSpy.mock.calls[0][0]).toMatchObject({ beta_access_status: 'requested' });
+  });
+
+  it('is a no-op for an already-live user (no grant, no waitlist write)', async () => {
+    mockInviteCode = 'SECRET-123';
+    mockProfile = { user_status: 'live', access_tier: 'beta', beta_access_status: 'approved' };
+    mockUserMetadata = { invite_code: 'SECRET-123' };
+
+    const result = await resolveBetaAccess({ id: 'u1', email: 'a@b.com' });
+
+    expect(result).toEqual({ userStatus: 'live', accessTier: 'beta' });
+    expect(updateSpy).not.toHaveBeenCalled();
+    expect(getUserByIdSpy).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## KAN-336 — optional sign-up code that skips the waitlist and grants beta

**What.** Reshape the dormant KAN-258 invite mechanism from a *hard invite-only gate* into an **optional skip-the-waitlist code**: entering the correct `LYRA_INVITE_CODE` on `/signup` fast-tracks the user into beta; no code → normal waitlist signup (unchanged).

**How.** `signUp` validates the optional code and carries the **secret value** through the OTP `data`; `resolveBetaAccess` re-validates it server-side (the security boundary — `user_metadata` is user-settable) and, on a match, applies the canonical `computeAccessTransition('enable_beta')` column set via the service-role client (`user_status='live'` + `access_tier='beta'` + legacy lockstep). Social sign-in is now always shown.

**Tests.** New `resolveBetaAccess` grant suite (4 cases) + 5 new `signUp` cases; the one old hard-gate test updated to the new optional behaviour (owner-approved intentional change). Full unit suite **1748** green; `tsc` + eslint clean.

**Env.** Set `LYRA_INVITE_CODE` on dev (+ prod/beta at prod ship).
**MCP coverage:** N/A — onboarding/auth flow, not an agent-facing data op.

> ⚠️ Prod ship gated on the `develop→main` promotion-blocker decision (half-merged KAN-309 admin code) — tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)