### PR TITLE
KAN-404 #8/#9 + #12: save-model rework + inline item-edit (web)

### DIFF
--- a/src/app/dashboard/profile/actions.ts
+++ b/src/app/dashboard/profile/actions.ts
@@ -4,6 +4,7 @@ import { createClient } from '@/lib/supabase-server';
 import { revalidatePath } from 'next/cache';
 import { sanitiseText, sanitiseUrl, type ActionResult } from '@/lib/sanitise';
 import { moderateAndAudit } from '@/lib/moderation-audit';
+import type { WizardItem } from './steps/types';
 import { checkProfileWriteRateLimit } from '@/lib/profile-rate-limit';
 import { getMyFeatureEntitlements } from '@/lib/features/entitlements';
 import { isAgeVerificationRequired, canPublishWithAge, AGE_GATE_BLOCK_MESSAGE } from '@/lib/age/gate';
@@ -232,6 +233,117 @@ export async function updateProfileItemVisibility(
   if (error) return { success: false, error: error.message };
   revalidatePath('/dashboard/profile');
   return { success: true };
+}
+
+// KAN-404 (#12) — richer result for updateProfileItem so the inline editor
+// can optimistically show the saved row. Additive union: existing callers
+// that only read `.success`/`.error` are unaffected.
+export type ItemActionResult =
+  | { success: true; item: WizardItem }
+  | { success: false; error: string };
+
+/**
+ * KAN-404 (#12) — edit an existing profile item's text (title / description /
+ * url). Mirrors `addProfileItem` for sanitise + moderation, and
+ * `updateProfileItemVisibility` for owner-scoping (KAN-260). Only the fields
+ * the caller passes are updated; an empty description clears it to NULL and an
+ * empty url clears it to NULL, so a user can remove a description/link via
+ * edit, not only replace it. Category is intentionally NOT editable here
+ * (text-only edit — changing category is a separate concern).
+ */
+export async function updateProfileItem(
+  itemId: string,
+  data: { title?: string; description?: string; url?: string },
+): Promise<ItemActionResult> {
+  const { user, supabase, error: authError } = await getAuthenticatedUser();
+  if (authError) return { success: false, error: authError };
+
+  // KAN-231 — profile-save rate limiting (edits are user-driven writes too).
+  const rl = await checkProfileWriteRateLimit(user!.id);
+  // A rate-limit block is always a failure; narrow to the failure shape so it
+  // fits ItemActionResult (which requires `item` on success).
+  if (!rl.allowed) {
+    return { success: false, error: 'error' in rl.result ? rl.result.error : 'Too many changes, please slow down.' };
+  }
+
+  // KAN-260 — belt-and-braces ownership: scope the write to the caller's own
+  // profile in code, not by RLS alone.
+  const profile = await getUserProfile(supabase, user!.id);
+  if (!profile) return { success: false, error: 'Profile not found' };
+
+  // Build the partial update only from the fields the caller passed, matching
+  // addProfileItem's sanitise + per-field moderation exactly.
+  const updates: Record<string, string | null> = {};
+
+  if (data.title !== undefined) {
+    const sanitisedTitle = sanitiseText(data.title, 200);
+    const titleMod = await moderateAndAudit(supabase, {
+      text: sanitisedTitle,
+      fieldType: 'public',
+      field: 'profile_items.title',
+      profileId: profile.id,
+      source: 'web_app',
+    });
+    if (!titleMod.ok) return { success: false, error: titleMod.error };
+    updates.title = sanitisedTitle;
+  }
+
+  if (data.description !== undefined) {
+    // Empty string clears the description to NULL (mirrors the add path).
+    const sanitisedDesc = data.description.trim() !== ''
+      ? sanitiseText(data.description, 1000)
+      : null;
+    if (sanitisedDesc) {
+      const descMod = await moderateAndAudit(supabase, {
+        text: sanitisedDesc,
+        fieldType: 'public',
+        field: 'profile_items.description',
+        profileId: profile.id,
+        source: 'web_app',
+      });
+      if (!descMod.ok) return { success: false, error: descMod.error };
+    }
+    updates.description = sanitisedDesc;
+  }
+
+  if (data.url !== undefined) {
+    // Empty → NULL; non-empty must pass sanitiseUrl (http(s) only), same as add.
+    if (data.url.trim() === '') {
+      updates.url = null;
+    } else {
+      const cleaned = sanitiseUrl(data.url);
+      if (!cleaned) {
+        return { success: false, error: 'Invalid URL — must start with http:// or https://' };
+      }
+      updates.url = cleaned;
+    }
+  }
+
+  // Empty-patch guard — no-op rather than firing an UPDATE with empty SET.
+  // Re-read the row so the caller still gets the current item back.
+  if (Object.keys(updates).length === 0) {
+    const { data: current, error: readErr } = await supabase
+      .from('profile_items')
+      .select('id, category, title, description, url, visibility')
+      .eq('id', itemId)
+      .eq('profile_id', profile.id)
+      .single();
+    if (readErr || !current) return { success: false, error: readErr?.message ?? 'Item not found' };
+    return { success: true, item: current as WizardItem };
+  }
+
+  const { data: row, error } = await supabase
+    .from('profile_items')
+    .update(updates)
+    .eq('id', itemId)
+    .eq('profile_id', profile.id)
+    .select('id, category, title, description, url, visibility')
+    .single();
+
+  if (error) return { success: false, error: error.message };
+  if (!row) return { success: false, error: 'Item not found' };
+  revalidatePath('/dashboard/profile');
+  return { success: true, item: row as WizardItem };
 }
 
 export async function removeProfileItem(itemId: string): Promise<ActionResult> {

--- a/src/app/dashboard/profile/edit-profile-form.tsx
+++ b/src/app/dashboard/profile/edit-profile-form.tsx
@@ -23,6 +23,7 @@ import Image from 'next/image';
 import {
   addProfileItem,
   removeProfileItem,
+  updateProfileItem,
   updateProfileItemVisibility,
   addExternalLink,
   removeExternalLink,
@@ -49,6 +50,8 @@ import {
   BioSection,
   ManualOfMeSection,
   AffiliationsSection,
+  AutoSaveStatusLabel,
+  type AutoSaveStatus,
 } from './sections';
 import type { ManualOfMe } from './manual-of-me-fields';
 
@@ -170,6 +173,29 @@ export function EditProfileForm({
   const [isPending, startTransition] = useTransition();
   const [publishError, setPublishError] = useState<string | null>(null);
 
+  // KAN-404 (#8/#9): list sections (items/links/starters) commit each row
+  // instantly on Add/Remove, so there's nothing buffered to flush — a Save
+  // button would be a no-op. Instead give each its own transient
+  // Saving…/Saved indicator, keyed by section id, so every section visibly
+  // shows saved-state while honouring "everything autosaves". A short-lived
+  // 'saved' auto-clears back to 'idle'.
+  const [sectionStatus, setSectionStatus] = useState<Record<string, AutoSaveStatus>>({});
+
+  const runSectionSave = (sectionId: string, action: () => Promise<{ success: boolean } | void>) => {
+    setSectionStatus((prev) => ({ ...prev, [sectionId]: 'saving' }));
+    startTransition(async () => {
+      const res = await action();
+      const ok = res == null || res.success !== false;
+      router.refresh();
+      setSectionStatus((prev) => ({ ...prev, [sectionId]: ok ? 'saved' : 'error' }));
+      if (ok) {
+        setTimeout(() => {
+          setSectionStatus((prev) => (prev[sectionId] === 'saved' ? { ...prev, [sectionId]: 'idle' } : prev));
+        }, 2000);
+      }
+    });
+  };
+
   // SSR-safe: all expanded by default (no flash on desktop). On mount,
   // matchMedia narrows to mobile and we collapse all but the first.
   const [openSections, setOpenSections] = useState<Set<string>>(
@@ -194,6 +220,10 @@ export function EditProfileForm({
   };
 
   const renderItemsSection = (s: SectionDef) => (
+    <div className="space-y-3">
+      <div className="flex justify-end">
+        <AutoSaveStatusLabel status={sectionStatus[s.id] ?? 'idle'} />
+      </div>
     <ItemsStep
       title=""
       description={s.description ?? ''}
@@ -202,26 +232,30 @@ export function EditProfileForm({
       // KAN-266: redesign drops per-item visibility.
       hideVisibility
       onAdd={(data) => {
-        startTransition(async () => {
-          await addProfileItem(data);
-          router.refresh();
-        });
+        runSectionSave(s.id, () => addProfileItem(data));
       }}
       onRemove={(id) => {
-        startTransition(async () => {
-          await removeProfileItem(id);
-          router.refresh();
-        });
+        runSectionSave(s.id, () => removeProfileItem(id));
       }}
       onUpdateVisibility={(id, visibility) => {
-        startTransition(async () => {
-          await updateProfileItemVisibility(id, visibility);
-          router.refresh();
-        });
+        runSectionSave(s.id, () => updateProfileItemVisibility(id, visibility));
       }}
+      // KAN-404 (#12): inline edit — call the action directly and await the
+      // result so the row can surface a moderation error in place (a
+      // startTransition without a return value couldn't). router.refresh() on
+      // success re-pulls the persisted row.
+      onEdit={async (id, data) => {
+        const res = await updateProfileItem(id, data);
+        if (res.success) router.refresh();
+        return { success: res.success, error: res.success ? undefined : res.error };
+      }}
+      // KAN-404 (#8/#9): drop the misleading "Continue →" button (it only
+      // collapsed the section). Collapse stays available via the header chevron.
+      showContinue={false}
       onNext={() => toggleSection(s.id)}
       isPending={isPending}
     />
+    </div>
   );
 
   return (
@@ -337,49 +371,46 @@ export function EditProfileForm({
                     {s.kind === 'manual' && <ManualOfMeSection manualOfMe={manualOfMe} />}
                     {s.kind === 'items' && renderItemsSection(s)}
                     {s.kind === 'links' && (
-                      <LinksStep
-                        links={links}
-                        onAdd={(data) => {
-                          startTransition(async () => {
-                            await addExternalLink(data);
-                            router.refresh();
-                          });
-                        }}
-                        onRemove={(id) => {
-                          startTransition(async () => {
-                            await removeExternalLink(id);
-                            router.refresh();
-                          });
-                        }}
-                        onNext={() => toggleSection(s.id)}
-                        isPending={isPending}
-                      />
+                      <div className="space-y-3">
+                        <div className="flex justify-end">
+                          <AutoSaveStatusLabel status={sectionStatus[s.id] ?? 'idle'} />
+                        </div>
+                        <LinksStep
+                          links={links}
+                          onAdd={(data) => {
+                            runSectionSave(s.id, () => addExternalLink(data));
+                          }}
+                          onRemove={(id) => {
+                            runSectionSave(s.id, () => removeExternalLink(id));
+                          }}
+                          showContinue={false}
+                          onNext={() => toggleSection(s.id)}
+                          isPending={isPending}
+                        />
+                      </div>
                     )}
                     {s.kind === 'starters' && (
-                      <ConversationStartersStep
-                        prompts={conversationPrompts}
-                        answers={conversationAnswers}
-                        onAdd={(input) => {
-                          startTransition(async () => {
-                            await addConversationStarter(input);
-                            router.refresh();
-                          });
-                        }}
-                        onUpdate={(id, answer) => {
-                          startTransition(async () => {
-                            await updateConversationStarter(id, answer);
-                            router.refresh();
-                          });
-                        }}
-                        onRemove={(id) => {
-                          startTransition(async () => {
-                            await removeConversationStarter(id);
-                            router.refresh();
-                          });
-                        }}
-                        onNext={() => toggleSection(s.id)}
-                        isPending={isPending}
-                      />
+                      <div className="space-y-3">
+                        <div className="flex justify-end">
+                          <AutoSaveStatusLabel status={sectionStatus[s.id] ?? 'idle'} />
+                        </div>
+                        <ConversationStartersStep
+                          prompts={conversationPrompts}
+                          answers={conversationAnswers}
+                          onAdd={(input) => {
+                            runSectionSave(s.id, () => addConversationStarter(input));
+                          }}
+                          onUpdate={(id, answer) => {
+                            runSectionSave(s.id, () => updateConversationStarter(id, answer));
+                          }}
+                          onRemove={(id) => {
+                            runSectionSave(s.id, () => removeConversationStarter(id));
+                          }}
+                          showContinue={false}
+                          onNext={() => toggleSection(s.id)}
+                          isPending={isPending}
+                        />
+                      </div>
                     )}
                   </div>
                 )}
@@ -394,7 +425,7 @@ export function EditProfileForm({
         <div className="max-w-5xl mx-auto flex items-center justify-between gap-4">
           <div className="min-w-0">
             <p className="text-xs text-[var(--color-muted)] hidden sm:block">
-              Changes save automatically as you type.
+              Everything saves automatically — use Save on any section to save it right away.
             </p>
             {publishError && (
               <p className="text-xs text-red-700 mt-0.5">{publishError}</p>

--- a/src/app/dashboard/profile/sections/auto-save-core.ts
+++ b/src/app/dashboard/profile/sections/auto-save-core.ts
@@ -1,0 +1,41 @@
+/**
+ * KAN-404 (#8/#9) — framework-agnostic core of the auto-save status
+ * transition, shared by the debounced timer path AND the eager flush()
+ * path in `use-auto-save.tsx`.
+ *
+ * Kept free of React so the saving→saved / saving→error contract can be
+ * unit-tested directly (the project's jest env is `node`, so hooks that
+ * touch the DOM can't be rendered). Both call sites go through this one
+ * function so the two paths can never drift.
+ */
+
+export type AutoSaveStatus = 'idle' | 'saving' | 'saved' | 'error';
+
+export type AutoSaveResult =
+  | { success: true }
+  | { success: false; error: string }
+  | void;
+
+/**
+ * Run a single save: flip to 'saving', await the save, then settle on
+ * 'saved' (success / void) or 'error' (an `{ success: false }` result or a
+ * throw). Never rejects — the status is the only channel for failure so
+ * callers (a debounce timer, a Save-button click) don't need try/catch.
+ */
+export async function runSave<T>(
+  save: (v: T) => Promise<AutoSaveResult>,
+  value: T,
+  setStatus: (s: AutoSaveStatus) => void,
+): Promise<void> {
+  setStatus('saving');
+  try {
+    const result = await save(value);
+    if (result && 'success' in result && result.success === false) {
+      setStatus('error');
+    } else {
+      setStatus('saved');
+    }
+  } catch {
+    setStatus('error');
+  }
+}

--- a/src/app/dashboard/profile/sections/basic-info-section.tsx
+++ b/src/app/dashboard/profile/sections/basic-info-section.tsx
@@ -26,7 +26,8 @@ import { useRef, useState, useTransition } from 'react';
 import { Field, type WizardProfile } from '../steps/types';
 import { updateProfileFields, uploadAvatar } from '../actions';
 import { resolveCityFromPostcode } from '../city-actions';
-import { AutoSaveStatusLabel, useAutoSave } from './use-auto-save';
+import { useAutoSave } from './use-auto-save';
+import { SectionSaveBar } from './section-save-bar';
 
 interface BasicInfoDraft {
   display_name: string;
@@ -48,7 +49,7 @@ export function BasicInfoSection({ profile }: { profile: WizardProfile }) {
   const [uploadingAvatar, startUploadAvatar] = useTransition();
   const fileRef = useRef<HTMLInputElement>(null);
 
-  const status = useAutoSave(draft, async (v) => {
+  const { status, flush } = useAutoSave(draft, async (v) => {
     return updateProfileFields({
       display_name: v.display_name,
       headline: v.headline,
@@ -110,10 +111,9 @@ export function BasicInfoSection({ profile }: { profile: WizardProfile }) {
 
   return (
     <div className="space-y-6">
-      {/* Status indicator — rendered inline so the user can see autosave fire */}
-      <div className="flex justify-end">
-        <AutoSaveStatusLabel status={status} />
-      </div>
+      {/* KAN-404: visible per-section Save (flushes the debounce now) beside
+          the existing autosave status label. */}
+      <SectionSaveBar status={status} onSave={flush} />
 
       {/* Avatar */}
       <div className="flex items-center gap-4">

--- a/src/app/dashboard/profile/sections/bio-section.tsx
+++ b/src/app/dashboard/profile/sections/bio-section.tsx
@@ -10,18 +10,17 @@
 import { useState } from 'react';
 import type { WizardProfile } from '../steps/types';
 import { updateProfileFields } from '../actions';
-import { AutoSaveStatusLabel, useAutoSave } from './use-auto-save';
+import { useAutoSave } from './use-auto-save';
+import { SectionSaveBar } from './section-save-bar';
 
 export function BioSection({ profile }: { profile: WizardProfile }) {
   const [bio, setBio] = useState(profile.bio_short || '');
 
-  const status = useAutoSave(bio, async (v) => updateProfileFields({ bio_short: v }));
+  const { status, flush } = useAutoSave(bio, async (v) => updateProfileFields({ bio_short: v }));
 
   return (
     <div className="space-y-3">
-      <div className="flex justify-end">
-        <AutoSaveStatusLabel status={status} />
-      </div>
+      <SectionSaveBar status={status} onSave={flush} />
       <div>
         <label htmlFor="bio_short" className="block text-sm font-medium text-[var(--color-ink)] mb-1">
           Short bio

--- a/src/app/dashboard/profile/sections/index.ts
+++ b/src/app/dashboard/profile/sections/index.ts
@@ -10,4 +10,5 @@ export { BioSection } from './bio-section';
 export { ManualOfMeSection } from './manual-of-me-section';
 export { AffiliationsSection } from './affiliations-section';
 export { useAutoSave, AutoSaveStatusLabel } from './use-auto-save';
-export type { AutoSaveStatus, AutoSaveResult } from './use-auto-save';
+export type { AutoSaveStatus, AutoSaveResult, UseAutoSaveReturn } from './use-auto-save';
+export { SectionSaveBar } from './section-save-bar';

--- a/src/app/dashboard/profile/sections/manual-of-me-section.tsx
+++ b/src/app/dashboard/profile/sections/manual-of-me-section.tsx
@@ -12,7 +12,8 @@ import { useState } from 'react';
 import type { ManualOfMe } from '../manual-of-me-fields';
 import { MANUAL_OF_ME_MAX_LENGTHS } from '../manual-of-me-fields';
 import { updateManualOfMe } from '../manual-of-me-actions';
-import { AutoSaveStatusLabel, useAutoSave } from './use-auto-save';
+import { useAutoSave } from './use-auto-save';
+import { SectionSaveBar } from './section-save-bar';
 
 interface ManualOfMeDraft {
   good_to_know: string;
@@ -35,7 +36,7 @@ export function ManualOfMeSection({ manualOfMe }: { manualOfMe: ManualOfMe }) {
 
   // `updateManualOfMe` takes Record<string, string | null>; ManualOfMeDraft's
   // typed keys narrow it to a literal-keyed object, so we widen explicitly.
-  const status = useAutoSave(draft, async (v) =>
+  const { status, flush } = useAutoSave(draft, async (v) =>
     updateManualOfMe(v as unknown as Record<string, string | null>),
   );
 
@@ -46,9 +47,7 @@ export function ManualOfMeSection({ manualOfMe }: { manualOfMe: ManualOfMe }) {
   // in the same order the public profile renders them.
   return (
     <div className="space-y-5">
-      <div className="flex justify-end">
-        <AutoSaveStatusLabel status={status} />
-      </div>
+      <SectionSaveBar status={status} onSave={flush} />
 
       <p className="text-sm text-[var(--color-muted)]">
         A few little prompts to help people understand you. Every one is optional — fill in only what feels right.

--- a/src/app/dashboard/profile/sections/section-save-bar.tsx
+++ b/src/app/dashboard/profile/sections/section-save-bar.tsx
@@ -1,0 +1,58 @@
+'use client';
+
+/**
+ * KAN-404 (#8/#9) — per-section Save affordance for the single-page
+ * editor's free-text sections (BasicInfo, Bio, ManualOfMe).
+ *
+ * The free-text sections already debounce-autosave; this bar adds a
+ * VISIBLE Save button (founder ask) that flushes the pending debounce
+ * immediately, alongside the existing Saving…/Saved/Save-failed label so
+ * the eye finds save-state and the Save control in one spot. It does not
+ * replace autosave — it's a belt-and-braces "save right now" for users who
+ * don't trust silent autosave.
+ *
+ * List sections (items/links/starters/affiliations) commit each row
+ * instantly on Add/Remove, so there's nothing buffered to flush — they use
+ * a bare status indicator instead of this button (see edit-profile-form).
+ */
+
+import { useState } from 'react';
+import { AutoSaveStatusLabel, type AutoSaveStatus } from './use-auto-save';
+
+export function SectionSaveBar({
+  status,
+  onSave,
+  disabled = false,
+}: {
+  status: AutoSaveStatus;
+  onSave: () => void | Promise<void>;
+  disabled?: boolean;
+}) {
+  const [saving, setSaving] = useState(false);
+  // Disable while an explicit save is in flight or the debounce is mid-save,
+  // so a double-click can't fire two overlapping saves.
+  const isBusy = saving || status === 'saving' || disabled;
+
+  const handleClick = async () => {
+    setSaving(true);
+    try {
+      await onSave();
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <div className="flex items-center justify-end gap-3">
+      <AutoSaveStatusLabel status={status} />
+      <button
+        type="button"
+        onClick={handleClick}
+        disabled={isBusy}
+        className="px-4 py-1.5 rounded-lg bg-[var(--color-sage)] text-white text-sm font-medium hover:opacity-90 disabled:opacity-50 transition-opacity"
+      >
+        Save
+      </button>
+    </div>
+  );
+}

--- a/src/app/dashboard/profile/sections/use-auto-save.tsx
+++ b/src/app/dashboard/profile/sections/use-auto-save.tsx
@@ -15,6 +15,14 @@
  *   - Returns a status the section can render in its header
  *     ("Saving…" / "Saved" / "Save failed").
  *
+ * KAN-404 (#8/#9): the hook ALSO returns a `flush()` function so a visible
+ * per-section Save button can force-save the newest value immediately
+ * instead of waiting for the 800ms debounce. flush() cancels the pending
+ * timer, runs the save once with the latest value, and drives the same
+ * saving→saved / saving→error status transitions. The debounce, the
+ * first-render skip, the 800ms default, and the last-write-wins semantics
+ * are all unchanged — only an eager, user-initiated path was added.
+ *
  * The 800ms default is a balance between "feels instant" and "respects
  * the user's pause". Server Actions deduplicate concurrent writes
  * through Postgres transactions; if the user types again during a
@@ -22,7 +30,8 @@
  * matching what users expect from auto-save.
  */
 
-import { useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { runSave } from './auto-save-core';
 
 export type AutoSaveStatus = 'idle' | 'saving' | 'saved' | 'error';
 
@@ -31,15 +40,36 @@ export type AutoSaveResult =
   | { success: false; error: string }
   | void;
 
+export interface UseAutoSaveReturn {
+  status: AutoSaveStatus;
+  /**
+   * Force-save the latest value immediately, bypassing the debounce.
+   * Cancels any pending debounced save first so the two paths never race.
+   * Resolves once the save (and its status transition) has settled.
+   */
+  flush: () => Promise<void>;
+}
+
 export function useAutoSave<T>(
   value: T,
   save: (v: T) => Promise<AutoSaveResult>,
   debounceMs: number = 800,
-): AutoSaveStatus {
-  // Hold save in a ref so that re-creating the function on each parent
-  // render doesn't continually re-trigger the effect.
+): UseAutoSaveReturn {
+  // Hold `save` and the newest `value` in refs so flush() can force-save the
+  // current value with the current save fn, and so re-creating `save` on every
+  // parent render doesn't re-trigger the debounce effect. Both are synced in a
+  // commit effect — react-hooks/refs disallows writing refs during render, and
+  // an effect commits before any user click can call flush(), so the refs are
+  // always current at flush time.
   const saveRef = useRef(save);
-  saveRef.current = save;
+  const latestValueRef = useRef(value);
+  useEffect(() => {
+    saveRef.current = save;
+    latestValueRef.current = value;
+  });
+
+  // Track the live debounce timer so flush() can cancel it.
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const [status, setStatus] = useState<AutoSaveStatus>('idle');
   const isFirstRender = useRef(true);
@@ -49,25 +79,31 @@ export function useAutoSave<T>(
       isFirstRender.current = false;
       return;
     }
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- KAN-220/KAN-404: reset the visible status to 'idle' as a new debounce window is armed. Guarded by the first-render skip above, so it never fires on mount and can't cascade; it only runs in response to a user edit changing `value`.
     setStatus('idle');
-    const timer = setTimeout(async () => {
-      setStatus('saving');
-      try {
-        const result = await saveRef.current(value);
-        if (result && 'success' in result && result.success === false) {
-          setStatus('error');
-        } else {
-          setStatus('saved');
-        }
-      } catch {
-        setStatus('error');
-      }
+    const timer = setTimeout(() => {
+      timerRef.current = null;
+      // Debounce path: save the value captured for THIS window (last-write-wins
+      // across overlapping windows, unchanged from KAN-220).
+      void runSave(saveRef.current, value, setStatus);
     }, debounceMs);
-    return () => clearTimeout(timer);
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- KAN-220: saveRef intentionally not a dep; re-creating the save function on every parent render would otherwise re-trigger the effect. See file comment.
+    timerRef.current = timer;
+    return () => {
+      clearTimeout(timer);
+      if (timerRef.current === timer) timerRef.current = null;
+    };
   }, [value, debounceMs]);
 
-  return status;
+  const flush = useCallback(async () => {
+    // Cancel any in-flight debounce so the eager save is the last write.
+    if (timerRef.current !== null) {
+      clearTimeout(timerRef.current);
+      timerRef.current = null;
+    }
+    await runSave(saveRef.current, latestValueRef.current, setStatus);
+  }, []);
+
+  return { status, flush };
 }
 
 /** Small render-helper for the autosave status indicator. Sections that

--- a/src/app/dashboard/profile/steps/conversation-starters-step.tsx
+++ b/src/app/dashboard/profile/steps/conversation-starters-step.tsx
@@ -31,6 +31,7 @@ export function ConversationStartersStep({
   onRemove,
   onNext,
   isPending,
+  showContinue = true,
 }: {
   prompts: ConversationPrompt[];
   answers: ConversationAnswer[];
@@ -39,6 +40,9 @@ export function ConversationStartersStep({
   onRemove: (id: string) => void;
   onNext: () => void;
   isPending: boolean;
+  // KAN-404 (#8/#9): the single-page editor sets showContinue={false} to drop
+  // the misleading "Continue →" button; the legacy wizard keeps the default.
+  showContinue?: boolean;
 }) {
   const [openPromptId, setOpenPromptId] = useState<string | null>(null);
   const [newAnswer, setNewAnswer] = useState('');
@@ -215,7 +219,7 @@ export function ConversationStartersStep({
         </div>
       )}
 
-      <SaveButton onClick={onNext} isPending={false} label="Continue →" />
+      {showContinue && <SaveButton onClick={onNext} isPending={false} label="Continue →" />}
     </div>
   );
 }

--- a/src/app/dashboard/profile/steps/files-step.tsx
+++ b/src/app/dashboard/profile/steps/files-step.tsx
@@ -54,6 +54,7 @@ export function FilesStep({
   onUpdateVisibility,
   onNext,
   isPending,
+  showContinue = true,
 }: {
   files: WizardFile[];
   onUpload: (formData: FormData) => void;
@@ -61,6 +62,9 @@ export function FilesStep({
   onUpdateVisibility: (id: string, visibility: string) => void;
   onNext: () => void;
   isPending: boolean;
+  // KAN-404 (#8/#9): the single-page editor sets showContinue={false} to drop
+  // the misleading "Continue →" button; the legacy wizard keeps the default.
+  showContinue?: boolean;
 }) {
   const fileInputRef = useRef<HTMLInputElement>(null);
   const [visibility, setVisibility] = useState<string>('public');
@@ -194,7 +198,7 @@ export function FilesStep({
         )}
       </div>
 
-      <SaveButton onClick={onNext} isPending={false} label="Continue →" />
+      {showContinue && <SaveButton onClick={onNext} isPending={false} label="Continue →" />}
     </div>
   );
 }

--- a/src/app/dashboard/profile/steps/items-step.tsx
+++ b/src/app/dashboard/profile/steps/items-step.tsx
@@ -28,7 +28,7 @@ const visibilityShort: Record<string, string> = {
 // KAN-234: short label for the NULL/inherit case in the per-item selector.
 const INHERIT_SHORT = '↗ Inherit';
 
-export function ItemsStep({ title, description, categories, items, onAdd, onRemove, onUpdateVisibility, onNext, isPending, hideVisibility = false }: {
+export function ItemsStep({ title, description, categories, items, onAdd, onRemove, onUpdateVisibility, onEdit, onNext, isPending, hideVisibility = false, showContinue = true }: {
   title: string; description: string; categories: string[]; items: WizardItem[];
   // KAN-219 — items now carry an optional URL (Python `lyra-app` parity).
   // Server-side `addProfileItem` runs the value through `sanitiseUrl`, which
@@ -37,6 +37,12 @@ export function ItemsStep({ title, description, categories, items, onAdd, onRemo
   onAdd: (data: { category: string; title: string; description?: string; url?: string; visibility?: string }) => void;
   onRemove: (id: string) => void;
   onUpdateVisibility: (id: string, visibility: string) => void;
+  // KAN-404 (#12) — edit an existing item's text (title/description/url).
+  // Optional so legacy wizard callers that don't pass it keep compiling and
+  // simply don't render the inline Edit affordance. Returns the action result
+  // so the row can surface a moderation error in place (same red-text pattern
+  // as blocked adds) without a page reload.
+  onEdit?: (id: string, data: { title?: string; description?: string; url?: string }) => Promise<{ success: boolean; error?: string }>;
   onNext: () => void; isPending: boolean;
   // KAN-266: the June-2026 redesign drops per-item visibility (the profile is
   // simply public; affiliations are the only hidden-by-default thing). When
@@ -44,6 +50,11 @@ export function ItemsStep({ title, description, categories, items, onAdd, onRemo
   // rendered and new items inherit the section default (NULL → public). The
   // legacy wizard still passes hideVisibility=false to keep its controls.
   hideVisibility?: boolean;
+  // KAN-404 (#8/#9): the single-page editor sets showContinue={false} to drop
+  // the misleading "Continue →" button (it only collapsed the section, which
+  // read as navigation that went nowhere). The legacy wizard keeps the default
+  // true so "Continue →" still advances steps there — zero legacy change.
+  showContinue?: boolean;
 }) {
   const [category, setCategory] = useState(categories[0]);
   const [itemTitle, setItemTitle] = useState('');
@@ -51,6 +62,47 @@ export function ItemsStep({ title, description, categories, items, onAdd, onRemo
   const [itemUrl, setItemUrl] = useState('');
   // KAN-234: new items default to '' (inherit from section default).
   const [itemVisibility, setItemVisibility] = useState<string>('');
+
+  // KAN-404 (#12): inline edit state. Only one row edits at a time.
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [editTitle, setEditTitle] = useState('');
+  const [editDesc, setEditDesc] = useState('');
+  const [editUrl, setEditUrl] = useState('');
+  const [editError, setEditError] = useState<string | null>(null);
+  const [editSaving, setEditSaving] = useState(false);
+
+  const startEdit = (item: WizardItem) => {
+    setEditingId(item.id);
+    setEditTitle(item.title);
+    setEditDesc(item.description ?? '');
+    setEditUrl(item.url ?? '');
+    setEditError(null);
+  };
+
+  const cancelEdit = () => {
+    setEditingId(null);
+    setEditError(null);
+  };
+
+  const saveEdit = async (id: string) => {
+    if (!onEdit || !editTitle.trim()) return;
+    setEditSaving(true);
+    setEditError(null);
+    const res = await onEdit(id, {
+      title: editTitle.trim(),
+      // Send description/url even when empty so the user can CLEAR them
+      // (the action treats '' description as null; '' url as "no URL").
+      description: editDesc,
+      url: editUrl.trim(),
+    });
+    setEditSaving(false);
+    if (res.success) {
+      setEditingId(null);
+      setEditError(null);
+    } else {
+      setEditError(res.error ?? 'Could not save. Please try again.');
+    }
+  };
 
   const categoryLabels: Record<string, string> = {
     likes: '💚 Like', dislikes: '💔 Dislike',
@@ -96,56 +148,119 @@ export function ItemsStep({ title, description, categories, items, onAdd, onRemo
       {items.length > 0 && (
         <div className="space-y-2">
           {items.map((item: WizardItem) => (
-            <div key={item.id} className="flex items-center justify-between bg-white rounded-lg border border-[var(--color-border)] px-4 py-3">
-              <div className="flex-1 min-w-0">
-                <p className="text-sm font-medium text-[var(--color-ink)]">
-                  <span className="opacity-60">{categoryLabels[item.category] || item.category}</span> — {item.title}
-                  {/* KAN-219: ↗ chip when an item has a URL. Open in new tab
-                      with noopener+noreferrer to prevent tab-nabbing. */}
-                  {item.url && (
-                    <a
-                      href={item.url}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className="ml-1.5 text-xs text-[var(--color-sage)] hover:underline"
-                      aria-label={`Open link for ${item.title}`}
+            <div key={item.id} className="bg-white rounded-lg border border-[var(--color-border)] px-4 py-3">
+              {onEdit && editingId === item.id ? (
+                /* KAN-404 (#12): inline edit mode — reuses the add-form input
+                   styling. Save runs onEdit; a moderation block shows in place. */
+                <div className="space-y-3">
+                  <Field label="Title" value={editTitle} onChange={setEditTitle} placeholder="e.g. Dark chocolate, hiking boots" />
+                  <div>
+                    <label className="block text-sm font-medium text-[var(--color-ink)] mb-1">Description (optional)</label>
+                    <input
+                      value={editDesc}
+                      onChange={(e) => setEditDesc(e.target.value)}
+                      className="w-full px-3 py-2 rounded-lg border border-[var(--color-border)] bg-white text-sm focus:outline-none focus:ring-2 focus:ring-[var(--color-sage)]"
+                      placeholder="Any extra detail"
+                    />
+                  </div>
+                  <div>
+                    <label className="block text-sm font-medium text-[var(--color-ink)] mb-1" htmlFor={`edit-item-url-${item.id}`}>
+                      Link (optional)
+                    </label>
+                    <input
+                      id={`edit-item-url-${item.id}`}
+                      type="url"
+                      value={editUrl}
+                      onChange={(e) => setEditUrl(e.target.value)}
+                      className="w-full px-3 py-2 rounded-lg border border-[var(--color-border)] bg-white text-sm focus:outline-none focus:ring-2 focus:ring-[var(--color-sage)]"
+                      placeholder="https://example.com/this-book"
+                    />
+                  </div>
+                  {editError && <p role="alert" className="text-sm text-red-600">{editError}</p>}
+                  <div className="flex items-center gap-2">
+                    <button
+                      type="button"
+                      onClick={() => saveEdit(item.id)}
+                      disabled={editSaving || isPending || !editTitle.trim()}
+                      className="px-4 py-2 rounded-lg bg-[var(--color-sage)] text-white text-sm font-medium hover:opacity-90 disabled:opacity-40 transition-opacity"
                     >
-                      ↗
-                    </a>
-                  )}
-                </p>
-                {item.description && <p className="text-xs text-[var(--color-muted)] mt-0.5">{item.description}</p>}
-              </div>
-              <div className="flex items-center gap-2 ml-3">
-                {!hideVisibility && (
-                  <>
-                    <label className="sr-only" htmlFor={`vis-${item.id}`}>Visibility</label>
-                    <select
-                      id={`vis-${item.id}`}
-                      aria-label={`Visibility for ${item.title}`}
-                      // KAN-234: NULL stored visibility → '' in the form = inherit.
-                      // Known string → its real value. Unknown string → 'public' (defence).
-                      value={
-                        item.visibility == null || item.visibility === ''
-                          ? ''
-                          : visibilityShort[item.visibility]
-                            ? item.visibility
-                            : 'public'
-                      }
-                      onChange={(e) => onUpdateVisibility(item.id, e.target.value)}
-                      disabled={isPending}
-                      className="text-xs px-2 py-1 rounded border border-[var(--color-border)] bg-white text-[var(--color-ink)]"
+                      {editSaving ? 'Saving…' : 'Save'}
+                    </button>
+                    <button
+                      type="button"
+                      onClick={cancelEdit}
+                      disabled={editSaving}
+                      className="px-4 py-2 rounded-lg text-sm font-medium text-[var(--color-muted)] hover:text-[var(--color-ink)] transition-colors"
                     >
-                      {VISIBILITY_OPTIONS.map((opt) => (
-                        <option key={opt.value || 'inherit'} value={opt.value}>
-                          {opt.value === '' ? INHERIT_SHORT : visibilityShort[opt.value]}
-                        </option>
-                      ))}
-                    </select>
-                  </>
-                )}
-                <button onClick={() => onRemove(item.id)} disabled={isPending} className="text-xs text-red-400 hover:text-red-600">Remove</button>
-              </div>
+                      Cancel
+                    </button>
+                  </div>
+                </div>
+              ) : (
+                <div className="flex items-center justify-between">
+                  <div className="flex-1 min-w-0">
+                    <p className="text-sm font-medium text-[var(--color-ink)]">
+                      <span className="opacity-60">{categoryLabels[item.category] || item.category}</span> — {item.title}
+                      {/* KAN-219: ↗ chip when an item has a URL. Open in new tab
+                          with noopener+noreferrer to prevent tab-nabbing. */}
+                      {item.url && (
+                        <a
+                          href={item.url}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="ml-1.5 text-xs text-[var(--color-sage)] hover:underline"
+                          aria-label={`Open link for ${item.title}`}
+                        >
+                          ↗
+                        </a>
+                      )}
+                    </p>
+                    {item.description && <p className="text-xs text-[var(--color-muted)] mt-0.5">{item.description}</p>}
+                  </div>
+                  <div className="flex items-center gap-2 ml-3">
+                    {!hideVisibility && (
+                      <>
+                        <label className="sr-only" htmlFor={`vis-${item.id}`}>Visibility</label>
+                        <select
+                          id={`vis-${item.id}`}
+                          aria-label={`Visibility for ${item.title}`}
+                          // KAN-234: NULL stored visibility → '' in the form = inherit.
+                          // Known string → its real value. Unknown string → 'public' (defence).
+                          value={
+                            item.visibility == null || item.visibility === ''
+                              ? ''
+                              : visibilityShort[item.visibility]
+                                ? item.visibility
+                                : 'public'
+                          }
+                          onChange={(e) => onUpdateVisibility(item.id, e.target.value)}
+                          disabled={isPending}
+                          className="text-xs px-2 py-1 rounded border border-[var(--color-border)] bg-white text-[var(--color-ink)]"
+                        >
+                          {VISIBILITY_OPTIONS.map((opt) => (
+                            <option key={opt.value || 'inherit'} value={opt.value}>
+                              {opt.value === '' ? INHERIT_SHORT : visibilityShort[opt.value]}
+                            </option>
+                          ))}
+                        </select>
+                      </>
+                    )}
+                    {/* KAN-404 (#12): Edit is only offered when a handler is wired
+                        (redesign editor); the legacy wizard omits onEdit. */}
+                    {onEdit && (
+                      <button
+                        type="button"
+                        onClick={() => startEdit(item)}
+                        disabled={isPending}
+                        className="text-xs text-[var(--color-muted)] hover:text-[var(--color-ink)]"
+                      >
+                        Edit
+                      </button>
+                    )}
+                    <button onClick={() => onRemove(item.id)} disabled={isPending} className="text-xs text-red-400 hover:text-red-600">Remove</button>
+                  </div>
+                </div>
+              )}
             </div>
           ))}
         </div>
@@ -207,7 +322,7 @@ export function ItemsStep({ title, description, categories, items, onAdd, onRemo
           + Add item
         </button>
       </div>
-      <SaveButton onClick={onNext} isPending={false} label="Continue →" />
+      {showContinue && <SaveButton onClick={onNext} isPending={false} label="Continue →" />}
     </div>
   );
 }

--- a/src/app/dashboard/profile/steps/links-step.tsx
+++ b/src/app/dashboard/profile/steps/links-step.tsx
@@ -3,10 +3,13 @@
 import { useState } from 'react';
 import { Field, SaveButton, type WizardLink } from './types';
 
-export function LinksStep({ links, onAdd, onRemove, onNext, isPending }: {
+export function LinksStep({ links, onAdd, onRemove, onNext, isPending, showContinue = true }: {
   links: WizardLink[];
   onAdd: (data: { title: string; url: string; link_type?: string }) => void;
   onRemove: (id: string) => void; onNext: () => void; isPending: boolean;
+  // KAN-404 (#8/#9): the single-page editor sets showContinue={false} to drop
+  // the misleading "Continue →" button; the legacy wizard keeps the default.
+  showContinue?: boolean;
 }) {
   const [title, setTitle] = useState('');
   const [url, setUrl] = useState('');
@@ -56,7 +59,7 @@ export function LinksStep({ links, onAdd, onRemove, onNext, isPending }: {
           + Add link
         </button>
       </div>
-      <SaveButton onClick={onNext} isPending={false} label="Continue →" />
+      {showContinue && <SaveButton onClick={onNext} isPending={false} label="Continue →" />}
     </div>
   );
 }

--- a/tests/unit/auto-save-flush.test.ts
+++ b/tests/unit/auto-save-flush.test.ts
@@ -1,0 +1,152 @@
+/**
+ * KAN-404 (#8/#9) — coverage for the save-model rework.
+ *
+ * Two layers, both runnable in the project's `node` jest env (no jsdom):
+ *
+ * 1. Behavioural tests for `runSave`, the framework-agnostic core that BOTH
+ *    the debounced timer path and the eager flush() path in `use-auto-save`
+ *    go through. This is where the saving→saved / saving→error contract
+ *    lives, so testing it directly proves the Save button (flush) and the
+ *    debounce transition identically — the E2E's `/Saved|Saving/` assertion
+ *    depends on exactly these transitions.
+ *
+ * 2. Static-source guards that `useAutoSave` returns `{ status, flush }`,
+ *    that flush cancels the pending debounce timer, that the free-text
+ *    sections render a visible Save button via SectionSaveBar, and that the
+ *    single-page editor drops the "Continue →" button while the legacy
+ *    wizard keeps it. Rendering React hooks needs a DOM env the repo's jest
+ *    config doesn't provide (see affiliations-and-autosave.test.ts), so we
+ *    assert the contract at the source level as that file does.
+ */
+
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { runSave } from '@/app/dashboard/profile/sections/auto-save-core';
+
+const ROOT = resolve(__dirname, '../..');
+const SECTIONS = resolve(ROOT, 'src/app/dashboard/profile/sections');
+
+// ─────────── 1. runSave behaviour ───────────
+
+describe('KAN-404: runSave status transitions', () => {
+  test('success → saving then saved, save called once with the value', async () => {
+    const statuses: string[] = [];
+    const save = jest.fn().mockResolvedValue({ success: true });
+    await runSave(save, 'hello', (s) => statuses.push(s));
+    expect(save).toHaveBeenCalledTimes(1);
+    expect(save).toHaveBeenCalledWith('hello');
+    expect(statuses).toEqual(['saving', 'saved']);
+  });
+
+  test('void result (legacy save fn) is treated as success', async () => {
+    const statuses: string[] = [];
+    const save = jest.fn().mockResolvedValue(undefined);
+    await runSave(save, 42, (s) => statuses.push(s));
+    expect(statuses).toEqual(['saving', 'saved']);
+  });
+
+  test('{ success: false } result → saving then error', async () => {
+    const statuses: string[] = [];
+    const save = jest.fn().mockResolvedValue({ success: false, error: 'nope' });
+    await runSave(save, 'x', (s) => statuses.push(s));
+    expect(statuses).toEqual(['saving', 'error']);
+  });
+
+  test('a throw → saving then error (never rejects)', async () => {
+    const statuses: string[] = [];
+    const save = jest.fn().mockRejectedValue(new Error('boom'));
+    await expect(
+      runSave(save, 'x', (s) => statuses.push(s)),
+    ).resolves.toBeUndefined();
+    expect(statuses).toEqual(['saving', 'error']);
+  });
+
+  test('flush saves the LATEST value handed to it', async () => {
+    // The hook keeps a latestValueRef and passes ref.current to runSave, so
+    // flush persists what the user currently sees. Simulate by calling runSave
+    // with the newest value directly.
+    const save = jest.fn().mockResolvedValue({ success: true });
+    await runSave(save, 'newest', () => {});
+    expect(save).toHaveBeenCalledWith('newest');
+  });
+});
+
+// ─────────── 2. Static contract guards ───────────
+
+describe('KAN-404: use-auto-save exposes flush + cancels the debounce', () => {
+  const src = readFileSync(resolve(SECTIONS, 'use-auto-save.tsx'), 'utf-8');
+
+  test('hook returns { status, flush }', () => {
+    expect(src).toMatch(/return\s*\{\s*status,\s*flush\s*\}/);
+    expect(src).toMatch(/flush:\s*\(\)\s*=>\s*Promise<void>/);
+  });
+
+  test('flush clears the pending debounce timer before saving', () => {
+    // flush must cancel the in-flight timer so the eager save is the last write.
+    expect(src).toMatch(/const flush =/);
+    expect(src).toMatch(/clearTimeout\(timerRef\.current\)/);
+  });
+
+  test('debounce default is still 800ms and both paths route through runSave', () => {
+    expect(src).toMatch(/debounceMs:\s*number\s*=\s*800/);
+    const runSaveCalls = (src.match(/runSave\(/g) || []).length;
+    expect(runSaveCalls).toBeGreaterThanOrEqual(2); // debounced timer + flush
+  });
+
+  test('AutoSaveStatusLabel keeps the exact Saving…/Saved text (E2E depends on it)', () => {
+    expect(src).toMatch(/'Saving…'/);
+    expect(src).toMatch(/'Saved'/);
+  });
+});
+
+describe('KAN-404: SectionSaveBar + free-text sections render a visible Save', () => {
+  test('SectionSaveBar renders the status label + a Save button and disables while saving', () => {
+    const src = readFileSync(resolve(SECTIONS, 'section-save-bar.tsx'), 'utf-8');
+    expect(src).toMatch(/AutoSaveStatusLabel/);
+    expect(src).toMatch(/>\s*Save\s*</);
+    expect(src).toMatch(/onSave/);
+    expect(src).toMatch(/status === 'saving'/);
+  });
+
+  test.each(['basic-info-section.tsx', 'bio-section.tsx', 'manual-of-me-section.tsx'])(
+    '%s uses flush from useAutoSave and renders SectionSaveBar',
+    (file) => {
+      const src = readFileSync(resolve(SECTIONS, file), 'utf-8');
+      expect(src).toMatch(/const\s*\{\s*status,\s*flush\s*\}\s*=\s*useAutoSave/);
+      expect(src).toMatch(/<SectionSaveBar\s+status=\{status\}\s+onSave=\{flush\}/);
+    },
+  );
+});
+
+describe('KAN-404: Continue button gated behind showContinue', () => {
+  const STEPS = resolve(ROOT, 'src/app/dashboard/profile/steps');
+
+  test.each(['items-step.tsx', 'links-step.tsx', 'conversation-starters-step.tsx', 'files-step.tsx'])(
+    '%s only renders the Continue button when showContinue is not false',
+    (file) => {
+      const src = readFileSync(resolve(STEPS, file), 'utf-8');
+      expect(src).toMatch(/showContinue\?:\s*boolean/);
+      expect(src).toMatch(/showContinue\s*=\s*true/);
+      // The Continue button is gated behind showContinue.
+      expect(src).toMatch(/\{showContinue && <SaveButton/);
+      expect(src).toMatch(/label="Continue →"/);
+    },
+  );
+
+  test('single-page editor passes showContinue={false} to the list steps', () => {
+    const src = readFileSync(
+      resolve(ROOT, 'src/app/dashboard/profile/edit-profile-form.tsx'),
+      'utf-8',
+    );
+    const count = (src.match(/showContinue=\{false\}/g) || []).length;
+    expect(count).toBeGreaterThanOrEqual(3); // items + links + starters
+  });
+
+  test('legacy wizard.tsx does NOT pass showContinue (keeps the default true)', () => {
+    const src = readFileSync(
+      resolve(ROOT, 'src/app/dashboard/profile/wizard.tsx'),
+      'utf-8',
+    );
+    expect(src).not.toMatch(/showContinue/);
+  });
+});

--- a/tests/unit/inline-item-edit.test.ts
+++ b/tests/unit/inline-item-edit.test.ts
@@ -1,0 +1,70 @@
+/**
+ * KAN-404 (#12) — inline item-edit UI contract.
+ *
+ * The behavioural coverage for the `updateProfileItem` server action lives in
+ * tests/unit/moderation-actions.test.ts (moderation + write) and
+ * tests/unit/profile-ownership.test.ts (owner-scope + auth). This file guards
+ * the UI wiring at the source level (the repo's jest env is `node`, so the
+ * React row can't be rendered — same pattern as affiliations-and-autosave).
+ */
+
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const ROOT = resolve(__dirname, '../..');
+const PROFILE = resolve(ROOT, 'src/app/dashboard/profile');
+
+describe('KAN-404 (#12): ItemsStep inline edit', () => {
+  const src = readFileSync(resolve(PROFILE, 'steps/items-step.tsx'), 'utf-8');
+
+  test('accepts an optional onEdit prop returning success/error', () => {
+    expect(src).toMatch(/onEdit\?:/);
+    expect(src).toMatch(/Promise<\{\s*success:\s*boolean;\s*error\?:\s*string\s*\}>/);
+  });
+
+  test('renders an Edit button only when onEdit is wired', () => {
+    expect(src).toMatch(/onEdit && \(/);
+    expect(src).toMatch(/onClick=\{\(\) => startEdit\(item\)\}/);
+  });
+
+  test('inline edit mode has Save + Cancel and surfaces editError in place', () => {
+    expect(src).toMatch(/saveEdit\(item\.id\)/);
+    expect(src).toMatch(/onClick=\{cancelEdit\}/);
+    expect(src).toMatch(/editError/);
+  });
+
+  test('saveEdit sends title/description/url so a user can clear as well as edit', () => {
+    expect(src).toMatch(/title:\s*editTitle\.trim\(\)/);
+    expect(src).toMatch(/description:\s*editDesc/);
+    expect(src).toMatch(/url:\s*editUrl\.trim\(\)/);
+  });
+});
+
+describe('KAN-404 (#12): editor wires updateProfileItem into ItemsStep', () => {
+  const src = readFileSync(resolve(PROFILE, 'edit-profile-form.tsx'), 'utf-8');
+
+  test('imports updateProfileItem', () => {
+    expect(src).toMatch(/updateProfileItem/);
+  });
+
+  test('passes an onEdit that calls updateProfileItem and returns the result', () => {
+    expect(src).toMatch(/onEdit=\{async \(id, data\) =>/);
+    expect(src).toMatch(/await updateProfileItem\(id, data\)/);
+    expect(src).toMatch(/return \{ success: res\.success/);
+  });
+});
+
+describe('KAN-404 (#12): updateProfileItem action shape', () => {
+  const src = readFileSync(resolve(PROFILE, 'actions.ts'), 'utf-8');
+
+  test('exports updateProfileItem returning ItemActionResult', () => {
+    expect(src).toMatch(/export type ItemActionResult/);
+    expect(src).toMatch(/export async function updateProfileItem/);
+  });
+
+  test('is owner-scoped (double .eq) and moderates title + description', () => {
+    expect(src).toMatch(/\.eq\('id', itemId\)\s*\n\s*\.eq\('profile_id', profile\.id\)/);
+    expect(src).toMatch(/field:\s*'profile_items\.title'/);
+    expect(src).toMatch(/field:\s*'profile_items\.description'/);
+  });
+});

--- a/tests/unit/moderation-actions.test.ts
+++ b/tests/unit/moderation-actions.test.ts
@@ -59,11 +59,31 @@ jest.mock('@/lib/supabase-server', () => ({
         },
         update: (data: unknown) => {
           mockUpdateCapture(tableName, data);
-          return {
-            eq: () => ({
-              eq: () => Promise.resolve({ error: null }),
+          // KAN-404 (#12): updateProfileItem chains
+          // .update().eq().eq().select().single() to return the saved row.
+          // The `.eq()` result is awaitable (existing update callers) AND
+          // exposes .select().single() (the row-returning path). Additive —
+          // doesn't change the existing empty-return update assertions.
+          const eqResult = {
+            eq: () => eqResult,
+            select: () => ({
+              single: () =>
+                Promise.resolve({
+                  data: {
+                    id: 'test-item-id',
+                    category: 'gift_ideas',
+                    title: 'Updated title',
+                    description: null,
+                    url: null,
+                    visibility: null,
+                  },
+                  error: null,
+                }),
             }),
+            then: (resolve: (v: { error: null }) => unknown) =>
+              Promise.resolve({ error: null }).then(resolve),
           };
+          return { eq: () => eqResult };
         },
       };
     }),
@@ -72,6 +92,7 @@ jest.mock('@/lib/supabase-server', () => ({
 
 import {
   addProfileItem,
+  updateProfileItem,
   addSchoolAffiliation,
   addExternalLink,
   updateProfileFields,
@@ -138,6 +159,63 @@ describe('KAN-241: addProfileItem moderation', () => {
       expect(result.error).toMatch(/personal information/i);
     }
     expect(mockInsertCapture).not.toHaveBeenCalledWith('profile_items', expect.anything());
+  });
+});
+
+// ───────────── updateProfileItem (KAN-404 #12) ─────────────
+
+describe('KAN-404: updateProfileItem moderation + write', () => {
+  test('clean title + description → updates profile_items with sanitised values', async () => {
+    const result = await updateProfileItem('item-1', {
+      title: 'Fresh title',
+      description: 'A clean description',
+    });
+    expect(result.success).toBe(true);
+    expect(mockUpdateCapture).toHaveBeenCalledWith(
+      'profile_items',
+      expect.objectContaining({
+        title: 'Fresh title',
+        description: 'A clean description',
+      }),
+    );
+  });
+
+  test('empty description clears it to null', async () => {
+    await updateProfileItem('item-1', { title: 'Keep', description: '' });
+    expect(mockUpdateCapture).toHaveBeenCalledWith(
+      'profile_items',
+      expect.objectContaining({ description: null }),
+    );
+  });
+
+  test('profane title → blocked, no update to profile_items', async () => {
+    const result = await updateProfileItem('item-1', { title: 'fuck this' });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error).toMatch(/inappropriate language/i);
+    }
+    expect(mockUpdateCapture).not.toHaveBeenCalledWith('profile_items', expect.anything());
+  });
+
+  test('profane description → blocked, no update to profile_items', async () => {
+    const result = await updateProfileItem('item-1', {
+      title: 'Coffee',
+      description: 'this fuck is great',
+    });
+    expect(result.success).toBe(false);
+    expect(mockUpdateCapture).not.toHaveBeenCalledWith('profile_items', expect.anything());
+  });
+
+  test('invalid url (javascript:) → blocked with http(s) error, no update', async () => {
+    const result = await updateProfileItem('item-1', {
+      title: 'Coffee',
+      url: 'javascript:alert(1)',
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error).toMatch(/http:\/\/ or https:\/\//i);
+    }
+    expect(mockUpdateCapture).not.toHaveBeenCalledWith('profile_items', expect.anything());
   });
 });
 

--- a/tests/unit/profile-ownership.test.ts
+++ b/tests/unit/profile-ownership.test.ts
@@ -46,7 +46,11 @@ jest.mock('@/lib/supabase-server', () => {
         Promise.resolve(
           table === 'profiles'
             ? { data: { id: 'profile-1' }, error: null }
-            : { data: null, error: null },
+            : table === 'profile_items'
+              // KAN-404 (#12): updateProfileItem's .update().eq().eq().select()
+              // .single() returns the saved row so the action resolves success.
+              ? { data: { id: 'item-x' }, error: null }
+              : { data: null, error: null },
         ),
       then: (resolve, reject) =>
         Promise.resolve({ error: mockState.mutationError }).then(resolve, reject),
@@ -68,6 +72,7 @@ import {
   removeProfileItem,
   removeSchoolAffiliation,
   removeExternalLink,
+  updateProfileItem,
   updateProfileItemVisibility,
   updateAffiliationVisibility,
 } from '@/app/dashboard/profile/actions';
@@ -97,6 +102,21 @@ describe('KAN-260: profile mutations are owner-scoped in code (not RLS alone)', 
     const res = await updateProfileItemVisibility('item-9', 'public');
     expect(res).toEqual({ success: true });
     expect(ownerScoped('profile_items')).toBe(true);
+  });
+
+  // KAN-404 (#12): editing an item's text is owner-scoped in code too.
+  test('updateProfileItem scopes the update to the caller profile_id', async () => {
+    const res = await updateProfileItem('item-x', { title: 'Hi' });
+    expect(res.success).toBe(true);
+    expect(mockEqCalls['profile_items']).toContainEqual(['id', 'item-x']);
+    expect(ownerScoped('profile_items')).toBe(true);
+  });
+
+  test('updateProfileItem: not authenticated → no write attempted', async () => {
+    mockState.userId = null;
+    const res = await updateProfileItem('item-x', { title: 'Hi' });
+    expect(res).toEqual({ success: false, error: 'Not authenticated' });
+    expect(mockEqCalls['profile_items']).toBeUndefined();
   });
 
   test('removeSchoolAffiliation scopes the delete to the caller profile_id', async () => {


### PR DESCRIPTION
Implements two KAN-404 wave-4 **web** items in one PR — they share the profile editor files, so shipped together to avoid conflicts.

## #8/#9 — Save-model rework
- **Removes the misleading "Continue →" button** from the single-page editor. It only collapsed a section (reads as navigation that goes nowhere). Gated behind a new optional `showContinue` prop (default `true`) on `ItemsStep`/`LinksStep`/`ConversationStartersStep`/`FilesStep`. The **legacy `wizard.tsx` is untouched** and still passes no prop → keeps the default → "Continue →" still advances steps there. Collapse remains available via the section header chevron.
- **Visible per-section Save button** (`SectionSaveBar`) on the free-text sections (basic/bio/manual). `useAutoSave` now returns `{ status, flush }`; clicking Save calls `flush()`, which cancels the pending debounce and force-saves the latest value. Both the debounce timer and `flush()` route through one node-testable `runSave` core so they can never drift.
- **List sections** (items/links/starters) get a per-section transient `Saving…`/`Saved` indicator instead of a Save button — rows commit instantly on Add/Remove, so there's nothing buffered to flush.
- Sticky-bar autosave hint reworded to mention the per-section Save.

**E2E safety:** the exact `AutoSaveStatusLabel` text (`Saving…` / `Saved`) and the debounce/first-render/last-write-wins behaviour are unchanged, so the authed KAN-271 journey assertion (`getByText(/Saved|Saving/)`) still passes. `profile-redesign.spec.ts` and `journey.authed.spec.ts` are not modified.

## #12 — Inline item-edit
- New **own-profile-only** server action `updateProfileItem(itemId, { title?, description?, url? })`: sanitise + per-field `moderateAndAudit` parity with `addProfileItem`, owner-scoped double `.eq('id').eq('profile_id')` (KAN-260), empty description/url clears to `NULL`, invalid URL rejected with the http(s) error. Returns the saved row via an additive `ItemActionResult` union.
- Inline **Edit / Save / Cancel** UI in `ItemsStep` behind an optional `onEdit` prop (legacy wizard omits it). Moderation blocks surface in place using the existing red-error pattern.
- Wired into `edit-profile-form.tsx`; `onEdit` awaits the action and `router.refresh()`es on success.

## MCP (out of scope here)
The lockstep MCP tool `lyra_update_item` is built by a **separate agent in the `lyra-mcp-server` repo** — this PR is **web-only** (server action + inline UI + tests). No `lyra-mcp-server` changes are included.

## Tests (additive)
- `updateProfileItem`: moderation (clean/profane title+description, invalid URL), owner-scope (`.eq('profile_id')`), unauthenticated → no write (extended `moderation-actions.test.ts` + `profile-ownership.test.ts`; the shared supabase mocks were extended additively to expose `.select().single()` on the update chain).
- `runSave` status transitions + `flush`/save-model + Continue-gating contract guards (`auto-save-flush.test.ts`).
- Inline-edit UI contract (`inline-item-edit.test.ts`).

## Verification
- Full unit suite green: **2002 passed / 161 suites**.
- `npx tsc --noEmit` clean.
- `eslint` clean on all changed + new files.
- No DB migration; no prod DB writes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)