### PR TITLE
fix(SEC-45): scope profile_items public-read RLS to visibility='public'

### DIFF
--- a/supabase/migrations/20260704070000_sec45_profile_items_public_read_visibility.sql
+++ b/supabase/migrations/20260704070000_sec45_profile_items_public_read_visibility.sql
@@ -1,0 +1,77 @@
+-- SEC-45 (finding web-rls-1) — profile_items over-permissive public-read RLS
+--
+-- Phase 0 · Severity High.
+--
+-- The 20260516120000_admin_and_moderation.sql migration re-created a public
+-- SELECT policy on profile_items — "Anyone can read items from published
+-- non-suspended profiles" — that adds the is_suspended=false check but DROPS
+-- the visibility='public' predicate the 20260514054350_profile_items_visibility
+-- migration had introduced. Because RLS SELECT policies are OR-combined
+-- (permissive), that over-broad policy lets anonymous callers (public anon key,
+-- via PostgREST) read members_only / draft / private items of any published,
+-- non-suspended profile — defeating KAN-143 per-item visibility. For an
+-- under-18 product this leaks data users explicitly chose to keep private
+-- (UK-GDPR confidentiality / data-minimisation).
+--
+-- Fix: drop the over-broad policy and consolidate the public-read paths so each
+-- carries BOTH the visibility predicate AND the is_suspended=false predicate:
+--   - anonymous + authenticated: visibility='public'       (published + non-suspended)
+--   - authenticated only:        visibility='members_only' (published + non-suspended)
+-- draft / private items remain owner-only via the existing
+-- "Users can manage own profile items" ALL policy, which this migration does
+-- NOT touch.
+--
+-- Note: dev (and possibly other envs) also carried an untracked ad-hoc
+-- duplicate policy "Read public items from published profiles" (role
+-- {anon,authenticated}, same predicate minus is_suspended). It is dropped here
+-- so there is a single canonical public-read definition. The drops are
+-- drop-if-exists, so this migration is idempotent and a no-op where a policy is
+-- already absent.
+--
+-- Rollback (manual, NOT recommended — restores the leak):
+--   drop policy "Anyone can read public items from published profiles" on public.profile_items;
+--   drop policy "Members can read members_only items from published profiles" on public.profile_items;
+--   create policy "Anyone can read items from published non-suspended profiles"
+--     on public.profile_items for select
+--     using (exists (select 1 from public.profiles
+--       where id = profile_items.profile_id and is_published = true and is_suspended = false));
+
+-- ============================================================
+-- 1. Remove the over-broad policy (no visibility predicate) — the CVE.
+-- ============================================================
+drop policy if exists "Anyone can read items from published non-suspended profiles" on public.profile_items;
+
+-- ============================================================
+-- 2. Remove the untracked ad-hoc duplicate public-read policy, if present.
+-- ============================================================
+drop policy if exists "Read public items from published profiles" on public.profile_items;
+
+-- ============================================================
+-- 3. Canonical public-item read: public items of published, non-suspended
+--    profiles — visible to anonymous and authenticated viewers alike.
+-- ============================================================
+drop policy if exists "Anyone can read public items from published profiles" on public.profile_items;
+create policy "Anyone can read public items from published profiles"
+  on public.profile_items for select
+  using (
+    visibility = 'public'
+    and profile_id in (
+      select id from public.profiles
+      where is_published = true and is_suspended = false
+    )
+  );
+
+-- ============================================================
+-- 4. members_only read: authenticated viewers only, published + non-suspended.
+-- ============================================================
+drop policy if exists "Members can read members_only items from published profiles" on public.profile_items;
+create policy "Members can read members_only items from published profiles"
+  on public.profile_items for select
+  using (
+    auth.uid() is not null
+    and visibility = 'members_only'
+    and profile_id in (
+      select id from public.profiles
+      where is_published = true and is_suspended = false
+    )
+  );

--- a/tests/unit/sec45-profile-items-public-read-rls.test.js
+++ b/tests/unit/sec45-profile-items-public-read-rls.test.js
@@ -1,0 +1,140 @@
+/**
+ * SEC-45 (finding web-rls-1) — profile_items public-read RLS visibility guard.
+ *
+ * A public anon SELECT policy on profile_items that lacks a `visibility`
+ * predicate lets anonymous callers (public anon key, via PostgREST) read
+ * members_only / draft / private items of any published profile. The
+ * 20260516120000_admin_and_moderation.sql migration re-introduced exactly such
+ * a policy ("Anyone can read items from published non-suspended profiles"),
+ * silently defeating KAN-143 per-item visibility.
+ *
+ * These are static file-content checks (migrations are applied via the
+ * Supabase MCP after review, per CLAUDE.md "Supabase Migration Rules"), not
+ * DB-execution tests. Group 2 models the *final* effective policy set across
+ * every migration so that any FUTURE migration re-creating an over-broad
+ * public-read policy fails CI.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const root = path.join(__dirname, '../..');
+const migrationsDir = path.join(root, 'supabase/migrations');
+
+const OVERBROAD_POLICY = 'Anyone can read items from published non-suspended profiles';
+const ADHOC_DUPLICATE = 'Read public items from published profiles';
+
+function findSec45Migration() {
+  const files = fs.readdirSync(migrationsDir);
+  const match = files.find((f) =>
+    /sec45_profile_items_public_read_visibility\.sql$/.test(f)
+  );
+  return match ? path.join(migrationsDir, match) : null;
+}
+
+describe('SEC-45 — profile_items public-read RLS fix migration', () => {
+  test('migration file exists with a 14-digit timestamp prefix', () => {
+    const filePath = findSec45Migration();
+    expect(filePath).not.toBeNull();
+    expect(path.basename(filePath)).toMatch(/^\d{14}_/);
+  });
+
+  test('drops the over-broad policy that lacked a visibility predicate', () => {
+    const sql = fs.readFileSync(findSec45Migration(), 'utf8');
+    expect(sql).toMatch(
+      new RegExp(`drop policy if exists\\s+"${OVERBROAD_POLICY}"\\s+on\\s+public\\.profile_items`, 'i')
+    );
+  });
+
+  test('drops the untracked ad-hoc duplicate public-read policy', () => {
+    const sql = fs.readFileSync(findSec45Migration(), 'utf8');
+    expect(sql).toMatch(
+      new RegExp(`drop policy if exists\\s+"${ADHOC_DUPLICATE}"\\s+on\\s+public\\.profile_items`, 'i')
+    );
+  });
+
+  test('recreates the public-read policy carrying visibility AND is_suspended', () => {
+    const sql = fs.readFileSync(findSec45Migration(), 'utf8');
+    const block = sql.match(
+      /create policy\s+"Anyone can read public items from published profiles"\s+on\s+public\.profile_items\s+for\s+select([\s\S]*?);/i
+    );
+    expect(block).not.toBeNull();
+    expect(block[1]).toMatch(/visibility = 'public'/);
+    expect(block[1]).toMatch(/is_suspended = false/);
+  });
+
+  test('recreates the members_only policy: authenticated + members_only + non-suspended', () => {
+    const sql = fs.readFileSync(findSec45Migration(), 'utf8');
+    const block = sql.match(
+      /create policy\s+"Members can read members_only items from published profiles"\s+on\s+public\.profile_items\s+for\s+select([\s\S]*?);/i
+    );
+    expect(block).not.toBeNull();
+    expect(block[1]).toMatch(/auth\.uid\(\) is not null/i);
+    expect(block[1]).toMatch(/visibility = 'members_only'/);
+    expect(block[1]).toMatch(/is_suspended = false/);
+  });
+
+  test('does NOT drop or alter the owner "Users can manage own profile items" policy', () => {
+    const sql = fs.readFileSync(findSec45Migration(), 'utf8');
+    expect(sql).not.toMatch(/drop\s+policy[^;]*"Users can manage own profile items"/i);
+    expect(sql).not.toMatch(/alter\s+policy[^;]*"Users can manage own profile items"/i);
+  });
+});
+
+describe('SEC-45 — cross-migration invariant: no public-reachable profile_items read policy may omit a visibility predicate', () => {
+  // Model the FINAL effective set of profile_items policies by replaying every
+  // migration in timestamp order (drop / create). A policy that is reachable by
+  // anonymous callers (not gated by auth.uid(), not restricted `to authenticated`)
+  // and can return rows via SELECT (FOR SELECT, FOR ALL, or no FOR clause) MUST
+  // carry a `visibility` predicate — otherwise it leaks non-public items.
+  const effective = new Map(); // policyName -> { canSelect, publicReachable, hasVisibility, file }
+
+  const files = fs
+    .readdirSync(migrationsDir)
+    .filter((f) => f.endsWith('.sql'))
+    .sort();
+
+  for (const file of files) {
+    const sql = fs.readFileSync(path.join(migrationsDir, file), 'utf8');
+
+    // Drops: mark the policy as gone.
+    const dropRe = /drop policy if exists\s+"([^"]+)"\s+on\s+public\.profile_items/gi;
+    let d;
+    while ((d = dropRe.exec(sql)) !== null) {
+      effective.delete(d[1]);
+    }
+
+    // Creates: capture the full statement up to its terminating semicolon.
+    const createRe = /create policy\s+"([^"]+)"\s+on\s+public\.profile_items([\s\S]*?);/gi;
+    let c;
+    while ((c = createRe.exec(sql)) !== null) {
+      const name = c[1];
+      const body = c[2];
+      const hasForClause = /\bfor\s+(select|all|insert|update|delete)\b/i.test(body);
+      const forSelectOrAll = /\bfor\s+(select|all)\b/i.test(body) || !hasForClause;
+      const authGated = /auth\.uid\(\)/i.test(body);
+      const restrictedToAuthed =
+        /\bto\s+authenticated\b/i.test(body) && !/\bto\s+[^\n]*\banon\b/i.test(body);
+      effective.set(name, {
+        canSelect: forSelectOrAll,
+        publicReachable: !authGated && !restrictedToAuthed,
+        hasVisibility: /visibility\s*=/.test(body),
+        file,
+      });
+    }
+  }
+
+  test('every anon-reachable profile_items read policy carries a visibility predicate', () => {
+    const offenders = [];
+    for (const [name, p] of effective.entries()) {
+      if (p.canSelect && p.publicReachable && !p.hasVisibility) {
+        offenders.push(`"${name}" (created in ${p.file})`);
+      }
+    }
+    expect(offenders).toEqual([]);
+  });
+
+  test('the over-broad SEC-45 policy is not present in the final effective set', () => {
+    expect(effective.has(OVERBROAD_POLICY)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

A public anon `SELECT` policy on `profile_items` — **"Anyone can read items from published non-suspended profiles"** (added in `20260516120000_admin_and_moderation.sql`) — lacked a `visibility` predicate. Because RLS `SELECT` policies are OR-combined (permissive), it let anonymous callers (public anon key, via PostgREST) read `members_only` / `draft` / `private` items of any published, non-suspended profile — defeating KAN-143 per-item visibility (UK-GDPR confidentiality / data-minimisation, under-18 product).

The consumer page (`src/app/[slug]/page.tsx`) renders via the service-role client (RLS bypassed) with app-side visibility filtering, so the affected surface is specifically the **direct anon-key / PostgREST** read path, which RLS gates.

### Change
New migration `20260704070000_sec45_profile_items_public_read_visibility.sql`:
- **Drops** the over-broad policy (no visibility predicate) — the leak.
- **Drops** an untracked ad-hoc duplicate (`"Read public items from published profiles"`, present on dev, in no migration).
- **Consolidates** the public-read paths so each carries **both** `visibility` and `is_suspended = false`:
  - anon + authenticated → `visibility = 'public'`
  - authenticated only → `visibility = 'members_only'`
- `draft` / `private` remain owner-only via the existing `Manage own profile items` ALL policy (**untouched**).

### Verification (dev Supabase `ilprytcrnqyrsbsrfujj`)
- Migration applied; final `profile_items` SELECT policy set = 2 policies, each with `visibility` + `is_suspended` predicates; over-broad + duplicate gone.
- Functional anon-role simulation: **0** non-public items visible to `anon` (227 public still visible).
- `tests/unit/sec45-profile-items-public-read-rls.test.js` — SEC-45 asserts + a **cross-migration invariant** that models the final effective policy set and fails if any future migration re-creates an anon-reachable `profile_items` read policy without a visibility predicate. 8 tests green; sibling `profile-items-visibility-migration.test.js` still green; eslint clean; no existing test modified.

**Staging/prod:** migration must still be applied to staging + prod (supervised order dev→staging→prod) at a promote — dev only in this PR.

## Jira Ticket

SEC-45

## Checklist

- [x] Unit tests added/updated for new/changed functionality
- [x] All existing tests pass (relevant suites; no existing test modified)
- [x] Lint passes (new file eslint-clean)
- [ ] Type check passes (no TS/app code changed — SQL migration + JS test only)
- [ ] Build succeeds (no app code changed)
- [x] Coverage has not decreased (net-new tests only)
- [x] No eslint-disable or ts-ignore without KAN-XX reference
- [ ] ARCHITECTURE.md updated if architectural changes were made (n/a — RLS hardening, no architectural change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EJ4N5FDsDDsXn7BBseJYia

---
_Generated by [Claude Code](https://claude.ai/code/session_01EJ4N5FDsDDsXn7BBseJYia)_