### PR TITLE
SEC-44: gate suspended profiles on public /[slug] page

### DIFF
--- a/src/app/[slug]/page.tsx
+++ b/src/app/[slug]/page.tsx
@@ -87,6 +87,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
     .select('display_name, headline, bio_short')
     .eq('slug', slug)
     .eq('is_published', true)
+    .eq('is_suspended', false) // SEC-44: service-role render must exclude suspended profiles
     .single();
 
   if (!profile) {
@@ -175,6 +176,7 @@ export default async function PublicProfilePage({ params }: Props) {
     .select('*')
     .eq('slug', slug)
     .eq('is_published', true)
+    .eq('is_suspended', false) // SEC-44: suspended profiles must 404 on the public page, not render
     .single();
 
   if (!profile) {

--- a/tests/unit/public-profile-suspended-gating.test.ts
+++ b/tests/unit/public-profile-suspended-gating.test.ts
@@ -1,0 +1,52 @@
+/**
+ * SEC-44 / KAN-355 — the public profile page (`/[slug]`) renders via the
+ * RLS-bypassing service-role client, so the suspension guard must be an
+ * EXPLICIT `.eq('is_suspended', false)` filter on every profile lookup.
+ * Without it, an admin-suspended profile stays fully publicly viewable — a
+ * safeguarding + UK-GDPR exposure on an under-18-facing platform.
+ *
+ * Both the `generateMetadata` fetch and the page fetch must carry the filter
+ * (alongside `is_published = true`) so a suspended published profile 404s.
+ * These source assertions lock the filter in against regression, mirroring the
+ * sibling SEC-19/F-13 guard in `recommendations-routes-security.test.ts`.
+ */
+import fs from 'fs';
+import path from 'path';
+
+const root = path.join(__dirname, '../..');
+const pagePath = 'src/app/[slug]/page.tsx';
+
+describe('SEC-44: public profile page filters suspended profiles', () => {
+  const content = fs.readFileSync(path.join(root, pagePath), 'utf8');
+
+  test(`${pagePath} exists`, () => {
+    expect(fs.existsSync(path.join(root, pagePath))).toBe(true);
+  });
+
+  test('excludes suspended profiles via .eq(\'is_suspended\', false)', () => {
+    expect(content).toMatch(/\.eq\(\s*['"]is_suspended['"]\s*,\s*false\s*\)/);
+  });
+
+  test('applies the suspension filter on BOTH the metadata and page fetches', () => {
+    // The two service-role reads are distinguished by their select() shape:
+    // generateMetadata selects specific columns; the page fetch selects '*'.
+    const metaFetch = content.slice(
+      content.indexOf("select('display_name, headline, bio_short')"),
+    );
+    const pageFetch = content.slice(content.indexOf(".select('*')"));
+
+    const suspensionFilter = /\.eq\(\s*['"]is_suspended['"]\s*,\s*false\s*\)/;
+
+    // Each fetch block ends at its `.single()`; assert the filter appears
+    // before that terminator in both.
+    const metaBlock = metaFetch.slice(0, metaFetch.indexOf('.single()'));
+    const pageBlock = pageFetch.slice(0, pageFetch.indexOf('.single()'));
+
+    expect(metaBlock).toMatch(suspensionFilter);
+    expect(pageBlock).toMatch(suspensionFilter);
+  });
+
+  test('still requires is_published = true (does not weaken the existing guard)', () => {
+    expect(content).toMatch(/\.eq\(\s*['"]is_published['"]\s*,\s*true\s*\)/);
+  });
+});


### PR DESCRIPTION
## Summary

The public profile page (`src/app/[slug]/page.tsx`) renders via the RLS-bypassing **service-role** client and filtered only on `is_published`, so an admin-**suspended** profile stayed fully publicly viewable at `/[slug]` — moderation was silently ineffective on the primary surface (a safeguarding + UK-GDPR exposure on an under-18-facing platform).

This adds `.eq('is_suspended', false)` to **both** the `generateMetadata` fetch and the page fetch, so a suspended published profile now returns 404 (`notFound()`). This mirrors the existing SEC-19/F-13 filter already applied on the recommendation routes (`src/app/api/recommendations/[slug]/route.ts`), which the page had drifted from.

A new source-assertion regression guard (`tests/unit/public-profile-suspended-gating.test.ts`) locks the filter in on both fetches, matching the sibling `recommendations-routes-security.test.ts` pattern. This covers the KAN-355 suspended-profile invariant ("a suspended published profile 404s on `/[slug]`").

**Scope note:** KAN-355 also asks for Convene cron/`drain-queue` auth tests — those are a separate slice and remain open on KAN-355. This PR delivers the SEC-44 fix + the suspended-profile behavioural guard.

## Jira Ticket

SEC-44 (fix) · KAN-355 (suspended-profile test portion)

## Changes

- `src/app/[slug]/page.tsx` — `.eq('is_suspended', false)` on the metadata fetch and the page fetch (2 lines).
- `tests/unit/public-profile-suspended-gating.test.ts` — new regression guard (4 assertions): filter present, present on both fetches, `is_published=true` not weakened.

## Verification

- `npx jest` on the new + related suites: **12 passed** (incl. 4 new).
- `npx tsc --noEmit`: clean.
- `npx eslint` on changed files: clean.
- No existing test modified/weakened/skipped.

## Checklist

- [x] Unit tests added/updated for new/changed functionality
- [x] All existing tests pass (related suites; full suite runs in CI)
- [x] Lint passes (changed files)
- [x] Type check passes
- [ ] Build succeeds (`npm run build`) — deferred to CI
- [x] Coverage has not decreased (net-new tests only)
- [x] No eslint-disable or ts-ignore without KAN-XX reference
- [ ] ARCHITECTURE.md updated if architectural changes were made — n/a (behaviour-preserving authz fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DS4F1mFsx4V15FPYLEsYcB

---
_Generated by [Claude Code](https://claude.ai/code/session_01DS4F1mFsx4V15FPYLEsYcB)_