### PR TITLE
fix(KAN-326): beta sign-up shows waitlist framing (match the gate), not "Create account"

### DIFF
--- a/src/app/(auth)/signup/page.tsx
+++ b/src/app/(auth)/signup/page.tsx
@@ -3,7 +3,7 @@ import Image from 'next/image';
 import { signUp } from '../actions';
 import { SocialLoginButtons } from '../social-login-buttons';
 import { env } from '@/lib/env';
-import { isProdDeploy } from '@/lib/beta-access/flow';
+import { isProdFamily } from '@/lib/beta-access/flow';
 
 export const metadata = {
   title: 'Create your Lyra profile',
@@ -20,13 +20,17 @@ export default async function SignUpPage({
   // entering the correct code skips the waitlist and grants beta directly. No
   // code = a normal waitlist signup. Social sign-in stays available either way.
   const hasInviteCode = !!env.inviteCode();
-  // KAN-273/KAN-287 — on the public production deploy, prod is the doorway into
-  // the gated beta app: signing up records a request and lands the user on the
-  // waitlist. Frame the page as "join the waitlist". `?preview=waitlist`
-  // renders this on any deploy so it can be verified before reaching prod.
-  // LYRA_FORCE_WAITLIST mirrors this framing on a non-prod env (e.g. dev) without
-  // flipping isProdDeploy() (which also drives auth routing). Framing only.
-  const waitlist = isProdDeploy() || process.env.LYRA_FORCE_WAITLIST === 'true' || params.preview === 'waitlist';
+  // KAN-273/KAN-287/KAN-326 — sign-up is gated by the waitlist across the whole
+  // PROD FAMILY (prod AND beta): both enforce the gate (betaRedirectUrl +
+  // middleware redirect a non-'live' user to /waitlist), so the sign-up copy must
+  // say "join the waitlist" on BOTH, not just prod. We therefore key the framing
+  // off isProdFamily() (prod OR beta) rather than isProdDeploy() (prod only), so
+  // the sign-up framing can never drift from the gate that actually runs. (The
+  // homepage deliberately stays a product showcase on beta — it keys off
+  // isProdDeploy() — so the curated "people to meet" examples stay visible there
+  // while signing up is still waitlisted.) `?preview=waitlist` + LYRA_FORCE_WAITLIST
+  // still force the framing on any single-env deploy (e.g. dev). Framing only.
+  const waitlist = isProdFamily() || process.env.LYRA_FORCE_WAITLIST === 'true' || params.preview === 'waitlist';
 
   return (
     <main className="min-h-screen flex items-center justify-center px-4">

--- a/tests/unit/homepage-content.test.js
+++ b/tests/unit/homepage-content.test.js
@@ -189,11 +189,14 @@ describe('KAN-273/287: Production waitlist front door', () => {
     expect(home).toContain('A few people to meet');
   });
 
-  test('signup page reframes as "join the waitlist" on prod / preview', () => {
-    expect(signup).toContain('isProdDeploy');
+  test('signup page reframes as "join the waitlist" across the prod family (prod + beta)', () => {
+    // KAN-326: sign-up framing keys off isProdFamily() (prod OR beta), not
+    // isProdDeploy() (prod only), so the copy matches the waitlist gate beta also
+    // enforces — beta now shows "join the waitlist" instead of "Create account".
+    expect(signup).toContain('isProdFamily');
     expect(signup).toContain('Join the Lyra waitlist');
     expect(signup).toContain('Join the waitlist');
-    // Default copy preserved for the non-prod path.
+    // Default copy preserved for the non-prod-family path (dev/stage without the flag).
     expect(signup).toContain('Create your profile');
     expect(signup).toContain('Create account');
   });


### PR DESCRIPTION
## KAN-326 — beta sign-up framing matches the gate

### Problem (owner-reported)
On beta, `/signup` showed **"Create account"** product framing, so it looked like open signup. But the **waitlist gate is enforced** on beta — a no-code beta signup lands on `/waitlist` (verified live: `ben+betagate@…` → `user_status='waitlist'`, "You're on the list"). The framing keyed off `isProdDeploy()` (prod only) while the gate keys off `isProdFamily()` (prod **+ beta**), so copy and gate had drifted.

### Fix
- **`src/app/(auth)/signup/page.tsx`**: key the waitlist framing off **`isProdFamily()`** so beta's sign-up reads **"Join the Lyra waitlist"**, matching the gate it already enforces. Framing can no longer drift from the gate on the prod family.
- **Homepage left on `isProdDeploy()` deliberately**: beta keeps the **product showcase** homepage so the curated "A few people to meet" examples stay visible (the Q1 seed). Only the *sign-up* surface is waitlist-framed on beta. This asymmetry is intentional and documented in-code.

### Tests
`tests/unit/homepage-content.test.js` signup assertion updated `isProdDeploy → isProdFamily` (**intentional, owner-approved** behaviour change per the Test Integrity Policy). tsc clean; framing tests 23/23; 200 auth/beta/waitlist unit tests green.

### Not a security bug
The gate was always working — this only corrects the **copy**. No change to auth routing, `isProdDeploy()`, or the gate itself.

MCP coverage: N/A (UI framing, no data surface).

🤖 Generated with [Claude Code](https://claude.com/claude-code)