### PR TITLE
SEC-54/SEC-56/BUGS-65: SECURITY DEFINER + RLS + grant hygiene batch

### DIFF
--- a/supabase/migrations/20260704180000_sec54_sec56_bugs65_secdef_rls_grant_batch.sql
+++ b/supabase/migrations/20260704180000_sec54_sec56_bugs65_secdef_rls_grant_batch.sql
@@ -1,0 +1,76 @@
+-- SEC-54 / SEC-56 / BUGS-65 — SECURITY DEFINER + RLS + grant hygiene batch
+-- Epic KAN-350 (2026-06-30 codebase review). Three defence-in-depth findings,
+-- one migration. Apply order: dev -> staging -> prod (supervised; autopilot
+-- applies dev only). All statements are idempotent / safe to re-run.
+--
+-- Rollback (per section): see the inline "-- Rollback:" notes below. None of
+-- these changes remove data; they tighten privileges and pin a search_path.
+
+-- ============================================================================
+-- SEC-54 (finding web-secdef-1) — pin handle_new_user search_path
+-- ============================================================================
+-- The handle_new_user SECURITY DEFINER trigger shipped with a mutable
+-- (unpinned) search_path — the classic search_path-injection priv-esc vector
+-- and the Supabase `function_search_path_mutable` advisor finding. The
+-- 2026-06-21 audit pinned ~11 other functions but missed this one.
+--
+-- Re-create it with `set search_path = ''` AND a fully schema-qualified body,
+-- so the function is correct on every environment regardless of whether that
+-- env still carries the original (unqualified) body. `public.profiles` is
+-- explicitly qualified; split_part/coalesce/lower/replace/substr are pg_catalog
+-- built-ins and resolve via the always-implicit pg_catalog even with an empty
+-- search_path.
+--
+-- Rollback: CREATE OR REPLACE the same body without the `SET search_path`
+-- clause (restores the mutable search_path — not recommended).
+create or replace function public.handle_new_user()
+returns trigger
+language plpgsql
+security definer
+set search_path = ''
+as $function$
+begin
+  insert into public.profiles (user_id, display_name, slug)
+  values (
+    new.id,
+    coalesce(new.raw_user_meta_data->>'full_name', split_part(new.email, '@', 1)),
+    lower(replace(coalesce(new.raw_user_meta_data->>'full_name', split_part(new.email, '@', 1)), ' ', '-'))
+      || '-' || substr(new.id::text, 1, 8)
+  );
+  return new;
+end;
+$function$;
+
+-- ============================================================================
+-- SEC-56 (finding web-oauth-5) — lock down oauth_connections direct writes
+-- ============================================================================
+-- The oauth_connections UPDATE RLS policy was column-unrestricted, so an
+-- authenticated user could repoint their refresh_token_secret_id at another
+-- user's Vault secret and have the server mint live Google/Microsoft tokens for
+-- the victim (cross-user token-theft primitive). Every legitimate write already
+-- goes through the service-role upsertConnection path (src/lib/convene/
+-- oauth-connections.ts), which is unaffected by these grants. Remove direct
+-- INSERT/UPDATE/DELETE from anon + authenticated; owner SELECT (table grant +
+-- RLS `oauth_connections_owner_select`) is retained.
+--
+-- Rollback: GRANT INSERT, UPDATE, DELETE ON public.oauth_connections
+--           TO authenticated, anon;  (re-opens the priv-esc — not recommended)
+revoke insert, update, delete on public.oauth_connections from authenticated;
+revoke insert, update, delete on public.oauth_connections from anon;
+
+-- ============================================================================
+-- BUGS-65 (B9 residual, post-BUGS-48) — revoke PUBLIC execute on 2 newer
+-- SECURITY DEFINER trigger functions
+-- ============================================================================
+-- block_admin_is_suspended_self_set and prevent_feature_entitlement_self_grant
+-- were created 2026-06-22 (one day after BUGS-48 closed) and so were never
+-- included in that revoke sweep. Both RETURNS trigger (grant-independent when
+-- fired as triggers — PostgREST cannot supply TriggerData via /rpc), but both
+-- still carry the inherited default PUBLIC EXECUTE grant. Mirror BUGS-48's
+-- shape: revoke from PUBLIC/anon/authenticated, keep service_role.
+--
+-- Rollback: GRANT EXECUTE ON FUNCTION public.<fn>() TO public;  (not recommended)
+revoke execute on function public.block_admin_is_suspended_self_set() from public, anon, authenticated;
+revoke execute on function public.prevent_feature_entitlement_self_grant() from public, anon, authenticated;
+grant execute on function public.block_admin_is_suspended_self_set() to service_role;
+grant execute on function public.prevent_feature_entitlement_self_grant() to service_role;

--- a/tests/unit/sec54-sec56-bugs65-secdef-rls-grant-batch.test.js
+++ b/tests/unit/sec54-sec56-bugs65-secdef-rls-grant-batch.test.js
@@ -1,0 +1,107 @@
+/**
+ * SEC-54 / SEC-56 / BUGS-65 — SECURITY DEFINER + RLS + grant hygiene batch guard.
+ *
+ * One migration (20260704180000_sec54_sec56_bugs65_secdef_rls_grant_batch.sql)
+ * carries three defence-in-depth findings from the 2026-06-30 review (KAN-350):
+ *
+ *   SEC-54  handle_new_user SECURITY DEFINER trigger had a mutable search_path
+ *           (function_search_path_mutable priv-esc vector). Re-create it with
+ *           `set search_path = ''` and a fully schema-qualified body.
+ *   SEC-56  oauth_connections UPDATE RLS was column-unrestricted (cross-user
+ *           Vault refresh-token theft primitive). Revoke direct INSERT/UPDATE/
+ *           DELETE from authenticated + anon; legit writes use the service role.
+ *   BUGS-65 Two SECURITY DEFINER trigger fns created after BUGS-48 closed still
+ *           carried the default PUBLIC EXECUTE grant. Revoke PUBLIC/anon/
+ *           authenticated; keep service_role.
+ *
+ * These are static file-content checks (migrations are applied via the Supabase
+ * MCP after review, per CLAUDE.md "Supabase Migration Rules"), not DB-execution
+ * tests — they fail CI if the migration is dropped or a future edit weakens any
+ * of the three controls.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const migrationsDir = path.join(__dirname, '../../supabase/migrations');
+
+function readBatchMigration() {
+  const files = fs.readdirSync(migrationsDir);
+  const match = files.find((f) =>
+    /_sec54_sec56_bugs65_secdef_rls_grant_batch\.sql$/.test(f)
+  );
+  expect(match).toBeTruthy();
+  expect(path.basename(match)).toMatch(/^\d{14}_/);
+  return fs.readFileSync(path.join(migrationsDir, match), 'utf8');
+}
+
+describe('SEC-54/56/BUGS-65 — SECURITY DEFINER + RLS + grant hygiene migration', () => {
+  test('migration file exists with a 14-digit timestamp prefix', () => {
+    // readBatchMigration asserts existence + prefix
+    expect(readBatchMigration().length).toBeGreaterThan(0);
+  });
+
+  describe('SEC-54 — handle_new_user search_path pin', () => {
+    test('re-creates handle_new_user', () => {
+      expect(readBatchMigration()).toMatch(
+        /create or replace function\s+public\.handle_new_user\s*\(\s*\)/i
+      );
+    });
+
+    test('pins the search_path to empty', () => {
+      expect(readBatchMigration()).toMatch(/set search_path\s*=\s*''/i);
+    });
+
+    test('body is schema-qualified (public.profiles), so search_path=\'\' is safe', () => {
+      expect(readBatchMigration()).toMatch(/insert into\s+public\.profiles/i);
+    });
+  });
+
+  describe('SEC-56 — oauth_connections write lockdown', () => {
+    test('revokes INSERT/UPDATE/DELETE from authenticated', () => {
+      expect(readBatchMigration()).toMatch(
+        /revoke\s+insert,\s*update,\s*delete\s+on\s+public\.oauth_connections\s+from\s+authenticated/i
+      );
+    });
+
+    test('revokes INSERT/UPDATE/DELETE from anon', () => {
+      expect(readBatchMigration()).toMatch(
+        /revoke\s+insert,\s*update,\s*delete\s+on\s+public\.oauth_connections\s+from\s+anon/i
+      );
+    });
+
+    test('does NOT revoke SELECT (owner read must survive)', () => {
+      // guard against an over-broad revoke that also strips owner SELECT
+      expect(readBatchMigration()).not.toMatch(
+        /revoke[^;]*\bselect\b[^;]*on\s+public\.oauth_connections/i
+      );
+    });
+  });
+
+  describe('BUGS-65 — revoke PUBLIC execute on 2 newer trigger fns', () => {
+    const fns = [
+      'block_admin_is_suspended_self_set',
+      'prevent_feature_entitlement_self_grant',
+    ];
+
+    fns.forEach((fn) => {
+      test(`revokes EXECUTE on ${fn} from public/anon/authenticated`, () => {
+        expect(readBatchMigration()).toMatch(
+          new RegExp(
+            `revoke execute on function\\s+public\\.${fn}\\s*\\(\\s*\\)\\s+from\\s+public,\\s*anon,\\s*authenticated`,
+            'i'
+          )
+        );
+      });
+
+      test(`retains EXECUTE on ${fn} for service_role`, () => {
+        expect(readBatchMigration()).toMatch(
+          new RegExp(
+            `grant execute on function\\s+public\\.${fn}\\s*\\(\\s*\\)\\s+to\\s+service_role`,
+            'i'
+          )
+        );
+      });
+    });
+  });
+});


### PR DESCRIPTION
## Summary

One SQL migration (`20260704180000_sec54_sec56_bugs65_secdef_rls_grant_batch.sql`) carrying three defence-in-depth findings from the 2026-06-30 codebase review (epic KAN-350):

- **SEC-54** (`web-secdef-1`) — the `handle_new_user` SECURITY DEFINER trigger shipped with a mutable (unpinned) `search_path` (the classic search_path-injection priv-esc vector and the Supabase `function_search_path_mutable` advisor finding; the 2026-06-21 sweep pinned ~11 others but missed this one). Re-create it with `set search_path = ''` **and** a fully schema-qualified body (`public.profiles`; built-ins resolve via the always-implicit `pg_catalog`) so it is correct on every env regardless of whether that env still carries the original unqualified body.
- **SEC-56** (`web-oauth-5`) — the `oauth_connections` UPDATE RLS policy was column-unrestricted, so an authenticated user could repoint their `refresh_token_secret_id` at another user's Vault secret and have the server mint live Google/Microsoft tokens for the victim (cross-user token-theft primitive). Revoke direct `INSERT/UPDATE/DELETE` from `authenticated` + `anon`; all legitimate writes already go through the service-role `upsertConnection` path. Owner `SELECT` (table grant + RLS `oauth_connections_owner_select`) retained.
- **BUGS-65** (B9 residual, post-BUGS-48) — `block_admin_is_suspended_self_set` and `prevent_feature_entitlement_self_grant` (created 2026-06-22, one day after BUGS-48's revoke sweep closed) still carried the default PUBLIC EXECUTE grant. Both `RETURNS trigger` (grant-independent when fired as triggers), but revoke PUBLIC/anon/authenticated and keep `service_role`, mirroring BUGS-48's shape.

### Verification on DEV (`ilprytcrnqyrsbsrfujj`)
Migration applied + verified via Supabase MCP:
- `handle_new_user.proconfig` = `search_path=""` (pinned).
- `oauth_connections`: `anon`/`authenticated` retain only `REFERENCES,SELECT,TRIGGER,TRUNCATE` — no `INSERT/UPDATE/DELETE`.
- Both trigger fns: `EXECUTE` only for `postgres,service_role`.
- `get_advisors(security)` no longer reports `function_search_path_mutable` for `handle_new_user` nor `*_security_definer_function_executable` for either trigger fn. (Remaining WARNs are the intentional `admin_*` RPCs per BUGS-60 and `search_by_contact_hash` — out of scope; that's SEC-43.)

**Staging + prod are deferred to a supervised promote** (autopilot never writes prod DB; same pattern as SEC-45). The committed migration carries to those envs in dev→staging→prod order.

MCP coverage: N/A — infrastructure / RLS-grant hardening, no user-facing data-model change (per KAN-222 "when it doesn't apply").

## Jira Ticket

SEC-54, SEC-56, BUGS-65

## Checklist

- [x] Unit tests added/updated for new/changed functionality — new `tests/unit/sec54-sec56-bugs65-secdef-rls-grant-batch.test.js` (12 assertions), static guards against dropping/weakening any of the three controls
- [x] All existing tests pass (`npm run test:unit`) — new suite green + all 158 migration-directory-scanning tests green; no existing test touched
- [x] Lint passes (`npm run lint`) — SQL + a new `.test.js` only
- [x] Type check passes (`npm run type-check`) — no TS/app-code change
- [ ] Build succeeds (`npm run build`) — CI
- [x] Coverage has not decreased — net-new tests only
- [x] No eslint-disable or ts-ignore without KAN-XX reference — none added
- [x] ARCHITECTURE.md updated if architectural changes were made — N/A (SQL grant/search_path hygiene, no architecture change)
- [x] Ops routine / Control-Room registry updated if scheduled-routine behaviour changed — N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_017pST4GdZZiFmrUZz6jpkFi)_