### PR TITLE
SEC-53: bound + validate the unauthenticated Convene RSVP write

### DIFF
--- a/src/app/r/[token]/actions.ts
+++ b/src/app/r/[token]/actions.ts
@@ -2,22 +2,62 @@
 
 import { getInviteeByToken, recordRsvpResponse } from '@/lib/convene/invites/repository';
 import { isConveneEnabled } from '@/lib/convene/flags';
+import { sanitiseText } from '@/lib/sanitise';
+import { checkModeration } from '@/lib/moderation-policy';
 
 type Result = { ok: true } | { ok: false; error: string };
 
+/**
+ * SEC-53 (finding web-input-02) — this is the ONLY unauthenticated Convene
+ * write: anyone holding an invite token can reach it and the DB write goes
+ * through the RLS-bypassing service-role client. Every field is therefore
+ * bounded and validated at runtime BEFORE it reaches the DB:
+ *
+ *   - `status` is checked against the allowed set. The TypeScript union is
+ *     erased at runtime and a server action can be invoked with arbitrary
+ *     args, so the DB CHECK must not be the sole backstop.
+ *   - `note` is HTML-stripped + capped at 500 chars via `sanitiseText`
+ *     (mirrors the ≤500 cap on POST /api/reports), then run through the
+ *     standard moderation pipeline — it is surfaced to the host, so
+ *     block-severity content (profanity / PII) is rejected, not stored.
+ */
+const RSVP_STATUSES = ['accepted', 'declined', 'tentative'] as const;
+type RsvpStatus = (typeof RSVP_STATUSES)[number];
+
+const NOTE_MAX = 500;
+
 export async function submitRsvp(
   token: string,
-  status: 'accepted' | 'declined' | 'tentative',
+  status: string,
   note?: string
 ): Promise<Result> {
   if (!isConveneEnabled()) return { ok: false, error: 'Convene is not enabled' };
+
+  // Runtime status validation — the TS union above is erased at runtime.
+  if (!RSVP_STATUSES.includes(status as RsvpStatus)) {
+    return { ok: false, error: 'Invalid RSVP status' };
+  }
+
+  // Bound + sanitise the free-text note, then moderate the post-strip text
+  // (so anything hidden inside stripped HTML is still caught) before it can
+  // reach the service-role DB write.
+  let cleanedNote: string | undefined;
+  if (note != null) {
+    const sanitised = sanitiseText(note, NOTE_MAX);
+    if (sanitised) {
+      const mod = checkModeration(sanitised, 'public', 'rsvp.note');
+      if (!mod.ok) return { ok: false, error: mod.error };
+      cleanedNote = sanitised;
+    }
+  }
+
   const invitee = await getInviteeByToken(token);
   if (!invitee) return { ok: false, error: 'Invalid or expired invitation link' };
   if (invitee.tokenExpiresAt && new Date(invitee.tokenExpiresAt) < new Date()) {
     return { ok: false, error: 'This invitation has expired' };
   }
   try {
-    await recordRsvpResponse(invitee.inviteeId, status, note?.trim() || undefined);
+    await recordRsvpResponse(invitee.inviteeId, status as RsvpStatus, cleanedNote);
     return { ok: true };
   } catch (e) {
     return { ok: false, error: e instanceof Error ? e.message : 'Failed to record response' };

--- a/tests/unit/convene/rsvp-submit-validation.test.ts
+++ b/tests/unit/convene/rsvp-submit-validation.test.ts
@@ -1,0 +1,144 @@
+/**
+ * SEC-53 (finding web-input-02) — submitRsvp input validation.
+ *
+ * submitRsvp is the only UNAUTHENTICATED Convene write (reachable by anyone
+ * holding an invite token, writing via the service-role client). These tests
+ * lock the three defences added under SEC-53:
+ *   1. `status` is runtime-validated against the allowed set (TS union is
+ *      erased at runtime; a bogus status must never reach the DB write).
+ *   2. `note` is HTML-stripped + capped at 500 chars before storage.
+ *   3. `note` is run through the moderation pipeline; block-severity content
+ *      (e.g. PII / profanity on a host-facing field) is rejected, not stored.
+ *
+ * The repository + flag modules are mocked; sanitise + moderation run for real.
+ */
+
+// ── Mutable mock state ──────────────────────────────────────
+let conveneEnabled = true;
+let inviteeResult: {
+  inviteeId: string;
+  tokenExpiresAt: string | null;
+} | null = { inviteeId: 'inv-1', tokenExpiresAt: null };
+
+const recordCalls: Array<{ inviteeId: string; status: string; note: string | undefined }> = [];
+
+jest.mock('@/lib/convene/flags', () => ({
+  isConveneEnabled: () => conveneEnabled,
+}));
+
+jest.mock('@/lib/convene/invites/repository', () => ({
+  getInviteeByToken: async () => inviteeResult,
+  recordRsvpResponse: async (inviteeId: string, status: string, note: string | undefined) => {
+    recordCalls.push({ inviteeId, status, note });
+  },
+}));
+
+import { submitRsvp } from '@/app/r/[token]/actions';
+
+beforeEach(() => {
+  conveneEnabled = true;
+  inviteeResult = { inviteeId: 'inv-1', tokenExpiresAt: null };
+  recordCalls.length = 0;
+});
+
+describe('submitRsvp — status runtime validation (SEC-53)', () => {
+  test('accepts each allowed status and writes it', async () => {
+    for (const status of ['accepted', 'declined', 'tentative']) {
+      recordCalls.length = 0;
+      const res = await submitRsvp('tok', status, undefined);
+      expect(res).toEqual({ ok: true });
+      expect(recordCalls).toHaveLength(1);
+      expect(recordCalls[0].status).toBe(status);
+    }
+  });
+
+  test('rejects a status outside the allowed set and never touches the DB', async () => {
+    const res = await submitRsvp('tok', 'going', 'hi');
+    expect(res).toEqual({ ok: false, error: 'Invalid RSVP status' });
+    expect(recordCalls).toHaveLength(0);
+  });
+
+  test('rejects an empty/garbage status before any DB write', async () => {
+    for (const bogus of ['', 'ACCEPTED', 'maybe', 'accepted; drop table']) {
+      recordCalls.length = 0;
+      const res = await submitRsvp('tok', bogus, undefined);
+      expect(res).toEqual({ ok: false, error: 'Invalid RSVP status' });
+      expect(recordCalls).toHaveLength(0);
+    }
+  });
+});
+
+describe('submitRsvp — note length cap + sanitisation (SEC-53)', () => {
+  test('caps an oversized note at 500 chars before storage', async () => {
+    const huge = 'x '.repeat(400); // 800 chars, no repeated-char/spam trigger
+    const res = await submitRsvp('tok', 'accepted', huge);
+    expect(res).toEqual({ ok: true });
+    expect(recordCalls).toHaveLength(1);
+    expect(recordCalls[0].note!.length).toBe(500);
+  });
+
+  test('strips HTML tags from the note', async () => {
+    const res = await submitRsvp('tok', 'accepted', '<b>Hello</b> <i>there</i>');
+    expect(res).toEqual({ ok: true });
+    expect(recordCalls[0].note).toBe('Hello there');
+    expect(recordCalls[0].note).not.toContain('<');
+    expect(recordCalls[0].note).not.toContain('>');
+  });
+
+  test('a whitespace-only note is stored as undefined, not an empty string', async () => {
+    const res = await submitRsvp('tok', 'accepted', '   \n\t  ');
+    expect(res).toEqual({ ok: true });
+    expect(recordCalls).toHaveLength(1);
+    expect(recordCalls[0].note).toBeUndefined();
+  });
+
+  test('omitted note records undefined', async () => {
+    const res = await submitRsvp('tok', 'declined');
+    expect(res).toEqual({ ok: true });
+    expect(recordCalls[0].note).toBeUndefined();
+  });
+
+  test('a clean note passes through intact', async () => {
+    const res = await submitRsvp('tok', 'tentative', 'See you there!');
+    expect(res).toEqual({ ok: true });
+    expect(recordCalls[0].note).toBe('See you there!');
+  });
+});
+
+describe('submitRsvp — moderation pipeline (SEC-53)', () => {
+  test('rejects a note containing PII (email) and never touches the DB', async () => {
+    const res = await submitRsvp('tok', 'accepted', 'reach me at attacker@evil.com');
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.error).toMatch(/Content rejected/i);
+    expect(recordCalls).toHaveLength(0);
+  });
+
+  test('rejects a note containing a phone number and never touches the DB', async () => {
+    const res = await submitRsvp('tok', 'accepted', 'call +44 7911 123456 when you arrive');
+    expect(res.ok).toBe(false);
+    expect(recordCalls).toHaveLength(0);
+  });
+});
+
+describe('submitRsvp — existing gates still hold (SEC-53 no regression)', () => {
+  test('returns error when Convene is disabled, before validating anything', async () => {
+    conveneEnabled = false;
+    const res = await submitRsvp('tok', 'going' /* invalid, but flag gate wins */, 'hi');
+    expect(res).toEqual({ ok: false, error: 'Convene is not enabled' });
+    expect(recordCalls).toHaveLength(0);
+  });
+
+  test('returns error for an invalid/expired token (no invitee)', async () => {
+    inviteeResult = null;
+    const res = await submitRsvp('bad-tok', 'accepted', 'hi');
+    expect(res).toEqual({ ok: false, error: 'Invalid or expired invitation link' });
+    expect(recordCalls).toHaveLength(0);
+  });
+
+  test('returns error for an expired token window', async () => {
+    inviteeResult = { inviteeId: 'inv-1', tokenExpiresAt: '2020-01-01T00:00:00Z' };
+    const res = await submitRsvp('tok', 'accepted', 'hi');
+    expect(res).toEqual({ ok: false, error: 'This invitation has expired' });
+    expect(recordCalls).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## What & Why

`submitRsvp()` (`src/app/r/[token]/actions.ts`) is the **only unauthenticated Convene write** — reachable by anyone holding an invite token, persisted via the RLS-bypassing service-role client (`recordRsvpResponse`). Before this change it:

- stored the free-text `note` with only `.trim()` — **no length cap, no moderation** (storage/DoS abuse + unmoderated text shown to the host), and
- relied on a DB CHECK as the **sole runtime backstop** for `status` (the TypeScript union is erased at runtime, and a server action can be invoked with arbitrary args).

Finding **web-input-02** (2026-06-30 review). Compare `api/reports/route.ts` which already caps its note ≤500 chars.

## Changes

- **Runtime `status` validation** against the allowed set (`accepted | declined | tentative`) before any DB write; widened the param to `string` so the check is meaningful.
- **`note` length cap + HTML strip** via `sanitiseText(note, 500)` (mirrors the ≤500 cap on `POST /api/reports`).
- **Moderation** of the sanitised note through `checkModeration(..., 'public', 'rsvp.note')` — block-severity content (PII / profanity surfaced to the host) is rejected, not stored. Moderation runs on the post-strip text so anything hidden inside stripped HTML is still caught.

## Tests

New behavioural test `tests/unit/convene/rsvp-submit-validation.test.ts` (13 assertions): status allow/reject (incl. `''`, `ACCEPTED`, injection-ish), 500-char cap, HTML strip, whitespace→`undefined`, omitted note→`undefined`, clean note passthrough, PII-email + phone block, plus no-regression of the existing Convene-disabled / invalid-token / expired-token gates. Repository + flag modules mocked; sanitise + moderation run for real.

- 385 convene tests green (26 suites); `tsc --noEmit` clean; eslint clean on changed files. No existing test modified.

## Security Review

Reduces attack surface on the only unauthenticated Convene write: bounds storage, prevents unmoderated host-facing text, removes reliance on the DB CHECK as the sole `status` backstop. No new auth/RLS surface; no schema change. **Decision to confirm:** the note is moderated as a `public` field (blocks PII such as phone/email). If a host-facing RSVP note should instead allow contact details (warn-only), switch to `'private'` — flagged for founder review on SEC-53.

## Architecture Impact

None. No new env vars, deps, or migrations. Server action file stays `'use server'`-clean (only async-function export; constants are module-local, not exported — Gotcha #18 safe).

MCP coverage: n/a — RSVP is an unauthenticated token flow with no agent-facing parity surface.

Closes SEC-53 once live (dev→staging per acceptance).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DdiUEXw5Js583vmfjRaAX9

---
_Generated by [Claude Code](https://claude.ai/code/session_01DdiUEXw5Js583vmfjRaAX9)_