### PR TITLE
Remove profile-completion pressure (%, journey framing, step counter)

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -63,8 +63,9 @@ export default async function DashboardPage() {
     hasAffiliations = (affs.count ?? 0) > 0;
   }
   // KAN-349 — `profiles.completion_score` is never maintained (vestigial column,
-  // 0 for all real users), so derive completion from live content. Drives the
-  // empty→drafted journey boundary + the "Completion: N%" display below.
+  // 0 for all real users), so derive completion from live content. Used ONLY to
+  // pick which supportive onboarding widget shows (the empty→drafted boundary) —
+  // it is never surfaced to the user as a score/percentage (no completion pressure).
   const completionScore = computeProfileCompletion({
     displayName: profile?.display_name,
     bioShort: (profile as { bio_short?: string | null } | null)?.bio_short,
@@ -92,7 +93,6 @@ export default async function DashboardPage() {
   });
   const widgetCtx: WidgetContext = {
     state: widgetResolution.state,
-    completionScore,
     canPublishAge: !needsAgeCheck,
     profileUrl: profile?.slug
       ? `${process.env.NEXT_PUBLIC_SITE_URL || 'https://checklyra.com'}/${profile.slug}`
@@ -170,10 +170,6 @@ export default async function DashboardPage() {
               <span className={isPublished ? 'text-green-600' : needsAgeCheck ? 'text-amber-600' : 'text-[var(--color-muted)]'}>
                 {isPublished ? 'Public' : needsAgeCheck ? 'Age check' : 'Private'}
               </span>
-            </div>
-            <div className="flex justify-between">
-              <span className="text-[var(--color-muted)]">Completion</span>
-              <span className="text-[var(--color-ink)]">{completionScore}%</span>
             </div>
           </div>
 

--- a/src/app/dashboard/profile/wizard.tsx
+++ b/src/app/dashboard/profile/wizard.tsx
@@ -88,9 +88,6 @@ export function ProfileWizard({
           <Link href="/dashboard" className="flex items-center">
             <Image src="/lyra-logo.png" alt="Lyra" width={32} height={32} className="h-8 w-auto" />
           </Link>
-          <span className="text-sm text-[var(--color-muted)]">
-            Step {step + 1} of {STEPS.length}
-          </span>
         </div>
       </header>
 

--- a/src/app/dashboard/widgets/dashboard-widgets.tsx
+++ b/src/app/dashboard/widgets/dashboard-widgets.tsx
@@ -22,7 +22,6 @@ import {
 
 export interface WidgetContext {
   state: OnboardingState;
-  completionScore: number;
   /** canPublishWithAge(age_status) — drives W2's "publish" vs "verify age" CTA. */
   canPublishAge: boolean;
   profileUrl: string | null;
@@ -93,10 +92,10 @@ function renderWidget(id: WidgetId, ctx: WidgetContext): ReactNode {
   switch (id) {
     case 'complete_profile':
       return (
-        <WidgetShell widgetId={id} state={ctx.state} title="Complete your profile" accent>
+        <WidgetShell widgetId={id} state={ctx.state} title="Tell people about you" accent>
           <Body>
-            You&rsquo;re {ctx.completionScore}% of the way there. Add a few more details so the
-            people in your life know what you&rsquo;d love.
+            Share a few details so the people in your life know what you&rsquo;d love — no rush,
+            add as much or as little as you like.
           </Body>
           <Cta href="/dashboard/profile" label="Edit profile →" />
         </WidgetShell>


### PR DESCRIPTION
**Ask (Luisa):** *"please remove % of profile completed. we don't want to add pressure to complete anything."*

A completeness sweep found the pressure showed up in **three** user-facing places, not just one:

| Surface | Before | After |
|---|---|---|
| Dashboard "Your profile" card | `Completion  73%` row | row removed |
| Onboarding widget (W1) | *"You're 73% of the way there…"* + title **"Complete your profile"** | title **"Tell people about you"** + *"Share a few details… — no rush, add as much or as little as you like."* (no number) |
| Legacy profile editor header | `Step 2 of 6` counter | counter removed (free-jump step pills stay) |

**Kept deliberately (not pressure):** the internal `computeProfileCompletion()` score + the 40-point empty→drafted threshold in `resolve-widgets.ts`. These are never shown to the user — they only decide *which* supportive widget appears. Touching them would break the onboarding state machine (and its tests) for no user benefit.

Also removed the now-dead `WidgetContext.completionScore` field + its assignment (the widget was its only reader), so the build stays clean.

**Verification**
- `npx tsc --noEmit` — 0 errors on the changed files.
- 28/28 unit tests pass (`dashboard-resolve-widgets`, `profile-completion`, `dashboard-dismissal`) — no test asserted on the removed/reworded copy, so none needed updating (Test Integrity Policy gate not tripped).
- Grep-verified: no remaining visible `%`/"of the way"/"Step X of Y" completion framing in `src/app`.

**Follow-up (separate, flagged not done here):** the MCP `get_onboarding_coaching` payload (`lyra-mcp-sec33/src/write-tools.ts`) still hands agents an ordered 1–11 sequence ending "Your profile is ready!". That's the agent-facing mirror of the same journey — per the KAN-222 MCP/app lockstep it should get a matching de-pressure reword, but it lives in a separate repo/branch and I didn't edit it blind. Happy to raise a ticket + do it if you want the assistant-driven onboarding softened too.

MCP coverage: N/A — dashboard UX copy/display change, no data-model or API change.