### PR TITLE
fix(privacy): gate Vercel Analytics behind cookie consent (SEC-72)

### DIFF
--- a/docs/COOKIE_AUDIT.md
+++ b/docs/COOKIE_AUDIT.md
@@ -2,11 +2,13 @@
 
 > Enumerates every cookie set on a Lyra visitor's browser, who sets it, on which domain, what changes (if anything) when affiliate links land. This is the canonical reference for the public `/cookies` and `/privacy` pages — keep it in sync when behaviour changes.
 
-Last audit: 2026-05-16.
+Last audit: 2026-05-16. Reconciled 2026-07-03 (SEC-72 — analytics now consent-gated).
 
 ## Cookies set on `*.checklyra.com`
 
 All current cookies are **strictly necessary** under UK GDPR / PECR. No consent is required for these because the user cannot expect the site to work without them.
+
+> **Analytics gating (SEC-72).** Vercel Analytics + Speed Insights are cookieless (no storage/access of information on the visitor's device — see the row below), so PECR Reg. 6 does not strictly require prior consent for them. Even so, Lyra treats analytics as **non-essential** and runs it **only after the visitor chooses "Accept all"** on the consent banner. "Essential only" (decline), or making no choice, keeps analytics off. The gate lives in `src/app/consented-analytics.tsx` (decision in `src/app/consent-state.ts`); the banner writes the choice in `src/app/cookie-consent.tsx`. This makes the banner's two buttons functional and keeps the privacy policy's "opt out of analytics via the cookie consent banner" claim honest.
 
 | Cookie | Set by | Purpose | Duration | Category |
 |---|---|---|---|---|
@@ -44,7 +46,7 @@ For internal analytics (per-merchant EPC, monthly reconciliation against Sovrn's
 
 ## Decisions arising from this audit
 
-1. **No cookie consent banner change required.** All cookies are essential. No new opt-in mechanic is needed for affiliate-link clicks because the cookie boundary is at Sovrn's domain, not ours.
+1. **No cookie consent banner change required *for affiliate-link clicks*.** All *cookies* are essential and the affiliate cookie boundary is at Sovrn's domain, not ours, so no new opt-in mechanic is needed for clicks. (Separately, SEC-72 later made the existing banner's analytics choice functional — see the "Analytics gating" note above. That did not add a cookie; it gated the cookieless Vercel Analytics behind explicit accept.)
 2. **No "Marketing / Affiliate" category in the consent UI.** Earlier drafts of KAN-193 considered adding one — confirmed unnecessary because Lyra sets no marketing/affiliate cookies on its own domain.
 3. **Privacy policy updated** (this PR) to explicitly disclose Sovrn as an affiliate partner, what data they receive when a user clicks, and the legitimate-interest lawful basis.
 4. **Cookie policy updated** (this PR) to add an "Affiliate links" section pointing out that the cookies are set off-domain, not by us, with links to Sovrn's and the retailer's policies.

--- a/src/app/consent-state.ts
+++ b/src/app/consent-state.ts
@@ -1,0 +1,43 @@
+// SEC-72 — shared cookie-consent state.
+//
+// Single source of truth for how Lyra reads the visitor's cookie-consent
+// choice, and for the one rule that decides whether non-essential analytics
+// may run. The banner (cookie-consent.tsx) writes the choice; the analytics
+// gate (consented-analytics.tsx) reads it through here so the two can never
+// drift apart. Kept free of React-component imports so the pure decision is
+// unit-testable in the node test environment.
+
+/** localStorage key the banner writes and the gate reads. */
+export const CONSENT_STORAGE_KEY = 'lyra-cookie-consent';
+
+// 'pending' — SSR / not yet hydrated; 'none' — no choice made yet;
+// 'accepted' — Accept all; 'declined' — Essential only.
+export type ConsentValue = 'pending' | 'none' | 'accepted' | 'declined';
+
+/** Client-side snapshot of the persisted choice. */
+export function getConsentSnapshot(): ConsentValue {
+  if (typeof window === 'undefined') return 'pending';
+  return (localStorage.getItem(CONSENT_STORAGE_KEY) as ConsentValue) || 'none';
+}
+
+/** Server render always sees 'pending' so hydration matches. */
+export function getServerConsentSnapshot(): ConsentValue {
+  return 'pending';
+}
+
+/** cookie-consent.tsx dispatches a 'storage' event on every choice. */
+export function subscribeConsent(callback: () => void): () => void {
+  window.addEventListener('storage', callback);
+  return () => window.removeEventListener('storage', callback);
+}
+
+/**
+ * Non-essential analytics (Vercel Analytics + Speed Insights) may run ONLY
+ * when the visitor has explicitly accepted. Every other state — no choice
+ * yet, "Essential only" (declined), or SSR pending — means no analytics.
+ * This is the line that makes the banner's "Essential only" button actually
+ * do something instead of being consent theatre.
+ */
+export function analyticsAllowed(consent: ConsentValue): boolean {
+  return consent === 'accepted';
+}

--- a/src/app/consented-analytics.tsx
+++ b/src/app/consented-analytics.tsx
@@ -1,0 +1,36 @@
+'use client';
+
+import { useSyncExternalStore } from 'react';
+import { Analytics } from '@vercel/analytics/react';
+import { SpeedInsights } from '@vercel/speed-insights/next';
+import {
+  analyticsAllowed,
+  getConsentSnapshot,
+  getServerConsentSnapshot,
+  subscribeConsent,
+} from './consent-state';
+
+/**
+ * SEC-72 — gate Vercel Analytics + Speed Insights behind the cookie-consent
+ * choice. Previously both mounted unconditionally in layout.tsx, so the
+ * banner's "Essential only" button changed nothing ("consent theatre"). Now
+ * they render only once the visitor has chosen "Accept all"; declining, or
+ * not choosing yet, keeps them off. The banner dispatches a 'storage' event
+ * on every choice, which re-runs this component through useSyncExternalStore.
+ */
+export function ConsentedAnalytics() {
+  const consent = useSyncExternalStore(
+    subscribeConsent,
+    getConsentSnapshot,
+    getServerConsentSnapshot,
+  );
+
+  if (!analyticsAllowed(consent)) return null;
+
+  return (
+    <>
+      <Analytics />
+      <SpeedInsights />
+    </>
+  );
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,7 +1,6 @@
 import type { Metadata, Viewport } from "next";
 import { Inter } from "next/font/google";
-import { Analytics } from "@vercel/analytics/react";
-import { SpeedInsights } from "@vercel/speed-insights/next";
+import { ConsentedAnalytics } from "./consented-analytics";
 import { CookieConsent } from "./cookie-consent";
 import { Footer } from "./footer";
 import { InstallPrompt } from "./install-prompt";
@@ -120,8 +119,9 @@ export default function RootLayout({
         <CookieConsent />
         <InstallPrompt />
         <ServiceWorkerRegister />
-        <Analytics />
-        <SpeedInsights />
+        {/* SEC-72: analytics + speed-insights only run once the visitor has
+            accepted via the cookie-consent banner (Essential-only = off). */}
+        <ConsentedAnalytics />
       </body>
     </html>
   );

--- a/tests/unit/consented-analytics.test.ts
+++ b/tests/unit/consented-analytics.test.ts
@@ -1,0 +1,93 @@
+/**
+ * SEC-72 — cookie-consent must actually gate analytics.
+ *
+ * Before SEC-72 the banner's "Essential only" button was consent theatre:
+ * <Analytics/> + <SpeedInsights/> mounted unconditionally in layout.tsx. These
+ * tests lock in the gate (analytics runs ONLY on explicit accept) and the
+ * wiring (layout renders the gated component, not the raw Vercel components).
+ */
+
+import fs from 'fs';
+import path from 'path';
+import {
+  analyticsAllowed,
+  getConsentSnapshot,
+  getServerConsentSnapshot,
+  CONSENT_STORAGE_KEY,
+  type ConsentValue,
+} from '@/app/consent-state';
+
+const root = path.join(__dirname, '../..');
+
+describe('SEC-72 analytics consent gate', () => {
+  describe('analyticsAllowed', () => {
+    test('only "accepted" enables analytics', () => {
+      expect(analyticsAllowed('accepted')).toBe(true);
+    });
+
+    test.each<ConsentValue>(['pending', 'none', 'declined'])(
+      'blocks analytics for "%s"',
+      (value) => {
+        expect(analyticsAllowed(value)).toBe(false);
+      },
+    );
+
+    test('"Essential only" (declined) never enables analytics', () => {
+      // The whole point of the ticket: declining must change something.
+      expect(analyticsAllowed('declined')).toBe(false);
+    });
+  });
+
+  describe('snapshots', () => {
+    test('server snapshot is always pending (SSR-safe, no analytics)', () => {
+      expect(getServerConsentSnapshot()).toBe('pending');
+      expect(analyticsAllowed(getServerConsentSnapshot())).toBe(false);
+    });
+
+    test('client snapshot is pending when window is undefined (SSR)', () => {
+      // Node test env has no window, so this exercises the SSR branch.
+      expect(getConsentSnapshot()).toBe('pending');
+    });
+  });
+
+  describe('shared storage key', () => {
+    test('gate reads the same localStorage key the banner writes', () => {
+      expect(CONSENT_STORAGE_KEY).toBe('lyra-cookie-consent');
+      const banner = fs.readFileSync(
+        path.join(root, 'src/app/cookie-consent.tsx'),
+        'utf8',
+      );
+      expect(banner).toContain(CONSENT_STORAGE_KEY);
+    });
+  });
+
+  describe('layout wiring', () => {
+    const layout = fs.readFileSync(
+      path.join(root, 'src/app/layout.tsx'),
+      'utf8',
+    );
+
+    test('layout renders the gated ConsentedAnalytics component', () => {
+      expect(layout).toContain('ConsentedAnalytics');
+      expect(layout).toContain('<ConsentedAnalytics />');
+    });
+
+    test('layout no longer mounts Analytics/SpeedInsights directly', () => {
+      // Ungated mounts would re-open the consent-theatre hole.
+      expect(layout).not.toContain('<Analytics />');
+      expect(layout).not.toContain('<SpeedInsights />');
+      expect(layout).not.toContain("from \"@vercel/analytics/react\"");
+      expect(layout).not.toContain("from \"@vercel/speed-insights/next\"");
+    });
+
+    test('the gate component owns the Vercel analytics imports', () => {
+      const gate = fs.readFileSync(
+        path.join(root, 'src/app/consented-analytics.tsx'),
+        'utf8',
+      );
+      expect(gate).toContain('@vercel/analytics/react');
+      expect(gate).toContain('@vercel/speed-insights/next');
+      expect(gate).toContain('analyticsAllowed');
+    });
+  });
+});


### PR DESCRIPTION
## Summary

The cookie-consent banner offered **"Accept all"** vs **"Essential only"** and wrote the choice to `localStorage`, but `<Analytics/>` + `<SpeedInsights/>` mounted **unconditionally** in `layout.tsx` — the decline path changed nothing ("consent theatre"). This contradicted the privacy policy's *"opt out of analytics via the cookie consent banner"* claim (`src/app/(legal)/privacy/page.tsx:90,95`) and the banner's own wording.

This PR takes the ticket's **acceptance path** (*"the consent choice actually controls non-essential analytics"*):

- **`src/app/consent-state.ts`** (new) — shared, node-testable consent read + the single `analyticsAllowed()` rule (**accept-only**). Kept free of React-component imports so the decision is unit-testable in the `node` Jest env.
- **`src/app/consented-analytics.tsx`** (new) — client gate that renders Analytics + Speed Insights **only** once the visitor has accepted; re-reacts to the banner's `'storage'` event via `useSyncExternalStore`.
- **`layout.tsx`** — renders `<ConsentedAnalytics />` instead of the raw Vercel components (imports moved into the gate).
- **`docs/COOKIE_AUDIT.md`** — reconciled: Vercel Analytics is cookieless (PECR Reg. 6 doesn't strictly require consent) but is now treated as **non-essential** and gated behind explicit opt-in, which makes the banner's two buttons functional.

`cookie-consent.tsx` is intentionally **untouched** (the banner already writes the choice + dispatches the `storage` event; leaving it alone also keeps `gdpr.test.js`'s literal-key assertion green).

**MCP coverage: deferred — pure client-side UI/consent gating with no user-data model, API route, or server action (follow-up: n/a).** Per the KAN-222 "when it doesn't apply" clause (pure UI change, no data-model impact), no MCP tool is relevant.

## Jira Ticket

SEC-72

## Checklist

- [x] Unit tests added/updated for new/changed functionality (`tests/unit/consented-analytics.test.ts`, 11 tests)
- [x] All existing tests pass (`npm run test:unit` — 153 suites / 1896 tests green)
- [x] Lint passes (`npm run lint` — clean on changed files)
- [x] Type check passes (`npx tsc --noEmit` — clean)
- [ ] Build succeeds (`npm run build`) — not run in this slice; CI covers it
- [x] Coverage has not decreased (net-new tests only)
- [x] No eslint-disable or ts-ignore without KAN-XX reference
- [ ] ARCHITECTURE.md updated if architectural changes were made — n/a (no architectural change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014p5SJebc4jY5eWXWF32Av4

---
_Generated by [Claude Code](https://claude.ai/code/session_014p5SJebc4jY5eWXWF32Av4)_