### PR TITLE
KAN-404: require a postcode on school affiliations (web half)

### DIFF
--- a/src/app/dashboard/profile/actions.ts
+++ b/src/app/dashboard/profile/actions.ts
@@ -9,7 +9,7 @@ import { getMyFeatureEntitlements } from '@/lib/features/entitlements';
 import { isAgeVerificationRequired, canPublishWithAge, AGE_GATE_BLOCK_MESSAGE } from '@/lib/age/gate';
 import { isAllowedProfileField } from './profile-fields';
 import { coerceVisibility } from './visibility';
-import { coerceAffiliationType } from './affiliation-fields';
+import { coerceAffiliationType, requiresPostcode, isSchoolPostcodeValid } from './affiliation-fields';
 import {
   coerceSectionVisibility,
   isControllableSectionKey,
@@ -273,6 +273,19 @@ export async function addSchoolAffiliation(data: {
   const profile = await getUserProfile(supabase, user!.id);
   if (!profile) return { success: false, error: 'Profile not found' };
 
+  // KAN-404 — schools must carry a postcode (full or partial) so people can
+  // tell schools with the same name apart; orgs/communities keep location
+  // optional. Enforced server-side (the real boundary) BEFORE moderation or
+  // insert. Coerce the type first so a school smuggled in as something else
+  // still hits this gate.
+  const affiliationType = coerceAffiliationType(data.affiliation_type);
+  if (requiresPostcode(affiliationType) && !isSchoolPostcodeValid(data.school_location)) {
+    return {
+      success: false,
+      error: 'Schools need a postcode (full or partial) so people can tell schools with the same name apart.',
+    };
+  }
+
   // KAN-241 + KAN-244 — content moderation + audit log. Affiliations
   // show on the public profile.
   const sanitisedName = sanitiseText(data.school_name, 200);
@@ -305,7 +318,7 @@ export async function addSchoolAffiliation(data: {
       school_name: sanitisedName,
       school_location: sanitisedLoc,
       relationship: data.relationship || 'parent',
-      affiliation_type: coerceAffiliationType(data.affiliation_type),
+      affiliation_type: affiliationType,
     });
 
   if (error) return { success: false, error: error.message };

--- a/src/app/dashboard/profile/affiliation-fields.ts
+++ b/src/app/dashboard/profile/affiliation-fields.ts
@@ -43,3 +43,32 @@ export const AFFILIATION_SINGULAR: Record<AffiliationType, string> = {
   organisation: 'organisation',
   community: 'community',
 };
+
+/**
+ * KAN-404: schools MUST carry a postcode (full or partial) so people can
+ * tell schools with the same name apart. Organisations and communities
+ * keep location optional. This helper says which affiliation types require
+ * a postcode.
+ */
+export function requiresPostcode(type: string): boolean {
+  return type === 'school';
+}
+
+/**
+ * KAN-404: permissive / international postcode validator. We are NOT
+ * validating against any single country's format — Lyra has an international
+ * user base — so we only require enough structure to be a plausible
+ * postcode: a short-ish token that contains at least one letter AND at least
+ * one digit.
+ *
+ * Accepts: 'SW1A', 'M1', 'SW1A 1AA', 'B33 8TH' (UK full/partial),
+ * and other alphanumeric international codes.
+ * Rejects: '' (empty), 'London' (letters only, no digit),
+ * '12345' (digits only — no way to disambiguate a US-style all-numeric ZIP
+ * from a house number here; the letter+digit rule is the disambiguating
+ * signal we chose for this permissive check).
+ */
+export function isSchoolPostcodeValid(v: string | undefined | null): boolean {
+  const s = (v || '').trim();
+  return s.length >= 2 && s.length <= 12 && /[a-z]/i.test(s) && /\d/.test(s);
+}

--- a/src/app/dashboard/profile/sections/affiliations-section.tsx
+++ b/src/app/dashboard/profile/sections/affiliations-section.tsx
@@ -18,6 +18,8 @@ import { Field, type WizardSchool } from '../steps/types';
 import {
   AFFILIATION_LABELS,
   AFFILIATION_SINGULAR,
+  requiresPostcode,
+  isSchoolPostcodeValid,
   type AffiliationType,
 } from '../affiliation-fields';
 import { addSchoolAffiliation, removeSchoolAffiliation, updateAffiliationVisibility } from '../actions';
@@ -97,12 +99,24 @@ function AffiliationGroup({
 }) {
   const [name, setName] = useState('');
   const [location, setLocation] = useState('');
+  const [locationError, setLocationError] = useState('');
+
+  const needsPostcode = requiresPostcode(type);
+  const postcodeInvalid = needsPostcode && !isSchoolPostcodeValid(location);
 
   const handleAdd = () => {
     if (!name.trim()) return;
+    // KAN-404 — schools require a valid postcode before we add the row.
+    if (postcodeInvalid) {
+      setLocationError(
+        'Enter a postcode (full or partial) so people can tell schools with the same name apart.',
+      );
+      return;
+    }
     onAdd(name.trim(), location.trim());
     setName('');
     setLocation('');
+    setLocationError('');
   };
 
   return (
@@ -156,15 +170,23 @@ function AffiliationGroup({
             'Local running club'
           }
         />
-        <Field
-          label="Location (optional)"
-          value={location}
-          onChange={setLocation}
-          placeholder="London"
-        />
+        <div>
+          <Field
+            label={needsPostcode ? 'Postcode' : 'Location (optional)'}
+            value={location}
+            onChange={(v) => {
+              setLocation(v);
+              if (locationError) setLocationError('');
+            }}
+            placeholder={needsPostcode ? 'SW1A 1AA' : 'London'}
+          />
+          {locationError && (
+            <p className="mt-1 text-xs text-red-500">{locationError}</p>
+          )}
+        </div>
         <button
           onClick={handleAdd}
-          disabled={isPending || !name.trim()}
+          disabled={isPending || !name.trim() || postcodeInvalid}
           className="px-4 py-2 rounded-lg bg-[#f4efe7] text-sm font-medium text-[var(--color-ink)] hover:bg-[#ece7df] disabled:opacity-40 transition-colors"
         >
           + Add {AFFILIATION_SINGULAR[type]}

--- a/src/app/dashboard/profile/steps/school-step.tsx
+++ b/src/app/dashboard/profile/steps/school-step.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from 'react';
 import { Field, SaveButton, type WizardSchool } from './types';
+import { isSchoolPostcodeValid } from '../affiliation-fields';
 
 export function SchoolStep({ schools, onAdd, onRemove, onNext, isPending }: {
   schools: WizardSchool[];
@@ -13,12 +14,23 @@ export function SchoolStep({ schools, onAdd, onRemove, onNext, isPending }: {
   const [name, setName] = useState('');
   const [location, setLocation] = useState('');
   const [relationship, setRelationship] = useState('parent');
+  const [locationError, setLocationError] = useState('');
+
+  // KAN-404 — schools require a postcode (full or partial).
+  const postcodeInvalid = !isSchoolPostcodeValid(location);
 
   const handleAdd = () => {
     if (!name.trim()) return;
+    if (postcodeInvalid) {
+      setLocationError(
+        'Enter a postcode (full or partial) so people can tell schools with the same name apart.',
+      );
+      return;
+    }
     onAdd({ school_name: name, school_location: location, relationship });
     setName('');
     setLocation('');
+    setLocationError('');
   };
 
   return (
@@ -44,7 +56,20 @@ export function SchoolStep({ schools, onAdd, onRemove, onNext, isPending }: {
 
       <div className="space-y-3 bg-white rounded-lg border border-[var(--color-border)] p-4">
         <Field label="School name" value={name} onChange={setName} placeholder="Greenfield Primary" />
-        <Field label="Location" value={location} onChange={setLocation} placeholder="London" />
+        <div>
+          <Field
+            label="Postcode"
+            value={location}
+            onChange={(v) => {
+              setLocation(v);
+              if (locationError) setLocationError('');
+            }}
+            placeholder="SW1A 1AA"
+          />
+          {locationError && (
+            <p className="mt-1 text-xs text-red-500">{locationError}</p>
+          )}
+        </div>
         <div>
           <label className="block text-sm font-medium text-[var(--color-ink)] mb-1">Relationship</label>
           <select value={relationship} onChange={(e) => setRelationship(e.target.value)}
@@ -56,7 +81,7 @@ export function SchoolStep({ schools, onAdd, onRemove, onNext, isPending }: {
             <option value="other">Other</option>
           </select>
         </div>
-        <button onClick={handleAdd} disabled={isPending || !name.trim()}
+        <button onClick={handleAdd} disabled={isPending || !name.trim() || postcodeInvalid}
           className="px-4 py-2 rounded-lg bg-[#f4efe7] text-sm font-medium text-[var(--color-ink)] hover:bg-[#ece7df] disabled:opacity-40 transition-colors">
           + Add school
         </button>

--- a/tests/unit/affiliations-and-autosave.test.ts
+++ b/tests/unit/affiliations-and-autosave.test.ts
@@ -79,6 +79,8 @@ import {
   AFFILIATION_SINGULAR,
   coerceAffiliationType,
   isAffiliationType,
+  requiresPostcode,
+  isSchoolPostcodeValid,
 } from '@/app/dashboard/profile/affiliation-fields';
 
 beforeEach(() => {
@@ -135,12 +137,56 @@ describe('KAN-220: affiliation-fields helpers', () => {
   });
 });
 
+// ─────────── 2b. KAN-404 postcode helpers ───────────
+
+describe('KAN-404: requiresPostcode', () => {
+  test('only schools require a postcode', () => {
+    expect(requiresPostcode('school')).toBe(true);
+    expect(requiresPostcode('organisation')).toBe(false);
+    expect(requiresPostcode('community')).toBe(false);
+    // Anything that isn't literally 'school' does not require a postcode.
+    expect(requiresPostcode('club')).toBe(false);
+    expect(requiresPostcode('')).toBe(false);
+  });
+});
+
+describe('KAN-404: isSchoolPostcodeValid (permissive / international)', () => {
+  test('accepts UK full and partial postcodes', () => {
+    expect(isSchoolPostcodeValid('SW1A')).toBe(true);
+    expect(isSchoolPostcodeValid('M1')).toBe(true);
+    expect(isSchoolPostcodeValid('SW1A 1AA')).toBe(true);
+    expect(isSchoolPostcodeValid('B33 8TH')).toBe(true);
+  });
+
+  test('trims surrounding whitespace before validating', () => {
+    expect(isSchoolPostcodeValid('  M1  ')).toBe(true);
+  });
+
+  test('rejects empty, nullish, and letters-only or digits-only values', () => {
+    expect(isSchoolPostcodeValid('')).toBe(false);
+    expect(isSchoolPostcodeValid('   ')).toBe(false);
+    expect(isSchoolPostcodeValid(undefined)).toBe(false);
+    expect(isSchoolPostcodeValid(null)).toBe(false);
+    expect(isSchoolPostcodeValid('London')).toBe(false); // letters only, no digit
+    expect(isSchoolPostcodeValid('12345')).toBe(false); // digits only, no letter
+  });
+
+  test('rejects a single character and over-long tokens', () => {
+    expect(isSchoolPostcodeValid('A')).toBe(false); // too short (< 2)
+    expect(isSchoolPostcodeValid('A1')).toBe(true); // exactly 2, letter + digit
+    expect(isSchoolPostcodeValid('ABCDEFGHIJ12')).toBe(true); // 12 chars, letter + digit
+    expect(isSchoolPostcodeValid('ABCDEFGHIJK12')).toBe(false); // 13 chars, too long
+  });
+});
+
 // ─────────── 3. addSchoolAffiliation server action ───────────
 
 describe('KAN-220: addSchoolAffiliation — affiliation_type handling', () => {
   test('inserts with affiliation_type=school by default (pre-KAN-220 caller compat)', async () => {
     const result = await addSchoolAffiliation({
       school_name: 'Greenfield Primary',
+      // KAN-404 — schools now require a postcode (full or partial).
+      school_location: 'SW1A 1AA',
     });
     expect(result).toEqual({ success: true });
     expect(mockInsertCapture).toHaveBeenCalledWith(
@@ -174,6 +220,8 @@ describe('KAN-220: addSchoolAffiliation — affiliation_type handling', () => {
   test('coerces unknown affiliation_type to "school" (defence in depth alongside DB CHECK)', async () => {
     await addSchoolAffiliation({
       school_name: 'Attempted bypass',
+      // KAN-404 — coerced to 'school', so a valid postcode is required.
+      school_location: 'SW1A 1AA',
       affiliation_type: 'club',
     });
     expect(mockInsertCapture).toHaveBeenCalledWith(
@@ -184,13 +232,16 @@ describe('KAN-220: addSchoolAffiliation — affiliation_type handling', () => {
   test('still sanitises school_name + location alongside affiliation_type', async () => {
     await addSchoolAffiliation({
       school_name: 'School <b>name</b>',
-      school_location: '<p>London</p>',
+      // KAN-404 — a valid school postcode ('M1') that is short enough to pass
+      // the permissive validator on the raw input yet still carries HTML, so
+      // we keep exercising the HTML-stripping path on both fields.
+      school_location: '<i>M1</i>',
       affiliation_type: 'school',
     });
     expect(mockInsertCapture).toHaveBeenCalledWith(
       expect.objectContaining({
         school_name: 'School name',
-        school_location: 'London',
+        school_location: 'M1',
         affiliation_type: 'school',
       }),
     );
@@ -199,10 +250,76 @@ describe('KAN-220: addSchoolAffiliation — affiliation_type handling', () => {
   test('relationship defaults to "parent" alongside affiliation_type=school', async () => {
     await addSchoolAffiliation({
       school_name: 'Primary',
+      // KAN-404 — schools now require a postcode (full or partial).
+      school_location: 'SW1A 1AA',
       affiliation_type: 'school',
     });
     expect(mockInsertCapture).toHaveBeenCalledWith(
       expect.objectContaining({ relationship: 'parent', affiliation_type: 'school' }),
+    );
+  });
+});
+
+// ─────────── 3b. KAN-404 — school postcode requirement ───────────
+
+describe('KAN-404: addSchoolAffiliation postcode requirement', () => {
+  const POSTCODE_ERROR =
+    'Schools need a postcode (full or partial) so people can tell schools with the same name apart.';
+
+  test('rejects a school with no postcode and never inserts', async () => {
+    const result = await addSchoolAffiliation({
+      school_name: 'Greenfield Primary',
+      affiliation_type: 'school',
+    });
+    expect(result).toEqual({ success: false, error: POSTCODE_ERROR });
+    expect(mockInsertCapture).not.toHaveBeenCalled();
+  });
+
+  test('rejects a school with an invalid postcode (no digit) and never inserts', async () => {
+    const result = await addSchoolAffiliation({
+      school_name: 'Greenfield Primary',
+      school_location: 'London',
+      affiliation_type: 'school',
+    });
+    expect(result).toEqual({ success: false, error: POSTCODE_ERROR });
+    expect(mockInsertCapture).not.toHaveBeenCalled();
+  });
+
+  test('rejects a school even when the type is smuggled in as something else (coerced to school)', async () => {
+    const result = await addSchoolAffiliation({
+      school_name: 'Attempted bypass',
+      affiliation_type: 'club', // coerces to 'school' → postcode required
+    });
+    expect(result).toEqual({ success: false, error: POSTCODE_ERROR });
+    expect(mockInsertCapture).not.toHaveBeenCalled();
+  });
+
+  test('accepts an organisation with an empty location (location stays optional)', async () => {
+    const result = await addSchoolAffiliation({
+      school_name: 'Acme Ltd',
+      affiliation_type: 'organisation',
+    });
+    expect(result).toEqual({ success: true });
+    expect(mockInsertCapture).toHaveBeenCalledWith(
+      expect.objectContaining({
+        affiliation_type: 'organisation',
+        school_name: 'Acme Ltd',
+        school_location: null,
+      }),
+    );
+  });
+
+  test('accepts a community with an empty location (location stays optional)', async () => {
+    const result = await addSchoolAffiliation({
+      school_name: 'Local running club',
+      affiliation_type: 'community',
+    });
+    expect(result).toEqual({ success: true });
+    expect(mockInsertCapture).toHaveBeenCalledWith(
+      expect.objectContaining({
+        affiliation_type: 'community',
+        school_location: null,
+      }),
     );
   });
 });

--- a/tests/unit/moderation-actions.test.ts
+++ b/tests/unit/moderation-actions.test.ts
@@ -181,7 +181,8 @@ describe('KAN-241: addSchoolAffiliation moderation', () => {
   test('clean school name → write succeeds', async () => {
     const result = await addSchoolAffiliation({
       school_name: 'Greenfield Primary',
-      school_location: 'London',
+      // KAN-404 — schools now require a postcode (full or partial).
+      school_location: 'SW1A 1AA',
     });
     expect(result).toEqual({ success: true });
     expect(mockInsertCapture).toHaveBeenCalledWith('school_affiliations', expect.objectContaining({


### PR DESCRIPTION
## KAN-404 #1 — WEB half

Require a postcode on **school** affiliations so people can tell schools with the same name apart. Organisations and communities keep their location **optional**.

### What changed
- **`affiliation-fields.ts`** (kept non-`'use server'`): new `requiresPostcode(type)` (only `school`) and a **permissive / international** `isSchoolPostcodeValid(v)` — requires a letter **and** a digit, length 2–12. Accepts `SW1A`, `M1`, `SW1A 1AA`, `B33 8TH`; rejects `''`, `London`, `12345`.
- **`actions.ts` `addSchoolAffiliation`**: enforces the postcode **server-side (the real boundary)** BEFORE moderation/insert. The affiliation type is coerced first so a school smuggled in as another type still hits the gate. Returns `Schools need a postcode (full or partial) so people can tell schools with the same name apart.` on failure.
- **`affiliations-section.tsx`**: schools relabel the location field to **`Postcode`** (required) with an inline error and a blocked add; orgs/communities keep `Location (optional)`.
- **`school-step.tsx`**: requires a valid postcode with the `Postcode` label; add is blocked until valid.

### Tests
Owner sign-off (Luisa, 2026-07-04) to update the named existing fixtures to supply a valid school postcode so they exercise the new contract with each test's original intent preserved (assertions not weakened):
- `tests/unit/affiliations-and-autosave.test.ts` — default-school, unknown→school coercion, sanitise (uses `<i>M1</i>` so raw input passes the validator yet still exercises HTML-stripping), relationship-default.
- `tests/unit/moderation-actions.test.ts` — `clean school name → write succeeds` now supplies a valid postcode.

New tests added: `isSchoolPostcodeValid` / `requiresPostcode` accept + reject cases; `addSchoolAffiliation` **rejects** a school with no/invalid postcode (and never inserts) and **accepts** an org/community with empty location.

### Verification
- `npm run test:unit` — **1965 passed / 158 suites**, green
- `tsc --noEmit` — clean
- `eslint` (touched files) — clean

### Out of scope (bundled separately)
The MCP `lyra_add_school` change (`affiliation_type` + `postcode`) ships in the **bundled MCP release**, NOT in this web PR. `lyra-mcp-server` is untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)