### PR TITLE
chore(copy): sync footer + waitlist hotfix to develop (#412 follow-up)

### DIFF
--- a/src/app/footer.tsx
+++ b/src/app/footer.tsx
@@ -59,7 +59,7 @@ export function Footer() {
 
         <p className="text-[12.5px] text-[var(--color-muted)] leading-relaxed max-w-[46em] mx-auto mb-2">
           Lyra gives every ordinary person a voice — a place to be understood,
-          in your own words. Keep it about you.
+          in your own words.
         </p>
 
         <p className="text-[11.5px] text-[var(--color-muted)] leading-relaxed max-w-[46em] mx-auto">

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -144,7 +144,7 @@ function WaitlistLanding() {
               We&rsquo;re opening Lyra a few people at a time.
             </h1>
             <p className="text-[15px] sm:text-base text-[var(--color-muted)] leading-relaxed max-w-md mb-8">
-              Lyra is a calm place to share who you are &mdash; the things you
+              Lyra is a place to share who you are &mdash; the things you
               love, the gifts that land, the boundaries that matter &mdash; with
               the people in your life. Join the waitlist and we&rsquo;ll email
               you the moment your spot opens up.

--- a/tests/unit/redesign-fidelity.test.js
+++ b/tests/unit/redesign-fidelity.test.js
@@ -131,7 +131,6 @@ describe('KAN-272 D: site-wide footer', () => {
 
   test('includes the mission line and the Companies Act legal line', () => {
     expect(footer).toContain('a place to be understood');
-    expect(footer).toContain('Keep it about you');
     expect(footer).toContain('CheckLyra Ltd');
     expect(footer).toContain('16351012');
     expect(footer).toContain('Shelton Street');


### PR DESCRIPTION
Env-sync follow-up to the production hotfix **#412** (which landed the same two cosmetic edits directly on `main`).

This puts the identical change on `develop` so dev + all future releases keep it, and `footer.tsx` stays consistent across every branch:
- Footer: drop trailing "Keep it about you."
- Homepage waitlist: "a calm place to share" → "a place to share"
- `redesign-fidelity` test updated to match.

No feature content — KAN-349 is untouched. Cherry-pick of the prod hotfix commit.

MCP coverage: deferred — pure UI copy, no data-model or API change.