### PR TITLE
KAN-341: remove unwired searchByCity dead code (/search is the city-discovery surface)

### DIFF
--- a/src/app/dashboard/settings/discoverability-actions.ts
+++ b/src/app/dashboard/settings/discoverability-actions.ts
@@ -207,40 +207,15 @@ export async function searchByPhone(phone: string): Promise<SearchResult> {
   return performHashedSearch('phone', hash, user.id);
 }
 
-// KAN-339: hashed searchByPostcode removed. KAN-341 replaces it with city search.
-
-/**
- * KAN-341 — town/city discovery. City is coarse and is already public on a
- * published profile, so (unlike phone) it is NOT hashed: we match PUBLISHED
- * profiles by their public city. Rate-limited per searcher; authenticated only.
- */
-export async function searchByCity(city: string): Promise<SearchResult> {
-  const supabase = await createClient();
-  const { data: { user } } = await supabase.auth.getUser();
-  if (!user) return { success: false, error: 'Not authenticated' };
-
-  const q = (city ?? '').trim();
-  if (q.length < 2) return { success: true, matches: [] };
-
-  const rl = rateLimit(`discoverability-search:${user.id}`, SEARCH_RATE_LIMIT);
-  if (rl.limited) {
-    return {
-      success: false,
-      error: `Too many lookups. Try again in ${rl.retryAfter ?? 60} seconds.`,
-    };
-  }
-
-  const { data, error } = await supabase
-    .from('profiles')
-    .select('id, slug')
-    .eq('is_published', true)
-    .ilike('city', q)
-    .limit(50);
-  if (error) {
-    return { success: false, error: 'Search failed. Please try again.' };
-  }
-  const matches = (data ?? [])
-    .filter((r): r is { id: string; slug: string } => typeof r.slug === 'string')
-    .map((r) => ({ id: r.id, slug: r.slug }));
-  return { success: true, matches };
-}
+// KAN-339: hashed searchByPostcode removed. KAN-341 replaces postcode
+// discovery with town/city discovery.
+//
+// KAN-341 decision (docs/KAN-349-UX-EPIC-REVIEW.md §4): city discovery is
+// served by the PUBLIC `/search` page (`src/app/search/page.tsx`), which
+// already ilike-matches `profiles.city` alongside name / headline / slug. A
+// dedicated authenticated `searchByCity` server action was prototyped here but
+// never wired to any UI; it duplicated `/search` more weakly (auth-only, exact
+// ilike with no wildcards, no is_homepage_example filter), so it was removed
+// rather than shipped as a second, divergent discovery path. Phone discovery
+// stays hashed and action-based (above) because a phone number is not public
+// profile data; a city is.


### PR DESCRIPTION
## Summary

Resolves the final residual of **KAN-341** (city-discovery search-UI surface), the first residual item of the KAN-349 UX epic.

Per the recorded decision in `docs/KAN-349-UX-EPIC-REVIEW.md` §4 — *"keep the logged-in dashboard a clean status hub; do NOT add a people-recommendations feed — route 'discover people' to `/search`"* — the public `/search` page **is** the city-discovery surface. It already `ilike`-matches `profiles.city` alongside name/headline/slug (predating this ticket, KAN-273 era).

The authenticated `searchByCity` server action in `discoverability-actions.ts` was prototyped but **never wired to any UI** (zero callers) and duplicated `/search` more weakly:
- auth-only (vs. public `/search`)
- exact `ilike` with no `%` wildcards
- no `is_homepage_example` filter (would surface curated demo profiles in real member discovery — the exact thing KAN-334 removed from `/search`)

Rather than ship a second, divergent discovery path, this removes the dead action and replaces it with a comment documenting where city discovery lives and why phone discovery (hashed, action-based) stays. Phone discovery is unaffected — a phone number is not public profile data; a city is.

This closes KAN-341.

## Jira Ticket

KAN-341

## MCP-main lockstep (KAN-222)

Not applicable — this **removes** an unwired action and adds no user-facing data path. City is already exposed on the public profile and via `/search`; no MCP change is warranted by this deletion.

## Checklist

- [x] Unit tests added/updated for new/changed functionality — n/a: `searchByCity` had **zero test coverage** and zero callers (pure dead code); nothing to update
- [x] All existing tests pass (`npm run test:unit`) — 1896 tests / 153 suites green
- [x] Lint passes (`npm run lint`) — clean
- [x] Type check passes (`npm run type-check`) — clean
- [ ] Build succeeds (`npm run build`) — not run locally; CI covers it
- [x] Coverage has not decreased — removed uncovered code only
- [x] No eslint-disable or ts-ignore without KAN-XX reference — none added
- [x] ARCHITECTURE.md updated if architectural changes were made — n/a

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017QkPFSWReGSeQqZy7exq2z

---
_Generated by [Claude Code](https://claude.ai/code/session_017QkPFSWReGSeQqZy7exq2z)_