### PR TITLE
fix(auth): don't show the 'For security purposes… N seconds' scold — keep signup momentum

### DIFF
--- a/src/app/(auth)/actions.ts
+++ b/src/app/(auth)/actions.ts
@@ -6,6 +6,7 @@ import { headers, cookies } from 'next/headers';
 
 import { env } from '@/lib/env';
 import { INVITE_COOKIE } from '@/lib/beta-access/invite-cookie';
+import { isEmailResendCooldown } from './auth-errors';
 
 function getSiteUrl() {
   return env.siteUrl();
@@ -61,6 +62,12 @@ export async function signUp(formData: FormData) {
   });
 
   if (error) {
+    if (isEmailResendCooldown(error)) {
+      return redirect(
+        '/signup?message=' +
+          encodeURIComponent('Check your email for a link to finish creating your account.'),
+      );
+    }
     return redirect('/signup?error=' + encodeURIComponent(error.message));
   }
 
@@ -92,6 +99,11 @@ export async function signIn(formData: FormData) {
   });
 
   if (error) {
+    if (isEmailResendCooldown(error)) {
+      return redirect(
+        '/login?message=' + encodeURIComponent('Check your email for a sign-in link.'),
+      );
+    }
     return redirect('/login?error=' + encodeURIComponent(error.message));
   }
 

--- a/src/app/(auth)/auth-errors.ts
+++ b/src/app/(auth)/auth-errors.ts
@@ -1,0 +1,20 @@
+/**
+ * Auth error helpers. Lives outside the `'use server'` actions module so it can
+ * export a plain (non-async) function and be unit-tested (BUGS-12 / gotcha #18).
+ */
+
+/**
+ * Supabase enforces a short per-email resend cooldown and returns
+ * "For security purposes, you can only request this after N seconds."
+ * (code `over_email_send_rate_limit`). This only fires when a magic link was
+ * ALREADY sent to that address moments ago — so rather than surfacing a
+ * momentum-killing security scold, callers should treat it like success and
+ * show the normal "check your email" message (the link is already on its way).
+ */
+export function isEmailResendCooldown(
+  error: { message?: string; code?: string } | null | undefined,
+): boolean {
+  if (!error) return false;
+  if (error.code === 'over_email_send_rate_limit') return true;
+  return /for security purposes|only request this after/i.test(error.message ?? '');
+}

--- a/tests/unit/auth-errors.test.ts
+++ b/tests/unit/auth-errors.test.ts
@@ -1,0 +1,29 @@
+import { isEmailResendCooldown } from '@/app/(auth)/auth-errors';
+
+describe('isEmailResendCooldown', () => {
+  it('matches the Supabase per-email resend cooldown by code', () => {
+    expect(isEmailResendCooldown({ code: 'over_email_send_rate_limit', message: 'x' })).toBe(true);
+  });
+
+  it('matches the "For security purposes" cooldown message (any wait time)', () => {
+    expect(
+      isEmailResendCooldown({
+        message: 'For security purposes, you can only request this after 58 seconds.',
+      }),
+    ).toBe(true);
+    expect(
+      isEmailResendCooldown({ message: 'you can only request this after 12 seconds' }),
+    ).toBe(true);
+  });
+
+  it('does NOT match unrelated auth errors', () => {
+    expect(isEmailResendCooldown({ message: 'Invalid login credentials' })).toBe(false);
+    expect(isEmailResendCooldown({ code: 'invalid_credentials', message: 'nope' })).toBe(false);
+    expect(isEmailResendCooldown({ message: '' })).toBe(false);
+  });
+
+  it('is null/undefined-safe', () => {
+    expect(isEmailResendCooldown(null)).toBe(false);
+    expect(isEmailResendCooldown(undefined)).toBe(false);
+  });
+});


### PR DESCRIPTION
**Problem:** during sign-up / sign-in, the app surfaced Supabase's raw error verbatim — *"For security purposes, you can only request this after 58 seconds."* — which reads as a security scold and kills onboarding momentum (reported on dev).

**Fix:** that cooldown (`over_email_send_rate_limit`) only fires when a magic link was **already sent to that address moments ago**, so we now treat it like success and show the normal **"Check your email…"** message instead of the error. The user just goes to their inbox — no lost momentum.

- Detection helper `isEmailResendCooldown` extracted to `src/app/(auth)/auth-errors.ts` (exported + unit-tested) so `actions.ts` stays a valid `'use server'` file (gotcha #18).
- New unit test `tests/unit/auth-errors.test.ts` (code match, message match, negative, null-safe).
- Applies to both `signUp` and `signIn`.

**Note:** this makes the block invisible/graceful. The underlying 60s Supabase cooldown still exists (a user can't get a *brand-new* link for ~1 min); if you want that window shortened too, that's a Supabase Auth rate-limit setting we can lower separately.

MCP coverage: N/A — auth error-handling UX, no data-model/API change.