### PR TITLE
feat(waitlist): skip-the-waitlist code entry for OAuth signups (KAN-336) + admin RPC grant (BUGS-60)

### DIFF
--- a/src/app/waitlist/actions.ts
+++ b/src/app/waitlist/actions.ts
@@ -1,0 +1,49 @@
+'use server';
+
+import { redirect } from 'next/navigation';
+import { createClient as createServiceRoleClient } from '@supabase/supabase-js';
+import { createClient } from '@/lib/supabase-server';
+import { env } from '@/lib/env';
+import { computeAccessTransition } from '@/app/admin/users/users-actions-shared';
+
+/**
+ * KAN-336 — redeem a skip-the-waitlist code from the /waitlist page.
+ *
+ * Google/OAuth signups can't carry an invite code: there's no signup form in
+ * the OAuth flow, so the code from KAN-336's signup field never reaches
+ * resolveBetaAccess and the user always lands on the waitlist. This action lets
+ * an already-authenticated waitlisted user paste the same code to skip the queue.
+ *
+ * The user is already signed in (they reached /waitlist past the auth gate), so
+ * possessing the correct code IS the authorisation. We re-validate the secret
+ * VALUE server-side against env.inviteCode() and grant beta via the service role
+ * (which passes the admin-only prevent_beta_self_elevation trigger) using the
+ * same canonical enable_beta transition as the signup fast-track — so the access
+ * model never drifts between the two entry points.
+ */
+export async function redeemWaitlistCode(formData: FormData): Promise<void> {
+  const code = String(formData.get('invite_code') ?? '').trim();
+
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) {
+    redirect('/login');
+  }
+
+  const configured = env.inviteCode();
+  if (!configured || code !== configured) {
+    // Wrong/blank code (or the feature isn't configured) — back to the waitlist
+    // with a flag so the page can show a gentle "not recognised" message.
+    redirect('/waitlist?error=invalid');
+  }
+
+  const svc = createServiceRoleClient(env.supabaseUrl(), env.supabaseServiceRoleKey());
+  const { update } = computeAccessTransition('enable_beta', {
+    now: new Date().toISOString(),
+  });
+  await svc.from('profiles').update(update).eq('user_id', user.id);
+
+  redirect('/dashboard');
+}

--- a/src/app/waitlist/page.tsx
+++ b/src/app/waitlist/page.tsx
@@ -2,6 +2,8 @@ import Link from 'next/link';
 import Image from 'next/image';
 import { redirect } from 'next/navigation';
 import { createClient } from '@/lib/supabase-server';
+import { env } from '@/lib/env';
+import { redeemWaitlistCode } from './actions';
 
 /**
  * KAN-175: beta waitlist landing page.
@@ -22,7 +24,13 @@ export const metadata = {
   description: 'Thanks for joining the Lyra beta waitlist. We’ll let you in soon.',
 };
 
-export default async function WaitlistPage() {
+export default async function WaitlistPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ error?: string }>;
+}) {
+  const { error } = await searchParams;
+
   // Side door: if a beta-eligible user lands here for some reason, send
   // them home rather than showing the "you're on the waitlist" message.
   const supabase = await createClient();
@@ -40,6 +48,13 @@ export default async function WaitlistPage() {
     }
   }
 
+  // KAN-336 — Google/OAuth signups can't carry an invite code through the
+  // magic-link flow, so they always land here. When the skip-the-waitlist code
+  // is configured (LYRA_INVITE_CODE, set on beta + prod), let an authenticated
+  // waitlisted user paste it to skip the queue. The action re-validates the
+  // code server-side and grants beta via the canonical transition.
+  const showCodeForm = Boolean(env.inviteCode()) && Boolean(user);
+
   return (
     <main className="min-h-screen bg-[var(--color-paper)] flex items-center justify-center px-6 py-12">
       <div className="max-w-md w-full text-center space-y-6">
@@ -55,6 +70,36 @@ export default async function WaitlistPage() {
           Thanks for trying the Lyra beta. Beta access is invite-only while we&rsquo;re polishing things.
           We&rsquo;ll send an email when your account is approved.
         </p>
+
+        {showCodeForm && (
+          <div className="space-y-3 rounded-2xl border border-[var(--color-sage)]/25 bg-white/60 p-5 text-left">
+            <p className="text-sm font-medium text-[var(--color-ink)]">
+              Have a code? Enter it to skip the waitlist.
+            </p>
+            {error === 'invalid' && (
+              <p className="text-sm text-red-700" role="alert">
+                That code wasn&rsquo;t recognised. Check it and try again.
+              </p>
+            )}
+            <form action={redeemWaitlistCode} className="flex gap-2">
+              <input
+                type="text"
+                name="invite_code"
+                required
+                autoComplete="off"
+                placeholder="Enter your code"
+                aria-label="Skip-the-waitlist code"
+                className="flex-1 rounded-full border border-[var(--color-muted)] bg-white px-4 py-2.5 text-sm text-[var(--color-ink)] placeholder:text-[var(--color-muted)] focus:outline-none focus:ring-2 focus:ring-[var(--color-sage)]"
+              />
+              <button
+                type="submit"
+                className="rounded-full bg-[var(--color-sage)] px-5 py-2.5 text-sm font-medium text-white transition-opacity hover:opacity-90"
+              >
+                Enter
+              </button>
+            </form>
+          </div>
+        )}
 
         <p className="text-[var(--color-muted)] leading-relaxed">
           In the meantime, you can use the live site at{' '}

--- a/supabase/migrations/20260628200000_bugs60_grant_admin_rpc_authenticated.sql
+++ b/supabase/migrations/20260628200000_bugs60_grant_admin_rpc_authenticated.sql
@@ -1,0 +1,25 @@
+-- BUGS-60 — restore EXECUTE for `authenticated` on the admin user-list RPCs.
+--
+-- SEC-29 revoked EXECUTE on admin_list_users + admin_filter_profile_ids from
+-- anon, authenticated and PUBLIC. The anon/PUBLIC revoke is correct defence-in-
+-- depth, but revoking `authenticated` broke the admin console: the admin pages
+-- call these SECURITY DEFINER functions via the *authenticated* admin session
+-- (src/app/admin/users/page.tsx, actions.ts), which they MUST — the functions
+-- gate on `auth.uid()` (`... where user_id = auth.uid() and is_admin = true`),
+-- so a service-role call (auth.uid() = null) would fail their own admin check.
+-- Symptom: "Could not load users: permission denied for function admin_list_users".
+--
+-- Granting `authenticated` is safe: the functions self-gate on is_admin, so a
+-- non-admin authenticated caller gets `admin only` (42501), never data. anon and
+-- PUBLIC stay revoked. This migration documents the intended end-state ACL for
+-- fresh DBs (the live grant was applied to dev/staging/prod on 2026-06-28).
+--
+-- Rollback: `revoke execute ... from authenticated` — but that re-breaks the
+-- admin console, so don't, unless the admin pages move to a service-role caller
+-- that injects the admin's JWT.
+
+revoke execute on function public.admin_list_users(text, text, boolean, boolean, boolean, integer, integer) from anon, public;
+revoke execute on function public.admin_filter_profile_ids(text, text, boolean, boolean, boolean, integer) from anon, public;
+
+grant execute on function public.admin_list_users(text, text, boolean, boolean, boolean, integer, integer) to authenticated;
+grant execute on function public.admin_filter_profile_ids(text, text, boolean, boolean, boolean, integer) to authenticated;

--- a/tests/unit/waitlist-redeem.test.ts
+++ b/tests/unit/waitlist-redeem.test.ts
@@ -1,0 +1,112 @@
+/**
+ * KAN-336 — redeemWaitlistCode: skip-the-waitlist code redemption from /waitlist.
+ *
+ * Google/OAuth signups can't carry an invite code through the magic-link flow,
+ * so they always land on the waitlist; this action lets an authenticated
+ * waitlisted user paste the same code to skip the queue. The grant goes through
+ * the service-role client (admin-only trigger) using the canonical enable_beta
+ * transition. We mock the server client, the service-role client, env and
+ * next/navigation's redirect (which throws), and assert each branch.
+ */
+
+let mockInviteCode = '';
+let mockUser: { id: string } | null = { id: 'u1' };
+const updateSpy = jest.fn();
+const eqSpy = jest.fn();
+
+jest.mock('@/lib/env', () => ({
+  env: {
+    supabaseUrl: () => 'https://x.supabase.co',
+    supabaseServiceRoleKey: () => 'svc-key',
+    inviteCode: () => mockInviteCode,
+  },
+}));
+
+jest.mock('@/lib/supabase-server', () => ({
+  createClient: () =>
+    Promise.resolve({
+      auth: { getUser: () => Promise.resolve({ data: { user: mockUser } }) },
+    }),
+}));
+
+jest.mock('@supabase/supabase-js', () => ({
+  createClient: () => ({
+    from: () => ({
+      update: (payload: Record<string, unknown>) => {
+        updateSpy(payload);
+        return {
+          eq: (col: string, val: string) => {
+            eqSpy(col, val);
+            return Promise.resolve({ data: null });
+          },
+        };
+      },
+    }),
+  }),
+}));
+
+class RedirectError extends Error {
+  constructor(public url: string) {
+    super(`REDIRECT:${url}`);
+  }
+}
+jest.mock('next/navigation', () => ({
+  redirect: (url: string) => {
+    throw new RedirectError(url);
+  },
+}));
+
+import { redeemWaitlistCode } from '@/app/waitlist/actions';
+
+function fd(code?: string): FormData {
+  const f = new FormData();
+  if (code !== undefined) f.set('invite_code', code);
+  return f;
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockInviteCode = 'SECRET-123';
+  mockUser = { id: 'u1' };
+});
+
+describe('KAN-336: redeemWaitlistCode', () => {
+  it('grants beta + redirects to /dashboard when the code matches', async () => {
+    await expect(redeemWaitlistCode(fd('SECRET-123'))).rejects.toThrow('REDIRECT:/dashboard');
+    // The canonical enable_beta column set was applied via the service role.
+    expect(updateSpy).toHaveBeenCalledTimes(1);
+    expect(updateSpy.mock.calls[0][0]).toMatchObject({ user_status: 'live', access_tier: 'beta' });
+    // KAN-326 Phase C: no legacy state columns are written.
+    for (const col of ['access_stage', 'early_access', 'is_beta_eligible', 'beta_access_status']) {
+      expect(updateSpy.mock.calls[0][0]).not.toHaveProperty(col);
+    }
+    expect(eqSpy).toHaveBeenCalledWith('user_id', 'u1');
+  });
+
+  it('trims surrounding whitespace before comparing', async () => {
+    await expect(redeemWaitlistCode(fd('  SECRET-123  '))).rejects.toThrow('REDIRECT:/dashboard');
+    expect(updateSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('does NOT grant + redirects with an error when the code is wrong', async () => {
+    await expect(redeemWaitlistCode(fd('WRONG'))).rejects.toThrow('REDIRECT:/waitlist?error=invalid');
+    expect(updateSpy).not.toHaveBeenCalled();
+  });
+
+  it('does NOT grant when the code is blank', async () => {
+    await expect(redeemWaitlistCode(fd(''))).rejects.toThrow('REDIRECT:/waitlist?error=invalid');
+    expect(updateSpy).not.toHaveBeenCalled();
+  });
+
+  it('does NOT grant when no code is configured (feature off)', async () => {
+    mockInviteCode = '';
+    await expect(redeemWaitlistCode(fd('SECRET-123'))).rejects.toThrow('REDIRECT:/waitlist?error=invalid');
+    expect(updateSpy).not.toHaveBeenCalled();
+  });
+
+  it('redirects unauthenticated users to /login without granting', async () => {
+    mockUser = null;
+    await expect(redeemWaitlistCode(fd('SECRET-123'))).rejects.toThrow('REDIRECT:/login');
+    expect(updateSpy).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## KAN-336 — waitlist code entry
Google/OAuth signups can't carry an invite code through the magic-link flow, so they always land on `/waitlist` with no way to use the skip-the-waitlist code. This adds an **env-gated code-entry form** on `/waitlist` (renders on beta + prod where `LYRA_INVITE_CODE` is set, for an authenticated waitlisted user) and a `redeemWaitlistCode` server action that re-validates the secret **value** server-side and grants beta via the canonical `computeAccessTransition('enable_beta')` through the service role — the same mechanism as the signup fast-track, so the two entry points never drift.

## BUGS-60 — admin RPC grant
SEC-29 over-revoked EXECUTE from `authenticated` on `admin_list_users` + `admin_filter_profile_ids`, breaking the admin user-list ("permission denied for function admin_list_users"). The admin pages call these SECURITY DEFINER functions via the **authenticated admin session** (they self-gate on `auth.uid()`+`is_admin`), so `authenticated` must keep EXECUTE; anon/PUBLIC stay revoked. **Already applied live to dev/staging/prod**; migration file is the fresh-DB repro record.

## Security
- Redeem: user already authed past the gate; possessing the correct code is the authorisation; value re-validated server-side; grant is service-role only (passes `prevent_beta_self_elevation`). No code configured → no form, action no-ops to `?error=invalid`.
- Grant: functions self-gate on is_admin, so `authenticated` EXECUTE exposes no data to non-admins.

MCP coverage: N/A (onboarding/auth + admin-only).

## Tests
6 new redeem cases; `tsc` clean; access-model + beta-access suites green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)