### PR TITLE
docs(SEC-2/SEC-3/KAN-283): UK compliance pack (ROPA, sub-processors, retention, DSAR/breach/complaints, founder checklist) + CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,42 @@
+# CODEOWNERS — Lyra (checklyra.com)
+#
+# SEC-3 (GOV-01) — segregation-of-duties baseline. This file declares who is
+# accountable for which areas of the codebase. When GitHub branch protection
+# has "Require review from Code Owners" enabled on `main`/`beta`, a PR that
+# touches an owned path needs an approving review from the listed owner before
+# it can merge — the independent second pair of eyes the audit flagged as
+# missing (the last 15 prod merges were authored AND merged by one person with
+# reviewDecision: NONE).
+#
+# Realistic note for a solo+1 team: where @luisa-sys is the only available
+# reviewer, a PR she authors cannot be self-approved under code-owner rules.
+# The compensating control until a second reviewer (@ben-*) is wired in is the
+# mandatory self-review checklist in docs/compliance/FOUNDER_CHECKLIST.md plus
+# post-merge review. Add Ben's GitHub handle to the security-critical lines
+# below as soon as his account has repo access — see SEC-3.
+
+# ── Default owner for everything ─────────────────────────────────────────────
+*                                   @luisa-sys
+
+# ── Security-critical surfaces (highest scrutiny) ────────────────────────────
+# Auth, OAuth 2.1 server, beta-access/entitlements, admin, RLS migrations.
+/src/app/(auth)/                    @luisa-sys
+/src/app/oauth/                     @luisa-sys
+/src/lib/oauth/                     @luisa-sys
+/src/lib/beta-access/               @luisa-sys
+/src/app/admin/                     @luisa-sys
+/src/lib/cookie-domain.ts           @luisa-sys
+/src/lib/env.ts                     @luisa-sys
+/supabase/migrations/               @luisa-sys
+
+# ── CI / release / infra (a bad change here ships to prod) ───────────────────
+/.github/workflows/                 @luisa-sys
+/scripts/                           @luisa-sys
+/vercel.json                        @luisa-sys
+/wrangler.toml                      @luisa-sys
+
+# ── Governance & compliance docs ─────────────────────────────────────────────
+/CODEOWNERS                         @luisa-sys
+/SECURITY.md                        @luisa-sys
+/docs/compliance/                   @luisa-sys
+/CLAUDE.md                          @luisa-sys

--- a/docs/compliance/DSAR_BREACH_COMPLAINTS.md
+++ b/docs/compliance/DSAR_BREACH_COMPLAINTS.md
@@ -1,0 +1,107 @@
+# Data-Subject Rights, Breach & Complaints Procedures
+
+> **Status: DRAFT for founder / legal review.** Prepared 2026-06-28 (SEC-2 / KAN-283).
+> Not legal advice. These procedures must be adopted by the controller, the
+> intake inboxes must be live and monitored, and the public-facing routes
+> (privacy notice / support pages) must link them before launch.
+
+**Controller:** CheckLyra Ltd (Lyra). **Intake:** privacy@checklyra.com.
+**Last reviewed:** 2026-06-28.
+
+---
+
+## 1. Data-Subject Access & Rights (DSAR) — UK GDPR Art. 12–22
+
+**Rights handled:** access (Art. 15), rectification (16), erasure (17),
+restriction (18), portability (20), objection (21).
+
+**Intake:** privacy@checklyra.com (also accept in-app requests). Log every
+request in the DSR log (date received, identity-verification status, type,
+due date, outcome date).
+
+**Clock:** respond **within one calendar month** of receipt, free of charge.
+May extend by up to two further months for complex/numerous requests — tell the
+requester within the first month, with reasons.
+
+**Steps:**
+1. **Acknowledge** on receipt; start the one-month clock.
+2. **Verify identity** proportionately (confirm control of the account email).
+   Don't over-collect ID. If genuinely unverifiable, explain and pause the clock.
+3. **Locate** the data: Supabase (profile, contacts, gatherings, tokens, age
+   result), Cloudflare KV (waitlist), Resend (email logs), Didit (age/biometric
+   — request via the provider). Use the ROPA as the checklist.
+4. **Action** the right: access → export the user's data in a portable format
+   (JSON/CSV); erasure → run the deletion/anonymisation per RETENTION_SCHEDULE.md
+   (note the time-limited backup exception); rectification → correct + confirm.
+5. **Respond** with the data/outcome and signpost the complaints route + ICO.
+6. **Close** the log entry with the outcome date.
+
+**Refusals** (manifestly unfounded/excessive, or an exemption applies) must be
+explained, with the right to complain to the ICO.
+
+---
+
+## 2. Personal-Data Breach — UK GDPR Art. 33/34
+
+**Definition:** any breach of security leading to accidental or unlawful
+destruction, loss, alteration, unauthorised disclosure of, or access to,
+personal data.
+
+**Golden rule: the 72-hour clock starts when you become *aware* a breach has
+*likely* occurred — not when the investigation finishes.**
+
+**Steps:**
+1. **Contain** — stop the leak (revoke keys/tokens, take a surface offline,
+   rotate credentials). Cross-reference the Incident Response runbook (OPS-02).
+2. **Log immediately** in the **breach register** (template below) — *every*
+   breach, notifiable or not. This record is itself an Art. 33(5) requirement.
+3. **Assess risk** to individuals (likelihood + severity of harm).
+4. **Notify the ICO within 72 hours** *if* the breach is likely to result in a
+   risk to people's rights and freedoms — via the ICO personal-data-breach
+   report form. If reporting after 72h, include the reasons for delay.
+5. **Notify affected individuals without undue delay** *if* the breach is likely
+   to result in a **high** risk to them (Art. 34), in plain language, with the
+   likely consequences and the steps you're taking.
+6. **Review** — root cause, remediation, lessons; update controls.
+
+**Breach register template (one row per incident):**
+
+| ID | Detected (date/time) | Description | Data + people affected | Risk assessment | ICO notified? (date / why not) | Individuals notified? | Remediation | Closed |
+|----|----|----|----|----|----|----|----|----|
+
+ICO breach-report form:
+https://ico.org.uk/for-organisations/report-a-breach/personal-data-breach/
+
+---
+
+## 3. Data-Protection Complaints — DUAA statutory duty (in force 19 June 2026)
+
+Under the Data (Use and Access) Act 2025, every controller must operate an
+accessible complaints process. This applies to Lyra from day one of launch.
+
+**Channel:** a clearly-signposted route on the site/support pages and via
+privacy@checklyra.com (and/or a web form). Must be easy to find and use.
+
+**Steps & timings:**
+1. **Acknowledge** a data-protection complaint **within 30 days** of receipt.
+2. **Investigate** without undue delay; keep the complainant informed of progress.
+3. **Communicate the outcome** in writing.
+4. **Signpost the ICO** (name + contact details) as the complainant's escalation
+   route if they remain dissatisfied.
+5. **Log** every complaint in the complaints log (below).
+
+**Complaints log template:**
+
+| ID | Received | Complainant | Summary | Acknowledged (≤30d) | Investigation notes | Outcome + date | ICO signposted? |
+|----|----|----|----|----|----|----|----|
+
+Align wording with the ICO's final guidance "How to deal with data protection
+complaints" (published 12 Feb 2026).
+
+---
+
+## Where these must appear publicly (before launch)
+- **Privacy notice:** name the controller, ICO registration reference, lawful
+  bases, retention, the DSAR route, the **complaints route**, and the
+  international-transfer safeguard. Cross-check against the ROPA.
+- **Support / contact pages:** link the complaints channel and privacy@ inbox.

--- a/docs/compliance/FOUNDER_CHECKLIST.md
+++ b/docs/compliance/FOUNDER_CHECKLIST.md
@@ -1,0 +1,48 @@
+# Founder Compliance Checklist (one page)
+
+> Prepared 2026-06-28 (SEC-2 / SEC-3 / KAN-283). These are the items **only the
+> founder can do** — they need legal sign-off, a payment, an account/identity, or
+> a GitHub/Cloudflare admin action. The supporting documents (ROPA, retention,
+> sub-processors, procedures) are drafted in this folder and just need your
+> review + sign-off. Tick as you go; record dates/references inline.
+
+## A. Legal registration & money (do first — cheap, enforcement risk)
+- [ ] **Pay the ICO data-protection fee** — ico.org.uk/registration, Tier 1, **£47/yr by Direct Debit** (£52 by card). Declare ≤10 staff / ≤£632k turnover. _Not registering is itself an enforcement matter._
+  - Registration reference: ________  ·  Renewal date: ________  ·  Calendar reminder set: ☐
+- [ ] Add the ICO reference to the public **privacy notice** + the ROPA header.
+
+## B. Data-protection documents (review + sign off the drafts in this folder)
+- [ ] **ROPA.md** — review; correct any data category / lawful basis; sign off.
+- [ ] **SUBPROCESSORS.md** — for each vendor, **accept/reference its DPA online** and record the date + link. Subscribe to sub-processor-change notices.
+- [ ] **RETENTION_SCHEDULE.md** — confirm the proposed periods.
+- [ ] **DSAR_BREACH_COMPLAINTS.md** — adopt; make `privacy@checklyra.com` live + monitored.
+- [ ] **DPIA** — complete a DPIA (audience + age-assurance/biometric-adjacent + contact/calendar data warrant one). Use the ICO template. _Not drafted here — needs the controller's risk judgement._
+- [ ] Confirm **Didit** (age provider): Art. 9 basis (explicit consent), biometric retention/deletion, transfer mechanism, and that Lyra never stores the raw selfie. ← special-category, highest diligence.
+
+## C. Publish the public-facing pieces (before 18+ launch)
+- [ ] Privacy notice names controller, ICO ref, lawful bases, retention, DSAR route, **complaints route**, transfer safeguard.
+- [ ] **DUAA complaints channel** visible on site/support (live duty from **19 Jun 2026**: 30-day acknowledgement, outcome, ICO signposting).
+
+## D. Governance / change control (SEC-3, GOV-01) — GitHub admin
+- [ ] Turn on branch protection on `main` + `beta` (both repos): **require ≥1 approving review**, **enable "Require review from Code Owners"** (CODEOWNERS now exists), set **enforce_admins = true**.
+- [ ] Give `staging` at least the PR Quality Gate as a required status check.
+- [ ] Protect `lyra-mcp-server/main` with required checks + review.
+- [ ] Add **Ben's GitHub handle** to the security-critical lines in `/CODEOWNERS` so PRs get an independent reviewer (until then, the compensating control is the self-review checklist below + post-merge review).
+- [ ] Mirror `CODEOWNERS` + `SECURITY.md` into `lyra-mcp-server` (and `lyra-admin-mcp-server`).
+
+## E. Security hygiene (SEC-21 and related — founder-gated)
+- [ ] **Rotate the dev Supabase service-role key** and move it out of loose `.env` into a secret store (Railway dev + Vercel dev + local).
+- [ ] **SEC-32** — record the admin-MCP pre-launch **security sign-off** (highest-privilege surface; verify CF Access policy scoping first).
+- [ ] DR secrets (SEC-23): provision the offline age key + write-only R2 + COMPLIANCE-locked bucket so daily encrypted backups run; do a first supervised restore drill.
+
+## F. Standing self-review control (until a 2nd reviewer is wired in)
+On any PR you author and must merge yourself, before merging confirm:
+1. Tests green + `tsc` clean; CI required checks green.
+2. No secrets/keys in the diff; no new silent-skip/error-swallow in workflows (per CLAUDE.md grep checks).
+3. RLS/auth/migration changes reviewed against the Security-Review section of the ticket.
+4. The change matches a tracked Jira ticket with the 6 sections.
+Record "self-reviewed against checklist" in the PR before merge; schedule a post-merge read-through.
+
+---
+**Annual review:** renew the ICO fee, re-check each vendor's sub-processor list,
+review the ROPA + retention schedule. (Add as a recurring Jira/calendar task.)

--- a/docs/compliance/README.md
+++ b/docs/compliance/README.md
@@ -1,0 +1,27 @@
+# Lyra Compliance Pack
+
+First-pass UK data-protection documentation for CheckLyra Ltd (Lyra), created
+2026-06-28 under **SEC-2** (DP-01..04), **SEC-3** (GOV-01) and **KAN-283**.
+
+> **These are DRAFTS for founder / legal review — not legal advice.** They give
+> Lyra a defensible documentation baseline that a micro-controller can stand up
+> with the free official ICO templates + the vendors' self-serve DPAs. The
+> founder owns the legal sign-off, the ICO fee, DPA acceptance, and the DPIA.
+
+| Document | Covers | UK GDPR / law |
+|---|---|---|
+| [ROPA.md](ROPA.md) | Record of Processing Activities — every data category, purpose, lawful basis, processor | Art. 30 |
+| [SUBPROCESSORS.md](SUBPROCESSORS.md) | Sub-processor register + international transfers + per-vendor TRA | Art. 28, 44–46 |
+| [RETENTION_SCHEDULE.md](RETENTION_SCHEDULE.md) | Retention periods + deletion mechanisms (incl. waitlist-KV TTL) | Art. 5(1)(e) |
+| [DSAR_BREACH_COMPLAINTS.md](DSAR_BREACH_COMPLAINTS.md) | Data-subject rights (1 month), breach (72h), DUAA complaints (30-day) | Art. 12–22, 33/34; DUAA 2025 |
+| [FOUNDER_CHECKLIST.md](FOUNDER_CHECKLIST.md) | One-page list of founder-only actions (ICO fee, DPAs, branch protection, sign-offs) | — |
+
+**Also relevant (existing):** `/SECURITY.md` (vuln disclosure), `/CODEOWNERS`
+(SEC-3 change-control), `docs/DISASTER_RECOVERY.md` (SEC-23 backups/restore),
+`docs/SECURITY_ROTATION.md` (secret rotation). The Risk Register lives in
+Confluence (TWC "Lyra Risk Register"); the SEC Jira epic (SEC-1) tracks findings.
+
+**Not in this pack (founder-owned, can't be auto-drafted):** the **DPIA** (needs
+the controller's risk judgement), the **ICO registration/payment**, **DPA
+acceptance** per vendor, and the **branch-protection** GitHub-admin changes — all
+listed in [FOUNDER_CHECKLIST.md](FOUNDER_CHECKLIST.md).

--- a/docs/compliance/RETENTION_SCHEDULE.md
+++ b/docs/compliance/RETENTION_SCHEDULE.md
@@ -1,0 +1,40 @@
+# Data Retention Schedule
+
+> **Status: DRAFT for founder / legal review.** Prepared 2026-06-28 (SEC-2 / KAN-283).
+> Not legal advice. Retention periods below are proposed defaults proportionate
+> to a low-risk UK consumer service; the founder must confirm them and ensure
+> the deletion/anonymisation mechanisms actually run. UK GDPR Art. 5(1)(e)
+> (storage limitation) requires data not be kept longer than necessary.
+
+**Controller:** CheckLyra Ltd (Lyra). **Last reviewed:** 2026-06-28.
+
+| Data | Store | Proposed retention | Deletion / anonymisation mechanism | Status |
+|---|---|---|---|---|
+| Account + auth (`auth.users`, profile core) | Supabase | While account active; **purge or anonymise within 30 days** of a verified deletion request | Account-deletion flow must purge/anonymise the profile + cascade rows | ☐ confirm flow purges |
+| Profile content ("Manual of Me", media) | Supabase DB + Storage | While account active / published | Removed on unpublish or account deletion; Storage objects deleted | ☐ confirm Storage delete |
+| Age-assurance result (`age_status`, band, ref) | Supabase | While account active (proof of assurance) | Removed with account | ☑ stored result only (no biometric) |
+| Didit biometric (selfie) | Didit | **Per Didit's policy — confirm + record** | Provider-side | ☐ confirm Didit retention |
+| Contacts + contact methods (third parties) | Supabase | While the owning account/contact exists | Removed when the user deletes the contact or the account | ☐ confirm cascade |
+| Google Calendar OAuth token | Supabase (encrypted) | Until the user disconnects or deletes the account | Deleted on disconnect (`lyra_disconnect_provider`) / account deletion | ☑ disconnect deletes token |
+| Gatherings / invitees / RSVPs | Supabase | While the gathering exists; suggest purge ~12 months after the event | Manual/cron purge of past gatherings | ☐ define purge job |
+| **Waitlist emails (DP-04)** | **Cloudflare KV** | **Add a TTL — proposed 12 months**, then auto-expire; bring into the data map | Set KV `expirationTtl` on write in the maintenance worker | ☐ **implement TTL (SEC-2)** |
+| Transactional email logs | Resend | Per Resend default (typically ~30 days) — confirm | Provider-side | ☐ confirm Resend window |
+| Affiliate click events | Supabase | Raw events ~13 months, then aggregate-only | Cron aggregate + purge raw | ☐ define purge job |
+| Moderation / admin audit logs | Supabase | **Retain ≥ 12 months** (security/audit; do not auto-delete short-term) | Reviewed, not auto-purged within the window | ☑ audit-first writes |
+| Operational/web logs (IP, UA) | Cloudflare/Vercel/Railway | Per platform default (short) — confirm | Provider-side | ☐ confirm windows |
+| Encrypted backups (WORM) | Cloudflare R2 | Per DISASTER_RECOVERY.md (object-lock window) | Object-lock expiry | ☑ see DR doc |
+| OAuth token registry / auth codes | Supabase | Access tokens: until expiry; auth codes: ≤10 min one-time; refresh: 30-day rotation | Expiry + rotation (migration `oauth_2_1_server`) | ☑ enforced in schema |
+
+## Deletion request → action
+On a verified erasure request (see `DSAR_BREACH_COMPLAINTS.md`): purge/anonymise
+the account + profile + media + contacts + tokens within **30 days**; remove the
+waitlist KV entry if present; note that **encrypted, object-locked backups** will
+age out per the DR retention window (document this in the DSAR response as a
+lawful, time-limited exception — erasure from immutable backups is not required
+to be immediate where they are securely isolated and expire on schedule).
+
+## Open implementation items (tracked under SEC-2)
+1. **Waitlist KV TTL (DP-04)** — set `expirationTtl` in the maintenance worker so waitlist emails expire (proposed 12 months). _Small worker change; two-step Cloudflare deploy._
+2. **Account-deletion purge** — verify the deletion flow demonstrably purges/anonymises in Supabase (not just deactivates).
+3. **Past-gathering + affiliate-raw purge jobs** — define and schedule.
+4. Confirm provider-side windows (Resend, Didit, platform logs) and record them above.

--- a/docs/compliance/ROPA.md
+++ b/docs/compliance/ROPA.md
@@ -1,0 +1,110 @@
+# Record of Processing Activities (ROPA)
+
+> **Status: DRAFT for founder / legal review.** Prepared 2026-06-28 (SEC-2 / KAN-283).
+> This is a first-pass record built from the codebase and architecture; it is
+> **not legal advice**. The controller (Luisa / Ben) must review, correct, sign
+> off, and keep it current. UK GDPR Art. 30 requires this record to be
+> maintained and made available to the ICO on request.
+
+**Controller:** CheckLyra Ltd (trading as Lyra), registered in England & Wales.
+**Contact:** privacy@checklyra.com · security@checklyra.com
+**ICO registration:** _<to be completed — see KAN-283; Tier 1 fee, £47/yr Direct Debit>_
+**DPO:** Not appointed — not legally required (Lyra is not a public authority and
+core activity is not large-scale special-category or systematic-monitoring
+processing). Founder is the accountable data-protection lead.
+**Last reviewed:** 2026-06-28 · **Next review due:** 2026-12-28 (6-monthly until launch, then annually).
+
+---
+
+## A. Categories of data subjects
+
+| # | Data subject | Notes |
+|---|---|---|
+| DS1 | **Registered users** (adults 18+) | Account holders who build a Lyra profile. Age-gated to 18+. |
+| DS2 | **Waitlist sign-ups** | People who submitted an email to join the waitlist but have not completed signup. |
+| DS3 | **Contacts** added by a user | Third parties (name + contact method) a user records for Convene/gatherings. Data subject ≠ the account holder. |
+| DS4 | **Gathering invitees** | Recipients of an event invite (subset of DS3). |
+
+## B. Processing activities
+
+### P1 — Account & authentication
+- **Personal data:** email address, display name, Supabase `auth.users` record, magic-link/OTP tokens, session cookies, IP + user-agent (web logs).
+- **Purpose:** create and secure the account; passwordless (magic-link) sign-in.
+- **Lawful basis:** Art. 6(1)(b) **contract** (necessary to provide the requested service).
+- **Retention:** while account active; purge/anonymise on deletion request (see RETENTION_SCHEDULE.md).
+- **Recipients/processors:** Supabase (auth + DB), Resend (sends the magic-link email), Cloudflare (edge/CDN), Vercel (app hosting).
+
+### P2 — Profile content ("Manual of Me")
+- **Personal data:** free-text fields (intro, things I love / boundaries / proud of, etc.), headline, city/country, avatar/photo, uploaded files/media, external links, schools/organisations, slug. User-authored, may reveal opinions/preferences.
+- **Purpose:** publish a profile page so people the user knows can understand them; power gift recommendations.
+- **Lawful basis:** Art. 6(1)(b) **contract** for storing/serving the profile to the user; **Art. 6(1)(a) consent / publication by the user** for making it *public* (the user chooses to publish).
+- **Special category note:** users may *volunteer* special-category-adjacent info in free text (health, beliefs, etc.). Lyra does not solicit it; privacy notice should warn against posting sensitive data. No deliberate Art. 9 processing.
+- **Retention:** while account active / published; removed on unpublish or deletion.
+- **Recipients/processors:** Supabase (DB + Storage for media), Vercel, Cloudflare.
+
+### P3 — Age assurance (Online Safety Act)
+- **Personal data:** age-check result (`age_status`), age band (`age_range`), provider reference (`age_provider_ref`), timestamp. The **biometric selfie itself is processed by the provider (Didit), not stored by Lyra** — Lyra receives only pass/fail + band.
+- **Purpose:** verify the user is 18+ before publishing (OSA / platform policy).
+- **Lawful basis:** Art. 6(1)(c) **legal obligation** (age assurance under the Online Safety Act) and/or Art. 6(1)(f) legitimate interests (child-safety). Provider's biometric step relies on the user's explicit consent captured by the provider.
+- **Special category:** the selfie is biometric (Art. 9) **at the provider**; Lyra's stored result is not biometric. Confirm Didit's Art. 9 basis (explicit consent) in their DPA.
+- **Retention:** result retained while account active (proof of assurance); provider retention per Didit's policy — confirm and record.
+- **Recipients/processors:** Didit (age-verification provider), Supabase.
+
+### P4 — Convene: contacts, calendars & gatherings
+- **Personal data:** contact names + contact methods (email/phone) of **third parties**; Google Calendar busy/free times via OAuth; encrypted OAuth refresh token; gathering details, invitees, RSVPs.
+- **Purpose:** help the user organise gatherings and find shared availability.
+- **Lawful basis:** Art. 6(1)(b) **contract** with the user; for the third-party contact data, Art. 6(1)(f) **legitimate interests** (the user's interest in coordinating with people they know) — balanced by data minimisation and the contact's right to object; **Art. 6(1)(a) consent** for connecting a Google Calendar (the user grants OAuth).
+- **Retention:** while the account/contact/gathering exists; OAuth token deleted on disconnect.
+- **Recipients/processors:** Google (Calendar API), Supabase, Resend (invite emails).
+
+### P5 — Waitlist
+- **Personal data:** email address (and name) submitted to join the waitlist.
+- **Purpose:** manage staged access; email the user when a spot opens.
+- **Lawful basis:** Art. 6(1)(a) **consent** (the user asks to be notified) / Art. 6(1)(b) pre-contractual steps.
+- **Retention:** until converted to an account or the user asks to be removed; **define a TTL** (DP-04 — waitlist emails currently sit in Cloudflare KV without expiry; see SEC-2 / RETENTION_SCHEDULE.md).
+- **Recipients/processors:** Cloudflare (KV + Worker), Supabase, Resend.
+
+### P6 — Gift recommendations & affiliate analytics
+- **Personal data:** profile-derived interests (input to the recommender); affiliate click events (which outbound link, when). Outbound links carry no PII in query strings.
+- **Purpose:** suggest relevant gifts; measure affiliate performance; earn commission.
+- **Lawful basis:** Art. 6(1)(f) **legitimate interests** (running the service / monetisation), with privacy-by-default (hidden affiliate links, no PII in outbound URLs).
+- **Retention:** aggregated analytics; click logs per RETENTION_SCHEDULE.md.
+- **Recipients/processors:** affiliate merchants (Amazon Associates, Bookshop.org, etc.) receive the *click* (not Lyra's user data); Supabase.
+
+### P7 — Transactional email
+- **Personal data:** email address, name, message content (magic links, beta notices, invites, weekly owner reports).
+- **Purpose:** operate the service.
+- **Lawful basis:** Art. 6(1)(b) contract (service emails); consent for any marketing.
+- **Recipients/processors:** Resend.
+
+### P8 — Security, abuse-prevention & audit
+- **Personal data:** IP/user-agent, moderation logs, admin actions, OAuth token registry (jti), backups.
+- **Purpose:** secure the platform, detect abuse, maintain an audit trail, disaster recovery.
+- **Lawful basis:** Art. 6(1)(f) **legitimate interests** (security) and Art. 6(1)(c) where a legal duty applies.
+- **Retention:** logs/backups per RETENTION_SCHEDULE.md (encrypted WORM backups per DISASTER_RECOVERY.md).
+- **Recipients/processors:** Supabase, Cloudflare, Vercel, Railway, R2 (backups).
+
+## C. International transfers
+
+Lyra's processors are predominantly US-headquartered. Transfers outside the UK
+rely on the **UK IDTA** or the **UK Addendum to the EU SCCs** incorporated by
+each processor's DPA, plus a short **Transfer Risk Assessment** per vendor. See
+SUBPROCESSORS.md for the per-vendor mechanism and TRA.
+
+## D. Technical & organisational security measures (summary)
+
+RLS on all user tables (deny-by-default); TLS in transit; encryption at rest
+(Supabase/AWS); passwordless auth; OAuth 2.1 with RS256/JWKS; service-role keys
+held in platform secret stores; Cloudflare Access on admin surfaces; daily
+encrypted WORM backups + restore drills (DISASTER_RECOVERY.md); least-privilege
+admin via a separate audited admin MCP. Full detail in ARCHITECTURE.md and the
+SEC epic.
+
+---
+
+### Cross-references
+- Sub-processors + transfer mechanisms → `SUBPROCESSORS.md`
+- Retention periods + deletion → `RETENTION_SCHEDULE.md`
+- DSAR / breach / complaints procedures → `DSAR_BREACH_COMPLAINTS.md`
+- Founder action list (ICO fee, DPAs, sign-off) → `FOUNDER_CHECKLIST.md`
+- Risk register (GOV/DP findings) → Confluence TWC "Lyra Risk Register"

--- a/docs/compliance/SUBPROCESSORS.md
+++ b/docs/compliance/SUBPROCESSORS.md
@@ -1,0 +1,65 @@
+# Sub-processor Register & International Transfers
+
+> **Status: DRAFT for founder / legal review.** Prepared 2026-06-28 (SEC-2 / KAN-283).
+> Not legal advice. The founder must (a) accept/reference each vendor's DPA,
+> (b) confirm the transfer mechanism is current, and (c) sign off the TRAs.
+> Review at least annually and whenever a vendor or a vendor's own
+> sub-processor list changes.
+
+**Controller:** CheckLyra Ltd (Lyra). **Last reviewed:** 2026-06-28.
+
+## How to read this
+- **Role:** processor = handles personal data on Lyra's instructions (Art. 28 DPA required). "Recipient (not processor)" = receives a click/onward action but not Lyra's user records.
+- **Transfer mechanism:** the safeguard for UK→non-UK transfers (UK IDTA, or the UK Addendum to the EU SCCs, incorporated by the vendor's DPA). Where data stays in the UK/EEA on an adequacy basis, noted as such.
+- **DPA status:** ☐ to accept/reference · ☑ accepted (record the date + link).
+
+## Register
+
+| Vendor | Purpose / data | Role | Region | Transfer mechanism | DPA status |
+|---|---|---|---|---|---|
+| **Supabase** | Postgres DB, Auth, Storage (profiles, contacts, media, OAuth tokens) | Processor | US (AWS; region TBC — prefer eu-west) | UK Addendum to EU SCCs via Supabase DPA | ☐ confirm + record |
+| **Vercel** | App hosting / serverless rendering | Processor | US/global edge | UK Addendum via Vercel DPA (vercel.com/legal/dpa) | ☐ confirm + record |
+| **Railway** | MCP server hosting (user-MCP + admin-MCP) | Processor | US | UK Addendum/IDTA via Railway DPA | ☐ confirm + record |
+| **Cloudflare** | DNS, CDN, Access (admin gate), KV (waitlist emails), R2 (backups) | Processor | US/global | UK Addendum via Cloudflare Customer DPA | ☐ confirm + record |
+| **Resend** | Transactional email (magic links, invites, notices) | Processor | US | UK Addendum/IDTA via Resend DPA | ☐ confirm + record |
+| **Didit** | Age-assurance / biometric selfie check (returns pass + band only) | Processor (Art. 9 at provider) | TBC | Confirm DPA + Art. 9 explicit-consent basis + biometric retention | ☐ **confirm — special category** |
+| **Google (OAuth/Calendar)** | Google sign-in; Calendar busy/free (Convene) | Processor | US | UK Addendum via Google Cloud/Workspace DPA | ☐ confirm + record |
+| **Cloudflare R2** | Encrypted WORM backups (age-encrypted) | Processor | US/global | As Cloudflare above | ☐ confirm + record |
+| **Affiliate merchants** (Amazon Associates, Bookshop.org, …) | Receive outbound affiliate clicks (no Lyra PII in URLs) | Recipient (not processor) | US/UK | N/A — no personal data transferred by Lyra | n/a |
+| **GitHub** | Source code, CI | Not a processor of user data | US | (internal tooling) | n/a |
+| **Atlassian** (Jira/Confluence) | Internal issue/risk tracking | Not a processor of user data | US/EU | (internal tooling) | n/a |
+| **Railway/Cloudflare/Vercel logs** | Operational logs (may include IP) | Processor | as above | as above | covered by each DPA |
+
+> **Action (founder):** for each row marked ☐, accept the vendor's standard DPA
+> online and record the acceptance date + link in this table. All of the major
+> infra vendors (Supabase, Vercel, Cloudflare, Resend, Google) incorporate the
+> UK Addendum/IDTA by reference, so no bespoke negotiation is needed.
+
+## Transfer Risk Assessments (TRA) — one paragraph per vendor
+
+For each US-based processor the transfer relies on the UK Addendum to the EU
+SCCs (or the UK IDTA) as the Art. 46 safeguard. Lyra's data is low-sensitivity
+consumer profile data (no financial, health, or government-ID data is stored by
+Lyra; the only biometric step is performed by Didit, which returns a result, not
+the image). The residual risk from US government access (FISA 702 / EO 12333) is
+low for this dataset: it is not of foreign-intelligence interest, volumes are
+small, and the major vendors publish transparency reports and challenge
+over-broad requests. Mitigations: encryption in transit and at rest, encryption
+of backups with a key held outside the storage provider (age + R2 WORM),
+least-privilege access, and the right to suspend a processor on a material
+change. **Conclusion (draft): transfers are permissible under the UK
+Addendum/IDTA with the above supplementary measures.** Founder to confirm
+per-vendor and re-assess on any change to the vendor's posture.
+
+**Didit is the exception requiring extra diligence** — biometric processing is
+Art. 9 special-category. Confirm (1) Didit's Art. 9 lawful basis (explicit
+consent, captured by Didit at the point of the selfie), (2) Didit's retention
+and deletion of the biometric image, (3) the transfer mechanism for Didit's
+region, and (4) that Lyra never receives or stores the raw biometric. Record the
+outcome here before relying on the age-assurance flow at scale.
+
+## Onward sub-processors
+Each processor maintains its own sub-processor list (e.g. Supabase→AWS,
+Vercel→AWS/Cloudflare, Resend→AWS). UK GDPR requires the controller be informed
+of changes and able to object. **Action (founder):** subscribe to each vendor's
+sub-processor-change notifications and record the subscription here.


### PR DESCRIPTION
## What & why
First-pass **UK data-protection documentation pack** + the **CODEOWNERS** governance file flagged by the second-line audit. Addresses the documentation half of **SEC-2** (DP-01..04), **SEC-3** (GOV-01 — CODEOWNERS), and **KAN-283** (UK GDPR baseline). **Docs-only — no code or runtime change.**

## Contents
- **CODEOWNERS** — SoD baseline; security-critical paths (auth, oauth, beta-access, admin, migrations, workflows) owned by `@luisa-sys`, ready for "Require review from Code Owners". Compensating-control note for the solo+1 case.
- **docs/compliance/ROPA.md** — Record of Processing Activities (Art. 30): 4 data-subject classes, 8 processing activities with lawful bases, transfers, security summary.
- **docs/compliance/SUBPROCESSORS.md** — sub-processor register + per-vendor transfer mechanism (UK Addendum/IDTA) + Transfer Risk Assessments. Flags **Didit** as the special-category exception.
- **docs/compliance/RETENTION_SCHEDULE.md** — retention per data type + deletion mechanisms; calls out the **DP-04 waitlist-KV TTL** gap as an implementation item.
- **docs/compliance/DSAR_BREACH_COMPLAINTS.md** — DSAR (1 month), breach (72h ICO duty + register template), **DUAA statutory complaints** (live 19 Jun 2026, 30-day ack).
- **docs/compliance/FOUNDER_CHECKLIST.md** — one-page list of the **founder-only** actions.

## Important framing
These are **DRAFTS for founder / legal sign-off — not legal advice.** The items only the founder can do (DPIA, ICO fee/registration, per-vendor DPA acceptance, GitHub branch-protection) are deliberately **not** auto-actioned — they're enumerated in `FOUNDER_CHECKLIST.md`.

## Tests
N/A (documentation + a CODEOWNERS file). No code paths touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)