### PR TITLE
fix(dashboard): compute profile completion from live content (KAN-349 journey)

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -10,6 +10,7 @@ import { isConveneEnabledForCurrentUser } from '@/lib/convene/flags-user';
 import { canPublishWithAge } from '@/lib/age/gate';
 import { resolveWidgets, resolveOnboardingState } from '@/lib/dashboard/resolve-widgets';
 import { dismissedForState, type DashboardWidgetState } from '@/lib/dashboard/dismissal';
+import { computeProfileCompletion } from '@/lib/dashboard/profile-completion';
 
 export const metadata = {
   title: 'Dashboard — Lyra',
@@ -61,9 +62,18 @@ export default async function DashboardPage() {
     hasGifts = (gifts.count ?? 0) > 0;
     hasAffiliations = (affs.count ?? 0) > 0;
   }
-  const completionScore = Number(
-    (profile as { completion_score?: number } | null)?.completion_score ?? 0,
-  );
+  // KAN-349 — `profiles.completion_score` is never maintained (vestigial column,
+  // 0 for all real users), so derive completion from live content. Drives the
+  // empty→drafted journey boundary + the "Completion: N%" display below.
+  const completionScore = computeProfileCompletion({
+    displayName: profile?.display_name,
+    bioShort: (profile as { bio_short?: string | null } | null)?.bio_short,
+    headline: (profile as { headline?: string | null } | null)?.headline,
+    city: (profile as { city?: string | null } | null)?.city,
+    avatarUrl: (profile as { avatar_url?: string | null } | null)?.avatar_url,
+    hasGifts,
+    hasAffiliations,
+  });
   const storedDismissals =
     (profile as { dashboard_widget_state?: DashboardWidgetState } | null)?.dashboard_widget_state ?? {};
   const onboardingState = resolveOnboardingState({
@@ -163,7 +173,7 @@ export default async function DashboardPage() {
             </div>
             <div className="flex justify-between">
               <span className="text-[var(--color-muted)]">Completion</span>
-              <span className="text-[var(--color-ink)]">{profile?.completion_score || 0}%</span>
+              <span className="text-[var(--color-ink)]">{completionScore}%</span>
             </div>
           </div>
 

--- a/src/lib/dashboard/profile-completion.ts
+++ b/src/lib/dashboard/profile-completion.ts
@@ -1,0 +1,52 @@
+/**
+ * KAN-349 — derived profile-completion score (0–100), computed at read-time.
+ *
+ * The stored `profiles.completion_score` column is vestigial: nothing in the
+ * app has computed it since the profile redesign, so it sits at 0 for real
+ * users (only seeded demo profiles carry a value). Both the dashboard journey
+ * (the empty→drafted boundary in resolve-widgets) and the "Completion: N%"
+ * display read a completion signal, so we derive it from the user's ACTUAL
+ * profile content on each render — always fresh, no migration or save-time
+ * recompute needed, and the dead column can be dropped later.
+ *
+ * Weights are a sensible default (they sum to 100) — tune freely; the founder
+ * may want to reweight which fields matter most. Keep them summing to 100 so
+ * the value reads as a percentage and the EMPTY_TO_DRAFTED_THRESHOLD (40) in
+ * resolve-widgets stays meaningful.
+ */
+export interface ProfileCompletionInput {
+  displayName?: string | null;
+  /** A short intro — either the dedicated bio or the headline counts. */
+  bioShort?: string | null;
+  headline?: string | null;
+  city?: string | null;
+  avatarUrl?: string | null;
+  /** At least one gift idea (profile_items category=gift_ideas). */
+  hasGifts: boolean;
+  /** At least one affiliation (school_affiliations row). */
+  hasAffiliations: boolean;
+}
+
+const filled = (v?: string | null): boolean => typeof v === 'string' && v.trim().length > 0;
+
+/** The components that make up a complete profile. Points sum to 100. */
+export const COMPLETION_COMPONENTS: ReadonlyArray<{
+  key: string;
+  points: number;
+  done: (i: ProfileCompletionInput) => boolean;
+}> = [
+  { key: 'display_name', points: 20, done: (i) => filled(i.displayName) },
+  { key: 'intro', points: 20, done: (i) => filled(i.bioShort) || filled(i.headline) },
+  { key: 'city', points: 15, done: (i) => filled(i.city) },
+  { key: 'avatar', points: 15, done: (i) => filled(i.avatarUrl) },
+  { key: 'gifts', points: 15, done: (i) => i.hasGifts },
+  { key: 'affiliations', points: 15, done: (i) => i.hasAffiliations },
+];
+
+/**
+ * Pure: 0–100 completion score from live profile content. Clamped to [0,100].
+ */
+export function computeProfileCompletion(input: ProfileCompletionInput): number {
+  const score = COMPLETION_COMPONENTS.reduce((sum, c) => sum + (c.done(input) ? c.points : 0), 0);
+  return Math.min(100, Math.max(0, score));
+}

--- a/tests/unit/profile-completion.test.ts
+++ b/tests/unit/profile-completion.test.ts
@@ -1,0 +1,72 @@
+import {
+  computeProfileCompletion,
+  COMPLETION_COMPONENTS,
+  type ProfileCompletionInput,
+} from '@/lib/dashboard/profile-completion';
+
+const EMPTY: ProfileCompletionInput = {
+  displayName: null,
+  bioShort: null,
+  headline: null,
+  city: null,
+  avatarUrl: null,
+  hasGifts: false,
+  hasAffiliations: false,
+};
+
+describe('KAN-349 computeProfileCompletion', () => {
+  it('is 0 for a brand-new empty profile', () => {
+    expect(computeProfileCompletion(EMPTY)).toBe(0);
+  });
+
+  it('the component weights sum to exactly 100', () => {
+    expect(COMPLETION_COMPONENTS.reduce((s, c) => s + c.points, 0)).toBe(100);
+  });
+
+  it('a just-signed-up user (name only) is below the drafted threshold (40)', () => {
+    const score = computeProfileCompletion({ ...EMPTY, displayName: 'Ben Stephens' });
+    expect(score).toBe(20);
+    expect(score).toBeLessThan(40); // stays "empty" → still shows Complete-profile
+  });
+
+  it('name + a short intro reaches the drafted threshold (40)', () => {
+    const score = computeProfileCompletion({
+      ...EMPTY,
+      displayName: 'Ben',
+      bioShort: 'I love a quiet morning.',
+    });
+    expect(score).toBe(40);
+    expect(score).toBeGreaterThanOrEqual(40); // becomes "drafted" → shows Publish
+  });
+
+  it('counts the headline as the intro when bio_short is empty', () => {
+    const withHeadline = computeProfileCompletion({ ...EMPTY, displayName: 'Ben', headline: 'Mum & coffee lover' });
+    const withBio = computeProfileCompletion({ ...EMPTY, displayName: 'Ben', bioShort: 'Mum & coffee lover' });
+    expect(withHeadline).toBe(withBio);
+    expect(withHeadline).toBe(40);
+  });
+
+  it('is 100 when every component is filled', () => {
+    expect(
+      computeProfileCompletion({
+        displayName: 'Ben',
+        bioShort: 'intro',
+        headline: 'headline',
+        city: 'London',
+        avatarUrl: 'https://x/y.jpg',
+        hasGifts: true,
+        hasAffiliations: true,
+      }),
+    ).toBe(100);
+  });
+
+  it('treats whitespace-only strings as empty', () => {
+    expect(computeProfileCompletion({ ...EMPTY, displayName: '   ' })).toBe(0);
+  });
+
+  it('gifts and affiliations each contribute', () => {
+    expect(computeProfileCompletion({ ...EMPTY, hasGifts: true })).toBe(15);
+    expect(computeProfileCompletion({ ...EMPTY, hasAffiliations: true })).toBe(15);
+    expect(computeProfileCompletion({ ...EMPTY, hasGifts: true, hasAffiliations: true })).toBe(30);
+  });
+});


### PR DESCRIPTION
## Problem (found in dev E2E)
Walking the new KAN-349 dashboard journey end-to-end as a fresh signup (ben@thestephens.org.uk) surfaced that **`profiles.completion_score` is never computed** — no trigger, function, or app code writes it (new editor or legacy). It defaults to 0 for every real user; only seeded demo profiles have a value.

The widget resolver uses it for the **empty→drafted** boundary, so a real new user stays in "empty" forever (only ever sees *Complete your profile*, never *Publish*), and the dashboard's "Completion: N%" card always reads 0%.

## Fix
Derive completion at **read-time** from live profile content — a pure `computeProfileCompletion()` helper (display_name / intro / city / avatar / gifts / affiliations; weights sum to 100). Used for both the journey boundary and the displayed %. No migration; the vestigial column can be dropped later.

A just-signed-up user (name only) = 20% → still *empty*; + a short intro = 40% → *drafted* → *Publish* widget appears. Weights are a sensible default — easy to tune (founder review).

## Verified
tsc clean; **143 suites / 1799 unit tests** (8 new). Will re-verify the full empty→drafted→publish→activate→grow journey on dev after deploy. Other journey states (empty / published_activate / published_grow / dismissal) already verified working on dev.

🤖 Generated with [Claude Code](https://claude.com/claude-code)