### PR TITLE
fix(copy): trim footer tagline + soften waitlist intro (prod hotfix)

### DIFF
--- a/src/app/footer.tsx
+++ b/src/app/footer.tsx
@@ -59,7 +59,7 @@ export function Footer() {
 
         <p className="text-[12.5px] text-[var(--color-muted)] leading-relaxed max-w-[46em] mx-auto mb-2">
           Lyra gives every ordinary person a voice — a place to be understood,
-          in your own words. Keep it about you.
+          in your own words.
         </p>
 
         <p className="text-[11.5px] text-[var(--color-muted)] leading-relaxed max-w-[46em] mx-auto">

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -144,7 +144,7 @@ function WaitlistLanding() {
               We&rsquo;re opening Lyra a few people at a time.
             </h1>
             <p className="text-[15px] sm:text-base text-[var(--color-muted)] leading-relaxed max-w-md mb-8">
-              Lyra is a calm place to share who you are &mdash; the things you
+              Lyra is a place to share who you are &mdash; the things you
               love, the gifts that land, the boundaries that matter &mdash; with
               the people in your life. Join the waitlist and we&rsquo;ll email
               you the moment your spot opens up.

--- a/tests/unit/redesign-fidelity.test.js
+++ b/tests/unit/redesign-fidelity.test.js
@@ -131,7 +131,6 @@ describe('KAN-272 D: site-wide footer', () => {
 
   test('includes the mission line and the Companies Act legal line', () => {
     expect(footer).toContain('a place to be understood');
-    expect(footer).toContain('Keep it about you');
     expect(footer).toContain('CheckLyra Ltd');
     expect(footer).toContain('16351012');
     expect(footer).toContain('Shelton Street');


### PR DESCRIPTION
**Contained production hotfix — owner-authorised.**

Removes two pieces of copy from the live site:
- **Footer:** drops the trailing "Keep it about you." sentence → "Lyra gives every ordinary person a voice — a place to be understood, in your own words."
- **Homepage waitlist:** "a calm place to share" → "a place to share"

Updates `tests/unit/redesign-fidelity.test.js` to match the new footer copy (owner sign-off given in-session).

### Why a hotfix off `main` (not the normal develop→…→main promote)
`develop` is ahead of `main` and carries the **KAN-349 dashboard-widget journey**, which is still pending founder review and must NOT go to prod yet. Branching this cosmetic-only change off `main` keeps KAN-349 out of the production payload. The same two edits will also land on `develop` to keep environments in sync.

### Scope / safety
- 3 files, 2 insertions / 3 deletions. Pure text. No logic, no data model, no deps.
- `redesign-fidelity` suite green locally (30/30).

MCP coverage: deferred — pure UI copy, no data-model or API change.