### PR TITLE
KAN-283/SEC-70: ICO ref ZC124222 + DUAA complaints channel + vendor DPAs recorded + DPIA draft

### DIFF
--- a/docs/compliance/DPIA.md
+++ b/docs/compliance/DPIA.md
@@ -1,0 +1,154 @@
+# Data Protection Impact Assessment (DPIA)
+
+> **Status: DRAFT — awaiting founder risk sign-off.** Not legal advice.
+> Prepared 2026-07-03 (SEC-70 / KAN-283) following the ICO DPIA template. Every
+> section below is filled from the existing compliance pack (ROPA, retention,
+> sub-processors, DSAR/breach/complaints) so that only the **residual-risk
+> judgement** (likelihood × severity scores) and the **sign-off block** at the
+> end remain for the controller to complete. This DPIA is the repo-canonical
+> version and supersedes/consolidates the two earlier DRAFTs in Confluence
+> (TWC pages 27000875 and 27033667), which the founder should retire in its
+> favour.
+
+**Controller:** CheckLyra Ltd (trading as Lyra), registered in England & Wales (company no. 16351012).
+**ICO registration:** ZC124222.
+**Contact / DP lead:** privacy@checklyra.com (founder is the accountable data-protection lead; no statutory DPO required).
+**Assessment date:** 2026-07-03 · **Scope:** the Lyra consumer service at launch (18+ profiles, age assurance, Convene, gift/affiliate analytics).
+
+---
+
+## 1. Identify the need for a DPIA
+
+A DPIA is carried out under UK GDPR Art. 35 because the processing is likely to
+result in a high risk to individuals. The triggers are:
+
+- **(a) Audience / children-likely-access.** Lyra is an adults-only (18+)
+  service, but it is a public, discoverable profile platform that children may
+  attempt to access. The ICO Children's Code and Art. 35 both point to a DPIA
+  where a service could be accessed by children even if not aimed at them.
+- **(b) Biometric special-category processing.** Age assurance uses Didit's
+  **biometric facial age-estimation** (a selfie/liveness check). Biometric data
+  used to estimate age is special-category data under Art. 9, and large-scale or
+  novel biometric processing is an ICO "likely high risk" trigger.
+- **(c) Systematic processing of third-party and calendar data.** Convene
+  processes **third-party contact data** (people who are not Lyra users and have
+  not themselves consented) and, optionally, **Google Calendar** busy/free data
+  via the `calendar.readonly` OAuth scope. Systematic processing of data about
+  non-users is an Art. 35 consideration.
+
+This DPIA is the Art. 35 assessment recorded against **SEC-70** and is a launch
+blocker until signed off.
+
+## 2. Describe the processing
+
+**Nature, scope, context and purposes** are drawn from the ROPA (P1–P8):
+
+| Ref | Purpose | Data | Notes |
+|---|---|---|---|
+| P1 | Account & authentication | email, display name | passwordless magic-link; no password stored |
+| P2 | Profile content ("Manual of Me") | headline, bio, city/country, preferences, likes/dislikes, boundaries, school, links, photo | all volunteered by the user; may contain free-text that reveals special-category data |
+| P3 | Age assurance (18+) | pass/fail result + age band from Didit | **Lyra never receives or stores the selfie image or biometric template** — only the result |
+| P4 | Convene: contacts, calendars, gatherings | third-party contact details, gathering data, Google Calendar busy/free | calendar via `calendar.readonly` only (read-only, no write); contacts are third-party data |
+| P5 | Waitlist | email | pre-launch interest capture (Cloudflare KV) |
+| P6 | Gift recommendations & affiliate analytics | opaque click identifier, standard browser metadata | no account email/name/profile shared with affiliate networks |
+| P7 | Transactional email | email, message content | magic links, invites, account notices (Resend) |
+| P8 | Security, abuse-prevention & audit | IP, security logs | 90-day retention |
+
+**Data flows.**
+- User → Supabase (Postgres/Auth/Storage) for account, profile, contacts.
+- Selfie → **Didit** on Didit's own systems; **only the result (pass + band)
+  returns to Lyra**. Lyra never stores the image or template.
+- Google Calendar → **busy/free times only** via OAuth `calendar.readonly`
+  (founder decision: read-only, never write; event contents are not read).
+  Tokens are deleted on disconnect.
+- Contacts are **third-party personal data** entered by the Lyra user about
+  other people.
+
+**Volumes / context.** Low-sensitivity consumer profile data; **adults-only
+(18+)**; no payment data, no precise location, no browsing history collected by
+Lyra. Media and backups are encrypted; backups are age-encrypted WORM in R2.
+
+## 3. Consultation process
+
+- **Internal:** the founder (accountable DP lead) reviews and signs off this
+  DPIA; engineering input is reflected in the ROPA and ARCHITECTURE.md.
+- **External guidance:** the ICO DPIA template, Children's Code, and
+  biometric/age-assurance guidance were used as the framework.
+- **Open (founder decision):** whether to consult data subjects or their
+  representatives — in particular whether to seek input on the children-access
+  risk and the biometric age-estimation step — and whether any ICO prior
+  consultation is warranted (see §6).
+
+## 4. Necessity and proportionality
+
+**Lawful bases (per ROPA):**
+- Art. 6(1)(b) contract — account/auth and the core profile service.
+- Art. 6(1)(a) consent — publishing a profile; connecting Google Calendar.
+- Art. 6(1)(f) legitimate interests — anonymised analytics, security/abuse
+  prevention, and processing third-party contact data to operate Convene
+  (balanced against the third party's interests; minimised, not published).
+- Art. 9(2)(a) explicit consent — the biometric age-estimation step, captured
+  by Didit at the point of the selfie check.
+
+**Data minimisation.**
+- `calendar.readonly` only — **busy/free, not event contents**; no write access.
+- **No selfie stored** — Didit returns only pass/fail + age band.
+- No precise location; no payment data; no browsing history.
+- Affiliate analytics use an **opaque identifier**, not account identity.
+- Contacts held to the minimum needed to run a gathering.
+
+**Retention** follows `RETENTION_SCHEDULE.md` — active-account data retained
+while active; deleted-account data purged within 30 days; security logs 90 days;
+backups 90-day WORM.
+
+**International transfers** follow `SUBPROCESSORS.md` — UK Addendum to the EU
+SCCs / UK IDTA incorporated by each processor's DPA, plus encryption in transit
+and at rest. Supabase DPA signed 2026-07-03; Vercel/Cloudflare(R2)/Resend
+recorded by reference 2026-07-03; Didit, Google and Railway remain to be
+confirmed (Didit at highest diligence as special-category).
+
+## 5. Identify and assess risks
+
+For each risk: the mitigation **already in place** is recorded; the
+**likelihood, severity and overall rating are left blank for the founder** to
+score (Low / Medium / High), and the **residual risk** after mitigation is the
+founder's judgement.
+
+| # | Risk to individuals | Mitigation already in place | Likelihood | Severity | Rating | Residual (founder) |
+|---|---|---|---|---|---|---|
+| R1 | **Under-18 access** despite the adults-only rule | Age gate + Didit biometric age-estimation before a profile can be created; 18+ self-declaration | ____ | ____ | ____ | ____ |
+| R2 | **Biometric misuse / over-retention at Didit** | Result-only architecture (Lyra never stores the image/template); Art. 9(2)(a) explicit consent captured by Didit; Didit DPA + biometric retention/deletion to be confirmed | ____ | ____ | ____ | ____ |
+| R3 | **Over-collection of third-party contact data** (contacts who never consented) | Art. 6(1)(f) with minimisation; contacts not published; used only to run gatherings; deletion on account deletion | ____ | ____ | ____ | ____ |
+| R4 | **Calendar data exposure** | `calendar.readonly` busy/free only (no event contents, no write); OAuth tokens deleted on disconnect | ____ | ____ | ____ | ____ |
+| R5 | **Re-identification / disclosure of special-category free-text** volunteered in profile fields | Privacy-notice warning against posting sensitive data; user controls publish/unpublish and edit/erase; RLS deny-by-default | ____ | ____ | ____ | ____ |
+| R6 | **International-transfer / US-government-access risk** | UK Addendum/IDTA via each DPA; encryption in transit + at rest; age-encrypted WORM backups; low-sensitivity dataset (TRA in SUBPROCESSORS.md) | ____ | ____ | ____ | ____ |
+| R7 | **Incomplete account deletion** | 30-day purge flow; deletion covers profile, media, contacts; backup rotation | ____ | ____ | ____ | ____ |
+
+## 6. Measures to reduce risk and sign-off
+
+**Technical & organisational measures (from ROPA §D):** RLS on all user tables
+(deny-by-default); TLS in transit; encryption at rest (Supabase/AWS);
+passwordless auth; OAuth 2.1 with RS256/JWKS; service-role keys in platform
+secret stores; Cloudflare Access on admin surfaces; daily encrypted WORM backups
++ restore drills (DISASTER_RECOVERY.md); least-privilege admin via a separate
+audited admin MCP; result-only age-assurance architecture; `calendar.readonly`
+scope with token deletion on disconnect; 30-day deletion purge.
+
+**Sign-off block (founder to complete):**
+
+- Residual risk (founder): ____________________
+- Additional measures required before launch (if any): ____________________
+- DPO / measures approved by: ____________________  date: __________
+- ICO prior consultation required? (only if residual risk remains **high**
+  after mitigations): ☐ yes ☐ no — rationale: ____________________
+- Review date: ____________________
+
+---
+
+### Cross-references
+- Processing purposes, lawful bases, TOMs → `ROPA.md`
+- Retention periods + deletion mechanisms → `RETENTION_SCHEDULE.md`
+- Sub-processors + transfer mechanisms + TRAs → `SUBPROCESSORS.md`
+- DSAR / breach / DUAA complaints procedures → `DSAR_BREACH_COMPLAINTS.md`
+- Founder action list → `FOUNDER_CHECKLIST.md`
+- Supersedes: Confluence TWC DRAFT DPIAs 27000875 and 27033667 (retire on sign-off).

--- a/docs/compliance/FOUNDER_CHECKLIST.md
+++ b/docs/compliance/FOUNDER_CHECKLIST.md
@@ -7,21 +7,21 @@
 > review + sign-off. Tick as you go; record dates/references inline.
 
 ## A. Legal registration & money (do first — cheap, enforcement risk)
-- [ ] **Pay the ICO data-protection fee** — ico.org.uk/registration, Tier 1, **£47/yr by Direct Debit** (£52 by card). Declare ≤10 staff / ≤£632k turnover. _Not registering is itself an enforcement matter._
-  - Registration reference: ________  ·  Renewal date: ________  ·  Calendar reminder set: ☐
-- [ ] Add the ICO reference to the public **privacy notice** + the ROPA header.
+- [x] **Pay the ICO data-protection fee** — ico.org.uk/registration, Tier 1, **£47/yr by Direct Debit** (£52 by card). Declare ≤10 staff / ≤£632k turnover. _Not registering is itself an enforcement matter._
+  - Registration reference: **ZC124222**  ·  Renewal date: **~17 Mar 2027**  ·  Calendar reminder set: ☐ _(founder to set)_
+- [x] Add the ICO reference to the public **privacy notice** + the ROPA header. _(done — ZC124222 in privacy/page.tsx + ROPA.md)_
 
 ## B. Data-protection documents (review + sign off the drafts in this folder)
 - [ ] **ROPA.md** — review; correct any data category / lawful basis; sign off.
-- [ ] **SUBPROCESSORS.md** — for each vendor, **accept/reference its DPA online** and record the date + link. Subscribe to sub-processor-change notices.
+- [ ] **SUBPROCESSORS.md** — for each vendor, **accept/reference its DPA online** and record the date + link. Subscribe to sub-processor-change notices. _(Supabase signed + Vercel/Cloudflare(R2)/Resend recorded by reference 2026-07-03; **Didit, Google, Railway still ☐**.)_
 - [ ] **RETENTION_SCHEDULE.md** — confirm the proposed periods.
 - [ ] **DSAR_BREACH_COMPLAINTS.md** — adopt; make `privacy@checklyra.com` live + monitored.
-- [ ] **DPIA** — complete a DPIA (audience + age-assurance/biometric-adjacent + contact/calendar data warrant one). Use the ICO template. _Not drafted here — needs the controller's risk judgement._
+- [ ] **DPIA** — **Drafted — `docs/compliance/DPIA.md` (SEC-70).** Complete the risk scores (likelihood × severity) + residual-risk cells, decide whether ICO prior consultation is needed, and sign off. Consolidate/retire the two Confluence DRAFT DPIAs (27000875, 27033667) in favour of the repo canonical.
 - [ ] Confirm **Didit** (age provider): Art. 9 basis (explicit consent), biometric retention/deletion, transfer mechanism, and that Lyra never stores the raw selfie. ← special-category, highest diligence.
 
 ## C. Publish the public-facing pieces (before 18+ launch)
-- [ ] Privacy notice names controller, ICO ref, lawful bases, retention, DSAR route, **complaints route**, transfer safeguard.
-- [ ] **DUAA complaints channel** visible on site/support (live duty from **19 Jun 2026**: 30-day acknowledgement, outcome, ICO signposting).
+- [x] Privacy notice names controller, ICO ref (ZC124222), lawful bases, retention, DSAR route, **complaints route**, transfer safeguard. _(done — privacy/page.tsx)_
+- [x] **DUAA complaints channel** visible on site/support (live duty from **19 Jun 2026**: 30-day acknowledgement, outcome, ICO signposting). _(done — /complaints page + footer link + privacy-notice section; **founder must make privacy@checklyra.com live + monitored** to honour the 30-day duty.)_
 
 ## D. Governance / change control (SEC-3, GOV-01) — GitHub admin
 - [ ] Turn on branch protection on `main` + `beta` (both repos): **require ≥1 approving review**, **enable "Require review from Code Owners"** (CODEOWNERS now exists), set **enforce_admins = true**.

--- a/docs/compliance/README.md
+++ b/docs/compliance/README.md
@@ -12,6 +12,7 @@ First-pass UK data-protection documentation for CheckLyra Ltd (Lyra), created
 |---|---|---|
 | [ROPA.md](ROPA.md) | Record of Processing Activities — every data category, purpose, lawful basis, processor | Art. 30 |
 | [SUBPROCESSORS.md](SUBPROCESSORS.md) | Sub-processor register + international transfers + per-vendor TRA | Art. 28, 44–46 |
+| [DPIA.md](DPIA.md) | Data Protection Impact Assessment — need, description, necessity/proportionality, risk table, measures + sign-off (children-access, Didit biometric, calendar, contacts). **Drafted — awaiting founder risk scores + sign-off (SEC-70).** | Art. 35 |
 | [RETENTION_SCHEDULE.md](RETENTION_SCHEDULE.md) | Retention periods + deletion mechanisms (incl. waitlist-KV TTL) | Art. 5(1)(e) |
 | [DSAR_BREACH_COMPLAINTS.md](DSAR_BREACH_COMPLAINTS.md) | Data-subject rights (1 month), breach (72h), DUAA complaints (30-day) | Art. 12–22, 33/34; DUAA 2025 |
 | [FOUNDER_CHECKLIST.md](FOUNDER_CHECKLIST.md) | One-page list of founder-only actions (ICO fee, DPAs, branch protection, sign-offs) | — |
@@ -21,7 +22,9 @@ First-pass UK data-protection documentation for CheckLyra Ltd (Lyra), created
 `docs/SECURITY_ROTATION.md` (secret rotation). The Risk Register lives in
 Confluence (TWC "Lyra Risk Register"); the SEC Jira epic (SEC-1) tracks findings.
 
-**Not in this pack (founder-owned, can't be auto-drafted):** the **DPIA** (needs
-the controller's risk judgement), the **ICO registration/payment**, **DPA
-acceptance** per vendor, and the **branch-protection** GitHub-admin changes — all
-listed in [FOUNDER_CHECKLIST.md](FOUNDER_CHECKLIST.md).
+**Founder-owned (drafted here, needs the controller's judgement/sign-off):** the
+**DPIA** ([DPIA.md](DPIA.md)) is now drafted from the pack — only the residual
+risk scores + signature remain (SEC-70). Still fully founder-owned and not
+auto-completable: **ICO registration/payment** (done — ref ZC124222), remaining
+**DPA acceptance** for Didit/Google/Railway, and the **branch-protection**
+GitHub-admin changes — all listed in [FOUNDER_CHECKLIST.md](FOUNDER_CHECKLIST.md).

--- a/docs/compliance/ROPA.md
+++ b/docs/compliance/ROPA.md
@@ -8,11 +8,11 @@
 
 **Controller:** CheckLyra Ltd (trading as Lyra), registered in England & Wales.
 **Contact:** privacy@checklyra.com · security@checklyra.com
-**ICO registration:** _<to be completed — see KAN-283; Tier 1 fee, £47/yr Direct Debit>_
+**ICO registration:** ZC124222 (CheckLyra Ltd; registered 17 Apr 2026; renewal ~17 Mar 2027; Tier 1, £47/yr Direct Debit).
 **DPO:** Not appointed — not legally required (Lyra is not a public authority and
 core activity is not large-scale special-category or systematic-monitoring
 processing). Founder is the accountable data-protection lead.
-**Last reviewed:** 2026-06-28 · **Next review due:** 2026-12-28 (6-monthly until launch, then annually).
+**Last reviewed:** 2026-07-03 · **Next review due:** 2026-12-28 (6-monthly until launch, then annually).
 
 ---
 

--- a/docs/compliance/SUBPROCESSORS.md
+++ b/docs/compliance/SUBPROCESSORS.md
@@ -6,7 +6,7 @@
 > Review at least annually and whenever a vendor or a vendor's own
 > sub-processor list changes.
 
-**Controller:** CheckLyra Ltd (Lyra). **Last reviewed:** 2026-06-28.
+**Controller:** CheckLyra Ltd (Lyra). **Last reviewed:** 2026-07-03.
 
 ## How to read this
 - **Role:** processor = handles personal data on Lyra's instructions (Art. 28 DPA required). "Recipient (not processor)" = receives a click/onward action but not Lyra's user records.
@@ -17,23 +17,26 @@
 
 | Vendor | Purpose / data | Role | Region | Transfer mechanism | DPA status |
 |---|---|---|---|---|---|
-| **Supabase** | Postgres DB, Auth, Storage (profiles, contacts, media, OAuth tokens) | Processor | US (AWS; region TBC — prefer eu-west) | UK Addendum to EU SCCs via Supabase DPA | ☐ confirm + record |
-| **Vercel** | App hosting / serverless rendering | Processor | US/global edge | UK Addendum via Vercel DPA (vercel.com/legal/dpa) | ☐ confirm + record |
+| **Supabase** | Postgres DB, Auth, Storage (profiles, contacts, media, OAuth tokens) | Processor | US (AWS; region TBC — prefer eu-west) | UK IDTA/Addendum via Supabase DPA | ☑ signed 2026-07-03 (Supabase Customer DPA, PandaDoc) |
+| **Vercel** | App hosting / serverless rendering | Processor | US/global edge | UK Addendum via Vercel DPA (vercel.com/legal/dpa) | ☑ by reference (vercel.com/legal/dpa), recorded 2026-07-03 |
 | **Railway** | MCP server hosting (user-MCP + admin-MCP) | Processor | US | UK Addendum/IDTA via Railway DPA | ☐ confirm + record |
-| **Cloudflare** | DNS, CDN, Access (admin gate), KV (waitlist emails), R2 (backups) | Processor | US/global | UK Addendum via Cloudflare Customer DPA | ☐ confirm + record |
-| **Resend** | Transactional email (magic links, invites, notices) | Processor | US | UK Addendum/IDTA via Resend DPA | ☐ confirm + record |
+| **Cloudflare** | DNS, CDN, Access (admin gate), KV (waitlist emails), R2 (backups) | Processor | US/global | UK Addendum via Cloudflare Customer DPA | ☑ by reference (cloudflare.com/cloudflare-customer-dpa), recorded 2026-07-03 |
+| **Resend** | Transactional email (magic links, invites, notices) | Processor | US | UK Addendum/IDTA via Resend DPA | ☑ by reference (resend.com/legal/dpa), recorded 2026-07-03 |
 | **Didit** | Age-assurance / biometric selfie check (returns pass + band only) | Processor (Art. 9 at provider) | TBC | Confirm DPA + Art. 9 explicit-consent basis + biometric retention | ☐ **confirm — special category** |
 | **Google (OAuth/Calendar)** | Google sign-in; Calendar busy/free (Convene) | Processor | US | UK Addendum via Google Cloud/Workspace DPA | ☐ confirm + record |
-| **Cloudflare R2** | Encrypted WORM backups (age-encrypted) | Processor | US/global | As Cloudflare above | ☐ confirm + record |
+| **Cloudflare R2** | Encrypted WORM backups (age-encrypted) | Processor | US/global | As Cloudflare above | ☑ by reference (cloudflare.com/cloudflare-customer-dpa), recorded 2026-07-03 |
 | **Affiliate merchants** (Amazon Associates, Bookshop.org, …) | Receive outbound affiliate clicks (no Lyra PII in URLs) | Recipient (not processor) | US/UK | N/A — no personal data transferred by Lyra | n/a |
 | **GitHub** | Source code, CI | Not a processor of user data | US | (internal tooling) | n/a |
 | **Atlassian** (Jira/Confluence) | Internal issue/risk tracking | Not a processor of user data | US/EU | (internal tooling) | n/a |
 | **Railway/Cloudflare/Vercel logs** | Operational logs (may include IP) | Processor | as above | as above | covered by each DPA |
 
-> **Action (founder):** for each row marked ☐, accept the vendor's standard DPA
-> online and record the acceptance date + link in this table. All of the major
-> infra vendors (Supabase, Vercel, Cloudflare, Resend, Google) incorporate the
-> UK Addendum/IDTA by reference, so no bespoke negotiation is needed.
+> **Action (founder):** the four infrastructure DPAs are now recorded (Supabase
+> signed 2026-07-03 via PandaDoc; Vercel, Cloudflare/R2, and Resend recorded
+> by-reference 2026-07-03). Only **Didit** (special category — highest diligence),
+> **Google** (Workspace/Cloud DPA for calendar.readonly), and **Railway** remain
+> marked ☐ — accept each vendor's standard DPA online and record the acceptance
+> date + link in this table. These vendors incorporate the UK Addendum/IDTA by
+> reference, so no bespoke negotiation is needed.
 
 ## Transfer Risk Assessments (TRA) — one paragraph per vendor
 

--- a/src/app/(legal)/complaints/page.tsx
+++ b/src/app/(legal)/complaints/page.tsx
@@ -1,0 +1,45 @@
+import Link from "next/link";
+import Image from "next/image";
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Data protection complaints — Lyra",
+  description: "How to raise a data-protection complaint with Lyra and escalate to the ICO.",
+};
+
+export default function ComplaintsPage() {
+  return (
+    <main className="min-h-screen bg-[var(--color-paper)]">
+      <nav className="border-b border-[var(--color-border)]/60">
+        <div className="max-w-3xl mx-auto px-6 h-14 flex items-center">
+          <Link href="/" className="flex items-center" aria-label="Lyra home">
+            <Image src="/lyra-logo.png" alt="Lyra" width={32} height={32} className="h-8 w-auto" priority />
+          </Link>
+        </div>
+      </nav>
+
+      <article className="max-w-3xl mx-auto px-6 py-10 prose prose-stone prose-sm">
+        <h1 className="text-2xl font-[family-name:var(--font-serif)] text-[var(--color-ink)]">Data protection complaints</h1>
+
+        <p>This page is for concerns about how Lyra handles your personal data. If you have a general question or another kind of problem, please use our <Link href="/contact" className="text-[var(--color-sage)]">contact page</Link> instead.</p>
+
+        <h2>How to make a complaint</h2>
+        <p>Email <a href="mailto:privacy@checklyra.com" className="text-[var(--color-sage)]">privacy@checklyra.com</a> with the word &quot;complaint&quot; in your message and a description of your concern. Tell us what happened, which of your personal data is involved, and what you would like us to do.</p>
+
+        <h2>What we will do</h2>
+        <p>We will <strong>acknowledge your complaint within 30 days</strong> of receiving it, investigate it without undue delay, keep you informed of progress, and write to you with the outcome. This reflects our statutory duty under the <strong>Data (Use and Access) Act 2025</strong>.</p>
+
+        <h2>Escalating to the ICO</h2>
+        <p>If you remain dissatisfied, you have the right to complain to the UK Information Commissioner&apos;s Office (ICO), our supervisory authority:</p>
+        <ul>
+          <li>Online: <a href="https://ico.org.uk/make-a-complaint/" target="_blank" rel="noopener noreferrer" className="text-[var(--color-sage)]">ico.org.uk/make-a-complaint</a></li>
+          <li>Helpline: 0303 123 1113</li>
+          <li>Post: Information Commissioner&apos;s Office, Wycliffe House, Water Lane, Wilmslow, Cheshire, SK9 5AF</li>
+        </ul>
+        <p>You can complain to the ICO at any time, but we would like the chance to resolve your concern first.</p>
+
+        <p>For the full detail of how we collect, use, and protect your personal data, see our <Link href="/privacy" className="text-[var(--color-sage)]">privacy policy</Link>.</p>
+      </article>
+    </main>
+  );
+}

--- a/src/app/(legal)/privacy/page.tsx
+++ b/src/app/(legal)/privacy/page.tsx
@@ -22,7 +22,7 @@ export default function PrivacyPolicyPage() {
         <p className="text-sm text-[var(--color-muted)]">Last updated: 3 July 2026</p>
 
         <h2>Who we are</h2>
-        <p>Lyra is operated by <strong>CheckLyra Ltd</strong> (&quot;we&quot;, &quot;us&quot;, &quot;our&quot;), a company registered in England &amp; Wales (company no. 16351012; registered office: 71–75 Shelton Street, Covent Garden, London, WC2H 9JQ). CheckLyra Ltd is the data controller for the personal data described here, and is registered with the UK Information Commissioner&apos;s Office (ICO). We are committed to protecting your privacy and handling your personal data transparently.</p>
+        <p>Lyra is operated by <strong>CheckLyra Ltd</strong> (&quot;we&quot;, &quot;us&quot;, &quot;our&quot;), a company registered in England &amp; Wales (company no. 16351012; registered office: 71–75 Shelton Street, Covent Garden, London, WC2H 9JQ). CheckLyra Ltd is the data controller for the personal data described here, and is registered with the UK Information Commissioner&apos;s Office (ICO) under registration reference <strong>ZC124222</strong>. We are committed to protecting your privacy and handling your personal data transparently.</p>
 
         <h2>What data we collect</h2>
         <p>When you create a Lyra profile, we collect:</p>
@@ -107,6 +107,17 @@ export default function PrivacyPolicyPage() {
 
         <h2>Changes to this policy</h2>
         <p>We may update this policy from time to time. We will notify you of significant changes via email or a notice on the website.</p>
+
+        <h2>Data protection complaints</h2>
+        <p>If you are unhappy with how we have handled your personal data, you can make a data-protection complaint to us. Email <a href="mailto:privacy@checklyra.com" className="text-[var(--color-sage)]">privacy@checklyra.com</a> with the word &quot;complaint&quot; and a description of your concern, or use our <Link href="/complaints" className="text-[var(--color-sage)]">complaints page</Link>.</p>
+        <p>We will <strong>acknowledge your complaint within 30 days</strong> of receiving it, investigate it without undue delay, keep you informed of progress, and write to you with the outcome. This reflects our statutory duty under the <strong>Data (Use and Access) Act 2025</strong>.</p>
+        <p>If you remain dissatisfied, you have the right to complain to the UK Information Commissioner&apos;s Office (ICO), our supervisory authority:</p>
+        <ul>
+          <li>Online: <a href="https://ico.org.uk/make-a-complaint/" target="_blank" rel="noopener noreferrer" className="text-[var(--color-sage)]">ico.org.uk/make-a-complaint</a></li>
+          <li>Helpline: 0303 123 1113</li>
+          <li>Post: Information Commissioner&apos;s Office, Wycliffe House, Water Lane, Wilmslow, Cheshire, SK9 5AF</li>
+        </ul>
+        <p>You can complain to the ICO at any time, but we would welcome the chance to resolve your concern first.</p>
 
         <h2>Contact</h2>
         <p>For privacy enquiries: privacy@checklyra.com</p>

--- a/src/app/footer.tsx
+++ b/src/app/footer.tsx
@@ -25,6 +25,7 @@ const LINKS: { href: string; label: string }[] = [
   { href: "/accessibility", label: "Accessibility" },
   { href: "/help", label: "Help" },
   { href: "/contact", label: "Contact" },
+  { href: "/complaints", label: "Complaints" },
   // KAN-184: the affiliate "Partners" link must stay reachable from the
   // footer — Sovrn's crawler follows it to verify Lyra owns checklyra.com.
   // Not in the mock-up's nine, appended here to preserve that verification.

--- a/tests/unit/privacy-complaints.test.js
+++ b/tests/unit/privacy-complaints.test.js
@@ -1,0 +1,93 @@
+/**
+ * KAN-283: the public privacy notice must show the ICO registration reference
+ * (ZC124222) and a DUAA-compliant data-protection complaints channel — a
+ * 30-day acknowledgement commitment citing the Data (Use and Access) Act 2025
+ * and ICO signposting (helpline + Wycliffe House postal address). A dedicated
+ * /complaints page must exist and be reachable from the site-wide footer.
+ *
+ * These are compliance-locking assertions (UK GDPR + DUAA 2025). If one breaks,
+ * raise with Luisa before changing it — do not weaken the assertion.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const root = path.join(__dirname, '../..');
+const privacyPath = path.join(root, 'src/app/(legal)/privacy/page.tsx');
+const complaintsPath = path.join(root, 'src/app/(legal)/complaints/page.tsx');
+const footerPath = path.join(root, 'src/app/footer.tsx');
+
+describe('KAN-283: privacy notice — ICO registration reference', () => {
+  let content;
+  beforeAll(() => {
+    content = fs.readFileSync(privacyPath, 'utf8');
+  });
+
+  test('shows the ICO registration reference ZC124222', () => {
+    expect(content).toContain('ZC124222');
+  });
+});
+
+describe('KAN-283: privacy notice — DUAA complaints section', () => {
+  let content;
+  beforeAll(() => {
+    content = fs.readFileSync(privacyPath, 'utf8');
+  });
+
+  test('has a "Data protection complaints" heading', () => {
+    expect(content).toContain('Data protection complaints');
+  });
+
+  test('commits to acknowledging a complaint within 30 days', () => {
+    expect(content).toContain('within 30 days');
+  });
+
+  test('cites the Data (Use and Access) Act 2025', () => {
+    expect(content).toContain('Data (Use and Access) Act 2025');
+  });
+
+  test('signposts the ICO with helpline and postal address', () => {
+    expect(content).toContain('0303 123 1113');
+    expect(content).toContain('Wycliffe House');
+  });
+
+  test('links to the dedicated complaints page', () => {
+    expect(content).toContain('/complaints');
+  });
+});
+
+describe('KAN-283: dedicated /complaints page', () => {
+  let content;
+  beforeAll(() => {
+    content = fs.readFileSync(complaintsPath, 'utf8');
+  });
+
+  test('the complaints page file exists', () => {
+    expect(fs.existsSync(complaintsPath)).toBe(true);
+  });
+
+  test('has a "Data protection complaints" heading', () => {
+    expect(content).toContain('Data protection complaints');
+  });
+
+  test('carries the same DUAA 30-day commitment + statute cite', () => {
+    expect(content).toContain('within 30 days');
+    expect(content).toContain('Data (Use and Access) Act 2025');
+  });
+
+  test('signposts the ICO with helpline and Wycliffe House address', () => {
+    expect(content).toContain('0303 123 1113');
+    expect(content).toContain('Wycliffe House');
+  });
+
+  test('routes complaints to the monitored privacy inbox', () => {
+    expect(content).toContain('privacy@checklyra.com');
+  });
+});
+
+describe('KAN-283: footer links to the complaints page', () => {
+  test('footer contains a /complaints link', () => {
+    const content = fs.readFileSync(footerPath, 'utf8');
+    expect(content).toContain('/complaints');
+  });
+});


### PR DESCRIPTION
## Summary
Completes the autonomously-completable ICO / UK-GDPR compliance baseline for KAN-283 and drafts the DPIA for SEC-70, so the "awaiting founder" backlog shrinks to only genuinely founder-gated items. No schema, migration, prod, or auth changes.

## Changes
1. **ICO reference ZC124222** added to the public privacy notice ("Who we are") and the `ROPA.md` header.
2. **DUAA data-protection complaints channel** published:
   - New `<h2>Data protection complaints</h2>` section in the privacy notice — 30-day acknowledgement, cite of the **Data (Use and Access) Act 2025**, ICO signposting (online, helpline **0303 123 1113**, postal **Wycliffe House, Water Lane, Wilmslow, Cheshire, SK9 5AF**).
   - New dedicated server page `src/app/(legal)/complaints/page.tsx` (modelled on `contact/page.tsx`), routing complaints to the monitored `privacy@checklyra.com` inbox and escalating to the ICO.
   - `Complaints` link added to the site-wide footer (after Contact, before Partners) → reachable on every page.
3. **Vendor DPAs recorded** in `SUBPROCESSORS.md`: Supabase ☑ signed 2026-07-03 (PandaDoc); Vercel / Cloudflare(+R2) / Resend ☑ by-reference recorded 2026-07-03. Didit / Google / Railway deliberately left ☐ (still founder-gated). No vendor row removed (keeps the SEC-73 privacy↔register sync test green).
4. **DPIA drafted** as `docs/compliance/DPIA.md` following the ICO template (need, description, consultation, necessity/proportionality, scored risk table, measures + sign-off block), covering children-likely-access, Didit biometric (Art. 9), Convene `calendar.readonly`, and third-party contact data — filled from ROPA/retention/subprocessors so only the residual-risk scores + signature remain. `README.md` + `FOUNDER_CHECKLIST.md` updated to reflect DPIA-drafted + items now done.
5. **New locking test** `tests/unit/privacy-complaints.test.js` asserts ZC124222, the complaints heading, "within 30 days", the DUAA cite, the ICO helpline + Wycliffe House, `/complaints` page existence + strings, and the footer link. Adds coverage; weakens nothing.

## Deliberate decision — locked "Last updated" date
The privacy notice keeps **"Last updated: 3 July 2026"** unchanged. That is the ICO/DPA confirmation date (this PR's substance is dated the same day) and it is compliance-locked by `tests/unit/privacy-affiliate-disclosure.test.js` (header: raise with Luisa before changing). If Luisa prefers a fresh date, that is a one-line follow-up plus a coordinated test update.

## Testing
- `npx tsc --noEmit`: no errors introduced by this change. (Pre-existing `Cannot find module 'jose'` errors exist on clean origin/develop too — `jose` is a declared dep missing from the shared install; none of my files touch it.)
- `npx jest tests/unit/privacy-complaints tests/unit/privacy-subprocessors tests/unit/privacy-affiliate-disclosure tests/unit/legal-pages tests/unit/gdpr` → **5 suites, 93 tests, all pass** (incl. the untouched locked "3 July 2026" and "17 June 2026" date assertions).
- Full `npx jest` → **1874 passed, 0 test failures**. The 11 erroring suites (4 Playwright e2e + 7 that import `jose`) fail identically on clean origin/develop — pre-existing environment gaps, not regressions. No existing test modified, skipped, or weakened.

## What still needs Luisa (founder-gated — NOT done here)
- Make `privacy@checklyra.com` a live, monitored inbox to honour the 30-day DUAA acknowledgement; stand up the complaints/DSR logs + breach register (templates in `DSAR_BREACH_COMPLAINTS.md`).
- Complete the DPIA risk scores + residual-risk cells, decide on ICO prior consultation, sign off, and retire the two Confluence DRAFT DPIAs (27000875, 27033667) in favour of the repo canonical (SEC-70).
- Accept/record the three remaining vendor DPAs: **Didit** (special-category, highest diligence), **Google** (calendar.readonly), **Railway**.
- Sign off the drafted ROPA / RETENTION / DSAR docs; set the ~17 Mar 2027 ICO-renewal reminder.

🤖 Generated with [Claude Code](https://claude.com/claude-code)