### PR TITLE
feat(beta): shareable /join?code= deep-link + dashboard Share beta access (KAN-337)

### DIFF
--- a/docs/TEST_RUNBOOK_SIGNUP_ACCESS_AGE_PUBLISH.md
+++ b/docs/TEST_RUNBOOK_SIGNUP_ACCESS_AGE_PUBLISH.md
@@ -10,7 +10,7 @@
 > Keep it green. A failing case here means a real regression in the gate that
 > protects who gets into the product and who can publish.
 
-**Owner:** Luisa / Ben · **Last updated:** 2026-06-28 · **Tracks:** KAN-326, KAN-336, KAN-334, KAN-282, KAN-273.
+**Owner:** Luisa / Ben · **Last updated:** 2026-06-29 · **Tracks:** KAN-326, KAN-336, KAN-337, KAN-334, KAN-282, KAN-273, SEC-37.
 
 ---
 
@@ -28,6 +28,7 @@ Four **independent** axes per environment — verify each matches this table fir
 | **Homepage** | waitlist landing (`LYRA_FORCE_WAITLIST=true`) | product showcase + "A few people to meet" band | waitlist landing (no band) |
 | **Sign-up framing** | "Join the waitlist" (`LYRA_FORCE_WAITLIST`) | "Join the waitlist" (`isProdFamily`, post-#397) | "Join the waitlist" |
 | **Invite-code field** | hidden (`LYRA_INVITE_CODE` unset) | **shown** (`LYRA_INVITE_CODE` set on beta scope, 2026-06-28) | shown (`LYRA_INVITE_CODE` set) |
+| **Beta-invite deep-link** (KAN-337) | off (no code) | `…/join?code=` works + dashboard "Share beta access" card | same — share link uses `checklyra.com` host |
 | **Homepage examples seeded** | 6 (`@seed`) — not shown (waitlist landing) | 6 (`@seed`) — **shown** in band | 6 (`@seed`) — not shown (waitlist landing) |
 | **`AGE_VERIFICATION_REQUIRED`** | per env (confirm) | `true` | `true` |
 | **MCP** | `mcp-dev.checklyra.com` (dev key) | `mcp.checklyra.com` (prod key) | `mcp.checklyra.com` (prod key) |
@@ -188,6 +189,52 @@ tested once until its account is removed. See **§6 Reset** to clear test accoun
 | **F1** | Adding/authenticating the prod connector shows **"Authenticate your Check Lyra account"** (not a blank `{}` — BUGS-59, via PRM `resource_name`). |
 | **F2** | An authenticated **write** tool succeeds with a valid key; a non-entitled feature (e.g. Convene) is correctly gated off. |
 | **F3** | `mcp.checklyra.com/.well-known/oauth-protected-resource` returns `resource_name:"Check Lyra"`; `…/mcp.json` `build_sha` == `origin/main`. |
+
+---
+
+## 7a. Beta-invite deep-link & dashboard share (KAN-337)
+
+The shareable link `https://checklyra.com/join?code=<LYRA_INVITE_CODE>` skips the
+waitlist for whoever clicks it — for **both** email magic-link and Google sign-up.
+The dashboard shows it as a "Share beta access" card and embeds it in the share
+message. The canonical link uses the **prod host** on the prod family (beta + prod
+share the public front door); dev uses the dev host.
+
+| Case | Steps | Expect |
+|---|---|---|
+| **G1** (link, logged out) | `curl -sI "https://<host>/join?code=<correct>"` | `307` → `Location: …/signup?invited=1`; `Set-Cookie: lyra_invite=<code>; HttpOnly; …; SameSite=lax` |
+| **G1b** (bad/no code) | `curl -sI "https://<host>/join?code=wrong"` and `…/join` | `307` → `…/signup` (no `?invited=1`), **no** `Set-Cookie` |
+| **G2** (email via link) | open `/join?code=<correct>` in a browser → `/signup` shows the green **"You've been invited…"** banner + no waitlist framing → sign up with a fresh `ben+tag@…` → open the magic link | lands in **beta** (dashboard, not `/waitlist`) |
+| **G3** (Google via link) | open `/join?code=<correct>` → **Continue with Google** with a fresh account → consent | lands in **beta** — the cookie carried the code through OAuth → resolveBetaAccess granted |
+| **G4** (dashboard share) | log in as a live beta user → dashboard | a **"Share beta access"** card shows the `…/join?code=…` link + Copy; the "Share Lyra" message CTA is the same link ("skips the waitlist") |
+| **G5** (feature off) | env with `LYRA_INVITE_CODE` unset (e.g. dev) | `/join?code=x` → `/signup`, no cookie, no banner, no dashboard card |
+
+DB check after G2/G3 (expect `live` / `beta`, no waitlist):
+```sql
+select user_status, access_tier from profiles p join auth.users u on u.id=p.user_id
+where u.email='<addr>';
+```
+
+---
+
+## 7b. Admin host isolation activation (SEC-37)
+
+Active once `CF_ACCESS_TEAM_DOMAIN` + `CF_ACCESS_AUD` (+ `ADMIN_HOST_ENFORCED=true`)
+are set on the env. The admin console then lives ONLY on the admin host behind
+Cloudflare Access **and** an in-app JWT verify. Run this 4-/5-layer canary right
+after activation (and on any release touching middleware / `cf-access.ts`):
+
+| Layer | Check | Expect |
+|---|---|---|
+| **H1** (edge) | `curl -sIL https://<admin-host>/` (logged out) | `302` → `…cloudflareaccess.com/cdn-cgi/access/login/<admin-host>?…aud=<AUD>` |
+| **H2** (host serves admin, no bounce) | logged-in admin opens `https://<admin-host>/` | serves the admin console (middleware rewrites `/`→`/admin`, **skips the beta gate** — this is the BUGS-56 "bounce to beta" fix) |
+| **H3** (in-app JWT) | hit the Vercel origin / a `*.vercel.app` preview with `Host: <admin-host>` and **no** CF JWT | **403** `Forbidden: Cloudflare Access required` |
+| **H4** (shared-host redirect) | `curl -sI https://checklyra.com/admin` | `30x` → `https://<admin-host>/admin` — `/admin` is never served on the public host |
+| **H5** (is_admin still applies) | a non-admin who passes CF Access opens the admin host | `/admin` denied/404 — the `is_admin` gate still runs under the CF layer |
+
+Per-env: dev `admin-dev.checklyra.com` (AUD `611d6bf7…`); prod `admin.checklyra.com`
+(AUD `c59e6cee…`), team `checklyra.cloudflareaccess.com`. **Rollback** = unset the
+CF env vars + redeploy → reverts to inert (`/admin` works on every host again).
 
 ---
 

--- a/src/app/(auth)/actions.ts
+++ b/src/app/(auth)/actions.ts
@@ -2,9 +2,10 @@
 
 import { createClient } from '@/lib/supabase-server';
 import { redirect } from 'next/navigation';
-import { headers } from 'next/headers';
+import { headers, cookies } from 'next/headers';
 
 import { env } from '@/lib/env';
+import { INVITE_COOKIE } from '@/lib/beta-access/invite-cookie';
 
 function getSiteUrl() {
   return env.siteUrl();
@@ -26,8 +27,14 @@ export async function signUp(formData: FormData) {
   // here for instant UX feedback, but the AUTHORITATIVE grant is re-checked
   // server-side in resolveBetaAccess at link-confirm time (user_metadata is
   // user-settable). Wrong non-empty code => rejected; empty => waitlist signup.
+  // KAN-337 — a beta-invite deep-link (/join) drops the code in an httpOnly
+  // cookie; fall back to it when the form field is blank so the email path
+  // carries the code through to resolveBetaAccess (a non-empty wrong field still
+  // takes precedence, so an explicit bad code is still rejected below).
   const configuredCode = env.inviteCode();
-  const submittedCode = ((formData.get('invite_code') as string | null) ?? '').trim();
+  const formCode = ((formData.get('invite_code') as string | null) ?? '').trim();
+  const cookieCode = ((await cookies()).get(INVITE_COOKIE)?.value ?? '').trim();
+  const submittedCode = formCode || cookieCode;
   if (configuredCode && submittedCode && submittedCode !== configuredCode) {
     return redirect(
       '/signup?error=' +

--- a/src/app/(auth)/signup/page.tsx
+++ b/src/app/(auth)/signup/page.tsx
@@ -1,9 +1,11 @@
 import Link from 'next/link';
 import Image from 'next/image';
+import { cookies } from 'next/headers';
 import { signUp } from '../actions';
 import { SocialLoginButtons } from '../social-login-buttons';
 import { env } from '@/lib/env';
 import { isProdFamily } from '@/lib/beta-access/flow';
+import { INVITE_COOKIE } from '@/lib/beta-access/invite-cookie';
 
 export const metadata = {
   title: 'Create your Lyra profile',
@@ -13,7 +15,7 @@ export const metadata = {
 export default async function SignUpPage({
   searchParams,
 }: {
-  searchParams: Promise<{ error?: string; message?: string; preview?: string }>;
+  searchParams: Promise<{ error?: string; message?: string; preview?: string; invited?: string }>;
 }) {
   const params = await searchParams;
   // KAN-336 — when a sign-up code is configured, offer it as an OPTIONAL field:
@@ -32,6 +34,13 @@ export default async function SignUpPage({
   // still force the framing on any single-env deploy (e.g. dev). Framing only.
   const waitlist = isProdFamily() || process.env.LYRA_FORCE_WAITLIST === 'true' || params.preview === 'waitlist';
 
+  // KAN-337 — a beta-invite deep-link (/join) sets the invite cookie; when it's
+  // present + valid the visitor is pre-approved for beta, so show the celebratory
+  // banner, carry the code via a hidden field, and drop the waitlist framing.
+  const inviteCookie = (await cookies()).get(INVITE_COOKIE)?.value ?? '';
+  const invited = hasInviteCode && inviteCookie === env.inviteCode();
+  const showWaitlistFraming = waitlist && !invited;
+
   return (
     <main className="min-h-screen flex items-center justify-center px-4">
       <div className="w-full max-w-sm">
@@ -40,16 +49,16 @@ export default async function SignUpPage({
             <Image src="/lyra-logo.png" alt="Lyra" width={48} height={48} className="h-12 w-auto" priority />
           </Link>
           <h1 className="mt-4 text-xl font-medium text-[var(--color-ink)]">
-            {waitlist ? 'Join the Lyra waitlist' : 'Create your profile'}
+            {showWaitlistFraming ? 'Join the Lyra waitlist' : 'Create your profile'}
           </h1>
           <p className="mt-1 text-sm text-[var(--color-muted)]">
-            {waitlist
+            {showWaitlistFraming
               ? "Lyra is opening in stages — sign up and we'll email you when your spot is ready."
               : 'So people in your life never have to guess'}
           </p>
         </div>
 
-        {waitlist && (
+        {showWaitlistFraming && (
           <ol className="mb-6 space-y-1.5 text-xs text-[var(--color-muted)] max-w-xs mx-auto">
             <li>1. Confirm your email with the secure link we send.</li>
             <li>2. You&rsquo;re added to the waitlist queue.</li>
@@ -69,6 +78,13 @@ export default async function SignUpPage({
           </div>
         )}
 
+        {invited && (
+          <div className="mb-4 p-3 rounded-lg bg-green-50 border border-green-200 text-sm text-green-800">
+            🎉 You&rsquo;ve been invited to the Lyra beta — finish signing up below and you&rsquo;ll
+            skip the waitlist and go straight in.
+          </div>
+        )}
+
         <SocialLoginButtons />
 
         <div className="flex items-center gap-3 my-6">
@@ -78,7 +94,11 @@ export default async function SignUpPage({
         </div>
 
         <form className="space-y-4">
-          {hasInviteCode && (
+          {invited ? (
+            // KAN-337 — invited via /join: the code is auto-applied (carried in a
+            // hidden field; the banner above explains it), no manual entry needed.
+            <input type="hidden" name="invite_code" value={inviteCookie} />
+          ) : hasInviteCode ? (
             <div>
               <label htmlFor="invite_code" className="block text-sm font-medium text-[var(--color-ink)] mb-1">
                 Invite code <span className="font-normal text-[var(--color-muted)]">(optional)</span>
@@ -95,7 +115,7 @@ export default async function SignUpPage({
                 Have a code? Enter it to skip the waitlist and go straight in.
               </p>
             </div>
-          )}
+          ) : null}
 
           <div>
             <label htmlFor="full_name" className="block text-sm font-medium text-[var(--color-ink)] mb-1">
@@ -147,7 +167,7 @@ export default async function SignUpPage({
             formAction={signUp}
             className="w-full py-3 rounded-lg bg-[var(--color-sage)] text-white text-base font-medium hover:opacity-90 transition-opacity cursor-pointer"
           >
-            {waitlist ? 'Join the waitlist →' : 'Create account →'}
+            {showWaitlistFraming ? 'Join the waitlist →' : 'Create account →'}
           </button>
         </form>
 

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -4,6 +4,8 @@ import Link from 'next/link';
 import Image from 'next/image';
 import { signOut } from '../(auth)/actions';
 import ShareProfile from './share-profile';
+import ShareBeta from './share-beta';
+import { betaInviteLink } from '@/lib/beta-access/invite-link';
 import { isConveneEnabledForCurrentUser } from '@/lib/convene/flags-user';
 import { canPublishWithAge } from '@/lib/age/gate';
 
@@ -35,6 +37,8 @@ export default async function DashboardPage() {
   const needsAgeCheck = !canPublishWithAge(
     (profile as { age_status?: string | null } | null)?.age_status,
   );
+  // KAN-337 — beta-invite deep-link to share (null unless LYRA_INVITE_CODE is set).
+  const inviteLink = betaInviteLink();
 
   return (
     <main className="min-h-screen">
@@ -158,9 +162,12 @@ export default async function DashboardPage() {
             <ShareProfile
               profileUrl={`${process.env.NEXT_PUBLIC_SITE_URL || 'https://checklyra.com'}/${profile.slug}`}
               displayName={profile.display_name}
+              betaLink={inviteLink}
             />
           )}
         </div>
+
+        {inviteLink && <ShareBeta inviteLink={inviteLink} />}
 
         {conveneEnabled && (
           <div className="bg-white rounded-xl border border-[var(--color-border)] p-6 mt-6">

--- a/src/app/dashboard/share-beta.tsx
+++ b/src/app/dashboard/share-beta.tsx
@@ -1,0 +1,65 @@
+'use client';
+
+import { useState } from 'react';
+
+/**
+ * KAN-337 — standalone "Share beta access" card.
+ *
+ * Shows the beta-invite deep-link (`/join?code=…`) with a one-click copy. The
+ * link carries the skip-the-waitlist code, so anyone the user shares it with
+ * lands on sign-up and goes straight into the beta. Shown on the dashboard only
+ * when LYRA_INVITE_CODE is configured (the parent passes a non-null link).
+ */
+export default function ShareBeta({ inviteLink }: { inviteLink: string }) {
+  const [status, setStatus] = useState<'idle' | 'copied' | 'error'>('idle');
+
+  async function handleCopy() {
+    try {
+      if (typeof navigator !== 'undefined' && navigator.clipboard) {
+        await navigator.clipboard.writeText(inviteLink);
+        setStatus('copied');
+        setTimeout(() => setStatus('idle'), 2000);
+        return;
+      }
+      setStatus('error');
+    } catch {
+      setStatus('error');
+    }
+  }
+
+  return (
+    <div className="bg-white rounded-xl border border-[var(--color-border)] p-6 mt-6">
+      <h3 className="text-lg font-medium text-[var(--color-ink)] mb-1">Share beta access</h3>
+      <p className="text-sm text-[var(--color-muted)] mb-4">
+        Lyra is invite-only right now. Send this link to someone you&rsquo;d like to bring in — it
+        skips the waitlist and drops them straight into the beta.
+      </p>
+
+      <label htmlFor="beta-invite-link" className="sr-only">
+        Beta invite link
+      </label>
+      <div className="flex flex-col sm:flex-row gap-2">
+        <input
+          id="beta-invite-link"
+          type="text"
+          readOnly
+          value={inviteLink}
+          onFocus={(e) => e.currentTarget.select()}
+          className="flex-1 px-3 py-2.5 text-sm rounded-lg border border-[var(--color-border)] bg-[#faf8f4] text-[var(--color-ink)] focus:outline-none focus:ring-2 focus:ring-[var(--color-sage)]"
+        />
+        <button
+          type="button"
+          onClick={handleCopy}
+          className="shrink-0 px-5 py-2.5 rounded-lg bg-[var(--color-sage)] text-white text-sm font-medium hover:opacity-90 transition-opacity"
+        >
+          Copy link
+        </button>
+      </div>
+
+      <span role="status" aria-live="polite" className="mt-2 block text-sm text-[var(--color-muted)]">
+        {status === 'copied' && 'Copied! Paste it into a message.'}
+        {status === 'error' && 'Copy not available — select the link and copy manually.'}
+      </span>
+    </div>
+  );
+}

--- a/src/app/dashboard/share-profile.tsx
+++ b/src/app/dashboard/share-profile.tsx
@@ -24,13 +24,16 @@ import { buildInviteText } from '@/lib/invite-text';
 export default function ShareProfile({
   profileUrl,
   displayName,
+  betaLink,
 }: {
   profileUrl?: string | null;
   displayName?: string | null;
+  betaLink?: string | null;
 }) {
   const initialText = buildInviteText({
     profileUrl,
     greeting: displayName ? `Hi! It's ${displayName}.` : undefined,
+    betaLink,
   });
 
   const [text, setText] = useState(initialText);

--- a/src/app/join/route.ts
+++ b/src/app/join/route.ts
@@ -1,0 +1,34 @@
+import { NextResponse, type NextRequest } from 'next/server';
+import { env } from '@/lib/env';
+import { INVITE_COOKIE, INVITE_COOKIE_MAX_AGE } from '@/lib/beta-access/invite-cookie';
+
+/**
+ * KAN-337 — beta-invite deep-link. `/join?code=<INVITE_CODE>` is the shareable
+ * link beta users hand out. A valid code is stowed in a short-lived httpOnly
+ * cookie (so it survives the Google-OAuth round-trip — resolveBetaAccess reads
+ * it on the callback) and the visitor lands on the sign-up page with the
+ * "you're invited" banner. Sign-up (email or Google) then re-validates the code
+ * server-side and grants beta, skipping the waitlist. An absent/wrong code just
+ * drops the visitor on the normal sign-up page (no cookie, no banner).
+ */
+export async function GET(request: NextRequest) {
+  const url = new URL(request.url);
+  const code = (url.searchParams.get('code') ?? '').trim();
+  const configured = env.inviteCode();
+  const valid = !!configured && code === configured;
+
+  const dest = new URL('/signup', url.origin);
+  if (valid) dest.searchParams.set('invited', '1');
+
+  const res = NextResponse.redirect(dest);
+  if (valid) {
+    res.cookies.set(INVITE_COOKIE, code, {
+      httpOnly: true,
+      secure: process.env.NODE_ENV === 'production',
+      sameSite: 'lax',
+      maxAge: INVITE_COOKIE_MAX_AGE,
+      path: '/',
+    });
+  }
+  return res;
+}

--- a/src/lib/auth/post-login-redirect.ts
+++ b/src/lib/auth/post-login-redirect.ts
@@ -11,8 +11,10 @@
  *
  * Extracted from /auth/callback so /auth/confirm reuses it verbatim (KAN-276/278).
  */
+import { cookies } from 'next/headers';
 import type { createClient } from '@/lib/supabase-server';
 import { resolveBetaAccess, betaRedirectUrl, isProdFamily } from '@/lib/beta-access/flow';
+import { INVITE_COOKIE } from '@/lib/beta-access/invite-cookie';
 
 type ServerClient = Awaited<ReturnType<typeof createClient>>;
 
@@ -34,9 +36,13 @@ export async function resolvePostLoginRedirect(
       next,
     });
   }
-  const { userStatus, accessTier } = await resolveBetaAccess({
-    id: user.id,
-    email: user.email,
-  });
+  // KAN-337 — a beta-invite deep-link (/join) leaves the code in an httpOnly
+  // cookie; for Google OAuth this is the only carrier (no sign-up form), so read
+  // it here and hand it to resolveBetaAccess for server-side re-validation.
+  const carriedCode = (await cookies()).get(INVITE_COOKIE)?.value;
+  const { userStatus, accessTier } = await resolveBetaAccess(
+    { id: user.id, email: user.email },
+    { carriedCode },
+  );
   return betaRedirectUrl({ origin, isProdFamily: isProdFamily(), userStatus, accessTier, next });
 }

--- a/src/lib/beta-access/flow.ts
+++ b/src/lib/beta-access/flow.ts
@@ -83,10 +83,13 @@ export function isProdFamily(e: NodeJS.ProcessEnv = process.env): boolean {
  * service role (admin-only trigger). Defensive: any failure must NOT break
  * sign-in — we log and treat the user as not-approved (→ waitlist).
  */
-export async function resolveBetaAccess(user: {
-  id: string;
-  email?: string | null;
-}): Promise<{ userStatus: UserStatus; accessTier: AccessTier }> {
+export async function resolveBetaAccess(
+  user: {
+    id: string;
+    email?: string | null;
+  },
+  opts?: { carriedCode?: string },
+): Promise<{ userStatus: UserStatus; accessTier: AccessTier }> {
   try {
     const svc = createServiceRoleClient(env.supabaseUrl(), env.supabaseServiceRoleKey());
 
@@ -104,17 +107,26 @@ export async function resolveBetaAccess(user: {
       return { userStatus, accessTier };
     }
 
-    // KAN-336 — fast-track: if this signup carried a valid invite code, grant
-    // beta directly (skip the waitlist). user_metadata is user-settable, so we
-    // re-validate the SECRET VALUE here, server-side, against env.inviteCode().
-    // Possessing the correct code IS the authorisation. Only runs when a code is
-    // configured, so it adds no work on envs without the feature.
+    // KAN-336 / KAN-337 — fast-track: if this signup carried a valid invite code,
+    // grant beta directly (skip the waitlist). The code reaches us two ways, both
+    // re-validated SERVER-SIDE here against env.inviteCode() (possessing the
+    // correct code IS the authorisation):
+    //   • carriedCode — the /join deep-link cookie, read by resolvePostLoginRedirect
+    //     (this is the ONLY carrier that survives the Google-OAuth round-trip), and
+    //   • user_metadata.invite_code — set by the email sign-up form (user-settable,
+    //     hence the re-validation).
+    // Only runs when a code is configured, so it adds no work on envs without it.
     const configuredCode = env.inviteCode();
     if (configuredCode) {
-      const { data: authData } = await svc.auth.admin.getUserById(user.id);
-      const carried =
-        (authData?.user?.user_metadata?.invite_code as string | undefined) ?? '';
-      if (carried && carried === configuredCode) {
+      const carriedCookie = (opts?.carriedCode ?? '').trim();
+      let granted = !!carriedCookie && carriedCookie === configuredCode;
+      if (!granted) {
+        const { data: authData } = await svc.auth.admin.getUserById(user.id);
+        const carried =
+          (authData?.user?.user_metadata?.invite_code as string | undefined) ?? '';
+        granted = !!carried && carried === configuredCode;
+      }
+      if (granted) {
         const { update } = computeAccessTransition('enable_beta', {
           now: new Date().toISOString(),
         });

--- a/src/lib/beta-access/invite-cookie.ts
+++ b/src/lib/beta-access/invite-cookie.ts
@@ -1,0 +1,10 @@
+/**
+ * KAN-337 — beta-invite deep-link cookie name + TTL.
+ *
+ * Kept in a leaf module with NO imports so the auth / sign-up paths
+ * (resolvePostLoginRedirect, signUp, the /join route, the signup page) can
+ * reference the cookie without pulling in the heavier beta-access/flow graph.
+ * The link builder (betaInviteLink) lives in ./invite-link.
+ */
+export const INVITE_COOKIE = 'lyra_invite';
+export const INVITE_COOKIE_MAX_AGE = 60 * 30; // 30 minutes

--- a/src/lib/beta-access/invite-link.ts
+++ b/src/lib/beta-access/invite-link.ts
@@ -1,0 +1,32 @@
+/**
+ * KAN-337 — shareable beta-invite deep-link.
+ *
+ * A beta user shares `https://checklyra.com/join?code=<INVITE_CODE>`. The /join
+ * route validates the code and stows it in a short-lived httpOnly cookie so the
+ * secret survives the Google-OAuth round-trip (resolveBetaAccess reads it on the
+ * callback); the email magic-link path also carries it in user_metadata. Either
+ * way the code is re-validated server-side before any grant — possessing the
+ * link is the authorisation, and it only ever grants BETA.
+ */
+import { env } from '@/lib/env';
+import { isProdFamily } from '@/lib/beta-access/flow';
+
+export { INVITE_COOKIE, INVITE_COOKIE_MAX_AGE } from './invite-cookie';
+
+/** Pure: build the public /join link for a given origin + code. */
+export function buildBetaInviteLink(origin: string, code: string): string {
+  return `${origin.replace(/\/+$/, '')}/join?code=${encodeURIComponent(code)}`;
+}
+
+/**
+ * The public beta-invite link to surface on the dashboard, or null when the
+ * feature is off (no LYRA_INVITE_CODE). Invitees always sign up at the public
+ * front door — checklyra.com on the prod family (beta + prod share it), or the
+ * env's own origin on dev/stage.
+ */
+export function betaInviteLink(): string | null {
+  const code = env.inviteCode();
+  if (!code) return null;
+  const origin = isProdFamily() ? 'https://checklyra.com' : env.siteUrl();
+  return buildBetaInviteLink(origin, code);
+}

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -26,7 +26,10 @@ export const env = {
   // KAN-336 (was KAN-258) — shared OPTIONAL sign-up code. When set, entering it
   // on /signup skips the waitlist and grants beta directly (re-validated
   // server-side in resolveBetaAccess). No code = normal waitlist signup; empty
-  // string = feature off (no code field shown).
-  inviteCode: () => optionalEnv('LYRA_INVITE_CODE', ''),
+  // string = feature off (no code field shown). Trimmed (KAN-337 review) so a
+  // configured code with stray whitespace still matches the trimmed input every
+  // comparison site uses (/join, signup, actions, resolveBetaAccess); a
+  // whitespace-only value collapses to '' = feature off.
+  inviteCode: () => optionalEnv('LYRA_INVITE_CODE', '').trim(),
 };
 // Force rebuild 20260329011858

--- a/src/lib/invite-text.ts
+++ b/src/lib/invite-text.ts
@@ -36,12 +36,17 @@ const SITE_LANDING =
 export function buildInviteText(opts: {
   profileUrl?: string | null;
   greeting?: string;
+  betaLink?: string | null;
 }): string {
   const greeting = (opts.greeting ?? "Hi!").trim();
   const myProfileLine = opts.profileUrl
     ? `Mine's here if you want to take a look: ${opts.profileUrl}`
     : null;
-  const ctaLine = `Here's where you can create yours: ${SITE_LANDING}`;
+  // KAN-337 — when a beta-invite deep-link is available, it becomes the CTA: it
+  // carries the skip-the-waitlist code, so the recipient goes straight in.
+  const ctaLine = opts.betaLink
+    ? `Here's where you can create yours — this link skips the waitlist: ${opts.betaLink}`
+    : `Here's where you can create yours: ${SITE_LANDING}`;
 
   return [
     greeting,

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -194,6 +194,7 @@ export async function middleware(request: NextRequest) {
     pathname === '/status' || // SEC-4: public status page is never beta-gated
     pathname === '/login' ||
     pathname === '/signup' ||
+    pathname === '/join' || // KAN-337: beta-invite deep-link sets a cookie + redirects to /signup
     pathname.startsWith('/auth/') ||
     pathname.startsWith('/_next/') ||
     pathname === '/favicon.ico';

--- a/tests/unit/auth-actions.test.ts
+++ b/tests/unit/auth-actions.test.ts
@@ -9,10 +9,16 @@ jest.mock('next/navigation', () => ({
   redirect: (...args: unknown[]) => { mockRedirect(...args); throw new Error('REDIRECT'); },
 }));
 
-// Mock next/headers
+// Mock next/headers — `headers` for the origin; `cookies` for the KAN-337
+// beta-invite deep-link cookie fallback in signUp (toggled via mockInviteCookie).
+let mockInviteCookie: string | undefined;
 jest.mock('next/headers', () => ({
   headers: jest.fn().mockResolvedValue({
     get: jest.fn().mockReturnValue('https://dev.checklyra.com'),
+  }),
+  cookies: jest.fn().mockResolvedValue({
+    get: (name: string) =>
+      name === 'lyra_invite' && mockInviteCookie ? { value: mockInviteCookie } : undefined,
   }),
 }));
 
@@ -53,6 +59,7 @@ function makeFormData(data: Record<string, string>): FormData {
 beforeEach(() => {
   jest.clearAllMocks();
   mockInviteCode = '';
+  mockInviteCookie = undefined;
 });
 
 describe('KAN-258: signUp action (passwordless)', () => {
@@ -129,6 +136,28 @@ describe('KAN-336: invite code (optional, skip-waitlist)', () => {
     const fd = makeFormData({ email: 'a@b.com', full_name: 'A', invite_code: '  LET-ME-IN  ' });
     await expect(signUp(fd)).rejects.toThrow('REDIRECT');
     expect(mockSignInWithOtp).toHaveBeenCalled();
+  });
+
+  // KAN-337 — beta-invite deep-link: the /join cookie carries the code when the
+  // form field is left blank, so the email path still fast-tracks into beta.
+  test('falls back to the lyra_invite cookie when the form field is blank', async () => {
+    mockInviteCode = 'LET-ME-IN';
+    mockInviteCookie = 'LET-ME-IN';
+    mockSignInWithOtp.mockResolvedValue({ error: null });
+    const fd = makeFormData({ email: 'a@b.com', full_name: 'A' }); // no invite_code field
+    await expect(signUp(fd)).rejects.toThrow('REDIRECT');
+    expect(mockSignInWithOtp.mock.calls[0][0].options.data).toEqual({
+      full_name: 'A',
+      invite_code: 'LET-ME-IN',
+    });
+  });
+
+  test('an explicit wrong form code is still rejected even when a cookie is present', async () => {
+    mockInviteCode = 'LET-ME-IN';
+    mockInviteCookie = 'LET-ME-IN';
+    const fd = makeFormData({ email: 'a@b.com', full_name: 'A', invite_code: 'nope' });
+    await expect(signUp(fd)).rejects.toThrow('REDIRECT');
+    expect(mockSignInWithOtp).not.toHaveBeenCalled();
   });
 });
 

--- a/tests/unit/beta-access-resolve.test.ts
+++ b/tests/unit/beta-access-resolve.test.ts
@@ -131,4 +131,39 @@ describe('KAN-336: resolveBetaAccess invite-code grant', () => {
     expect(updateSpy).not.toHaveBeenCalled();
     expect(getUserByIdSpy).not.toHaveBeenCalled();
   });
+
+  // KAN-337 — the /join deep-link cookie reaches resolveBetaAccess as carriedCode
+  // (the only carrier for Google OAuth, which has no sign-up form / user_metadata).
+  it('KAN-337: grants beta via the carried cookie code, skipping the metadata lookup', async () => {
+    mockInviteCode = 'SECRET-123';
+    mockUserMetadata = {}; // no code in user_metadata — OAuth path
+
+    const result = await resolveBetaAccess(
+      { id: 'u1', email: 'a@b.com' },
+      { carriedCode: 'SECRET-123' },
+    );
+
+    expect(result).toEqual({ userStatus: 'live', accessTier: 'beta' });
+    // The cookie matched first, so the user_metadata lookup is never made.
+    expect(getUserByIdSpy).not.toHaveBeenCalled();
+    expect(updateSpy).toHaveBeenCalledTimes(1);
+    expect(updateSpy.mock.calls[0][0]).toMatchObject({ user_status: 'live', access_tier: 'beta' });
+    for (const col of ['access_stage', 'early_access', 'is_beta_eligible', 'beta_access_status']) {
+      expect(updateSpy.mock.calls[0][0]).not.toHaveProperty(col);
+    }
+  });
+
+  it('KAN-337: a wrong carried cookie code falls through to user_metadata (no grant → waitlist)', async () => {
+    mockInviteCode = 'SECRET-123';
+    mockUserMetadata = { invite_code: 'WRONG' };
+
+    const result = await resolveBetaAccess(
+      { id: 'u1', email: 'a@b.com' },
+      { carriedCode: 'ALSO-WRONG' },
+    );
+
+    expect(result).toEqual({ userStatus: 'waitlist', accessTier: 'beta' });
+    expect(getUserByIdSpy).toHaveBeenCalledWith('u1'); // fell through to the metadata check
+    expect(mockSendBetaQueueNotice).toHaveBeenCalled();
+  });
 });

--- a/tests/unit/env-invite-code.test.ts
+++ b/tests/unit/env-invite-code.test.ts
@@ -1,0 +1,32 @@
+/**
+ * KAN-337 review — env.inviteCode() must trim.
+ *
+ * Every comparison site (/join route, signup page, signUp action,
+ * resolveBetaAccess) trims its input before comparing, so the configured code
+ * must be trimmed too — otherwise a LYRA_INVITE_CODE set with stray whitespace
+ * would silently break the whole beta-invite flow.
+ */
+import { env } from '@/lib/env';
+
+describe('KAN-337: env.inviteCode trimming', () => {
+  const original = process.env.LYRA_INVITE_CODE;
+  afterEach(() => {
+    if (original === undefined) delete process.env.LYRA_INVITE_CODE;
+    else process.env.LYRA_INVITE_CODE = original;
+  });
+
+  it('trims surrounding whitespace from a configured code', () => {
+    process.env.LYRA_INVITE_CODE = '  ABC-123  ';
+    expect(env.inviteCode()).toBe('ABC-123');
+  });
+
+  it('returns empty string (feature off) when unset', () => {
+    delete process.env.LYRA_INVITE_CODE;
+    expect(env.inviteCode()).toBe('');
+  });
+
+  it('collapses a whitespace-only value to empty (feature off)', () => {
+    process.env.LYRA_INVITE_CODE = '   ';
+    expect(env.inviteCode()).toBe('');
+  });
+});

--- a/tests/unit/invite-link.test.ts
+++ b/tests/unit/invite-link.test.ts
@@ -1,0 +1,59 @@
+/**
+ * KAN-337 — betaInviteLink / buildBetaInviteLink.
+ *
+ * The dashboard surfaces a shareable /join deep-link carrying the skip-the-
+ * waitlist code. On the prod family (beta + prod share the public front door)
+ * the link always points at checklyra.com; on dev/stage it uses the env origin;
+ * and it is null when the feature is off (no LYRA_INVITE_CODE).
+ */
+let mockInviteCode = '';
+let mockSiteUrl = 'https://dev.checklyra.com';
+let mockIsProdFamily = false;
+
+jest.mock('@/lib/env', () => ({
+  env: {
+    inviteCode: () => mockInviteCode,
+    siteUrl: () => mockSiteUrl,
+  },
+}));
+jest.mock('@/lib/beta-access/flow', () => ({
+  isProdFamily: () => mockIsProdFamily,
+}));
+
+import { betaInviteLink, buildBetaInviteLink } from '@/lib/beta-access/invite-link';
+
+beforeEach(() => {
+  mockInviteCode = '';
+  mockSiteUrl = 'https://dev.checklyra.com';
+  mockIsProdFamily = false;
+});
+
+describe('KAN-337 buildBetaInviteLink', () => {
+  it('builds a /join link with the URL-encoded code', () => {
+    expect(buildBetaInviteLink('https://checklyra.com', 'LYRA BETA')).toBe(
+      'https://checklyra.com/join?code=LYRA%20BETA',
+    );
+  });
+  it('strips a trailing slash from the origin', () => {
+    expect(buildBetaInviteLink('https://checklyra.com/', 'X')).toBe('https://checklyra.com/join?code=X');
+  });
+});
+
+describe('KAN-337 betaInviteLink', () => {
+  it('returns null when no code is configured (feature off)', () => {
+    mockInviteCode = '';
+    expect(betaInviteLink()).toBeNull();
+  });
+  it('points at checklyra.com on the prod family (beta + prod share the front door)', () => {
+    mockInviteCode = 'ABC123';
+    mockIsProdFamily = true;
+    mockSiteUrl = 'https://beta.checklyra.com';
+    expect(betaInviteLink()).toBe('https://checklyra.com/join?code=ABC123');
+  });
+  it("uses the env's own origin off the prod family (dev/stage)", () => {
+    mockInviteCode = 'ABC123';
+    mockIsProdFamily = false;
+    mockSiteUrl = 'https://dev.checklyra.com';
+    expect(betaInviteLink()).toBe('https://dev.checklyra.com/join?code=ABC123');
+  });
+});

--- a/tests/unit/invite-text.test.ts
+++ b/tests/unit/invite-text.test.ts
@@ -25,6 +25,20 @@ describe('KAN-154-B buildInviteText', () => {
     expect(out).toMatch(/Here['']s where you can create yours: https?:\/\//);
   });
 
+  test('KAN-337: a betaLink becomes the create-yours CTA (skips the waitlist)', () => {
+    const out = buildInviteText({
+      profileUrl: 'https://checklyra.com/luisa',
+      betaLink: 'https://checklyra.com/join?code=ABC',
+    });
+    expect(out).toContain('https://checklyra.com/join?code=ABC');
+    expect(out).toContain('skips the waitlist');
+  });
+
+  test('KAN-337: omits the join link when no betaLink is provided (back-compat)', () => {
+    const out = buildInviteText({ profileUrl: 'https://checklyra.com/luisa' });
+    expect(out).not.toContain('/join?code=');
+  });
+
   test('falls back to default greeting when none is provided', () => {
     const out = buildInviteText({ profileUrl: null });
     // The default opener has to keep working for users who copy the

--- a/tests/unit/join-route.test.ts
+++ b/tests/unit/join-route.test.ts
@@ -1,0 +1,59 @@
+/**
+ * KAN-337 — the /join beta-invite deep-link route.
+ *
+ * A valid code stows the secret in a short-lived httpOnly cookie (so it survives
+ * the Google-OAuth round-trip) and redirects to /signup?invited=1. An absent or
+ * wrong code just lands the visitor on /signup with no cookie and no banner.
+ */
+let mockInviteCode = '';
+jest.mock('@/lib/env', () => ({
+  env: { inviteCode: () => mockInviteCode },
+}));
+
+import { GET } from '@/app/join/route';
+import { NextRequest } from 'next/server';
+
+function call(url: string) {
+  return GET(new NextRequest(url));
+}
+
+beforeEach(() => {
+  mockInviteCode = 'SECRET-123';
+});
+
+describe('KAN-337 /join', () => {
+  it('valid code: sets the httpOnly lyra_invite cookie + redirects to /signup?invited=1', async () => {
+    const res = await call('https://checklyra.com/join?code=SECRET-123');
+    expect(res.status).toBe(307);
+    expect(res.headers.get('location')).toBe('https://checklyra.com/signup?invited=1');
+    expect(res.cookies.get('lyra_invite')?.value).toBe('SECRET-123');
+    const setCookie = res.headers.get('set-cookie') ?? '';
+    expect(setCookie).toMatch(/HttpOnly/i);
+    expect(setCookie).toMatch(/SameSite=lax/i);
+  });
+
+  it('trims surrounding whitespace before comparing', async () => {
+    const res = await call('https://checklyra.com/join?code=' + encodeURIComponent('  SECRET-123  '));
+    expect(res.headers.get('location')).toBe('https://checklyra.com/signup?invited=1');
+    expect(res.cookies.get('lyra_invite')?.value).toBe('SECRET-123');
+  });
+
+  it('wrong code: redirects to /signup with no cookie', async () => {
+    const res = await call('https://checklyra.com/join?code=nope');
+    expect(res.headers.get('location')).toBe('https://checklyra.com/signup');
+    expect(res.cookies.get('lyra_invite')).toBeUndefined();
+  });
+
+  it('no code: redirects to /signup with no cookie', async () => {
+    const res = await call('https://checklyra.com/join');
+    expect(res.headers.get('location')).toBe('https://checklyra.com/signup');
+    expect(res.cookies.get('lyra_invite')).toBeUndefined();
+  });
+
+  it('feature off (no configured code): never sets a cookie', async () => {
+    mockInviteCode = '';
+    const res = await call('https://checklyra.com/join?code=anything');
+    expect(res.headers.get('location')).toBe('https://checklyra.com/signup');
+    expect(res.cookies.get('lyra_invite')).toBeUndefined();
+  });
+});

--- a/tests/unit/post-login-redirect.test.ts
+++ b/tests/unit/post-login-redirect.test.ts
@@ -9,6 +9,7 @@
  */
 
 const mockResolveBetaAccess = jest.fn();
+const mockResolveBetaAccessOpts = jest.fn(); // KAN-337: captures the 2nd (carriedCode) arg
 const mockBetaRedirectUrl = jest.fn((opts?: unknown) => {
   void opts; // accept (and ignore) the opts arg; assertions use toHaveBeenCalledWith
   return 'REDIRECT_RESULT';
@@ -16,9 +17,23 @@ const mockBetaRedirectUrl = jest.fn((opts?: unknown) => {
 const mockIsProdFamily = jest.fn(() => false);
 
 jest.mock('@/lib/beta-access/flow', () => ({
-  resolveBetaAccess: (u: unknown) => mockResolveBetaAccess(u),
+  // The 1st arg still flows to mockResolveBetaAccess (existing assertions
+  // unchanged); the 2nd (carriedCode) is recorded separately for KAN-337.
+  resolveBetaAccess: (u: unknown, o: unknown) => {
+    mockResolveBetaAccessOpts(o);
+    return mockResolveBetaAccess(u);
+  },
   betaRedirectUrl: (o: unknown) => mockBetaRedirectUrl(o),
   isProdFamily: () => mockIsProdFamily(),
+}));
+
+// KAN-337: resolvePostLoginRedirect reads the /join beta-invite cookie.
+let mockInviteCookie: string | undefined;
+jest.mock('next/headers', () => ({
+  cookies: jest.fn().mockResolvedValue({
+    get: (name: string) =>
+      name === 'lyra_invite' && mockInviteCookie ? { value: mockInviteCookie } : undefined,
+  }),
 }));
 
 import { resolvePostLoginRedirect } from '@/lib/auth/post-login-redirect';
@@ -31,6 +46,8 @@ function fakeSupabase(user: unknown): any {
 
 beforeEach(() => {
   mockResolveBetaAccess.mockReset();
+  mockResolveBetaAccessOpts.mockReset();
+  mockInviteCookie = undefined;
   mockBetaRedirectUrl.mockClear();
   mockBetaRedirectUrl.mockReturnValue('REDIRECT_RESULT');
   mockIsProdFamily.mockReset();
@@ -76,5 +93,16 @@ describe('resolvePostLoginRedirect', () => {
     expect(mockBetaRedirectUrl).toHaveBeenCalledWith(
       expect.objectContaining({ isProdFamily: false, userStatus: 'live' }),
     );
+  });
+
+  test('KAN-337: passes the /join beta-invite cookie to resolveBetaAccess as carriedCode', async () => {
+    mockInviteCookie = 'INVITE-XYZ';
+    mockResolveBetaAccess.mockResolvedValue({ userStatus: 'live', accessTier: 'beta' });
+    const supabase = fakeSupabase({ id: 'user-9', email: 'new@example.com' });
+
+    await resolvePostLoginRedirect(supabase, 'https://checklyra.com', '/dashboard');
+
+    expect(mockResolveBetaAccess).toHaveBeenCalledWith({ id: 'user-9', email: 'new@example.com' });
+    expect(mockResolveBetaAccessOpts).toHaveBeenCalledWith({ carriedCode: 'INVITE-XYZ' });
   });
 });


### PR DESCRIPTION
## KAN-337 — shareable beta-invite deep-link
`https://checklyra.com/join?code=<INVITE_CODE>` skips the waitlist for whoever clicks it, for **both** email magic-link and Google OAuth.

- **/join** validates the code, sets a short-lived httpOnly `lyra_invite` cookie (the only carrier that survives the Google-OAuth round-trip), redirects to `/signup?invited=1`.
- **signup page**: green "invited" banner + hidden code + drops the waitlist framing.
- **signUp action**: cookie fallback when the form field is blank (email path → user_metadata).
- **resolveBetaAccess**: new `carriedCode` arg; grants beta via the canonical `computeAccessTransition('enable_beta')` through the service role.
- **dashboard**: standalone "Share beta access" card + the link as the share-message CTA.

## Security
Code is a **shared beta-gate secret by design** (only ever grants BETA). Re-validated server-side on every grant; cookie httpOnly+Secure+SameSite=Lax+30m. `/join`+`/signup` middleware-exempt. Adversarial review run (4 confirmed → 1 fixed: `env.inviteCode()` now trims; 3 rejected with reasoning).

## Tests
+5 new suites/cases (join route, invite-link, env trim, cookie fallback, carriedCode grant). **1775 unit tests green**, tsc clean. Runbook updated (G-cases deep-link, H-cases SEC-37 canary).

MCP coverage: N/A — onboarding/auth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)