### PR TITLE
feat(ux): KAN-349 — dashboard widget journey + postcode→city + gifts de-gate + two-version share

### DIFF
--- a/docs/KAN-349-UX-EPIC-REVIEW.md
+++ b/docs/KAN-349-UX-EPIC-REVIEW.md
@@ -1,0 +1,110 @@
+# KAN-349 UX epic — local build for review (not yet pushed to dev)
+
+**Branch:** `feature/kan-349-ux-dashboard-widgets` (local only — nothing promoted).
+**Built:** 2026-06-30 overnight, autonomously, per "code up everything you can and have it ready locally so we can review questions before finalising and pushing to dev."
+
+The epic was raised from a chat session **without code access**, so several of its
+"unresolved questions" are answered here directly from the codebase.
+
+---
+
+## 1. What's coded vs documented vs blocked
+
+| Ticket | Type | Status tonight | Notes |
+|---|---|---|---|
+| **KAN-340** dashboard widget journey | proposal | **CODED to a proposed spec** (§3 below) | "no build before sign-off" — spec + build done together for review; defaults flagged. |
+| **KAN-343** audit/reconcile | discovery | **DONE** (§4) | I had the repo access the chat session lacked. |
+| **KAN-344** state resolver | build | **CODED + 15 tests** | `src/lib/dashboard/resolve-widgets.ts` (pure). |
+| **KAN-345** dismissal persistence | build | **CODED + 5 tests + migration** | `dismissal.ts`, `widgets/actions.ts`, migration `20260630010000_…`. |
+| **KAN-346** widget framework | build | **CODED** | `widgets/dashboard-widgets.tsx` registry + shell; dashboard refit. |
+| **KAN-347** widgets W1–W6 | build | **CODED** (copy = PROPOSED) | all six render + gate; copy needs your confirm. |
+| **KAN-348** E2E | build | **NOT yet** | needs the dev migration applied + a live user; spec ready. |
+| **KAN-339** postcode removal | build | **documented, not coded** (§5) | needs KAN-153 test sign-off + privacy-policy edit; affiliate-safe (verified). |
+| **KAN-341** city via postcode lookup | build | **documented, buildable** (§6) | reuses the existing `GOOGLE_PLACES_API_KEY` — **no new secret**. |
+| **KAN-342** gifts de-gate | build | **documented** (§7) | rec engine already built on the profile; gating tweak. |
+| **KAN-338** establishment autocomplete | spike | **design recommendation** (§8) | reuse Places (existing key) vs UK-gov data — your call. |
+
+**Test status:** 1794/1795 unit pass + 20 new. The **1 failure is intentional** and needs your sign-off — see §9 Q1.
+
+---
+
+## 2. Key codebase facts (answers to the epic's open questions)
+
+- **Google Places is already integrated** (`lyra-mcp-server/src/convene-places-adapter.ts`, `lyra_suggest_venues`) and **`GOOGLE_PLACES_API_KEY` is set on dev + prod**. So KAN-341 (postcode→city) and KAN-338 (autocomplete) can reuse it via Places `searchText` (region=GB) — **no Geocoding key needed** unless you want true reverse-geocoding.
+- **`profiles.city` already exists** (so KAN-341 needs no schema add for the city field). Postcode is in **`profiles.postcode_prefix`**.
+- **Affiliate geo-signal uses `profiles.delivery_country_code`, NOT postcode** → KAN-339's postcode scrub is safe (epic Q6 ✓).
+- **Rec engine is built** and renders gift recommendations on the **public profile** (`[slug]/v2-recommendations-section.tsx`, `/api/recommendations`). KAN-342 is a gating tweak, not a new build.
+- **Completeness:** `profiles.completion_score` (%) + `onboarding_complete` (set on publish) already exist.
+
+---
+
+## 3. KAN-340 — the widget journey (built to this proposed spec)
+
+**State axes** (deliberately NOT `user_status`/access lifecycle): driven by `is_published` + `completion_score` + content signals; entitlements decide which widgets exist.
+
+| State | Trigger | Widget(s) shown (in order) |
+|---|---|---|
+| **empty** | not published, `completion_score < 40` | W1 Complete profile (primary, not dismissible) |
+| **drafted** | not published, `completion_score ≥ 40` | W2 Publish (primary; routes to /verify-age if age not passed) |
+| **published_activate** | published, missing gifts or affiliations | W3 Add gifts · W4 Add affiliations · W5 Share |
+| **published_grow** | published, has gifts + affiliations | W5 Share · W6 Convene (if `convene` entitled) |
+
+**Dismissal:** only secondary widgets (W3–W6) are dismissible; a dismissal is recorded with the state it happened in and **re-surfaces when the state changes**. Stored in `profiles.dashboard_widget_state` JSONB (KAN-345).
+
+**Layout:** one primary CTA in empty/drafted; a stack in published states. The registry in `widgets/dashboard-widgets.tsx` is the single place a future feature adds its widget (id in the resolver + a case here) — this is the "codify a widget when we add a feature" pattern you asked for.
+
+---
+
+## 4. KAN-343 — dashboard audit (reuse vs build-new)
+
+Current `/dashboard` hub (KAN-326): inline next-steps hub, profile-summary card, `ShareProfile`, `ShareBeta` (KAN-337), Convene card. No widget registry.
+
+- **Reused:** `ShareProfile` (now W5, added a `bare` prop), `ShareBeta` (kept standalone — a standing action), the profile-summary card (kept), the Convene CTA (now W6).
+- **Built-new:** the resolver, the registry/shell, dismissal.
+- **Removed:** the inline next-steps hub (→ W1/W2), the inline profile-share (→ W5), the standalone Convene card (→ W6).
+- **People-recommendations decision (epic Q2):** keep the logged-in dashboard a clean status hub; do NOT add a people-recommendations feed — route "discover people" to `/search`. (KAN-139 = gift recs on the *public* profile; KAN-334 = *logged-out* homepage demos. Neither belongs on the logged-in dashboard.)
+
+---
+
+## 5. KAN-339 — postcode removal (approach; not coded tonight)
+
+Surfaces: `profiles.postcode_prefix`; inputs in `dashboard/profile/profile-fields.ts` + `steps/types.tsx`; **discovery** in `dashboard/settings/discoverability-*`. **Phone search is separate and stays.** **Affiliate geo-signal uses country, not postcode (verified)** so the scrub is safe.
+Plan: remove the input + the postcode discovery query/UI, scrub `postcode_prefix = NULL` (migration), drop from MCP schema. **Needs:** Q3 (KAN-153 test sign-off — `discoverability-{helpers,actions}.test.ts`), Q4 (privacy-policy/ROPA edit), and sequencing with KAN-341 so discovery isn't dark.
+
+---
+
+## 6. KAN-341 — town/city via postcode lookup (buildable, no new secret)
+
+`profiles.city` exists. Reuse `GOOGLE_PLACES_API_KEY` via a server action that calls Places `searchText` with the postcode + `regionCode: 'GB'`, parses `postal_town`/`locality` from `addressComponents`, presents the city, stores **only the city** (postcode held in memory, never persisted/logged). City-based search replaces postcode search. **Needs:** Q4 (privacy-policy: disclose Google as a recipient), Q5 (confirm reuse of the Places key vs a dedicated Geocoding key).
+
+---
+
+## 7. KAN-342 — gifts de-gate (gating tweak)
+
+The rec engine renders on the public profile. Phase 1: decouple gift-section *visibility* from `paid_gift_links` (show the unpaid/plain-link path; no affiliate cookies). `paid_gift_links` then governs only monetisation. **Needs:** confirm the rec renderer has a plain-link path (likely yes — `eligibility-filter.ts`/`country-codes.ts`) + Q3-style test sign-off if a `paid_gift_links`-gating test must change. W3 (add-gifts widget) already assumes the unpaid path needs no entitlement.
+
+---
+
+## 8. KAN-338 — establishment autocomplete (spike recommendation)
+
+Affiliations are free-text today (`school_affiliations.school_name`). Recommendation: **MVP = Places `searchText` autocomplete** (reuses the existing key; dedup on `google_place_id`), with a **UK-gov data source** (EDUBASE schools / Companies House) as the higher-quality follow-up. Legal: confirm Places **caching ToS** for persisting `place_id`+name. **No build before your sign-off** (it's a spike).
+
+---
+
+## 9. Decisions I made (defaults) + questions needing your sign-off
+
+**Defaults applied (easy to change — all in `resolve-widgets.ts` / `dashboard-widgets.tsx`):**
+- Empty→drafted threshold = **completion_score ≥ 40**.
+- Dismissal = **per-widget, re-surfaces on state change**; W1/W2 not dismissible.
+- Layout = **one primary CTA in empty/drafted; stack in published**.
+- Widget copy = **proposed** (W1–W6) — see `dashboard-widgets.tsx`.
+
+**Questions / approvals:**
+1. **(test sign-off)** `convene-nav.test.ts` asserts the old inline Convene card on the dashboard page; the refit moved Convene to the W6 widget (still flag-gated). May I **re-point** the test to assert the new structure (not weaken it)?
+2. **(copy)** Confirm/adjust the W1–W6 widget copy.
+3. **(thresholds/model)** Confirm the 40% empty→drafted threshold, the dismissal model, and one-primary-vs-stack layout.
+4. **(KAN-339)** Go-ahead to remove postcode + sign-off to update the KAN-153 `discoverability-*` tests, + the privacy-policy/ROPA edit.
+5. **(KAN-341/338 Google)** OK to reuse `GOOGLE_PLACES_API_KEY` for postcode→city + establishment autocomplete (vs provisioning a dedicated Geocoding key)? + privacy-policy disclosure of Google as a recipient + Places caching-ToS legal check.
+6. **(KAN-338 source)** Establishment autocomplete backend: Places (fast, reuses key) vs UK-gov data (higher quality, more work) vs both?
+
+**Before this can go to dev:** apply migration `20260630010000_kan345_dashboard_widget_state.sql` to dev-lyra; write the KAN-348 E2E against the new dashboard.

--- a/docs/KAN-349-UX-EPIC-REVIEW.md
+++ b/docs/KAN-349-UX-EPIC-REVIEW.md
@@ -6,6 +6,15 @@
 The epic was raised from a chat session **without code access**, so several of its
 "unresolved questions" are answered here directly from the codebase.
 
+> **UPDATE 2026-06-30 — your answers applied; KAN-339 / KAN-341 / KAN-342 now COMPLETE + green.**
+> 3 commits on the branch: widget journey `f48c270`, KAN-339+342 `c654c2a`, KAN-341 `915af29`.
+> tsc clean; 141 suites / 1786 unit tests pass. Q1 convene test re-pointed (not weakened);
+> Q2 copy kept (review in dev); Q4 postcode removed everywhere + scrubbed + KAN-153 tests
+> updated; Q5/Q6 Places key reused, global. **Remaining before/at dev:** apply the 2
+> migrations to dev-lyra, the KAN-348 E2E, and a city-discovery *search-UI* surface (the
+> `searchByCity` backend is built + tested — same state as the phone-search backend, which
+> also has no dedicated search page).
+
 ---
 
 ## 1. What's coded vs documented vs blocked

--- a/src/app/(legal)/help/page.tsx
+++ b/src/app/(legal)/help/page.tsx
@@ -30,7 +30,7 @@ export default function HelpPage() {
 
         <h2>How do people find me?</h2>
         <p>
-          By name, school, organisation, or the first part of your postcode. Your affiliations help
+          By name, school, or organisation. Your affiliations help
           people find you <em>even when they&apos;re hidden</em> from your public page.
         </p>
 

--- a/src/app/(legal)/safe/page.tsx
+++ b/src/app/(legal)/safe/page.tsx
@@ -35,8 +35,8 @@ export default function SafePage() {
             happens offline, with people you choose.
           </li>
           <li>
-            <strong>No exact locations.</strong> We don&apos;t show addresses, and postcode search is
-            opt-in and stored scrambled (hashed).
+            <strong>No exact locations.</strong> We don&apos;t show addresses, and we don&apos;t
+            collect or store your postcode.
           </li>
           <li>
             <strong>Extra care for children.</strong> Children&apos;s profiles are parent-managed with

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -5,7 +5,7 @@ import Image from 'next/image';
 import { signOut } from '../(auth)/actions';
 import ShareBeta from './share-beta';
 import DashboardWidgets, { type WidgetContext } from './widgets/dashboard-widgets';
-import { betaInviteLink } from '@/lib/beta-access/invite-link';
+import { betaInviteLink, publicSignupUrl } from '@/lib/beta-access/invite-link';
 import { isConveneEnabledForCurrentUser } from '@/lib/convene/flags-user';
 import { canPublishWithAge } from '@/lib/age/gate';
 import { resolveWidgets, resolveOnboardingState } from '@/lib/dashboard/resolve-widgets';
@@ -89,6 +89,7 @@ export default async function DashboardPage() {
       : null,
     displayName: profile?.display_name ?? null,
     betaLink: inviteLink,
+    signupUrl: publicSignupUrl(),
   };
 
   return (
@@ -175,8 +176,10 @@ export default async function DashboardPage() {
               moved to the Convene widget (W6); both rendered by DashboardWidgets above. */}
         </div>
 
-        {/* KAN-337 — beta-access invite link (a standing action, not a journey step). */}
-        {inviteLink && <ShareBeta inviteLink={inviteLink} />}
+        {/* KAN-337/349 — beta-invite share. Once published it lives in the W5 widget;
+            before publishing, show it here too so beta users can invite friends straight
+            away (no duplication — W5's share only appears in the published states). */}
+        {inviteLink && !isPublished && <ShareBeta inviteLink={inviteLink} />}
       </div>
     </main>
   );

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -3,11 +3,13 @@ import { redirect } from 'next/navigation';
 import Link from 'next/link';
 import Image from 'next/image';
 import { signOut } from '../(auth)/actions';
-import ShareProfile from './share-profile';
 import ShareBeta from './share-beta';
+import DashboardWidgets, { type WidgetContext } from './widgets/dashboard-widgets';
 import { betaInviteLink } from '@/lib/beta-access/invite-link';
 import { isConveneEnabledForCurrentUser } from '@/lib/convene/flags-user';
 import { canPublishWithAge } from '@/lib/age/gate';
+import { resolveWidgets, resolveOnboardingState } from '@/lib/dashboard/resolve-widgets';
+import { dismissedForState, type DashboardWidgetState } from '@/lib/dashboard/dismissal';
 
 export const metadata = {
   title: 'Dashboard — Lyra',
@@ -39,6 +41,55 @@ export default async function DashboardPage() {
   );
   // KAN-337 — beta-invite deep-link to share (null unless LYRA_INVITE_CODE is set).
   const inviteLink = betaInviteLink();
+
+  // KAN-344/346 — onboarding-progress signals → the status-driven widget journey.
+  const profileId = (profile as { id?: string } | null)?.id;
+  let hasGifts = false;
+  let hasAffiliations = false;
+  if (profileId) {
+    const [gifts, affs] = await Promise.all([
+      supabase
+        .from('profile_items')
+        .select('id', { count: 'exact', head: true })
+        .eq('profile_id', profileId)
+        .eq('category', 'gift_ideas'),
+      supabase
+        .from('school_affiliations')
+        .select('id', { count: 'exact', head: true })
+        .eq('profile_id', profileId),
+    ]);
+    hasGifts = (gifts.count ?? 0) > 0;
+    hasAffiliations = (affs.count ?? 0) > 0;
+  }
+  const completionScore = Number(
+    (profile as { completion_score?: number } | null)?.completion_score ?? 0,
+  );
+  const storedDismissals =
+    (profile as { dashboard_widget_state?: DashboardWidgetState } | null)?.dashboard_widget_state ?? {};
+  const onboardingState = resolveOnboardingState({
+    isPublished,
+    completionScore,
+    hasGifts,
+    hasAffiliations,
+  });
+  const widgetResolution = resolveWidgets({
+    isPublished,
+    completionScore,
+    hasGifts,
+    hasAffiliations,
+    conveneEntitled: conveneEnabled,
+    dismissed: dismissedForState(storedDismissals, onboardingState),
+  });
+  const widgetCtx: WidgetContext = {
+    state: widgetResolution.state,
+    completionScore,
+    canPublishAge: !needsAgeCheck,
+    profileUrl: profile?.slug
+      ? `${process.env.NEXT_PUBLIC_SITE_URL || 'https://checklyra.com'}/${profile.slug}`
+      : null,
+    displayName: profile?.display_name ?? null,
+    betaLink: inviteLink,
+  };
 
   return (
     <main className="min-h-screen">
@@ -83,45 +134,11 @@ export default async function DashboardPage() {
           </p>
         </div>
 
-        {/* KAN-326: next-steps hub — lead with what to do next while unpublished. */}
-        {!isPublished && (
-          <div className="bg-white rounded-xl border border-[var(--color-border)] p-6 mb-6">
-            <h3 className="text-lg font-medium text-[var(--color-ink)] mb-4">Get your profile live</h3>
-            <ol className="space-y-3">
-              <li className="flex items-center justify-between gap-3">
-                <span className="text-sm text-[var(--color-ink)]">
-                  <span className="font-medium">1. Build your profile</span>
-                  <span className="text-[var(--color-muted)]"> · {profile?.completion_score || 0}% complete</span>
-                </span>
-                <Link href="/dashboard/profile" className="shrink-0 px-4 py-2 rounded-lg bg-[var(--color-sage)] text-white text-sm font-medium hover:opacity-90 transition-opacity">
-                  Edit profile →
-                </Link>
-              </li>
-              {needsAgeCheck && (
-                <li className="flex items-center justify-between gap-3">
-                  <span className="text-sm text-[var(--color-ink)]">
-                    <span className="font-medium">2. Verify your age</span>
-                    <span className="text-[var(--color-muted)]"> · required before publishing</span>
-                  </span>
-                  <Link href="/verify-age" className="shrink-0 px-4 py-2 rounded-lg bg-[#f4efe7] text-[var(--color-ink)] text-sm font-medium hover:bg-[#ece7df] transition-colors">
-                    Verify age →
-                  </Link>
-                </li>
-              )}
-              <li className="flex items-center justify-between gap-3">
-                <span className="text-sm text-[var(--color-ink)]">
-                  <span className="font-medium">{needsAgeCheck ? '3' : '2'}. Publish</span>
-                  <span className="text-[var(--color-muted)]"> · make your profile public</span>
-                </span>
-                <Link href="/dashboard/profile" className="shrink-0 px-4 py-2 rounded-lg bg-[#f4efe7] text-[var(--color-ink)] text-sm font-medium hover:bg-[#ece7df] transition-colors">
-                  Open editor →
-                </Link>
-              </li>
-            </ol>
-          </div>
-        )}
+        {/* KAN-340/346 — status-driven widget journey (replaces the KAN-326 next-steps hub).
+            One primary CTA in empty/drafted; a gifts/affiliations/share/convene stack once published. */}
+        <DashboardWidgets resolution={widgetResolution} ctx={widgetCtx} />
 
-        <div className="bg-white rounded-xl border border-[var(--color-border)] p-6">
+        <div className="bg-white rounded-xl border border-[var(--color-border)] p-6 mt-6">
           <h3 className="text-lg font-medium text-[var(--color-ink)] mb-4">
             Your profile
           </h3>
@@ -154,44 +171,12 @@ export default async function DashboardPage() {
               Edit your profile →
             </Link>
           )}
-
-          {/* KAN-154-B: shareable invite. Only shown once the profile has
-              a slug — before that there's nothing to share, and the
-              fallback CTA would just point at the public landing page. */}
-          {profile?.slug && (
-            <ShareProfile
-              profileUrl={`${process.env.NEXT_PUBLIC_SITE_URL || 'https://checklyra.com'}/${profile.slug}`}
-              displayName={profile.display_name}
-              betaLink={inviteLink}
-            />
-          )}
+          {/* Profile-sharing moved to the "Share your profile" widget (W5); Convene
+              moved to the Convene widget (W6); both rendered by DashboardWidgets above. */}
         </div>
 
+        {/* KAN-337 — beta-access invite link (a standing action, not a journey step). */}
         {inviteLink && <ShareBeta inviteLink={inviteLink} />}
-
-        {conveneEnabled && (
-          <div className="bg-white rounded-xl border border-[var(--color-border)] p-6 mt-6">
-            <h3 className="text-lg font-medium text-[var(--color-ink)] mb-1">Convene</h3>
-            <p className="text-sm text-[var(--color-muted)] mb-4">
-              Organise gatherings with the people in your life — pick a time that works, suggest a
-              place, and send invites.
-            </p>
-            <div className="flex flex-wrap gap-3">
-              <Link
-                href="/dashboard/convene/gatherings"
-                className="px-4 py-2 rounded-lg bg-[var(--color-sage)] text-white text-sm font-medium hover:opacity-90 transition-opacity"
-              >
-                Your gatherings
-              </Link>
-              <Link
-                href="/dashboard/convene/contacts"
-                className="px-4 py-2 rounded-lg bg-[#f4efe7] text-[var(--color-ink)] text-sm font-medium hover:bg-[#ece7df] transition-colors"
-              >
-                People
-              </Link>
-            </div>
-          </div>
-        )}
       </div>
     </main>
   );

--- a/src/app/dashboard/profile/city-actions.ts
+++ b/src/app/dashboard/profile/city-actions.ts
@@ -1,0 +1,39 @@
+'use server';
+
+/**
+ * KAN-341 (epic KAN-349) — resolve a town/city from a postcode (Google Places).
+ *
+ * The user enters a postcode; we resolve it to a town/city and return ONLY the
+ * city (+ optional region). The raw postcode is used transiently and is never
+ * persisted or logged — it lives only for the duration of this call. The caller
+ * then saves the chosen city via updateProfileFields (city is in the allowlist).
+ *
+ * '`use server`' constraint: every export is an async function. The pure Places
+ * client + extractor live in src/lib/geo/places-city.ts. See BUGS-12.
+ */
+import { createClient } from '@/lib/supabase-server';
+import { lookupCityFromPostcode } from '@/lib/geo/places-city';
+
+export type ResolveCityResult =
+  | { success: true; city: string; region: string | null }
+  | { success: false; error: string };
+
+export async function resolveCityFromPostcode(postcode: string): Promise<ResolveCityResult> {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) return { success: false, error: 'Not authenticated' };
+
+  const trimmed = (postcode ?? '').trim();
+  if (!trimmed) {
+    return { success: false, error: 'Enter a postcode to look up your town or city.' };
+  }
+
+  const result = await lookupCityFromPostcode(trimmed);
+  if (!result) {
+    // Never echo the postcode back in the error.
+    return { success: false, error: "We couldn't find a town for that postcode. You can type your town in directly." };
+  }
+  return { success: true, city: result.city, region: result.region };
+}

--- a/src/app/dashboard/profile/profile-fields.ts
+++ b/src/app/dashboard/profile/profile-fields.ts
@@ -24,7 +24,10 @@ export const ALLOWED_PROFILE_FIELDS = [
   'bio_short',
   'city',
   'region',
-  'postcode_prefix',
+  // KAN-339: `postcode_prefix` removed — postcode is no longer collected, stored,
+  // or used for discovery (replaced by town/city discovery, KAN-341). The column
+  // is retained nullable + scrubbed by the KAN-339 migration; it is no longer
+  // user-editable, so it is intentionally absent from this allowlist.
   'country',
   'avatar_url',
   'is_published',

--- a/src/app/dashboard/profile/sections/basic-info-section.tsx
+++ b/src/app/dashboard/profile/sections/basic-info-section.tsx
@@ -25,6 +25,7 @@
 import { useRef, useState, useTransition } from 'react';
 import { Field, type WizardProfile } from '../steps/types';
 import { updateProfileFields, uploadAvatar } from '../actions';
+import { resolveCityFromPostcode } from '../city-actions';
 import { AutoSaveStatusLabel, useAutoSave } from './use-auto-save';
 
 interface BasicInfoDraft {
@@ -58,6 +59,27 @@ export function BasicInfoSection({ profile }: { profile: WizardProfile }) {
 
   const set = <K extends keyof BasicInfoDraft>(key: K, value: BasicInfoDraft[K]) =>
     setDraft((d) => ({ ...d, [key]: value }));
+
+  // KAN-341 — postcode→town lookup. The postcode lives in local state only and is
+  // discarded immediately after the lookup; we store just the resolved city.
+  const [postcodeInput, setPostcodeInput] = useState('');
+  const [lookupError, setLookupError] = useState<string | null>(null);
+  const [lookingUp, startLookup] = useTransition();
+
+  const handlePostcodeLookup = () => {
+    const pc = postcodeInput.trim();
+    if (!pc) return;
+    setLookupError(null);
+    startLookup(async () => {
+      const result = await resolveCityFromPostcode(pc);
+      if (result.success) {
+        set('city', result.city);
+        setPostcodeInput('');
+      } else {
+        setLookupError(result.error);
+      }
+    });
+  };
 
   const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
@@ -144,6 +166,34 @@ export function BasicInfoSection({ profile }: { profile: WizardProfile }) {
           onChange={(v) => set('headline', v)}
           placeholder="Mum, teacher, coffee lover"
         />
+        {/* KAN-341 — optional: resolve your town from a postcode (postcode never stored). */}
+        <div>
+          <label className="block text-sm font-medium text-[var(--color-ink)] mb-1">
+            Find your town from a postcode{' '}
+            <span className="font-normal text-[var(--color-muted)]">(optional)</span>
+          </label>
+          <div className="flex gap-2">
+            <input
+              value={postcodeInput}
+              onChange={(e) => setPostcodeInput(e.target.value)}
+              placeholder="e.g. SW1A 1AA"
+              autoComplete="off"
+              className="flex-1 px-3 py-2 rounded-lg border border-[var(--color-border)] bg-white text-[var(--color-ink)] text-sm focus:outline-none focus:ring-2 focus:ring-[var(--color-sage)] focus:border-transparent"
+            />
+            <button
+              type="button"
+              onClick={handlePostcodeLookup}
+              disabled={lookingUp || !postcodeInput.trim()}
+              className="shrink-0 px-4 py-2 rounded-lg bg-[#f4efe7] text-[var(--color-ink)] text-sm font-medium hover:bg-[#ece7df] disabled:opacity-50 transition-colors"
+            >
+              {lookingUp ? 'Finding…' : 'Find town'}
+            </button>
+          </div>
+          <p className="mt-1 text-xs text-[var(--color-muted)]">
+            We use your postcode once to fill in your town — we never store it.
+          </p>
+          {lookupError && <p className="mt-1 text-xs text-red-500">{lookupError}</p>}
+        </div>
         <Field
           label="City"
           value={draft.city}

--- a/src/app/dashboard/profile/steps/types.tsx
+++ b/src/app/dashboard/profile/steps/types.tsx
@@ -6,7 +6,7 @@ export interface WizardProfile {
   bio_short: string | null;
   city: string | null;
   region: string | null;
-  postcode_prefix: string | null;
+  // KAN-339: postcode_prefix removed (postcode no longer collected/stored).
   country: string | null;
   // KAN-186: ISO-3166 alpha-2 country where gifts for this profile should
   // ship. Separate from `country` (which is freeform display text). NULL

--- a/src/app/dashboard/settings/discoverability-actions.ts
+++ b/src/app/dashboard/settings/discoverability-actions.ts
@@ -207,4 +207,40 @@ export async function searchByPhone(phone: string): Promise<SearchResult> {
   return performHashedSearch('phone', hash, user.id);
 }
 
-// KAN-339: searchByPostcode removed. Town/city discovery is delivered in KAN-341.
+// KAN-339: hashed searchByPostcode removed. KAN-341 replaces it with city search.
+
+/**
+ * KAN-341 — town/city discovery. City is coarse and is already public on a
+ * published profile, so (unlike phone) it is NOT hashed: we match PUBLISHED
+ * profiles by their public city. Rate-limited per searcher; authenticated only.
+ */
+export async function searchByCity(city: string): Promise<SearchResult> {
+  const supabase = await createClient();
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) return { success: false, error: 'Not authenticated' };
+
+  const q = (city ?? '').trim();
+  if (q.length < 2) return { success: true, matches: [] };
+
+  const rl = rateLimit(`discoverability-search:${user.id}`, SEARCH_RATE_LIMIT);
+  if (rl.limited) {
+    return {
+      success: false,
+      error: `Too many lookups. Try again in ${rl.retryAfter ?? 60} seconds.`,
+    };
+  }
+
+  const { data, error } = await supabase
+    .from('profiles')
+    .select('id, slug')
+    .eq('is_published', true)
+    .ilike('city', q)
+    .limit(50);
+  if (error) {
+    return { success: false, error: 'Search failed. Please try again.' };
+  }
+  const matches = (data ?? [])
+    .filter((r): r is { id: string; slug: string } => typeof r.slug === 'string')
+    .map((r) => ({ id: r.id, slug: r.slug }));
+  return { success: true, matches };
+}

--- a/src/app/dashboard/settings/discoverability-actions.ts
+++ b/src/app/dashboard/settings/discoverability-actions.ts
@@ -38,18 +38,15 @@ import type { ActionResult } from '@/lib/sanitise';
 import { rateLimit } from '@/lib/rate-limit';
 import {
   hashPhoneInput,
-  hashPostcodeInput,
   SEARCH_RATE_LIMIT,
 } from './discoverability-helpers';
 import { getMyFeatureEntitlements } from '@/lib/features/entitlements';
 
 interface DiscoverabilityInput {
   phone?: boolean;
-  postcode?: boolean;
   /** Required when phone flips from false → true. Ignored otherwise. */
   phoneValue?: string;
-  /** Required when postcode flips from false → true. Ignored otherwise. */
-  postcodeValue?: string;
+  // KAN-339: postcode discovery removed (replaced by town/city discovery, KAN-341).
 }
 
 export async function setDiscoverability(input: DiscoverabilityInput): Promise<ActionResult> {
@@ -59,7 +56,7 @@ export async function setDiscoverability(input: DiscoverabilityInput): Promise<A
 
   // KAN-309 — per-user feature gate (default on; an admin can revoke). Opting
   // OUT is always allowed so a revoked user can still turn discovery off.
-  if (input.phone === true || input.postcode === true) {
+  if (input.phone === true) {
     const features = await getMyFeatureEntitlements();
     if (!features.discovery) {
       return { success: false, error: 'Discovery is not enabled for your account.' };
@@ -71,7 +68,7 @@ export async function setDiscoverability(input: DiscoverabilityInput): Promise<A
   // column-privilege level — see migration).
   const { data: profile, error: readError } = await supabase
     .from('profiles')
-    .select('id, discoverable_by_phone, discoverable_by_postcode')
+    .select('id, discoverable_by_phone')
     .eq('user_id', user.id)
     .single();
   if (readError || !profile) {
@@ -107,29 +104,7 @@ export async function setDiscoverability(input: DiscoverabilityInput): Promise<A
     }
   }
 
-  // ── Postcode ────────────────────────────────────────────
-  if (typeof input.postcode === 'boolean') {
-    if (input.postcode === true) {
-      if (!input.postcodeValue || typeof input.postcodeValue !== 'string') {
-        return {
-          success: false,
-          error: 'A postcode is required to enable postcode discovery.',
-        };
-      }
-      const hash = hashPostcodeInput(input.postcodeValue);
-      if (!hash) {
-        return {
-          success: false,
-          error: 'Postcode could not be normalised. Use a UK format like SW1A 1AA.',
-        };
-      }
-      updates.discoverable_by_postcode = true;
-      updates.postcode_search_hash = hash;
-    } else {
-      updates.discoverable_by_postcode = false;
-      updates.postcode_search_hash = null;
-    }
-  }
+  // KAN-339: postcode discovery removed (replaced by town/city discovery, KAN-341).
 
   if (Object.keys(updates).length === 0) {
     return { success: true };
@@ -156,7 +131,7 @@ export async function setDiscoverability(input: DiscoverabilityInput): Promise<A
  * itself is never returned.
  */
 export async function getDiscoverability(): Promise<
-  | { success: true; phone: boolean; postcode: boolean }
+  | { success: true; phone: boolean }
   | { success: false; error: string }
 > {
   const supabase = await createClient();
@@ -165,7 +140,7 @@ export async function getDiscoverability(): Promise<
 
   const { data, error } = await supabase
     .from('profiles')
-    .select('discoverable_by_phone, discoverable_by_postcode')
+    .select('discoverable_by_phone')
     .eq('user_id', user.id)
     .single();
   if (error || !data) return { success: false, error: 'Profile not found' };
@@ -173,7 +148,6 @@ export async function getDiscoverability(): Promise<
   return {
     success: true,
     phone: !!data.discoverable_by_phone,
-    postcode: !!data.discoverable_by_postcode,
   };
 }
 
@@ -187,7 +161,7 @@ type SearchResult =
   | { success: false; error: string };
 
 async function performHashedSearch(
-  kind: 'phone' | 'postcode',
+  kind: 'phone',
   hash: string,
   userId: string
 ): Promise<SearchResult> {
@@ -233,15 +207,4 @@ export async function searchByPhone(phone: string): Promise<SearchResult> {
   return performHashedSearch('phone', hash, user.id);
 }
 
-export async function searchByPostcode(postcode: string): Promise<SearchResult> {
-  const supabase = await createClient();
-  const { data: { user } } = await supabase.auth.getUser();
-  if (!user) return { success: false, error: 'Not authenticated' };
-
-  const hash = hashPostcodeInput(postcode);
-  if (!hash) {
-    return { success: true, matches: [] };
-  }
-
-  return performHashedSearch('postcode', hash, user.id);
-}
+// KAN-339: searchByPostcode removed. Town/city discovery is delivered in KAN-341.

--- a/src/app/dashboard/settings/discoverability-client.tsx
+++ b/src/app/dashboard/settings/discoverability-client.tsx
@@ -1,14 +1,14 @@
 'use client';
 
 /**
- * KAN-153: Settings UI for opt-in phone/postcode discovery.
+ * KAN-153 / KAN-339: Settings UI for opt-in phone discovery.
  *
- * Two independent toggles. Enabling a toggle reveals an input where the
- * user enters their phone or postcode, which is then hashed server-side
- * and stored. We never display the previously-stored value (we don't have
- * it — only the hash is persisted), and disabling clears the hash.
+ * One toggle. Enabling it reveals an input where the user enters their phone
+ * number, which is hashed server-side and stored. We never display the
+ * previously-stored value (only the hash is persisted); disabling clears the hash.
  *
- * Consent copy is deliberately explicit per the privacy review on KAN-153.
+ * KAN-339: postcode discovery removed for privacy/data-minimisation. Coarse
+ * town/city discovery (KAN-341) replaces the location-based discovery path.
  */
 import { useEffect, useState, useTransition } from 'react';
 import { setDiscoverability, getDiscoverability } from './discoverability-actions';
@@ -18,11 +18,8 @@ type Banner = { type: 'success' | 'error'; text: string } | null;
 export function DiscoverabilityClient() {
   const [isPending, startTransition] = useTransition();
   const [phoneEnabled, setPhoneEnabled] = useState(false);
-  const [postcodeEnabled, setPostcodeEnabled] = useState(false);
   const [phoneInput, setPhoneInput] = useState('');
-  const [postcodeInput, setPostcodeInput] = useState('');
   const [showPhoneInput, setShowPhoneInput] = useState(false);
-  const [showPostcodeInput, setShowPostcodeInput] = useState(false);
   const [banner, setBanner] = useState<Banner>(null);
 
   useEffect(() => {
@@ -30,7 +27,6 @@ export function DiscoverabilityClient() {
       const result = await getDiscoverability();
       if (result.success) {
         setPhoneEnabled(result.phone);
-        setPostcodeEnabled(result.postcode);
       }
     });
   }, []);
@@ -75,50 +71,12 @@ export function DiscoverabilityClient() {
     });
   };
 
-  const handlePostcodeToggle = (next: boolean) => {
-    setBanner(null);
-    if (next) {
-      setShowPostcodeInput(true);
-      return;
-    }
-    startTransition(async () => {
-      const result = await setDiscoverability({ postcode: false });
-      if (result.success) {
-        setPostcodeEnabled(false);
-        setShowPostcodeInput(false);
-        setPostcodeInput('');
-        setBanner({ type: 'success', text: 'Postcode discovery disabled.' });
-      } else {
-        setBanner({ type: 'error', text: result.error });
-      }
-    });
-  };
-
-  const handlePostcodeSubmit = () => {
-    setBanner(null);
-    if (!postcodeInput) return;
-    startTransition(async () => {
-      const result = await setDiscoverability({ postcode: true, postcodeValue: postcodeInput });
-      if (result.success) {
-        setPostcodeEnabled(true);
-        setShowPostcodeInput(false);
-        setPostcodeInput('');
-        setBanner({
-          type: 'success',
-          text: 'Postcode discovery enabled. Your postcode is stored only as a salted hash.',
-        });
-      } else {
-        setBanner({ type: 'error', text: result.error });
-      }
-    });
-  };
-
   return (
     <div className="bg-white rounded-xl border border-[var(--color-border)] p-6">
-      <h2 className="text-lg font-medium text-[var(--color-ink)] mb-1">Discovery by phone or postcode</h2>
+      <h2 className="text-lg font-medium text-[var(--color-ink)] mb-1">Discovery by phone number</h2>
       <p className="text-sm text-[var(--color-muted)] mb-4">
-        Let people who know your phone number or postcode find your profile. Both are off by default.
-        Lyra never stores your number or postcode in plain text — only a one-way salted hash that can be
+        Let people who know your phone number find your profile. It&rsquo;s off by default.
+        Lyra never stores your number in plain text — only a one-way salted hash that can be
         matched against an exact lookup but cannot be reversed.
       </p>
 
@@ -135,7 +93,7 @@ export function DiscoverabilityClient() {
       )}
 
       {/* ── Phone toggle ────────────────────────────────────── */}
-      <div className="mb-6 pb-6 border-b border-[var(--color-border)]">
+      <div>
         <div className="flex items-start justify-between gap-4 mb-2">
           <div className="flex-1">
             <label htmlFor="discover-phone" className="block text-sm font-medium text-[var(--color-ink)]">
@@ -174,55 +132,6 @@ export function DiscoverabilityClient() {
             </button>
             <button
               onClick={() => { setShowPhoneInput(false); setPhoneInput(''); }}
-              disabled={isPending}
-              className="px-3 py-2 rounded-lg bg-[#f4efe7] text-sm font-medium text-[var(--color-ink)] hover:bg-[#ece7df] transition-colors"
-            >
-              Cancel
-            </button>
-          </div>
-        )}
-      </div>
-
-      {/* ── Postcode toggle ─────────────────────────────────── */}
-      <div>
-        <div className="flex items-start justify-between gap-4 mb-2">
-          <div className="flex-1">
-            <label htmlFor="discover-postcode" className="block text-sm font-medium text-[var(--color-ink)]">
-              Allow discovery by postcode
-            </label>
-            <p className="text-xs text-[var(--color-muted)] mt-1">
-              Anyone who knows your exact full postcode will be able to find your profile.
-              Partial postcodes and prefix searches are not supported.
-            </p>
-          </div>
-          <input
-            id="discover-postcode"
-            type="checkbox"
-            checked={postcodeEnabled || showPostcodeInput}
-            disabled={isPending}
-            onChange={(e) => handlePostcodeToggle(e.target.checked)}
-            className="mt-1 h-5 w-5 rounded border-[var(--color-border)] text-[var(--color-sage)] focus:ring-[var(--color-sage)]"
-          />
-        </div>
-        {showPostcodeInput && !postcodeEnabled && (
-          <div className="mt-3 flex gap-2">
-            <input
-              type="text"
-              value={postcodeInput}
-              onChange={(e) => setPostcodeInput(e.target.value)}
-              placeholder="SW1A 1AA"
-              autoComplete="off"
-              className="flex-1 px-3 py-2 rounded-lg border border-[var(--color-border)] bg-white text-sm focus:outline-none focus:ring-2 focus:ring-[var(--color-sage)] focus:border-transparent"
-            />
-            <button
-              onClick={handlePostcodeSubmit}
-              disabled={isPending || !postcodeInput}
-              className="px-4 py-2 rounded-lg bg-[var(--color-sage)] text-white text-sm font-medium hover:opacity-90 disabled:opacity-50 transition-opacity"
-            >
-              Enable
-            </button>
-            <button
-              onClick={() => { setShowPostcodeInput(false); setPostcodeInput(''); }}
               disabled={isPending}
               className="px-3 py-2 rounded-lg bg-[#f4efe7] text-sm font-medium text-[var(--color-ink)] hover:bg-[#ece7df] transition-colors"
             >

--- a/src/app/dashboard/settings/discoverability-helpers.ts
+++ b/src/app/dashboard/settings/discoverability-helpers.ts
@@ -19,8 +19,8 @@
  */
 import { createHmac } from 'crypto';
 
-/** What kind of contact value is being hashed. */
-export type ContactKind = 'phone' | 'postcode';
+/** What kind of contact value is being hashed. KAN-339: postcode removed; phone only. */
+export type ContactKind = 'phone';
 
 /** Per-user rate-limit for lookup attempts (defence against enumeration). */
 export const SEARCH_RATE_LIMIT = {
@@ -95,29 +95,6 @@ export function normalisePhone(input: string): string | null {
 }
 
 /**
- * Normalise a UK postcode to the canonical "AA9 9AA" (or shorter) form,
- * but for hashing we collapse to a no-space uppercase representation so
- * "SW1A 1AA" and "sw1a1aa" hash identically.
- *
- * Returns null when the input is empty or obviously non-postcode-shaped.
- * We do NOT enforce the full UK postcode regex here — the search hash
- * matches whatever the user opts in with, and over-tight validation
- * would surprise users with edge-case but real postcodes (e.g. crown
- * dependencies, BFPO).
- */
-export function normalisePostcode(input: string): string | null {
-  if (typeof input !== 'string') return null;
-  const trimmed = input.trim();
-  if (trimmed.length === 0) return null;
-  // Uppercase, remove all whitespace.
-  const collapsed = trimmed.toUpperCase().replace(/\s+/g, '');
-  // Conservative shape check: alphanumerics only, length 5-8 (UK postcodes
-  // are 5-7 chars without space; allow 8 to be forgiving).
-  if (!/^[A-Z0-9]{5,8}$/.test(collapsed)) return null;
-  return collapsed;
-}
-
-/**
  * Deterministic HMAC-SHA-256 hash, hex digest (SEC-18, F-04 part 2).
  *
  * Format: HMAC-SHA-256(key, kind || ':' || value)
@@ -154,12 +131,8 @@ export function hashPhoneInput(input: string): string | null {
   if (!normalised) return null;
   return hashContact('phone', normalised, getContactSearchHmacKey());
 }
-
-export function hashPostcodeInput(input: string): string | null {
-  const normalised = normalisePostcode(input);
-  if (!normalised) return null;
-  return hashContact('postcode', normalised, getContactSearchHmacKey());
-}
+// KAN-339: hashPostcodeInput / normalisePostcode removed — postcode discovery is
+// gone (replaced by town/city discovery, KAN-341).
 
 /**
  * Generic shape for the rate-limit store. Injected so tests can swap in a

--- a/src/app/dashboard/share-beta.tsx
+++ b/src/app/dashboard/share-beta.tsx
@@ -3,14 +3,28 @@
 import { useState } from 'react';
 
 /**
- * KAN-337 — standalone "Share beta access" card.
+ * KAN-337 / KAN-349 — shareable link card (used by W5 + the standing beta share).
  *
- * Shows the beta-invite deep-link (`/join?code=…`) with a one-click copy. The
- * link carries the skip-the-waitlist code, so anyone the user shares it with
- * lands on sign-up and goes straight into the beta. Shown on the dashboard only
- * when LYRA_INVITE_CODE is configured (the parent passes a non-null link).
+ * Defaults render the original "Share beta access" widget verbatim (used while
+ * the waitlist is in place — the link carries the skip-the-waitlist code). The
+ * same layout is reused for the post-waitlist version by passing a different
+ * title/description/link (e.g. a plain sign-up link once the gate is removed),
+ * so the wording/layout the founder likes is preserved, not overwritten.
  */
-export default function ShareBeta({ inviteLink }: { inviteLink: string }) {
+export default function ShareBeta({
+  inviteLink,
+  title = 'Share beta access',
+  description = 'Lyra is invite-only right now. Send this link to someone you’d like to bring in — it skips the waitlist and drops them straight into the beta.',
+  linkLabel = 'Beta invite link',
+  bare = false,
+}: {
+  inviteLink: string;
+  title?: string;
+  description?: string;
+  linkLabel?: string;
+  /** KAN-349: drop the outer card so it can be embedded in the W5 widget shell. */
+  bare?: boolean;
+}) {
   const [status, setStatus] = useState<'idle' | 'copied' | 'error'>('idle');
 
   async function handleCopy() {
@@ -28,19 +42,16 @@ export default function ShareBeta({ inviteLink }: { inviteLink: string }) {
   }
 
   return (
-    <div className="bg-white rounded-xl border border-[var(--color-border)] p-6 mt-6">
-      <h3 className="text-lg font-medium text-[var(--color-ink)] mb-1">Share beta access</h3>
-      <p className="text-sm text-[var(--color-muted)] mb-4">
-        Lyra is invite-only right now. Send this link to someone you&rsquo;d like to bring in — it
-        skips the waitlist and drops them straight into the beta.
-      </p>
+    <div className={bare ? '' : 'bg-white rounded-xl border border-[var(--color-border)] p-6 mt-6'}>
+      <h3 className="text-lg font-medium text-[var(--color-ink)] mb-1">{title}</h3>
+      <p className="text-sm text-[var(--color-muted)] mb-4">{description}</p>
 
-      <label htmlFor="beta-invite-link" className="sr-only">
-        Beta invite link
+      <label htmlFor="share-link-input" className="sr-only">
+        {linkLabel}
       </label>
       <div className="flex flex-col sm:flex-row gap-2">
         <input
-          id="beta-invite-link"
+          id="share-link-input"
           type="text"
           readOnly
           value={inviteLink}

--- a/src/app/dashboard/share-profile.tsx
+++ b/src/app/dashboard/share-profile.tsx
@@ -25,10 +25,13 @@ export default function ShareProfile({
   profileUrl,
   displayName,
   betaLink,
+  bare = false,
 }: {
   profileUrl?: string | null;
   displayName?: string | null;
   betaLink?: string | null;
+  /** KAN-346: drop the section divider styling when embedded as a dashboard widget. */
+  bare?: boolean;
 }) {
   const initialText = buildInviteText({
     profileUrl,
@@ -58,7 +61,7 @@ export default function ShareProfile({
   }
 
   return (
-    <div className="mt-6 pt-6 border-t border-[var(--color-border)]">
+    <div className={bare ? '' : 'mt-6 pt-6 border-t border-[var(--color-border)]'}>
       <h3 className="text-lg font-medium text-[var(--color-ink)] mb-1">
         Share Lyra with a friend
       </h3>

--- a/src/app/dashboard/widgets/actions.ts
+++ b/src/app/dashboard/widgets/actions.ts
@@ -1,0 +1,45 @@
+'use server';
+
+import { revalidatePath } from 'next/cache';
+import { createClient } from '@/lib/supabase-server';
+import { withDismissal, type DashboardWidgetState } from '@/lib/dashboard/dismissal';
+import { WIDGET_IDS, type WidgetId, type OnboardingState } from '@/lib/dashboard/resolve-widgets';
+
+const STATES: readonly string[] = ['empty', 'drafted', 'published_activate', 'published_grow'];
+
+/**
+ * KAN-345 — dismiss a dashboard widget for the current user + onboarding state.
+ * Owner-only write via the cookie client (RLS); dashboard_widget_state is not an
+ * admin-only column, so it passes the self-elevation guard. Re-surfaces on a
+ * state change because the dismissal records the state it happened in.
+ */
+export async function dismissWidget(formData: FormData): Promise<void> {
+  const widgetId = String(formData.get('widget_id') ?? '');
+  const state = String(formData.get('state') ?? '');
+  if (!(WIDGET_IDS as readonly string[]).includes(widgetId) || !STATES.includes(state)) {
+    return;
+  }
+
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) return;
+
+  const { data: profile } = await supabase
+    .from('profiles')
+    .select('id, dashboard_widget_state')
+    .eq('user_id', user.id)
+    .maybeSingle();
+  if (!profile?.id) return;
+
+  const next = withDismissal(
+    (profile.dashboard_widget_state as DashboardWidgetState | null) ?? {},
+    widgetId as WidgetId,
+    state as OnboardingState,
+    new Date().toISOString(),
+  );
+
+  await supabase.from('profiles').update({ dashboard_widget_state: next }).eq('id', profile.id);
+  revalidatePath('/dashboard');
+}

--- a/src/app/dashboard/widgets/dashboard-widgets.tsx
+++ b/src/app/dashboard/widgets/dashboard-widgets.tsx
@@ -1,0 +1,171 @@
+import Link from 'next/link';
+import type { ReactNode } from 'react';
+import ShareProfile from '../share-profile';
+import { dismissWidget } from './actions';
+import {
+  isDismissible,
+  type WidgetId,
+  type OnboardingState,
+  type WidgetResolution,
+} from '@/lib/dashboard/resolve-widgets';
+
+/**
+ * KAN-346/347 (epic KAN-349) — dashboard widget framework + the six widgets.
+ *
+ * Takes the resolver output (KAN-344) and renders the ordered, gated widget
+ * stack, reusing the KAN-326/337 share card for W5. The registry below is the
+ * one place a new feature adds its dashboard widget — add an id to the resolver
+ * + a case here. Dismissal is a server-action form (no client JS).
+ *
+ * ⚠️ COPY is PROPOSED — flagged for founder review (KAN-347 §6 "final copy").
+ */
+
+export interface WidgetContext {
+  state: OnboardingState;
+  completionScore: number;
+  /** canPublishWithAge(age_status) — drives W2's "publish" vs "verify age" CTA. */
+  canPublishAge: boolean;
+  profileUrl: string | null;
+  displayName: string | null;
+  betaLink: string | null;
+}
+
+/** Card shell with an optional server-action dismiss control (top-right ✕). */
+function WidgetShell({
+  widgetId,
+  state,
+  title,
+  accent,
+  children,
+}: {
+  widgetId: WidgetId;
+  state: OnboardingState;
+  title?: string;
+  accent?: boolean;
+  children: ReactNode;
+}) {
+  const dismissible = isDismissible(widgetId);
+  return (
+    <div
+      className={`relative bg-white rounded-xl border p-6 ${
+        accent ? 'border-[var(--color-sage)]/40' : 'border-[var(--color-border)]'
+      }`}
+    >
+      {dismissible && (
+        <form action={dismissWidget} className="absolute top-3 right-3">
+          <input type="hidden" name="widget_id" value={widgetId} />
+          <input type="hidden" name="state" value={state} />
+          <button
+            type="submit"
+            aria-label={`Dismiss ${title ?? widgetId}`}
+            className="text-[var(--color-muted)] hover:text-[var(--color-ink)] text-sm leading-none px-1"
+          >
+            ✕
+          </button>
+        </form>
+      )}
+      {title && <h3 className="text-lg font-medium text-[var(--color-ink)] mb-1 pr-6">{title}</h3>}
+      {children}
+    </div>
+  );
+}
+
+function Cta({ href, label }: { href: string; label: string }) {
+  return (
+    <Link
+      href={href}
+      className="mt-3 inline-block rounded-lg bg-[var(--color-sage)] px-4 py-2 text-sm font-medium text-white transition-opacity hover:opacity-90"
+    >
+      {label}
+    </Link>
+  );
+}
+
+function Body({ children }: { children: ReactNode }) {
+  return <p className="text-sm text-[var(--color-muted)] leading-relaxed">{children}</p>;
+}
+
+/** Render one widget by id. PROPOSED copy — review before finalising. */
+function renderWidget(id: WidgetId, ctx: WidgetContext): ReactNode {
+  switch (id) {
+    case 'complete_profile':
+      return (
+        <WidgetShell widgetId={id} state={ctx.state} title="Complete your profile" accent>
+          <Body>
+            You&rsquo;re {ctx.completionScore}% of the way there. Add a few more details so the
+            people in your life know what you&rsquo;d love.
+          </Body>
+          <Cta href="/dashboard/profile" label="Edit profile →" />
+        </WidgetShell>
+      );
+    case 'publish':
+      return ctx.canPublishAge ? (
+        <WidgetShell widgetId={id} state={ctx.state} title="Publish your profile" accent>
+          <Body>Your profile is ready — publish it so people can find you on Lyra.</Body>
+          <Cta href="/dashboard/profile" label="Open editor →" />
+        </WidgetShell>
+      ) : (
+        <WidgetShell widgetId={id} state={ctx.state} title="Verify your age to publish" accent>
+          <Body>A quick age check is required before your profile can go public.</Body>
+          <Cta href="/verify-age" label="Verify age →" />
+        </WidgetShell>
+      );
+    case 'add_gifts':
+      return (
+        <WidgetShell widgetId={id} state={ctx.state} title="Add a few gift ideas">
+          <Body>
+            Share some things you&rsquo;d genuinely love — it&rsquo;s the easiest way for people to
+            get it right.
+          </Body>
+          <Cta href="/dashboard/profile" label="Add gift ideas →" />
+        </WidgetShell>
+      );
+    case 'add_affiliations':
+      return (
+        <WidgetShell widgetId={id} state={ctx.state} title="Add your schools &amp; groups">
+          <Body>
+            Add the schools, organisations and communities you&rsquo;re part of so the right people
+            can find you.
+          </Body>
+          <Cta href="/dashboard/profile" label="Add affiliations →" />
+        </WidgetShell>
+      );
+    case 'share':
+      // Reuses the KAN-326/337 share card (its own heading serves as the title).
+      return (
+        <WidgetShell widgetId={id} state={ctx.state}>
+          <ShareProfile profileUrl={ctx.profileUrl} displayName={ctx.displayName} betaLink={ctx.betaLink} bare />
+        </WidgetShell>
+      );
+    case 'convene':
+      return (
+        <WidgetShell widgetId={id} state={ctx.state} title="Organise a gathering">
+          <Body>
+            Pick a time that works, suggest a place, and send invites — all from your dashboard with
+            Convene.
+          </Body>
+          <Cta href="/dashboard/convene/gatherings" label="Open Convene →" />
+        </WidgetShell>
+      );
+  }
+}
+
+export default function DashboardWidgets({
+  resolution,
+  ctx,
+}: {
+  resolution: WidgetResolution;
+  ctx: WidgetContext;
+}) {
+  if (resolution.widgets.length === 0) return null;
+  const fullCtx = { ...ctx, state: resolution.state };
+  return (
+    <div className="space-y-4 mb-6" data-onboarding-state={resolution.state}>
+      {resolution.widgets.map((w) => (
+        <div key={w.id} data-widget={w.id}>
+          {renderWidget(w.id, fullCtx)}
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/app/dashboard/widgets/dashboard-widgets.tsx
+++ b/src/app/dashboard/widgets/dashboard-widgets.tsx
@@ -1,6 +1,6 @@
 import Link from 'next/link';
 import type { ReactNode } from 'react';
-import ShareProfile from '../share-profile';
+import ShareBeta from '../share-beta';
 import { dismissWidget } from './actions';
 import {
   isDismissible,
@@ -27,7 +27,10 @@ export interface WidgetContext {
   canPublishAge: boolean;
   profileUrl: string | null;
   displayName: string | null;
+  /** The /join?code= deep-link while the waitlist is in place; null once removed. */
   betaLink: string | null;
+  /** The plain public sign-up link (used by the post-waitlist share version). */
+  signupUrl: string;
 }
 
 /** Card shell with an optional server-action dismiss control (top-right ✕). */
@@ -131,10 +134,23 @@ function renderWidget(id: WidgetId, ctx: WidgetContext): ReactNode {
         </WidgetShell>
       );
     case 'share':
-      // Reuses the KAN-326/337 share card (its own heading serves as the title).
+      // KAN-349 — TWO versions of the share card (founder request). While the
+      // waitlist is in place (a betaLink exists) we keep the exact existing
+      // "Share beta access" widget; once the gate is removed we show a sign-up-
+      // link version. Same layout/wording — reuses ShareBeta, not overwritten.
       return (
         <WidgetShell widgetId={id} state={ctx.state}>
-          <ShareProfile profileUrl={ctx.profileUrl} displayName={ctx.displayName} betaLink={ctx.betaLink} bare />
+          {ctx.betaLink ? (
+            <ShareBeta inviteLink={ctx.betaLink} bare />
+          ) : (
+            <ShareBeta
+              inviteLink={ctx.signupUrl}
+              bare
+              title="Share Lyra"
+              description="Invite someone to Lyra — send them this link to sign up and start their own profile."
+              linkLabel="Lyra sign-up link"
+            />
+          )}
         </WidgetShell>
       );
     case 'convene':

--- a/src/lib/beta-access/invite-link.ts
+++ b/src/lib/beta-access/invite-link.ts
@@ -30,3 +30,13 @@ export function betaInviteLink(): string | null {
   const origin = isProdFamily() ? 'https://checklyra.com' : env.siteUrl();
   return buildBetaInviteLink(origin, code);
 }
+
+/**
+ * KAN-349: the public sign-up URL to share once the waitlist/gate is removed
+ * (the post-waitlist counterpart to betaInviteLink — a plain sign-up link, no
+ * skip-the-waitlist code). Same public front door as the beta invite link.
+ */
+export function publicSignupUrl(): string {
+  const origin = isProdFamily() ? 'https://checklyra.com' : env.siteUrl();
+  return `${origin.replace(/\/+$/, '')}/signup`;
+}

--- a/src/lib/dashboard/dismissal.ts
+++ b/src/lib/dashboard/dismissal.ts
@@ -1,0 +1,45 @@
+/**
+ * KAN-345 (epic KAN-349) — dashboard widget dismissal state (pure helpers).
+ *
+ * Persisted as a JSONB map on `profiles.dashboard_widget_state`:
+ *   { [widget_id]: { dismissed_at, state } }
+ *
+ * A dismissal is recorded together with the onboarding STATE it happened in, so
+ * a widget re-surfaces when the state changes (the proposal default — "remind me
+ * later by progressing"). The user writes only their own row (RLS owner-update;
+ * not an admin-only column, so the self-elevation guard does not block it).
+ */
+import type { OnboardingState, WidgetId } from './resolve-widgets';
+
+export interface WidgetDismissal {
+  dismissed_at: string;
+  state: OnboardingState;
+}
+export type DashboardWidgetState = Partial<Record<WidgetId, WidgetDismissal>>;
+
+/**
+ * Map the persisted dismissals to the resolver's `dismissed` input for the
+ * CURRENT state. A widget is dismissed-for-this-state only if it was dismissed
+ * WHILE in this state — so a state change re-surfaces it.
+ */
+export function dismissedForState(
+  stored: DashboardWidgetState | null | undefined,
+  current: OnboardingState,
+): Partial<Record<WidgetId, boolean>> {
+  const out: Partial<Record<WidgetId, boolean>> = {};
+  if (!stored) return out;
+  for (const [id, d] of Object.entries(stored)) {
+    if (d && d.state === current) out[id as WidgetId] = true;
+  }
+  return out;
+}
+
+/** Pure: merge a new dismissal into the stored map. */
+export function withDismissal(
+  stored: DashboardWidgetState | null | undefined,
+  id: WidgetId,
+  state: OnboardingState,
+  now: string,
+): DashboardWidgetState {
+  return { ...(stored ?? {}), [id]: { dismissed_at: now, state } };
+}

--- a/src/lib/dashboard/resolve-widgets.ts
+++ b/src/lib/dashboard/resolve-widgets.ts
@@ -1,0 +1,114 @@
+/**
+ * KAN-344 (epic KAN-349) — onboarding-progress dashboard state resolver.
+ *
+ * Pure function: given the user's profile signals + entitlements + dismissals,
+ * return the onboarding STATE and the ordered list of eligible, non-dismissed
+ * dashboard widgets. No UI or DB coupling → fully unit-testable.
+ *
+ * State axes (deliberately NOT `user_status` from KAN-327, which is the access
+ * lifecycle): the journey is driven by `is_published` + profile completeness +
+ * derived content signals; feature entitlements decide which widgets exist at all.
+ *
+ * ── PROPOSED DEFAULTS — flagged for founder review (KAN-340 §7) ──────────────
+ *  • empty→drafted boundary: completion_score >= EMPTY_TO_DRAFTED_THRESHOLD (40).
+ *  • layout: a single primary CTA in empty/drafted; a stack in published states.
+ *  • dismissal: only secondary/grow widgets are dismissible (W1 "complete" and
+ *    W2 "publish" are the journey's single next step and are never dismissible);
+ *    a dismissal is keyed per-widget and re-surfaces when the state changes
+ *    (handled by the persistence layer, KAN-345).
+ * These are easy to change in one place — see the questions doc.
+ */
+
+export type OnboardingState = 'empty' | 'drafted' | 'published_activate' | 'published_grow';
+
+export const WIDGET_IDS = [
+  'complete_profile', // W1
+  'publish', // W2
+  'add_gifts', // W3
+  'add_affiliations', // W4
+  'share', // W5
+  'convene', // W6
+] as const;
+export type WidgetId = (typeof WIDGET_IDS)[number];
+
+/**
+ * Completion % at/above which an unpublished profile is treated as "drafted"
+ * (ready to publish) rather than "empty" (needs more content). Tunable default —
+ * founder to confirm the threshold.
+ */
+export const EMPTY_TO_DRAFTED_THRESHOLD = 40;
+
+/** W1/W2 are the single next step of the journey and cannot be dismissed. */
+const NON_DISMISSIBLE: readonly WidgetId[] = ['complete_profile', 'publish'];
+export function isDismissible(id: WidgetId): boolean {
+  return !NON_DISMISSIBLE.includes(id);
+}
+
+export interface WidgetResolverInput {
+  /** profiles.is_published */
+  isPublished: boolean;
+  /** profiles.completion_score (0–100) */
+  completionScore: number;
+  /** has at least one gift_ideas profile_item */
+  hasGifts: boolean;
+  /** has at least one school_affiliations row */
+  hasAffiliations: boolean;
+  /** feature_entitlements: convene (resolved, env-AND-entitlement) */
+  conveneEntitled: boolean;
+  /** persisted dismissal map for the CURRENT state (widget_id -> dismissed) */
+  dismissed?: Partial<Record<WidgetId, boolean>>;
+}
+
+export interface ResolvedWidget {
+  id: WidgetId;
+  order: number;
+}
+export interface WidgetResolution {
+  state: OnboardingState;
+  widgets: ResolvedWidget[];
+}
+
+/** Pure: derive the onboarding state from publish + completeness + content. */
+export function resolveOnboardingState(
+  input: Pick<WidgetResolverInput, 'isPublished' | 'completionScore' | 'hasGifts' | 'hasAffiliations'>,
+): OnboardingState {
+  if (!input.isPublished) {
+    return input.completionScore >= EMPTY_TO_DRAFTED_THRESHOLD ? 'drafted' : 'empty';
+  }
+  return input.hasGifts && input.hasAffiliations ? 'published_grow' : 'published_activate';
+}
+
+/**
+ * Pure: the ordered, eligible, non-dismissed widget set for the user's state.
+ * Order is contiguous (0..n) after dismissal filtering so the renderer is dumb.
+ */
+export function resolveWidgets(input: WidgetResolverInput): WidgetResolution {
+  const state = resolveOnboardingState(input);
+  const dismissed = input.dismissed ?? {};
+  const candidates: WidgetId[] = [];
+
+  switch (state) {
+    case 'empty':
+      candidates.push('complete_profile');
+      break;
+    case 'drafted':
+      candidates.push('publish');
+      break;
+    case 'published_activate':
+      // Lead with the growth actions the user hasn't done yet, then share.
+      if (!input.hasGifts) candidates.push('add_gifts');
+      if (!input.hasAffiliations) candidates.push('add_affiliations');
+      candidates.push('share');
+      break;
+    case 'published_grow':
+      candidates.push('share');
+      if (input.conveneEntitled) candidates.push('convene');
+      break;
+  }
+
+  const widgets = candidates
+    .filter((id) => !(isDismissible(id) && dismissed[id]))
+    .map((id, i) => ({ id, order: i }));
+
+  return { state, widgets };
+}

--- a/src/lib/geo/places-city.ts
+++ b/src/lib/geo/places-city.ts
@@ -1,0 +1,79 @@
+/**
+ * KAN-341 (epic KAN-349) — resolve a town/city from a postcode via Google Places
+ * (New) Text Search, reusing the existing GOOGLE_PLACES_API_KEY (KAN-207, the
+ * Convene venues integration). No new secret needed.
+ *
+ * PRIVACY INVARIANT (critical): the postcode is used ONLY transiently here — it
+ * is never persisted, never logged, and never placed in an error message. We
+ * return the coarse locality (town/city + optional region) only; the caller
+ * stores just the city in profiles.city. The raw postcode is discarded when this
+ * function returns.
+ *
+ * GLOBAL: the postcode is passed as a free-text query with no region restriction,
+ * so the same path resolves postcodes/zip codes in any country (Q6: "assume
+ * global so it's more reusable").
+ */
+
+const PLACES_TEXT_SEARCH_ENDPOINT = 'https://places.googleapis.com/v1/places:searchText';
+
+export interface CityLookupResult {
+  city: string;
+  /** administrative_area_level_1 (e.g. "Greater London", "California"), if present. */
+  region: string | null;
+}
+
+interface PlacesAddressComponent {
+  longText?: string;
+  types?: string[];
+}
+
+/**
+ * Pure: pick the coarse locality from a Places result's address components.
+ * Prefers postal_town (UK) → locality (most countries) → admin_area_2 (county).
+ * Exported for direct unit testing without a network call.
+ */
+export function extractCity(components: ReadonlyArray<PlacesAddressComponent>): CityLookupResult | null {
+  const pick = (type: string): string | null =>
+    components.find((c) => c.types?.includes(type))?.longText ?? null;
+
+  const city = pick('postal_town') ?? pick('locality') ?? pick('administrative_area_level_2');
+  if (!city) return null;
+  return { city, region: pick('administrative_area_level_1') };
+}
+
+/**
+ * Resolve a postcode to a town/city via Google Places. Returns null on any
+ * failure (no key, network error, no result) — the caller falls back to manual
+ * city entry. NEVER logs or returns the postcode.
+ */
+export async function lookupCityFromPostcode(
+  postcode: string,
+  // Injected for tests; defaults to the global fetch.
+  fetchImpl: typeof fetch = fetch,
+): Promise<CityLookupResult | null> {
+  const key = process.env.GOOGLE_PLACES_API_KEY;
+  const query = (postcode ?? '').trim();
+  if (!key || !query) return null;
+
+  try {
+    const res = await fetchImpl(PLACES_TEXT_SEARCH_ENDPOINT, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-Goog-Api-Key': key,
+        // Address components only — no place id, no lat/lng (data minimisation).
+        'X-Goog-FieldMask': 'places.addressComponents',
+      },
+      body: JSON.stringify({ textQuery: query, maxResultCount: 1 }),
+    });
+    if (!res.ok) return null;
+    const data = (await res.json()) as {
+      places?: Array<{ addressComponents?: PlacesAddressComponent[] }>;
+    };
+    const components = data.places?.[0]?.addressComponents ?? [];
+    return extractCity(components);
+  } catch {
+    // Swallow — never surface the postcode in an error path.
+    return null;
+  }
+}

--- a/supabase/migrations/20260630010000_kan345_dashboard_widget_state.sql
+++ b/supabase/migrations/20260630010000_kan345_dashboard_widget_state.sql
@@ -1,0 +1,22 @@
+-- KAN-345 (epic KAN-349) — per-user dashboard widget dismissal state.
+--
+-- A JSONB map { widget_id: { dismissed_at, state } } on profiles. This is the
+-- only genuinely new stored state the dashboard widget journey needs; everything
+-- else is derived (is_published / completion_score / has-gifts / has-affiliations
+-- / entitlements). A dismissal is recorded with the onboarding STATE it happened
+-- in, so a widget re-surfaces when the state changes.
+--
+-- Security: the user writes only their OWN dismissals. profiles already has an
+-- owner-update RLS policy (KAN-273/309), and dashboard_widget_state is NOT one of
+-- the admin-only columns guarded by prevent_beta_self_elevation (access_tier,
+-- user_status, age_status, beta_*), so an owner UPDATE that touches only this
+-- column passes both the RLS and the self-elevation trigger. No new policy needed.
+-- Stores no PII — widget ids + timestamps + state label only.
+--
+-- Rollback: alter table public.profiles drop column if exists dashboard_widget_state;
+
+alter table public.profiles
+  add column if not exists dashboard_widget_state jsonb not null default '{}'::jsonb;
+
+comment on column public.profiles.dashboard_widget_state is
+  'KAN-345: per-user dashboard widget dismissals { widget_id: { dismissed_at, state } }. User-writable on own row (RLS owner-update).';

--- a/supabase/migrations/20260630020000_kan339_scrub_postcode.sql
+++ b/supabase/migrations/20260630020000_kan339_scrub_postcode.sql
@@ -1,0 +1,23 @@
+-- KAN-339 (epic KAN-349) — scrub postcode data; retain the columns nullable.
+--
+-- Postcode is no longer collected, stored, or used for discovery (replaced by
+-- town/city discovery, KAN-341). This NULLs every existing postcode value and
+-- disables postcode discovery for all rows. The columns are RETAINED (nullable)
+-- so no dependent objects break; the app no longer reads or writes them (see
+-- profile-fields.ts ALLOWED_PROFILE_FIELDS + discoverability-*).
+--
+-- The affiliate geo-signal uses profiles.delivery_country_code (country), NOT
+-- postcode, so scrubbing postcode has no effect on recommendations (verified).
+--
+-- Privacy: postcode plaintext was never stored (only postcode_prefix, which the
+-- user typed, and a salted HMAC search hash). Both are erased here.
+--
+-- Rollback: the DATA is intentionally erased (no rollback). The columns remain.
+
+update public.profiles
+set postcode_prefix = null,
+    discoverable_by_postcode = false,
+    postcode_search_hash = null
+where postcode_prefix is not null
+   or discoverable_by_postcode is true
+   or postcode_search_hash is not null;

--- a/tests/unit/convene/convene-nav.test.ts
+++ b/tests/unit/convene/convene-nav.test.ts
@@ -23,10 +23,16 @@ describe('Convene nav entry points (KAN-303)', () => {
     test('gates the header Convene link on the flag', () => {
       expect(src).toMatch(/conveneEnabled &&[\s\S]{0,200}\/dashboard\/convene\/gatherings/);
     });
-    test('gates a landing card on the flag and links to People', () => {
-      expect(src).toMatch(/\/dashboard\/convene\/contacts/);
-      // Both the header link and the landing card are wrapped in `conveneEnabled &&`.
-      expect((src.match(/conveneEnabled &&/g) || []).length).toBeGreaterThanOrEqual(2);
+    test('gates the Convene widget (W6) by wiring the per-user flag into the resolver (KAN-349)', () => {
+      // KAN-349 moved the old inline Convene landing card to the W6 dashboard widget
+      // (src/app/dashboard/widgets/dashboard-widgets.tsx). It stays flag-gated: the page
+      // passes the live per-user flag into resolveWidgets({ conveneEntitled }). Re-pointed,
+      // not weakened — see the resolver assertion below for the actual gating.
+      expect(src).toMatch(/conveneEntitled:\s*conveneEnabled/);
+    });
+    test('the widget resolver only emits the convene widget when entitled (KAN-349)', () => {
+      const resolverSrc = fs.readFileSync(path.join(ROOT, 'src/lib/dashboard/resolve-widgets.ts'), 'utf8');
+      expect(resolverSrc).toMatch(/if \(input\.conveneEntitled\)[\s\S]{0,80}'convene'/);
     });
   });
 

--- a/tests/unit/convene/sec18-hmac-hash.test.ts
+++ b/tests/unit/convene/sec18-hmac-hash.test.ts
@@ -42,9 +42,9 @@ describe('SEC-18 HMAC contact hashing', () => {
     expect(a).not.toBe(c);
   });
 
-  test('kind namespacing holds under HMAC', () => {
-    expect(hashContact('phone', 'SAMEVALUE', KEY)).not.toBe(hashContact('postcode', 'SAMEVALUE', KEY));
-  });
+  // KAN-339: the phone/postcode kind-namespacing test was removed with postcode
+  // discovery — only the 'phone' ContactKind remains, so two kinds can't be
+  // compared. hashContact still namespaces by `kind` in the HMAC message.
 
   test('getContactSearchHmacKey prefers CONTACT_SEARCH_HMAC_KEY, falls back to the pepper', () => {
     const orig = process.env.CONTACT_SEARCH_HMAC_KEY;

--- a/tests/unit/dashboard-dismissal.test.ts
+++ b/tests/unit/dashboard-dismissal.test.ts
@@ -1,0 +1,32 @@
+/**
+ * KAN-345 — dashboard widget dismissal helpers: re-surface on state change.
+ */
+import { dismissedForState, withDismissal, type DashboardWidgetState } from '@/lib/dashboard/dismissal';
+
+describe('KAN-345 dismissal helpers', () => {
+  it('withDismissal records the widget with the current state + timestamp', () => {
+    const next = withDismissal({}, 'share', 'published_grow', '2026-06-30T00:00:00Z');
+    expect(next.share).toEqual({ dismissed_at: '2026-06-30T00:00:00Z', state: 'published_grow' });
+  });
+
+  it('withDismissal merges without clobbering other widgets', () => {
+    const start: DashboardWidgetState = { share: { dismissed_at: 't1', state: 'published_grow' } };
+    const next = withDismissal(start, 'convene', 'published_grow', 't2');
+    expect(Object.keys(next).sort()).toEqual(['convene', 'share']);
+  });
+
+  it('dismissedForState marks a widget dismissed only IN the state it was dismissed', () => {
+    const stored: DashboardWidgetState = { add_gifts: { dismissed_at: 't', state: 'published_activate' } };
+    expect(dismissedForState(stored, 'published_activate')).toEqual({ add_gifts: true });
+  });
+
+  it('a widget re-surfaces when the state changes (different state → not dismissed)', () => {
+    const stored: DashboardWidgetState = { share: { dismissed_at: 't', state: 'published_activate' } };
+    expect(dismissedForState(stored, 'published_grow')).toEqual({});
+  });
+
+  it('null/empty store → nothing dismissed', () => {
+    expect(dismissedForState(null, 'empty')).toEqual({});
+    expect(dismissedForState({}, 'drafted')).toEqual({});
+  });
+});

--- a/tests/unit/dashboard-resolve-widgets.test.ts
+++ b/tests/unit/dashboard-resolve-widgets.test.ts
@@ -1,0 +1,107 @@
+/**
+ * KAN-344 — onboarding-progress state resolver. Table-driven coverage of the
+ * §5/§6 mapping: state derivation + the ordered, gated, non-dismissed widget set.
+ */
+import {
+  resolveWidgets,
+  resolveOnboardingState,
+  isDismissible,
+  EMPTY_TO_DRAFTED_THRESHOLD,
+  type WidgetResolverInput,
+  type WidgetId,
+} from '@/lib/dashboard/resolve-widgets';
+
+function input(overrides: Partial<WidgetResolverInput> = {}): WidgetResolverInput {
+  return {
+    isPublished: false,
+    completionScore: 0,
+    hasGifts: false,
+    hasAffiliations: false,
+    conveneEntitled: false,
+    ...overrides,
+  };
+}
+const ids = (r: { widgets: { id: WidgetId }[] }) => r.widgets.map((w) => w.id);
+
+describe('KAN-344 resolveOnboardingState', () => {
+  it('empty: unpublished + below the completion threshold', () => {
+    expect(resolveOnboardingState({ isPublished: false, completionScore: EMPTY_TO_DRAFTED_THRESHOLD - 1, hasGifts: false, hasAffiliations: false })).toBe('empty');
+  });
+  it('drafted: unpublished + at/above the completion threshold', () => {
+    expect(resolveOnboardingState({ isPublished: false, completionScore: EMPTY_TO_DRAFTED_THRESHOLD, hasGifts: false, hasAffiliations: false })).toBe('drafted');
+  });
+  it('published_activate: published but missing gifts or affiliations', () => {
+    expect(resolveOnboardingState({ isPublished: true, completionScore: 100, hasGifts: false, hasAffiliations: true })).toBe('published_activate');
+    expect(resolveOnboardingState({ isPublished: true, completionScore: 100, hasGifts: true, hasAffiliations: false })).toBe('published_activate');
+  });
+  it('published_grow: published with both gifts and affiliations', () => {
+    expect(resolveOnboardingState({ isPublished: true, completionScore: 100, hasGifts: true, hasAffiliations: true })).toBe('published_grow');
+  });
+});
+
+describe('KAN-344 resolveWidgets — widget sets per state', () => {
+  it('empty → single W1 complete_profile', () => {
+    const r = resolveWidgets(input({ completionScore: 10 }));
+    expect(r.state).toBe('empty');
+    expect(ids(r)).toEqual(['complete_profile']);
+  });
+
+  it('drafted → single W2 publish', () => {
+    const r = resolveWidgets(input({ completionScore: 60 }));
+    expect(r.state).toBe('drafted');
+    expect(ids(r)).toEqual(['publish']);
+  });
+
+  it('published_activate, no gifts/affiliations → add_gifts, add_affiliations, share', () => {
+    const r = resolveWidgets(input({ isPublished: true, completionScore: 100 }));
+    expect(r.state).toBe('published_activate');
+    expect(ids(r)).toEqual(['add_gifts', 'add_affiliations', 'share']);
+    expect(r.widgets.map((w) => w.order)).toEqual([0, 1, 2]);
+  });
+
+  it('published_activate, has gifts only → add_affiliations, share (no add_gifts)', () => {
+    const r = resolveWidgets(input({ isPublished: true, completionScore: 100, hasGifts: true }));
+    expect(ids(r)).toEqual(['add_affiliations', 'share']);
+  });
+
+  it('published_grow → share only (no convene without entitlement)', () => {
+    const r = resolveWidgets(input({ isPublished: true, completionScore: 100, hasGifts: true, hasAffiliations: true }));
+    expect(r.state).toBe('published_grow');
+    expect(ids(r)).toEqual(['share']);
+  });
+
+  it('published_grow + convene entitlement → share, convene', () => {
+    const r = resolveWidgets(input({ isPublished: true, completionScore: 100, hasGifts: true, hasAffiliations: true, conveneEntitled: true }));
+    expect(ids(r)).toEqual(['share', 'convene']);
+  });
+});
+
+describe('KAN-344 dismissal', () => {
+  it('a dismissed secondary widget is removed + order recompacts', () => {
+    const r = resolveWidgets(input({ isPublished: true, completionScore: 100, dismissed: { add_gifts: true } }));
+    expect(ids(r)).toEqual(['add_affiliations', 'share']);
+    expect(r.widgets.map((w) => w.order)).toEqual([0, 1]);
+  });
+
+  it('W1 complete_profile is NOT dismissible (primary CTA survives a stale dismissal)', () => {
+    expect(isDismissible('complete_profile')).toBe(false);
+    const r = resolveWidgets(input({ completionScore: 10, dismissed: { complete_profile: true } as Record<WidgetId, boolean> }));
+    expect(ids(r)).toEqual(['complete_profile']);
+  });
+
+  it('W2 publish is NOT dismissible', () => {
+    expect(isDismissible('publish')).toBe(false);
+  });
+
+  it('secondary widgets ARE dismissible', () => {
+    for (const id of ['add_gifts', 'add_affiliations', 'share', 'convene'] as WidgetId[]) {
+      expect(isDismissible(id)).toBe(true);
+    }
+  });
+
+  it('all secondary dismissed in grow → empty widget list (clean dashboard)', () => {
+    const r = resolveWidgets(input({ isPublished: true, completionScore: 100, hasGifts: true, hasAffiliations: true, conveneEntitled: true, dismissed: { share: true, convene: true } }));
+    expect(r.state).toBe('published_grow');
+    expect(ids(r)).toEqual([]);
+  });
+});

--- a/tests/unit/discoverability-actions.test.ts
+++ b/tests/unit/discoverability-actions.test.ts
@@ -1,38 +1,30 @@
 /**
- * KAN-153: unit tests for the discoverability server actions.
+ * KAN-153 / KAN-339: unit tests for the discoverability server actions.
  *
- * Covers:
- *   - setDiscoverability flips flag ON and sets hash when given a value.
- *   - setDiscoverability flips flag OFF and clears the hash.
+ * Covers (phone only — KAN-339 removed postcode discovery):
+ *   - setDiscoverability flips the phone flag ON and sets the hash with a value.
+ *   - setDiscoverability flips it OFF and clears the hash.
  *   - setDiscoverability rejects opt-in without a value.
- *   - setDiscoverability rejects an unnormalisable value WITHOUT echoing it
- *     back in the error message.
- *   - searchByPhone / searchByPostcode call the RPC with the right kind/hash.
- *   - search returns generic empty matches for unnormalisable input
- *     (no distinction between "bad input" and "unknown value").
+ *   - setDiscoverability rejects an unnormalisable value WITHOUT echoing it back.
+ *   - searchByPhone calls the RPC with the right kind/hash.
+ *   - search returns generic empty matches for unnormalisable input.
  *   - Rate-limit kicks in after 10 calls per user per hour.
- *   - Plain phone/postcode values NEVER appear in any returned error.
+ *   - Plain phone values NEVER appear in any returned error.
  *
- * Supabase + next/cache are mocked. The pepper is set in beforeAll.
+ * Supabase + next/cache are mocked. The pepper is set before import.
  */
 
-// Set pepper before importing any module that calls getSearchPepper.
 process.env.LYRA_SEARCH_PEPPER = 'unit-test-pepper-long-enough-for-validation';
 
-// Mock next/cache.
 const mockRevalidatePath = jest.fn();
 jest.mock('next/cache', () => ({
   revalidatePath: (...args: unknown[]) => mockRevalidatePath(...args),
 }));
 
-// KAN-309: setDiscoverability now checks the per-user 'discovery' entitlement
-// before an opt-in. Mock the new dependency as entitled (the default) so the
-// existing behavioural assertions exercise the same path as before.
 jest.mock('@/lib/features/entitlements', () => ({
   getMyFeatureEntitlements: jest.fn(async () => ({ discovery: true })),
 }));
 
-// Capture supabase interactions.
 const mockUpdateCapture = jest.fn();
 const mockUpdateEq = jest.fn().mockResolvedValue({ error: null });
 const mockSelectEq = jest.fn();
@@ -40,11 +32,9 @@ const mockRpc = jest.fn();
 let mockProfileRow: {
   id: string;
   discoverable_by_phone: boolean;
-  discoverable_by_postcode: boolean;
 } | null = {
   id: 'profile-1',
   discoverable_by_phone: false,
-  discoverable_by_postcode: false,
 };
 let mockUserId: string | null = 'test-user-id';
 
@@ -77,7 +67,6 @@ jest.mock('@/lib/supabase-server', () => ({
   })),
 }));
 
-// Mock the rate limiter so we can drive it deterministically.
 const mockRateLimit = jest.fn();
 jest.mock('@/lib/rate-limit', () => {
   const actual = jest.requireActual('@/lib/rate-limit');
@@ -91,7 +80,6 @@ jest.mock('@/lib/rate-limit', () => {
 import {
   setDiscoverability,
   searchByPhone,
-  searchByPostcode,
 } from '@/app/dashboard/settings/discoverability-actions';
 
 beforeEach(() => {
@@ -106,7 +94,6 @@ beforeEach(() => {
   mockProfileRow = {
     id: 'profile-1',
     discoverable_by_phone: false,
-    discoverable_by_postcode: false,
   };
   mockUserId = 'test-user-id';
 });
@@ -132,31 +119,8 @@ describe('setDiscoverability', () => {
     expect(written.phone_search_hash).toBeNull();
   });
 
-  test('enabling postcode with a valid value writes flag + hash', async () => {
-    const result = await setDiscoverability({ postcode: true, postcodeValue: 'SW1A 1AA' });
-    expect(result).toEqual({ success: true });
-    const written = mockUpdateCapture.mock.calls[0][0] as Record<string, unknown>;
-    expect(written.discoverable_by_postcode).toBe(true);
-    expect(typeof written.postcode_search_hash).toBe('string');
-  });
-
-  test('disabling postcode clears the hash to null', async () => {
-    mockProfileRow!.discoverable_by_postcode = true;
-    const result = await setDiscoverability({ postcode: false });
-    expect(result).toEqual({ success: true });
-    const written = mockUpdateCapture.mock.calls[0][0] as Record<string, unknown>;
-    expect(written.discoverable_by_postcode).toBe(false);
-    expect(written.postcode_search_hash).toBeNull();
-  });
-
   test('rejects opting in to phone with no value', async () => {
     const result = await setDiscoverability({ phone: true });
-    expect(result.success).toBe(false);
-    expect(mockUpdateCapture).not.toHaveBeenCalled();
-  });
-
-  test('rejects opting in to postcode with no value', async () => {
-    const result = await setDiscoverability({ postcode: true });
     expect(result.success).toBe(false);
     expect(mockUpdateCapture).not.toHaveBeenCalled();
   });
@@ -167,16 +131,6 @@ describe('setDiscoverability', () => {
     expect(result.success).toBe(false);
     if (!result.success) {
       // Critical: the error message MUST NOT contain the user's input.
-      expect(result.error).not.toContain(badInput);
-    }
-    expect(mockUpdateCapture).not.toHaveBeenCalled();
-  });
-
-  test('rejects opting in with an unnormalisable postcode — error does NOT echo the input', async () => {
-    const badInput = 'NOT-A-VALID-POSTCODE!!';
-    const result = await setDiscoverability({ postcode: true, postcodeValue: badInput });
-    expect(result.success).toBe(false);
-    if (!result.success) {
       expect(result.error).not.toContain(badInput);
     }
     expect(mockUpdateCapture).not.toHaveBeenCalled();
@@ -196,9 +150,9 @@ describe('setDiscoverability', () => {
   });
 });
 
-// ── searchByPhone / searchByPostcode ───────────────────────
-describe('searchByPhone / searchByPostcode', () => {
-  test('searchByPhone calls the RPC with kind=phone and a hex hash', async () => {
+// ── searchByPhone ──────────────────────────────────────────
+describe('searchByPhone', () => {
+  test('calls the RPC with kind=phone and a hex hash', async () => {
     mockRpc.mockResolvedValueOnce({ data: [{ id: 'p1', slug: 'alice' }], error: null });
     const result = await searchByPhone('07700900000');
     expect(result).toEqual({ success: true, matches: [{ id: 'p1', slug: 'alice' }] });
@@ -209,50 +163,25 @@ describe('searchByPhone / searchByPostcode', () => {
     expect((args as { p_hash: string }).p_hash).toMatch(/^[a-f0-9]{64}$/);
   });
 
-  test('searchByPostcode calls the RPC with kind=postcode and a hex hash', async () => {
-    mockRpc.mockResolvedValueOnce({ data: [], error: null });
-    const result = await searchByPostcode('SW1A 1AA');
-    expect(result).toEqual({ success: true, matches: [] });
-    expect(mockRpc).toHaveBeenCalledTimes(1);
-    const [, args] = mockRpc.mock.calls[0];
-    expect((args as { p_kind: string }).p_kind).toBe('postcode');
-  });
-
-  test('searchByPhone returns empty matches (NOT an error) for malformed input', async () => {
-    // Indistinguishable response between "bad input" and "no match" —
-    // we should not call the RPC at all in this case.
+  test('returns empty matches (NOT an error) for malformed input', async () => {
     const result = await searchByPhone('not a phone');
     expect(result).toEqual({ success: true, matches: [] });
     expect(mockRpc).not.toHaveBeenCalled();
   });
 
-  test('searchByPostcode returns empty matches (NOT an error) for malformed input', async () => {
-    const result = await searchByPostcode('!!!');
-    expect(result).toEqual({ success: true, matches: [] });
-    expect(mockRpc).not.toHaveBeenCalled();
-  });
-
-  test('searchByPhone surfaces a generic error on RPC failure — no hash leakage', async () => {
+  test('surfaces a generic error on RPC failure — no hash leakage', async () => {
     mockRpc.mockResolvedValueOnce({ data: null, error: { message: 'pgrst something' } });
     const result = await searchByPhone('07700900000');
     expect(result.success).toBe(false);
     if (!result.success) {
-      // The error must not contain the RPC's internal message OR the hash.
       expect(result.error).not.toContain('pgrst');
       expect(result.error).not.toMatch(/[a-f0-9]{32}/);
     }
   });
 
-  test('searchByPhone rejects unauthenticated callers', async () => {
+  test('rejects unauthenticated callers', async () => {
     mockUserId = null;
     const result = await searchByPhone('07700900000');
-    expect(result.success).toBe(false);
-    expect(mockRpc).not.toHaveBeenCalled();
-  });
-
-  test('searchByPostcode rejects unauthenticated callers', async () => {
-    mockUserId = null;
-    const result = await searchByPostcode('SW1A 1AA');
     expect(result.success).toBe(false);
     expect(mockRpc).not.toHaveBeenCalled();
   });
@@ -279,7 +208,6 @@ describe('discoverability search rate-limit', () => {
       expect(result.error).toMatch(/Too many/);
       expect(result.error).toContain('123');
     }
-    // Critical: we must NOT have called the RPC when rate-limited.
     expect(mockRpc).not.toHaveBeenCalled();
   });
 
@@ -295,12 +223,5 @@ describe('discoverability search rate-limit', () => {
     const keys = mockRateLimit.mock.calls.map((c) => c[0]);
     expect(keys).toContain('discoverability-search:user-a');
     expect(keys).toContain('discoverability-search:user-b');
-  });
-
-  test('rate-limit applies to postcode search as well', async () => {
-    mockRateLimit.mockReturnValue({ limited: true, retryAfter: 60 });
-    const result = await searchByPostcode('SW1A 1AA');
-    expect(result.success).toBe(false);
-    expect(mockRpc).not.toHaveBeenCalled();
   });
 });

--- a/tests/unit/discoverability-helpers.test.ts
+++ b/tests/unit/discoverability-helpers.test.ts
@@ -1,22 +1,19 @@
 /**
- * KAN-153: unit tests for the pure phone/postcode discoverability helpers.
+ * KAN-153 / KAN-339: unit tests for the pure phone discoverability helpers.
  *
- * These cover:
+ * Covers:
  *   - normalisePhone: E.164 normalisation, UK default, rejects bad input.
- *   - normalisePostcode: uppercase / no-space normalisation, rejects bad
- *     input.
- *   - hashContact: determinism, pepper sensitivity, kind-namespacing.
- *   - hashPhoneInput / hashPostcodeInput: end-to-end with a pepper from env.
+ *   - hashContact: determinism, key sensitivity.
+ *   - hashPhoneInput: end-to-end with a pepper from env.
  *   - getSearchPepper: throws when missing or too short.
  *
- * No Supabase / network — all pure functions.
+ * KAN-339 removed postcode discovery, so the normalisePostcode /
+ * hashPostcodeInput cases are gone with the functions. No Supabase / network.
  */
 import {
   normalisePhone,
-  normalisePostcode,
   hashContact,
   hashPhoneInput,
-  hashPostcodeInput,
   getSearchPepper,
 } from '@/app/dashboard/settings/discoverability-helpers';
 
@@ -67,46 +64,6 @@ describe('normalisePhone', () => {
   });
 });
 
-// ── normalisePostcode ──────────────────────────────────────
-describe('normalisePostcode', () => {
-  test('uppercases and removes spaces', () => {
-    expect(normalisePostcode('sw1a 1aa')).toBe('SW1A1AA');
-    expect(normalisePostcode('SW1A 1AA')).toBe('SW1A1AA');
-  });
-
-  test('handles already-uppercase / no-space', () => {
-    expect(normalisePostcode('M11AE')).toBe('M11AE');
-  });
-
-  test('trims surrounding whitespace', () => {
-    expect(normalisePostcode('  E1 6AN  ')).toBe('E16AN');
-  });
-
-  test('rejects empty string', () => {
-    expect(normalisePostcode('')).toBeNull();
-  });
-
-  test('rejects too short', () => {
-    expect(normalisePostcode('SW1A')).toBeNull();
-  });
-
-  test('rejects non-alphanumerics', () => {
-    expect(normalisePostcode('SW1A-1AA')).toBeNull();
-    expect(normalisePostcode('SW1A!1AA')).toBeNull();
-  });
-
-  test('rejects too long', () => {
-    expect(normalisePostcode('SW1A1AABBB')).toBeNull();
-  });
-
-  test('rejects null/undefined gracefully', () => {
-    // @ts-expect-error — testing runtime behaviour with bad input
-    expect(normalisePostcode(null)).toBeNull();
-    // @ts-expect-error — testing runtime behaviour with bad input
-    expect(normalisePostcode(undefined)).toBeNull();
-  });
-});
-
 // ── hashContact ────────────────────────────────────────────
 describe('hashContact', () => {
   const pepper = 'test-pepper-at-least-16-chars-long';
@@ -122,7 +79,7 @@ describe('hashContact', () => {
     expect(h).toMatch(/^[a-f0-9]{64}$/);
   });
 
-  test('different pepper produces different hash', () => {
+  test('different key produces different hash', () => {
     const a = hashContact('phone', '+447700900000', pepper);
     const b = hashContact('phone', '+447700900000', 'different-pepper-also-long');
     expect(a).not.toBe(b);
@@ -131,14 +88,6 @@ describe('hashContact', () => {
   test('different value produces different hash', () => {
     const a = hashContact('phone', '+447700900000', pepper);
     const b = hashContact('phone', '+447700900001', pepper);
-    expect(a).not.toBe(b);
-  });
-
-  test('phone and postcode kinds are namespaced apart', () => {
-    // Even if a user happened to enter the same string for both, the
-    // resulting hashes MUST differ.
-    const a = hashContact('phone', 'SAMEVALUE', pepper);
-    const b = hashContact('postcode', 'SAMEVALUE', pepper);
     expect(a).not.toBe(b);
   });
 
@@ -176,7 +125,6 @@ describe('getSearchPepper', () => {
 
   test('error message does NOT include the pepper value (privacy)', () => {
     process.env.LYRA_SEARCH_PEPPER = 'secret-pepper-value-that-should-not-leak';
-    // (Pepper IS long enough — but we re-verify the empty case here)
     delete process.env.LYRA_SEARCH_PEPPER;
     try {
       getSearchPepper();
@@ -188,8 +136,8 @@ describe('getSearchPepper', () => {
   });
 });
 
-// ── hashPhoneInput / hashPostcodeInput (end-to-end) ────────
-describe('hashPhoneInput / hashPostcodeInput', () => {
+// ── hashPhoneInput (end-to-end) ────────────────────────────
+describe('hashPhoneInput', () => {
   const originalPepper = process.env.LYRA_SEARCH_PEPPER;
   beforeAll(() => {
     process.env.LYRA_SEARCH_PEPPER = 'unit-test-pepper-long-enough-for-validation';
@@ -210,34 +158,8 @@ describe('hashPhoneInput / hashPostcodeInput', () => {
     expect(a).toBe(c);
   });
 
-  test('different formatting of the same UK postcode produces the SAME hash', () => {
-    const a = hashPostcodeInput('sw1a 1aa');
-    const b = hashPostcodeInput('SW1A1AA');
-    const c = hashPostcodeInput('  SW1A 1AA  ');
-    expect(a).not.toBeNull();
-    expect(a).toBe(b);
-    expect(a).toBe(c);
-  });
-
   test('returns null for unnormalisable phone', () => {
     expect(hashPhoneInput('not a phone')).toBeNull();
     expect(hashPhoneInput('')).toBeNull();
-  });
-
-  test('returns null for unnormalisable postcode', () => {
-    expect(hashPostcodeInput('!')).toBeNull();
-    expect(hashPostcodeInput('')).toBeNull();
-  });
-
-  test('phone and postcode with same normalised form still hash differently', () => {
-    // Crafted overlap: 'SW1A1AA' could theoretically be a normalised
-    // postcode AND… well, it can't be a phone (phones must start with +).
-    // But for a string value that COULD be either, kind-namespacing
-    // ensures distinct hashes. Test directly via hashContact already
-    // covers this; we re-verify via the public end-to-end entry points
-    // by hashing the same normalised string under both kinds manually.
-    const phoneHash = hashPhoneInput('+447700900000');
-    const postcodeHash = hashPostcodeInput('SW1A1AA');
-    expect(phoneHash).not.toBe(postcodeHash);
   });
 });

--- a/tests/unit/kan342-gift-visibility.test.ts
+++ b/tests/unit/kan342-gift-visibility.test.ts
@@ -1,0 +1,41 @@
+/**
+ * KAN-342 (epic KAN-349) — gift recommendations are visible WITHOUT the
+ * `paid_gift_links` entitlement; that entitlement governs MONETISATION only.
+ *
+ * The rec engine already renders the unpaid/plain-link path: the v2 pipeline
+ * always produces recommendations and `isPaidLinksAllowedForRecipient` only flips
+ * `monetised` (raw merchant URL + no affiliate tracking when off). So Phase 1
+ * ("show gifts via the unpaid path, de-gated from paid_gift_links") is the
+ * implemented behaviour. This is a STRUCTURAL GUARD so a future change can't
+ * accidentally re-gate gift VISIBILITY behind the entitlement.
+ */
+import fs from 'fs';
+import path from 'path';
+
+const ROOT = path.join(__dirname, '..', '..');
+const read = (p: string) => fs.readFileSync(path.join(ROOT, p), 'utf8');
+
+describe('KAN-342 gift visibility is not gated by paid_gift_links', () => {
+  it('the public profile renders the recommendations section with no paid_gift_links visibility gate', () => {
+    const page = read('src/app/[slug]/page.tsx');
+    expect(page).toMatch(/RecommendationsSection/);
+    // Visibility must not reference the monetisation entitlement.
+    expect(page).not.toMatch(/paid_gift_links/);
+  });
+
+  it('paid_gift_links is consumed only by the monetisation gate, not visibility', () => {
+    const svc = read('src/lib/features/entitlements-service.ts');
+    expect(svc).toMatch(/isPaidLinksAllowedForRecipient/);
+    // The v2 pipeline always runs; the entitlement only decides monetisation.
+    const pipeline = read('src/lib/recommender/v2/pipeline.ts');
+    expect(pipeline).toMatch(/isPaidLinksAllowedForRecipient/);
+    expect(pipeline).toMatch(/monetised/);
+  });
+
+  it('the dashboard add-gifts widget (W3) does not require an entitlement', () => {
+    // W3 is emitted in published_activate purely on "has no gifts" — no entitlement gate.
+    const resolver = read('src/lib/dashboard/resolve-widgets.ts');
+    expect(resolver).toMatch(/if \(!input\.hasGifts\) candidates\.push\('add_gifts'\)/);
+    expect(resolver).not.toMatch(/paid_gift_links/);
+  });
+});

--- a/tests/unit/places-city.test.ts
+++ b/tests/unit/places-city.test.ts
@@ -1,0 +1,87 @@
+/**
+ * KAN-341 — postcode→city resolver (Google Places). Covers the pure extractor
+ * and the fetch path (injected mock). The postcode is transient — never
+ * persisted or logged; only the coarse city/region is returned.
+ */
+import { extractCity, lookupCityFromPostcode } from '@/lib/geo/places-city';
+
+describe('KAN-341 extractCity', () => {
+  it('prefers postal_town (UK) and includes the region', () => {
+    expect(
+      extractCity([
+        { longText: 'London', types: ['postal_town'] },
+        { longText: 'Greater London', types: ['administrative_area_level_1'] },
+      ]),
+    ).toEqual({ city: 'London', region: 'Greater London' });
+  });
+
+  it('falls back to locality, then administrative_area_level_2', () => {
+    expect(extractCity([{ longText: 'Paris', types: ['locality'] }])).toEqual({ city: 'Paris', region: null });
+    expect(extractCity([{ longText: 'Kent', types: ['administrative_area_level_2'] }])).toEqual({
+      city: 'Kent',
+      region: null,
+    });
+  });
+
+  it('returns null when no locality component is present', () => {
+    expect(extractCity([{ longText: 'High St', types: ['route'] }])).toBeNull();
+    expect(extractCity([])).toBeNull();
+  });
+});
+
+describe('KAN-341 lookupCityFromPostcode', () => {
+  const ORIGINAL = process.env.GOOGLE_PLACES_API_KEY;
+  afterEach(() => {
+    if (ORIGINAL === undefined) delete process.env.GOOGLE_PLACES_API_KEY;
+    else process.env.GOOGLE_PLACES_API_KEY = ORIGINAL;
+  });
+
+  it('returns null when the API key is not configured (no call made)', async () => {
+    delete process.env.GOOGLE_PLACES_API_KEY;
+    const fetchMock = jest.fn();
+    expect(await lookupCityFromPostcode('SW1A 1AA', fetchMock as unknown as typeof fetch)).toBeNull();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('resolves the city from a Places response (global free-text query)', async () => {
+    process.env.GOOGLE_PLACES_API_KEY = 'test-key';
+    const fetchMock = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        places: [
+          {
+            addressComponents: [
+              { longText: 'Manchester', types: ['postal_town'] },
+              { longText: 'England', types: ['administrative_area_level_1'] },
+            ],
+          },
+        ],
+      }),
+    });
+    const result = await lookupCityFromPostcode('M1 1AE', fetchMock as unknown as typeof fetch);
+    expect(result).toEqual({ city: 'Manchester', region: 'England' });
+    const [, init] = fetchMock.mock.calls[0];
+    expect(JSON.parse((init as RequestInit).body as string)).toMatchObject({ textQuery: 'M1 1AE' });
+    // Field mask is address components only (data minimisation — no lat/lng/place id).
+    expect((init as RequestInit).headers).toMatchObject({ 'X-Goog-FieldMask': 'places.addressComponents' });
+  });
+
+  it('returns null on a non-OK response', async () => {
+    process.env.GOOGLE_PLACES_API_KEY = 'test-key';
+    const fetchMock = jest.fn().mockResolvedValue({ ok: false, json: async () => ({}) });
+    expect(await lookupCityFromPostcode('X1', fetchMock as unknown as typeof fetch)).toBeNull();
+  });
+
+  it('returns null (does not throw) on a fetch error', async () => {
+    process.env.GOOGLE_PLACES_API_KEY = 'test-key';
+    const fetchMock = jest.fn().mockRejectedValue(new Error('network'));
+    expect(await lookupCityFromPostcode('X1', fetchMock as unknown as typeof fetch)).toBeNull();
+  });
+
+  it('returns null for an empty/whitespace postcode (no call made)', async () => {
+    process.env.GOOGLE_PLACES_API_KEY = 'test-key';
+    const fetchMock = jest.fn();
+    expect(await lookupCityFromPostcode('   ', fetchMock as unknown as typeof fetch)).toBeNull();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/share-versions.test.ts
+++ b/tests/unit/share-versions.test.ts
@@ -1,0 +1,56 @@
+/**
+ * KAN-349 — the dashboard share widget has TWO versions: the existing
+ * "Share beta access" card while the waitlist is in place (wording preserved),
+ * and a sign-up-link version once the gate is removed. Plus publicSignupUrl.
+ */
+let mockInviteCode = '';
+let mockSiteUrl = 'https://dev.checklyra.com';
+let mockIsProdFamily = false;
+
+jest.mock('@/lib/env', () => ({
+  env: { inviteCode: () => mockInviteCode, siteUrl: () => mockSiteUrl },
+}));
+jest.mock('@/lib/beta-access/flow', () => ({ isProdFamily: () => mockIsProdFamily }));
+
+import { publicSignupUrl } from '@/lib/beta-access/invite-link';
+import fs from 'fs';
+import path from 'path';
+
+const ROOT = path.join(__dirname, '..', '..');
+const read = (p: string) => fs.readFileSync(path.join(ROOT, p), 'utf8');
+
+beforeEach(() => {
+  mockInviteCode = '';
+  mockSiteUrl = 'https://dev.checklyra.com';
+  mockIsProdFamily = false;
+});
+
+describe('KAN-349 publicSignupUrl', () => {
+  it('points at checklyra.com/signup on the prod family', () => {
+    mockIsProdFamily = true;
+    mockSiteUrl = 'https://beta.checklyra.com';
+    expect(publicSignupUrl()).toBe('https://checklyra.com/signup');
+  });
+  it("uses the env's own origin off the prod family (dev)", () => {
+    expect(publicSignupUrl()).toBe('https://dev.checklyra.com/signup');
+  });
+});
+
+describe('KAN-349 the existing beta share wording is preserved', () => {
+  const shareBeta = read('src/app/dashboard/share-beta.tsx');
+  it('keeps the exact "Share beta access" default title + waitlist description', () => {
+    expect(shareBeta).toContain("title = 'Share beta access'");
+    expect(shareBeta).toMatch(/skips the waitlist and drops them straight into the beta/);
+  });
+  it('supports a bare mode so it can embed in the W5 widget shell', () => {
+    expect(shareBeta).toMatch(/bare\s*=\s*false/);
+  });
+});
+
+describe('KAN-349 W5 renders both versions', () => {
+  const widgets = read('src/app/dashboard/widgets/dashboard-widgets.tsx');
+  it('shows the beta widget when a betaLink exists, else the sign-up version', () => {
+    expect(widgets).toMatch(/ctx\.betaLink \?[\s\S]{0,400}ShareBeta inviteLink=\{ctx\.betaLink\}/);
+    expect(widgets).toMatch(/inviteLink=\{ctx\.signupUrl\}[\s\S]{0,200}title="Share Lyra"/);
+  });
+});


### PR DESCRIPTION
Epic **KAN-349** UX work (founder-reviewed locally; decisions in Confluence p32079873).

**Widget journey (KAN-340 cluster)** — pure state resolver (empty/drafted/published-activate/published-grow → ordered, gated, dismissible widgets), `dashboard_widget_state` dismissal persistence (+ migration), registry/framework, W1–W6, dashboard refit. The registry is the single place a new feature adds its widget.

**KAN-339** — postcode removed from inputs/editor/discovery/help-copy; scrub migration; KAN-153 tests phone-only (Q4). Phone search untouched. Affiliate geo-signal uses country, not postcode.

**KAN-341** — "Find your town from a postcode" via Google Places (reuses existing key, global); **postcode never stored/logged**; `searchByCity` backend.

**KAN-342** — confirmed gifts already de-gated from `paid_gift_links` (visibility); guard test added.

**Two-version share (founder request)** — the existing "Share beta access" widget preserved verbatim (default), W5 switches to a sign-up-link version once the gate is removed.

**Migrations to apply to dev-lyra:** `20260630010000_kan345_dashboard_widget_state` + `20260630020000_kan339_scrub_postcode`.

tsc clean; 142 suites / 1791 unit tests green. Q1 convene test re-pointed (not weakened). MCP coverage: N/A (dashboard/onboarding internal; postcode removed from MCP scope).

🤖 Generated with [Claude Code](https://claude.com/claude-code)