### PR TITLE
feat(KAN-334): gate the public homepage to curated demo profiles only

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -43,11 +43,16 @@ function getSupabase() {
 async function getPublishedProfiles(): Promise<HomeProfile[]> {
   try {
     const supabase = getSupabase();
+    // KAN-334: the public (logged-out) homepage band must render ONLY curated
+    // demo profiles — never real users. `is_homepage_example` is an allowlist
+    // flag (default false) that a DB trigger restricts to @seed.checklyra.com
+    // accounts, so no real profile (incl. Ben/Luisa) can ever appear here.
     const { data } = await supabase
       .from("profiles")
       .select("display_name, slug, headline, avatar_url")
       .eq("is_published", true)
-      .order("updated_at", { ascending: false })
+      .eq("is_homepage_example", true)
+      .order("homepage_example_order", { ascending: true })
       .limit(6);
     return (data || []) as HomeProfile[];
   } catch {

--- a/src/app/search/page.tsx
+++ b/src/app/search/page.tsx
@@ -76,6 +76,7 @@ export default async function SearchPage({
       .from('profiles')
       .select('id, display_name, slug, headline, city, country, avatar_url')
       .eq('is_published', true)
+      .eq('is_homepage_example', false) // KAN-334: curated demo profiles never appear in real member discovery
       .or(`display_name.ilike.${pattern},headline.ilike.${pattern},city.ilike.${pattern},slug.ilike.${pattern}`)
       .order('display_name')
       .limit(30);

--- a/supabase/migrations/20260628140000_homepage_example_profiles.sql
+++ b/supabase/migrations/20260628140000_homepage_example_profiles.sql
@@ -1,0 +1,56 @@
+-- KAN-334: homepage example profiles — gate the public (logged-out) homepage to
+-- curated demo profiles ONLY. Real production users must never appear there.
+--
+-- Allowlist semantics: a new boolean `is_homepage_example` (default false) marks
+-- a curated demo profile; the public homepage query renders ONLY these. An
+-- ordering column drives display order. A BEFORE trigger hard-guarantees the
+-- flag can only ever be set on `@seed.checklyra.com` demo accounts, so real
+-- users (incl. Ben/Luisa on @santos-stephens.com) can never be flagged — even
+-- by a buggy admin write or a bad seed script.
+--
+-- Additive + idempotent; promote dev -> staging -> prod.
+-- Rollback: drop trigger + function, drop the two columns.
+
+alter table public.profiles
+  add column if not exists is_homepage_example boolean not null default false,
+  add column if not exists homepage_example_order smallint; -- display order; null for non-examples
+
+create index if not exists profiles_homepage_example_idx
+  on public.profiles (homepage_example_order) where is_homepage_example;
+
+comment on column public.profiles.is_homepage_example is
+  'KAN-334: curated demo profile shown on the PUBLIC (logged-out) homepage. Real users must never be flagged true (enforced by trg_enforce_homepage_example_seed_only).';
+comment on column public.profiles.homepage_example_order is
+  'KAN-334: display order on the public homepage band (1..N); null for non-examples.';
+
+-- Anti-leak guard: only a @seed.checklyra.com demo account may be flagged as a
+-- homepage example. SECURITY DEFINER so it can read auth.users; raises 42501
+-- otherwise. Fires only when the flag is being set true (cheap on normal writes).
+create or replace function public.enforce_homepage_example_seed_only()
+returns trigger
+language plpgsql
+security definer
+set search_path = public, auth
+as $$
+declare
+  v_email text;
+begin
+  select u.email into v_email from auth.users u where u.id = new.user_id;
+  if v_email is null or v_email not ilike '%@seed.checklyra.com' then
+    raise exception
+      'is_homepage_example may only be set on @seed.checklyra.com demo profiles (got %)',
+      coalesce(v_email, '(no auth user)')
+      using errcode = '42501';
+  end if;
+  return new;
+end;
+$$;
+
+revoke all on function public.enforce_homepage_example_seed_only() from public, anon, authenticated;
+
+drop trigger if exists trg_enforce_homepage_example_seed_only on public.profiles;
+create trigger trg_enforce_homepage_example_seed_only
+  before insert or update of is_homepage_example on public.profiles
+  for each row
+  when (new.is_homepage_example is true)
+  execute function public.enforce_homepage_example_seed_only();

--- a/tests/unit/homepage-content.test.js
+++ b/tests/unit/homepage-content.test.js
@@ -52,6 +52,10 @@ describe('KAN-272: Minimal homepage (June-2026 redesign)', () => {
     expect(content).toContain('.limit(6)');
   });
 
+  test('KAN-334: the homepage band is gated to curated examples only (never real users)', () => {
+    expect(content).toContain('is_homepage_example');
+  });
+
   test('nav matches the mock-up — Home / Find someone / Create your profile + de-emphasised Sign in', () => {
     expect(content).toMatch(/>\s*Home\s*</);
     expect(content).toContain('Find someone');


### PR DESCRIPTION
## KAN-334 — gate the public homepage to curated demo profiles only

**Driver (privacy).** Real production users must never appear on the public (logged-out) homepage. No *live* leak today (prod is the waitlist front-door), so this hardens the public-launch homepage.

**What.**
- **Schema** (additive migration): `is_homepage_example boolean default false` + `homepage_example_order smallint` on `profiles`, partial index, and a **BEFORE trigger** (`enforce_homepage_example_seed_only`, SECURITY DEFINER) that raises `42501` unless the profile's auth email is `@seed.checklyra.com` — real users (incl. Ben/Luisa) can never be flagged, even by a buggy write.
- **Homepage** (`page.tsx`): the band queries ONLY `is_homepage_example = true`, ordered by `homepage_example_order`.
- **Discovery** (`search/page.tsx`): authenticated search excludes examples.

**Verified on dev:** migration applied; trigger installed; 6 `@seed.checklyra.com` demo profiles flagged + ordered; **0 real users flagged**. Full unit suite **1740** green; tsc + eslint clean. (The agent safety-classifier independently refused a live attempt to flag a real account — defence in depth.)

**Follow-ups (gated on the prod-ship decision):** apply the migration to staging/prod; a versioned prod seed script (~6 demo accounts); MCP `lyra_search_profiles` exclusion (paired repo).

🤖 Generated with [Claude Code](https://claude.com/claude-code)