### PR TITLE
KAN-404 #14: raise conversation-starter cap 5 → 10

### DIFF
--- a/src/app/dashboard/profile/conversation-starters-actions.ts
+++ b/src/app/dashboard/profile/conversation-starters-actions.ts
@@ -19,7 +19,7 @@ import { checkProfileWriteRateLimit } from '@/lib/profile-rate-limit';
  *     length cap mirrors the DB CHECK (≤500 chars). Empty / whitespace-
  *     only answers rejected client- and server-side.
  *
- * The 5-answer cap is enforced by the DB trigger `pcs_cap`; we surface
+ * The answer cap is enforced by the DB trigger `pcs_cap`; we surface
  * it as a user-facing error instead of a raw Postgres exception.
  */
 
@@ -86,10 +86,11 @@ export async function addConversationStarter(input: {
     });
 
   if (error) {
-    // The DB trigger raises a custom message for the 5-cap; surface it
-    // verbatim so the UI can show a clean toast.
-    if (error.message.includes('limit (5)')) {
-      return { success: false, error: 'You can answer up to 5 prompts. Remove one to add another.' };
+    // The DB trigger raises a custom message for the answer cap; surface
+    // it as a clean toast. Match the limit generically (any digits) so the
+    // copy survives future cap changes without a code edit.
+    if (/limit \(\d+\) reached/.test(error.message)) {
+      return { success: false, error: 'You can answer up to 10 prompts. Remove one to add another.' };
     }
     // 23505 = unique_violation on (profile_id, prompt_id)
     if (error.code === '23505') {

--- a/src/app/dashboard/profile/steps/conversation-starters-step.tsx
+++ b/src/app/dashboard/profile/steps/conversation-starters-step.tsx
@@ -12,16 +12,16 @@ import { SaveButton, type ConversationPrompt, type ConversationAnswer } from './
  *      edit + remove. Edit is in-place (no separate route) to keep the
  *      flow tight in a multi-step wizard.
  *   2. **Unanswered** — prompts not yet answered, each clickable to
- *      expand into an answer form. Hidden when the 5-answer cap is hit
+ *      expand into an answer form. Hidden when the answer cap is hit
  *      so the user isn't tempted by something they can't add.
  *
- * 5-answer cap is enforced at the DB layer (BEFORE INSERT trigger); the
+ * The answer cap is enforced at the DB layer (BEFORE INSERT trigger); the
  * UI mirrors it for a friendly nudge and to hide the "add" affordances
  * when at limit.
  */
 
 const ANSWER_MAX = 500;
-const ANSWER_CAP = 5;
+const ANSWER_CAP = 10;
 
 export function ConversationStartersStep({
   prompts,

--- a/supabase/migrations/20260704130000_raise_pcs_cap_to_10.sql
+++ b/supabase/migrations/20260704130000_raise_pcs_cap_to_10.sql
@@ -1,0 +1,23 @@
+-- KAN-404 #14: raise the conversation-starter answer cap from 5 to 10.
+--
+-- The original cap (5) was enforced by the BEFORE INSERT trigger
+-- `pcs_cap` calling `public.enforce_pcs_cap()`, defined in
+-- 20260516200000_conversation_starters.sql. This migration idempotently
+-- redefines that function with the new limit of 10 and an updated
+-- exception message. The trigger itself is unchanged (it already points
+-- at this function), so only the function body needs replacing.
+--
+-- Apply to dev + staging ONLY. Do NOT apply to prod (production cap
+-- change is gated on separate sign-off).
+--   dev    (ilprytcrnqyrsbsrfujj): pending
+--   stage  (uobmlkzrjkptwhttzmmi): pending
+--   prod   (llzkgprqewuwkiwclowi): DO NOT APPLY
+
+create or replace function public.enforce_pcs_cap()
+returns trigger as $$
+begin
+  if (select count(*) from public.profile_conversation_starters where profile_id = new.profile_id) >= 10 then
+    raise exception 'Conversation-starter answer limit (10) reached';
+  end if;
+  return new;
+end$$ language plpgsql;

--- a/supabase/migrations/20260704130000_raise_pcs_cap_to_10.sql
+++ b/supabase/migrations/20260704130000_raise_pcs_cap_to_10.sql
@@ -2,10 +2,18 @@
 --
 -- The original cap (5) was enforced by the BEFORE INSERT trigger
 -- `pcs_cap` calling `public.enforce_pcs_cap()`, defined in
--- 20260516200000_conversation_starters.sql. This migration idempotently
--- redefines that function with the new limit of 10 and an updated
--- exception message. The trigger itself is unchanged (it already points
--- at this function), so only the function body needs replacing.
+-- 20260516200000_conversation_starters.sql and later HARDENED by
+-- 20260621090200_security_audit_fn_searchpath_and_view_invoker.sql
+-- (SET search_path = '' — red-team F-series finding). This migration
+-- idempotently redefines that function with the new limit of 10 and an
+-- updated exception message. The trigger itself is unchanged (it already
+-- points at this function), so only the function body needs replacing.
+--
+-- IMPORTANT: CREATE OR REPLACE FUNCTION resets any attribute not restated,
+-- so we MUST re-declare `set search_path to ''` here or the SEC-audit
+-- hardening would be silently dropped. The table reference below is
+-- schema-qualified (public.…) so it resolves correctly under an empty
+-- search_path.
 --
 -- Apply to dev + staging ONLY. Do NOT apply to prod (production cap
 -- change is gated on separate sign-off).
@@ -14,10 +22,13 @@
 --   prod   (llzkgprqewuwkiwclowi): DO NOT APPLY
 
 create or replace function public.enforce_pcs_cap()
-returns trigger as $$
+returns trigger
+language plpgsql
+set search_path to ''
+as $$
 begin
   if (select count(*) from public.profile_conversation_starters where profile_id = new.profile_id) >= 10 then
     raise exception 'Conversation-starter answer limit (10) reached';
   end if;
   return new;
-end$$ language plpgsql;
+end$$;

--- a/tests/unit/conversation-starters.test.ts
+++ b/tests/unit/conversation-starters.test.ts
@@ -85,13 +85,23 @@ describe('KAN-181 conversation starters — surface-area regression guards', () 
     expect(src).toMatch(/500/);
   });
 
-  test('server-actions file surfaces the 5-answer cap as a clean error', () => {
+  test('server-actions file surfaces the answer cap as a clean error', () => {
     const src = readFileSync(
       resolve(ROOT, 'src/app/dashboard/profile/conversation-starters-actions.ts'),
       'utf-8',
     );
-    expect(src).toMatch(/limit \(5\)/);
-    expect(src).toMatch(/up to 5/);
+    // KAN-404 #14: the actions file now matches the trigger message with a
+    // robust regex (any digit count) rather than a hard-coded "limit (5)",
+    // and the friendly copy advertises the raised cap of 10.
+    expect(src).toMatch(/limit \\\(\\d\+\\\) reached/);
+    expect(src).toMatch(/up to 10/);
+
+    // Coverage not weakened: the robust regex the actions file uses must
+    // still map the LEGACY 'limit (5) reached' message (e.g. a stale DB
+    // env pre-migration) as well as the new 'limit (10) reached'.
+    const capRegex = /limit \(\d+\) reached/;
+    expect(capRegex.test('Conversation-starter answer limit (5) reached')).toBe(true);
+    expect(capRegex.test('Conversation-starter answer limit (10) reached')).toBe(true);
   });
 
   test('wizard step component exists', () => {


### PR DESCRIPTION
## KAN-404 #14 — raise conversation-starter answer cap 5 → 10

### What
- **Migration** `supabase/migrations/20260704130000_raise_pcs_cap_to_10.sql`: idempotent `CREATE OR REPLACE` of `enforce_pcs_cap()` with `>= 10` and message `Conversation-starter answer limit (10) reached`. Header marks **apply dev+staging only, never prod**. **Not applied** (file only, per task rules).
- **UI** `conversation-starters-step.tsx`: `ANSWER_CAP` 5 → 10 (all "N left"/"max" copy is derived from the constant, so it now reads 10). Comment wording de-hardcoded.
- **Actions** `conversation-starters-actions.ts`: error match `error.message.includes('limit (5)')` → `/limit \(\d+\) reached/.test(error.message)` (robust to future cap changes); friendly copy → "You can answer up to 10 prompts. Remove one to add another."

### Tests (owner sign-off — Luisa, 2026-07-04)
Updated only the two **actions-file** assertions in `tests/unit/conversation-starters.test.ts` (`describe` block "server-actions file surfaces the … cap as a clean error") to assert the new behaviour, and **added** a legacy-mapping assertion so the robust regex still maps the old `limit (5) reached` message — coverage not weakened. The migration-level assertions (targeting the original `20260516200000` file, which still says `limit (5) reached`) are **untouched**.

### Verification (all green)
- `npx jest conversation-starters` → 11 passed
- `npm run test:unit` → 1955 passed / 158 suites
- `npx tsc --noEmit` → clean
- `eslint` on touched files → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)