### PR TITLE
refactor(KAN-326 Phase C): drop the legacy access-state columns (access_stage/early_access/is_beta_eligible/beta_access_status)

### DIFF
--- a/src/app/admin/beta-queue/actions.ts
+++ b/src/app/admin/beta-queue/actions.ts
@@ -7,8 +7,8 @@ import { sendBetaApprovedEmail } from '@/lib/beta-access/email';
 /**
  * KAN-277 (epic KAN-273): approve a queued user into the beta.
  *
- * Admin-gated (getCurrentAdmin). Sets beta_access_status='approved' +
- * is_beta_eligible=true + beta_approved_at via the service-role client (which
+ * Admin-gated (getCurrentAdmin). Sets user_status='live' + access_tier='beta'
+ * (+ the beta_approved_at audit timestamp) via the service-role client (which
  * passes the admin-only trigger from 20260620120100_beta_access_lockdown.sql),
  * audit-logs a 'grant_beta_access' moderation action, then emails the user a
  * "you're in" link (best-effort — degrades gracefully without RESEND_API_KEY).
@@ -31,8 +31,6 @@ export async function approveBetaUser(formData: FormData): Promise<void> {
     .update({
       user_status: 'live',
       access_tier: 'beta',
-      beta_access_status: 'approved',
-      is_beta_eligible: true,
       beta_approved_at: new Date().toISOString(),
     })
     .eq('id', profileId);

--- a/src/app/admin/monitoring/page.tsx
+++ b/src/app/admin/monitoring/page.tsx
@@ -32,9 +32,9 @@ async function getCounts() {
   const svc = getAdminServiceClient();
   const sevenDaysAgo = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000).toISOString();
   const [waitlist, beta, live, suspended, pendingReports, flags7d, admins, total] = await Promise.all([
-    svc.from('profiles').select('id', { count: 'exact', head: true }).eq('access_stage', 'waitlist'),
-    svc.from('profiles').select('id', { count: 'exact', head: true }).eq('access_stage', 'beta'),
-    svc.from('profiles').select('id', { count: 'exact', head: true }).eq('access_stage', 'live'),
+    svc.from('profiles').select('id', { count: 'exact', head: true }).eq('user_status', 'waitlist'),
+    svc.from('profiles').select('id', { count: 'exact', head: true }).eq('user_status', 'live').eq('access_tier', 'beta'),
+    svc.from('profiles').select('id', { count: 'exact', head: true }).eq('user_status', 'live').eq('access_tier', 'prod'),
     svc.from('profiles').select('id', { count: 'exact', head: true }).eq('is_suspended', true),
     svc.from('reports').select('id', { count: 'exact', head: true }).eq('status', 'pending'),
     svc.from('content_moderation_flags').select('id', { count: 'exact', head: true }).gte('created_at', sevenDaysAgo),

--- a/src/app/admin/users/BulkBar.tsx
+++ b/src/app/admin/users/BulkBar.tsx
@@ -32,9 +32,6 @@ export interface BulkUserRow {
   is_suspended: boolean;
   is_admin: boolean;
   has_revoked_ga_feature: boolean;
-  // legacy columns still returned during the transition; not rendered.
-  access_stage?: 'waitlist' | 'beta' | 'live';
-  early_access?: boolean;
 }
 
 function actionLabel(value: string): string {

--- a/src/app/admin/users/page.tsx
+++ b/src/app/admin/users/page.tsx
@@ -60,9 +60,9 @@ async function listUsers(filter: UserFilter, page: number): Promise<{ rows: Bulk
 async function stageCounts(): Promise<{ waitlist: number; beta: number; live: number; suspended: number }> {
   const svc = getAdminServiceClient();
   const [waitlist, beta, live, suspended] = await Promise.all([
-    svc.from('profiles').select('id', { count: 'exact', head: true }).eq('access_stage', 'waitlist'),
-    svc.from('profiles').select('id', { count: 'exact', head: true }).eq('access_stage', 'beta'),
-    svc.from('profiles').select('id', { count: 'exact', head: true }).eq('access_stage', 'live'),
+    svc.from('profiles').select('id', { count: 'exact', head: true }).eq('user_status', 'waitlist'),
+    svc.from('profiles').select('id', { count: 'exact', head: true }).eq('user_status', 'live').eq('access_tier', 'beta'),
+    svc.from('profiles').select('id', { count: 'exact', head: true }).eq('user_status', 'live').eq('access_tier', 'prod'),
     svc.from('profiles').select('id', { count: 'exact', head: true }).eq('is_suspended', true),
   ]);
   return {

--- a/src/app/admin/users/users-actions-shared.ts
+++ b/src/app/admin/users/users-actions-shared.ts
@@ -57,11 +57,11 @@ export interface AccessTransition {
 /**
  * Map a bulk action onto the concrete column changes + audit action.
  *
- * KAN-326: the clean axes (user_status, access_tier) are the source of truth.
- * The legacy columns (access_stage, early_access, is_beta_eligible,
- * beta_access_status) are written together in lockstep until they're dropped in
- * the follow-up migration, so the model and the gate can never drift. `now` and
- * `reason` are passed in to keep this function pure (no Date.now / no I/O).
+ * KAN-326: the clean axes (user_status, access_tier) are the SOLE source of
+ * truth. The legacy state columns (access_stage, early_access, is_beta_eligible,
+ * beta_access_status) were dropped in Phase C — this function no longer writes
+ * them. `beta_approved_at` / `beta_requested_at` are kept as audit timestamps.
+ * `now` and `reason` are passed in to keep this function pure (no Date.now / no I/O).
  */
 export function computeAccessTransition(
   action: BulkAction,
@@ -73,10 +73,6 @@ export function computeAccessTransition(
         update: {
           user_status: 'live',
           access_tier: 'beta',
-          access_stage: 'beta',
-          early_access: true,
-          is_beta_eligible: true,
-          beta_access_status: 'approved',
           beta_approved_at: opts.now,
         },
         moderationAction: 'enable_beta',
@@ -87,10 +83,6 @@ export function computeAccessTransition(
         update: {
           user_status: 'waitlist',
           access_tier: 'beta',
-          access_stage: 'waitlist',
-          early_access: false,
-          is_beta_eligible: false,
-          beta_access_status: 'none',
           beta_approved_at: null,
         },
         moderationAction: 'disable_beta',
@@ -101,25 +93,20 @@ export function computeAccessTransition(
         update: {
           user_status: 'live',
           access_tier: 'prod',
-          access_stage: 'live',
-          early_access: true,
-          is_beta_eligible: true,
-          beta_access_status: 'approved',
         },
         moderationAction: 'promote_live',
         sendApprovalEmail: true,
       };
     case 'promote_live_no_beta':
       return {
+        // KAN-326 Phase C: with the legacy early_access flag dropped, "with" vs
+        // "without beta features" no longer differs at the column level — both
+        // set access_tier='prod'. Experimental-feature access for a prod-tier
+        // user is now an explicit feature_entitlements grant (KAN-328), not a
+        // profile column. The two actions still differ in the approval email.
         update: {
           user_status: 'live',
           access_tier: 'prod',
-          access_stage: 'live',
-          early_access: false,
-          // Still beta-eligible so the launched user passes the enforced gate;
-          // early_access=false is the "no experimental features" switch.
-          is_beta_eligible: true,
-          beta_access_status: 'approved',
         },
         moderationAction: 'promote_live',
         sendApprovalEmail: false,

--- a/src/app/waitlist/page.tsx
+++ b/src/app/waitlist/page.tsx
@@ -7,10 +7,10 @@ import { createClient } from '@/lib/supabase-server';
  * KAN-175: beta waitlist landing page.
  *
  * Reached via the middleware redirect when an authenticated user visits any
- * page on `beta.checklyra.com` (i.e. IS_BETA_DEPLOY=true) but does not have
- * `is_beta_eligible = true` on their profile.
+ * page on `beta.checklyra.com` (i.e. IS_BETA_DEPLOY=true) but is not yet a live
+ * beta user (`user_status !== 'live'`).
  *
- * If the user is already beta-eligible (e.g. they navigated here directly),
+ * If the user is already a live beta user (e.g. they navigated here directly),
  * we send them back to the dashboard instead of showing the waitlist UI.
  *
  * If the user is not signed in, we just show the public-facing waitlist

--- a/src/lib/admin.ts
+++ b/src/lib/admin.ts
@@ -48,9 +48,9 @@ export type ModerationAction =
   | 'revoke_admin'
   | 'grant_beta_access' // KAN-273: approve a queued user into the beta
   // KAN-309: two-axis access model transitions from the user-management console
-  | 'enable_beta' // waitlist -> beta (also sets is_beta_eligible=true)
-  | 'disable_beta' // beta -> waitlist (revokes is_beta_eligible)
-  | 'promote_live' // promote to the launched product (± early_access)
+  | 'enable_beta' // waitlist -> beta (user_status=live, access_tier=beta)
+  | 'disable_beta' // beta -> waitlist (user_status=waitlist, access_tier=beta)
+  | 'promote_live' // promote to the launched product (user_status=live, access_tier=prod)
   // KAN-309 follow-on: per-user feature entitlement toggles
   | 'enable_feature'
   | 'disable_feature'

--- a/src/lib/beta-access/flow.ts
+++ b/src/lib/beta-access/flow.ts
@@ -92,7 +92,7 @@ export async function resolveBetaAccess(user: {
 
     const { data: profile } = await svc
       .from('profiles')
-      .select('user_status, access_tier, beta_access_status, display_name')
+      .select('user_status, access_tier, display_name, beta_requested_at')
       .eq('user_id', user.id)
       .maybeSingle();
 
@@ -123,20 +123,20 @@ export async function resolveBetaAccess(user: {
       }
     }
 
-    // Brand-new signup: record the request once + notify the admin. We key the
-    // idempotent transition + the one-shot notice off the legacy
-    // beta_access_status (kept in sync until the legacy columns are dropped).
-    const legacyStatus = profile?.beta_access_status as string | undefined;
-    if (legacyStatus === undefined || legacyStatus === 'none') {
+    // Brand-new signup: record the request once + notify the admin. KAN-326
+    // Phase C — the legacy beta_access_status column is gone; we key the one-shot
+    // notice off the beta_requested_at audit timestamp being null, so the
+    // first-request transition stays atomic + idempotent (the .is(null) guard
+    // means a concurrent/retried call updates 0 rows and won't re-notify).
+    if (!profile?.beta_requested_at) {
       const { data: updated } = await svc
         .from('profiles')
         .update({
           user_status: 'waitlist',
-          beta_access_status: 'requested',
           beta_requested_at: new Date().toISOString(),
         })
         .eq('user_id', user.id)
-        .eq('beta_access_status', 'none') // idempotent: only the none->requested transition
+        .is('beta_requested_at', null) // idempotent: only the first request notifies
         .select('user_id');
 
       if (updated && updated.length > 0) {

--- a/supabase/migrations/20260628190000_kan326_phase_c_drop_legacy_access_cols.sql
+++ b/supabase/migrations/20260628190000_kan326_phase_c_drop_legacy_access_cols.sql
@@ -1,0 +1,176 @@
+-- KAN-326 Phase C — drop the redundant legacy access-state columns.
+--
+-- user_status + access_tier are the SOLE source of truth for the access model.
+-- The four legacy state columns (access_stage, early_access, is_beta_eligible,
+-- beta_access_status) duplicated that state and were written in lockstep; the
+-- web app (computeAccessTransition, beta-queue approve, resolveBetaAccess, admin
+-- pages) no longer reads or writes them. This migration re-points the three DB
+-- objects that still referenced them, then drops the columns.
+--
+-- KEPT: beta_requested_at / beta_approved_at — these are audit timestamps, not
+-- redundant state. resolveBetaAccess now keys the one-shot waitlist notice off
+-- beta_requested_at IS NULL.
+--
+-- Order matters: rewrite the functions FIRST (so nothing references the columns),
+-- THEN drop the columns. The two indexes (profiles_access_stage_idx,
+-- profiles_beta_access_requested_idx) and the column defaults cascade with DROP
+-- COLUMN. CREATE OR REPLACE preserves each function's existing ACL, so the SEC-29
+-- EXECUTE revoke on the admin RPCs is retained.
+--
+-- Rollback: re-add the columns nullable, backfill from user_status/access_tier
+--   (waitlist→access_stage='waitlist'; live+beta→'beta'; live+prod→'live'), and
+--   restore the prior function bodies from git history.
+
+-- ── 1. Self-elevation guard: drop the 4 legacy-col checks (user_status /
+--       access_tier / age_status / the audit timestamps stay guarded). ─────────
+create or replace function public.prevent_beta_self_elevation()
+ returns trigger
+ language plpgsql
+ security definer
+ set search_path to 'public', 'pg_temp'
+as $function$
+begin
+  if auth.uid() is null then
+    return new;
+  end if;
+
+  if new.beta_requested_at is distinct from old.beta_requested_at
+  or new.beta_approved_at  is distinct from old.beta_approved_at
+  or new.user_status       is distinct from old.user_status
+  or new.access_tier       is distinct from old.access_tier
+  or new.age_status        is distinct from old.age_status then
+    raise exception 'access-control columns are admin-only (KAN-273 / KAN-309 / KAN-319 / status-model)'
+      using errcode = '42501';
+  end if;
+
+  return new;
+end;
+$function$;
+
+-- ── 2. admin_list_users: remap the p_stage filter to user_status/access_tier,
+--       make p_early a no-op (signature kept), drop legacy cols from the JSON. ──
+create or replace function public.admin_list_users(p_search text default null::text, p_stage text default null::text, p_early boolean default null::boolean, p_suspended boolean default null::boolean, p_admin boolean default null::boolean, p_limit integer default 20, p_offset integer default 0)
+ returns json
+ language plpgsql
+ security definer
+ set search_path to 'public', 'pg_temp'
+as $function$
+declare
+  v_total  bigint;
+  v_rows   json;
+  v_limit  int  := least(greatest(coalesce(p_limit, 20), 1), 100);
+  v_offset int  := greatest(coalesce(p_offset, 0), 0);
+  v_search text := nullif(btrim(coalesce(p_search, '')), '');
+begin
+  if not exists (
+    select 1 from public.profiles
+     where user_id = auth.uid() and is_admin = true
+  ) then
+    raise exception 'admin only' using errcode = '42501';
+  end if;
+
+  select count(*) into v_total
+    from public.profiles p
+    join auth.users u on u.id = p.user_id
+   where (v_search is null
+          or u.email          ilike '%' || v_search || '%'
+          or p.display_name   ilike '%' || v_search || '%'
+          or p.slug           ilike '%' || v_search || '%')
+     and (p_stage is null
+          or (p_stage = 'waitlist' and p.user_status = 'waitlist')
+          or (p_stage = 'beta'     and p.user_status = 'live' and p.access_tier = 'beta')
+          or (p_stage = 'live'     and p.user_status = 'live' and p.access_tier = 'prod'))
+     -- p_early kept for signature compatibility; early_access dropped (Phase C) → no-op
+     and (p_suspended is null or p.is_suspended = p_suspended)
+     and (p_admin     is null or p.is_admin     = p_admin);
+
+  select coalesce(json_agg(r), '[]'::json) into v_rows
+    from (
+      select p.id,
+             p.user_id,
+             u.email,
+             p.display_name,
+             p.slug,
+             p.created_at,
+             p.user_status,
+             p.access_tier,
+             p.is_published,
+             p.age_status,
+             p.beta_requested_at,
+             p.beta_approved_at,
+             p.is_suspended,
+             p.is_admin,
+             exists (
+               select 1 from public.feature_entitlements fe
+                where fe.profile_id = p.id
+                  and fe.enabled = false
+                  and fe.feature_key in ('media_uploads', 'discovery')
+             ) as has_revoked_ga_feature
+        from public.profiles p
+        join auth.users u on u.id = p.user_id
+       where (v_search is null
+              or u.email        ilike '%' || v_search || '%'
+              or p.display_name ilike '%' || v_search || '%'
+              or p.slug         ilike '%' || v_search || '%')
+         and (p_stage is null
+              or (p_stage = 'waitlist' and p.user_status = 'waitlist')
+              or (p_stage = 'beta'     and p.user_status = 'live' and p.access_tier = 'beta')
+              or (p_stage = 'live'     and p.user_status = 'live' and p.access_tier = 'prod'))
+         and (p_suspended is null or p.is_suspended = p_suspended)
+         and (p_admin     is null or p.is_admin     = p_admin)
+       order by p.created_at desc
+       limit v_limit offset v_offset
+    ) r;
+
+  return json_build_object('rows', v_rows, 'total', v_total);
+end;
+$function$;
+
+-- ── 3. admin_filter_profile_ids: same p_stage remap, p_early no-op. ───────────
+create or replace function public.admin_filter_profile_ids(p_search text default null::text, p_stage text default null::text, p_early boolean default null::boolean, p_suspended boolean default null::boolean, p_admin boolean default null::boolean, p_cap integer default 500)
+ returns uuid[]
+ language plpgsql
+ security definer
+ set search_path to 'public', 'pg_temp'
+as $function$
+declare
+  v_ids    uuid[];
+  v_cap    int  := least(greatest(coalesce(p_cap, 500), 1), 1000);
+  v_search text := nullif(btrim(coalesce(p_search, '')), '');
+begin
+  if not exists (
+    select 1 from public.profiles
+     where user_id = auth.uid() and is_admin = true
+  ) then
+    raise exception 'admin only' using errcode = '42501';
+  end if;
+
+  select array_agg(id) into v_ids
+    from (
+      select p.id
+        from public.profiles p
+        join auth.users u on u.id = p.user_id
+       where (v_search is null
+              or u.email        ilike '%' || v_search || '%'
+              or p.display_name ilike '%' || v_search || '%'
+              or p.slug         ilike '%' || v_search || '%')
+         and (p_stage is null
+              or (p_stage = 'waitlist' and p.user_status = 'waitlist')
+              or (p_stage = 'beta'     and p.user_status = 'live' and p.access_tier = 'beta')
+              or (p_stage = 'live'     and p.user_status = 'live' and p.access_tier = 'prod'))
+         and (p_suspended is null or p.is_suspended = p_suspended)
+         and (p_admin     is null or p.is_admin     = p_admin)
+       order by p.created_at desc
+       limit v_cap
+    ) s;
+
+  return coalesce(v_ids, array[]::uuid[]);
+end;
+$function$;
+
+-- ── 4. Drop the redundant legacy state columns (indexes + defaults cascade). ──
+alter table public.profiles
+  drop column if exists access_stage,
+  drop column if exists early_access,
+  drop column if exists is_beta_eligible,
+  drop column if exists beta_access_status;

--- a/tests/unit/access-model-transitions.test.ts
+++ b/tests/unit/access-model-transitions.test.ts
@@ -11,61 +11,57 @@ import {
 
 const NOW = '2026-06-22T00:00:00.000Z';
 
-describe('computeAccessTransition (KAN-309)', () => {
-  it('enable_beta sets both axes + the enforced gate + approved, and emails', () => {
+// KAN-326 Phase C: the legacy state columns (access_stage, early_access,
+// is_beta_eligible, beta_access_status) were dropped — computeAccessTransition
+// must never write them again. user_status + access_tier are the sole truth.
+const LEGACY_COLS = ['access_stage', 'early_access', 'is_beta_eligible', 'beta_access_status'] as const;
+function expectNoLegacyCols(update: Record<string, unknown>) {
+  for (const col of LEGACY_COLS) expect(update).not.toHaveProperty(col);
+}
+
+describe('computeAccessTransition (KAN-309 / KAN-326)', () => {
+  it('enable_beta sets the new axes + approved-at, writes NO legacy cols, and emails', () => {
     const t = computeAccessTransition('enable_beta', { now: NOW });
     expect(t.update).toMatchObject({
       user_status: 'live',
       access_tier: 'beta',
-      access_stage: 'beta',
-      early_access: true,
-      is_beta_eligible: true,
-      beta_access_status: 'approved',
       beta_approved_at: NOW,
     });
+    expectNoLegacyCols(t.update);
     expect(t.moderationAction).toBe('enable_beta');
     expect(t.sendApprovalEmail).toBe(true);
   });
 
-  it('disable_beta revokes the gate, returns to waitlist, clears approval, no email', () => {
+  it('disable_beta returns to waitlist, clears approval, NO legacy cols, no email', () => {
     const t = computeAccessTransition('disable_beta', { now: NOW });
     expect(t.update).toMatchObject({
       user_status: 'waitlist',
       access_tier: 'beta',
-      access_stage: 'waitlist',
-      early_access: false,
-      is_beta_eligible: false,
-      beta_access_status: 'none',
       beta_approved_at: null,
     });
+    expectNoLegacyCols(t.update);
     expect(t.moderationAction).toBe('disable_beta');
     expect(t.sendApprovalEmail).toBe(false);
   });
 
-  it('promote_live_with_beta → live, early access on, stays beta-eligible, emails', () => {
+  it('promote_live_with_beta → live/prod, NO legacy cols, emails', () => {
     const t = computeAccessTransition('promote_live_with_beta', { now: NOW });
     expect(t.update).toMatchObject({
       user_status: 'live',
       access_tier: 'prod',
-      access_stage: 'live',
-      early_access: true,
-      is_beta_eligible: true,
-      beta_access_status: 'approved',
     });
+    expectNoLegacyCols(t.update);
     expect(t.moderationAction).toBe('promote_live');
     expect(t.sendApprovalEmail).toBe(true);
   });
 
-  it('promote_live_no_beta → live, early access OFF, still beta-eligible, no email', () => {
+  it('promote_live_no_beta → live/prod, NO legacy cols, no email', () => {
     const t = computeAccessTransition('promote_live_no_beta', { now: NOW });
     expect(t.update).toMatchObject({
       user_status: 'live',
       access_tier: 'prod',
-      access_stage: 'live',
-      early_access: false,
-      is_beta_eligible: true,
-      beta_access_status: 'approved',
     });
+    expectNoLegacyCols(t.update);
     expect(t.moderationAction).toBe('promote_live');
     expect(t.sendApprovalEmail).toBe(false);
   });

--- a/tests/unit/beta-access-resolve.test.ts
+++ b/tests/unit/beta-access-resolve.test.ts
@@ -39,8 +39,8 @@ jest.mock('@supabase/supabase-js', () => ({
           eq: () => ({
             // grant path: `await svc.from().update().eq()` resolves here
             then: (resolve: (v: unknown) => void) => resolve({ data: null }),
-            // waitlist path: `.eq().eq().select()`
-            eq: () => ({ select: () => Promise.resolve({ data: mockWaitlistUpdated }) }),
+            // waitlist path: `.eq().is().select()` (idempotent on beta_requested_at IS NULL)
+            is: () => ({ select: () => Promise.resolve({ data: mockWaitlistUpdated }) }),
           }),
         };
       },
@@ -64,7 +64,7 @@ beforeEach(() => {
   mockProfile = {
     user_status: 'waitlist',
     access_tier: 'beta',
-    beta_access_status: 'none',
+    beta_requested_at: null,
     display_name: 'A',
   };
   mockUserMetadata = {};
@@ -85,11 +85,11 @@ describe('KAN-336: resolveBetaAccess invite-code grant', () => {
     expect(updateSpy.mock.calls[0][0]).toMatchObject({
       user_status: 'live',
       access_tier: 'beta',
-      access_stage: 'beta',
-      early_access: true,
-      is_beta_eligible: true,
-      beta_access_status: 'approved',
     });
+    // KAN-326 Phase C: the grant writes only the new axes (+ audit ts), no legacy cols.
+    for (const col of ['access_stage', 'early_access', 'is_beta_eligible', 'beta_access_status']) {
+      expect(updateSpy.mock.calls[0][0]).not.toHaveProperty(col);
+    }
     // No waitlist queue notice for a self-redeemed code.
     expect(mockSendBetaQueueNotice).not.toHaveBeenCalled();
   });
@@ -104,7 +104,7 @@ describe('KAN-336: resolveBetaAccess invite-code grant', () => {
     expect(updateSpy).toHaveBeenCalledTimes(1);
     expect(updateSpy.mock.calls[0][0]).toMatchObject({
       user_status: 'waitlist',
-      beta_access_status: 'requested',
+      beta_requested_at: expect.any(String),
     });
     expect(mockSendBetaQueueNotice).toHaveBeenCalled();
   });
@@ -117,12 +117,12 @@ describe('KAN-336: resolveBetaAccess invite-code grant', () => {
 
     expect(result).toEqual({ userStatus: 'waitlist', accessTier: 'beta' });
     expect(getUserByIdSpy).not.toHaveBeenCalled();
-    expect(updateSpy.mock.calls[0][0]).toMatchObject({ beta_access_status: 'requested' });
+    expect(updateSpy.mock.calls[0][0]).toMatchObject({ user_status: 'waitlist', beta_requested_at: expect.any(String) });
   });
 
   it('is a no-op for an already-live user (no grant, no waitlist write)', async () => {
     mockInviteCode = 'SECRET-123';
-    mockProfile = { user_status: 'live', access_tier: 'beta', beta_access_status: 'approved' };
+    mockProfile = { user_status: 'live', access_tier: 'beta' };
     mockUserMetadata = { invite_code: 'SECRET-123' };
 
     const result = await resolveBetaAccess({ id: 'u1', email: 'a@b.com' });


### PR DESCRIPTION
## KAN-326 Phase C — drop the redundant legacy access-state columns

Closes out KAN-326: `user_status` + `access_tier` become the **sole** source of truth. The 4 legacy state columns written in lockstep — `access_stage`, `early_access`, `is_beta_eligible`, `beta_access_status` — are removed from the code and dropped via migration. The `beta_*_at` timestamps are **kept** as audit data.

### Web (8 files)
- `computeAccessTransition` + beta-queue approve: stop writing the 4 legacy cols.
- `resolveBetaAccess`: re-key the one-shot waitlist notice off **`beta_requested_at IS NULL`** (was `beta_access_status` none→requested) — still atomic + idempotent.
- admin monitoring/users counts: count by `user_status`/`access_tier`.
- BulkBar type, lib + waitlist comments: drop legacy references.

### DB — migration `20260628190000`
- **`prevent_beta_self_elevation`**: drop the 4 legacy-col checks; `user_status`/`access_tier`/`age_status` + the audit timestamps **stay guarded** → the self-elevation boundary is fully intact.
- **`admin_list_users` / `admin_filter_profile_ids`**: remap the `p_stage` filter to `user_status`/`access_tier`, `p_early` becomes a no-op (signature kept), drop the legacy cols from the returned JSON. `CREATE OR REPLACE` preserves the SEC-29 EXECUTE revoke.
- `ALTER TABLE ... DROP COLUMN` ×4 (indexes + defaults cascade).

### Rollout (code-before-drop, per env)
The refactored code is forward-compatible with the columns still present, so it can promote all the way to prod safely; the **column DROP is applied per-env after that env's code deploys**, prod-lyra last (the irreversible step). Sequence: merge → deploy/promote each env → `apply_migration` to dev-lyra → staging-lyra → prod-lyra.

### Verification
tsc clean; **1813 unit tests green** — the access-model + beta-access suites were rewritten to assert the legacy cols are **no longer written** (intentional, owner-approved per the "drop everywhere now" decision).

MCP coverage: N/A (access model is server/admin-internal).

🤖 Generated with [Claude Code](https://claude.com/claude-code)