### PR TITLE
feat(profile): editor tidy-up part 1 — remove sections, relabel, bio 600, add Plays (KAN-404)

### DIFF
--- a/src/app/(legal)/about/page.tsx
+++ b/src/app/(legal)/about/page.tsx
@@ -52,7 +52,7 @@ export default function AboutPage() {
 
         <p>
           Just honest pages, in people&apos;s own words — a little &ldquo;Wikipedia for real
-          people&rdquo;. Lyra is a small team. We hope it makes knowing each other a little kinder.
+          people&rdquo;. We hope it makes knowing each other a little kinder.
         </p>
 
         <p>

--- a/src/app/(legal)/accessibility/page.tsx
+++ b/src/app/(legal)/accessibility/page.tsx
@@ -27,7 +27,7 @@ export default function AccessibilityPage() {
           <strong>WCAG 2.2 AA</strong>.
         </p>
         <p>
-          We&apos;re a small team and we won&apos;t get everything right first time — if something is
+          We won&apos;t get everything right first time — if something is
           hard to use, please tell us via{" "}
           <Link href="/contact" className="text-[var(--color-sage)]">Contact</Link> and we&apos;ll fix
           it.

--- a/src/app/(legal)/contact/page.tsx
+++ b/src/app/(legal)/contact/page.tsx
@@ -30,7 +30,7 @@ export default function ContactPage() {
 
         <p>Questions, problems, ideas, or just hello — send us a note below.</p>
         <p className="text-[var(--color-muted)]">
-          Lyra is a small team, so replies can take a little while. We read everything, and
+          Replies can take a little while. We read everything, and
           we&apos;ll always come back to you. 💛
         </p>
         <p className="text-sm text-[var(--color-muted)]">

--- a/src/app/(legal)/help/page.tsx
+++ b/src/app/(legal)/help/page.tsx
@@ -48,7 +48,7 @@ export default function HelpPage() {
 
         <h2>Why is it taking so long to hear back from you?</h2>
         <p>
-          Lyra is a small team. We read everything and we <em>will</em> reply — just not always
+          We read everything and we <em>will</em> reply — just not always
           quickly. Thank you for bearing with us. 💛
         </p>
 

--- a/src/app/[slug]/page.tsx
+++ b/src/app/[slug]/page.tsx
@@ -452,15 +452,12 @@ export default async function PublicProfilePage({ params }: Props) {
 
           {/* Things I love + not for me */}
           <CardSection heading="💛 Things I love, can't get enough of, or have been dreaming about" items={groupedItems['gift_ideas']} />
-          <CardSection heading="💚 Things I'm into" items={groupedItems['likes']} />
           {notForMe.length > 0 && (
             <section className="mt-11">
               <SectionQ>🙅 Things that aren&apos;t really for me</SectionQ>
               <ItemCards items={notForMe} />
             </section>
           )}
-          <CardSection heading="🧭 Helpful to know" items={groupedItems['helpful_to_know']} />
-          <CardSection heading="🚧 My boundaries" items={groupedItems['boundaries']} />
           <CardSection heading="🌍 Causes close to my heart" items={groupedItems['causes']} />
           <CardSection heading="🏆 Things I'm proud of" items={groupedItems['proud_of']} />
 

--- a/src/app/dashboard/profile/edit-profile-form.tsx
+++ b/src/app/dashboard/profile/edit-profile-form.tsx
@@ -87,36 +87,12 @@ const SECTIONS: SectionDef[] = [
     description: "The things you'd genuinely love — to receive, to do, or to be surprised by.",
   },
   {
-    id: 'into',
-    label: "Things I'm into",
-    icon: '💚',
-    kind: 'items',
-    categories: ['likes'],
-    description: 'Interests, hobbies, the things you light up about.',
-  },
-  {
     id: 'notforme',
     label: "Things that aren't really for me",
     icon: '🙅',
     kind: 'items',
     categories: ['gifts_to_avoid', 'dislikes'],
     description: "Gentle no-thank-yous — so people don't have to guess.",
-  },
-  {
-    id: 'helpful',
-    label: 'Helpful to know',
-    icon: '🧭',
-    kind: 'items',
-    categories: ['helpful_to_know'],
-    description: 'Practical things that make life easier for the people around you.',
-  },
-  {
-    id: 'myboundaries',
-    label: 'My boundaries',
-    icon: '🚧',
-    kind: 'items',
-    categories: ['boundaries'],
-    description: "Anything you'd gently like respected.",
   },
   {
     id: 'causes',
@@ -139,8 +115,8 @@ const SECTIONS: SectionDef[] = [
     label: 'A few of my favourite things',
     icon: '⭐',
     kind: 'items',
-    categories: ['favourite_books', 'favourite_media', 'favourite_tv', 'quotes', 'favourite_places', 'favourite_music'],
-    description: 'Books, films, TV, music, places, and the quotes you come back to.',
+    categories: ['favourite_books', 'favourite_media', 'favourite_tv', 'plays', 'quotes', 'favourite_places', 'favourite_music'],
+    description: 'Books, films, TV, plays, music, places, and the quotes you come back to.',
   },
   {
     id: 'tips',
@@ -174,7 +150,6 @@ const SECTIONS: SectionDef[] = [
     description: "Your billboard message, and any other questions you'd love to be asked.",
   },
   { id: 'links', label: 'Links', icon: '🔗', kind: 'links' },
-  { id: 'files', label: 'Files & media', icon: '📎', kind: 'files' },
 ];
 
 export function EditProfileForm({

--- a/src/app/dashboard/profile/sections/bio-section.tsx
+++ b/src/app/dashboard/profile/sections/bio-section.tsx
@@ -31,11 +31,11 @@ export function BioSection({ profile }: { profile: WizardProfile }) {
           value={bio}
           onChange={(e) => setBio(e.target.value)}
           rows={4}
-          maxLength={300}
+          maxLength={600}
           className="w-full px-3 py-2 rounded-lg border border-[var(--color-border)] bg-white text-[var(--color-ink)] text-sm focus:outline-none focus:ring-2 focus:ring-[var(--color-sage)] focus:border-transparent resize-none"
           placeholder="I'm a primary school teacher who loves hiking, terrible puns, and finding the best flat white in town."
         />
-        <p className="text-xs text-[var(--color-muted)] mt-1">{bio.length}/300</p>
+        <p className="text-xs text-[var(--color-muted)] mt-1">{bio.length}/600</p>
       </div>
     </div>
   );

--- a/src/app/dashboard/profile/sections/manual-of-me-section.tsx
+++ b/src/app/dashboard/profile/sections/manual-of-me-section.tsx
@@ -55,8 +55,8 @@ export function ManualOfMeSection({ manualOfMe }: { manualOfMe: ManualOfMe }) {
       </p>
 
       <MoMField
-        label="Good to know about me"
-        helper="The little things that help people get you."
+        label="Good to know about me / Things I'm into"
+        helper="The little things that help people get you — and the things you're into."
         placeholder="I'm a slow texter but I always reply. I think out loud, so half of what I say is me working it out."
         value={draft.good_to_know}
         onChange={(v) => set('good_to_know', v)}

--- a/src/app/dashboard/profile/steps/items-step.tsx
+++ b/src/app/dashboard/profile/steps/items-step.tsx
@@ -56,7 +56,7 @@ export function ItemsStep({ title, description, categories, items, onAdd, onRemo
     likes: '💚 Like', dislikes: '💔 Dislike',
     gift_ideas: '🎁 Gift idea', gifts_to_avoid: '🚫 Avoid',
     boundaries: '🛑 Boundary', helpful_to_know: '💡 Helpful to know',
-    favourite_books: '📖 Book', favourite_media: '🎬 Movie/Series',
+    favourite_books: '📖 Book', favourite_media: '🎬 Movie',
     causes: '🌍 Cause', quotes: '💬 Quote',
     proud_of: '🏆 Proud of', life_hacks: '💡 Life hack',
     questions: '❓ Question', billboard: '📢 Billboard',
@@ -64,7 +64,7 @@ export function ItemsStep({ title, description, categories, items, onAdd, onRemo
     // challenges / projects / interests for networking + collaboration.
     current_problems: '🧩 Currently solving',
     // KAN-263: favourites split out for the redesign favourites grid.
-    favourite_tv: '📺 TV show', favourite_places: '📍 Place', favourite_music: '🎵 Music',
+    favourite_tv: '📺 TV show', plays: '🎭 Play', favourite_places: '📍 Place', favourite_music: '🎵 Music',
   };
 
   const handleAdd = () => {

--- a/supabase/migrations/20260630230000_add_plays_category.sql
+++ b/supabase/migrations/20260630230000_add_plays_category.sql
@@ -1,0 +1,6 @@
+-- KAN-404: add 'plays' to the item_category enum so profiles can list favourite
+-- Plays (theatre) alongside films/books/TV/music/places/quotes.
+--
+-- Rollback: enum values cannot be dropped in Postgres without recreating the
+-- type; 'plays' is additive and harmless if unused.
+alter type public.item_category add value if not exists 'plays';

--- a/tests/e2e/profile-redesign.spec.ts
+++ b/tests/e2e/profile-redesign.spec.ts
@@ -200,7 +200,6 @@ test.describe('Redesign — populated public profile structure', () => {
       /To understand me a little better/i,
       /A few more things about me/i,
       /Things I love/i,
-      /Things I'm into/i,
     ];
     const matches = await Promise.all(
       humanised.map((re) => page.getByText(re).count()),


### PR DESCRIPTION
First slice of the owner-requested **KAN-404** family-and-friends editor refinements. Ships the low-risk structural/copy changes so they're visible on **dev**; the heavier items follow.

### In this PR
- **Remove sections** (editor **and** public `/[slug]`): My boundaries, Things I'm into, Helpful to know, Files & media. The Manual-of-Me "My boundaries" *prompt* is retained.
- **#5** rename MoM "Good to know about me" → "Good to know about me / Things I'm into".
- **#10** favourites "Movie/Series" → "Movie".
- **#11** add **Plays** favourite category (+ `item_category` enum migration — already applied to dev-lyra).
- **#6** short bio limit 300 → 600 (no server/DB cap exists).
- **#3** remove "we are a small team" from About / Accessibility / Contact / Help.
- E2E: dropped the stale "Things I'm into" heading assertion (owner-approved).

### Not in this PR (KAN-404 follow-ups)
Save-model rework (#8/#9), edit-your-entries + MCP tool (#12), conversation-prompt cap 5→10 (#14, + migration), school-postcode (#1). **#2** age gate = flip the existing `AGE_VERIFICATION_REQUIRED` env switch (no code).

### Notes
- Migration `20260630230000_add_plays_category.sql` applied to **dev-lyra** already; staging/beta/prod on promotion.
- MCP coverage: deferred — `plays` is an additive enum (existing read tools surface it); the edit-item write tool ships with #12 (same epic).