### PR TITLE
SEC-55: scrub OAuth secrets & PII from Sentry (web beforeSend/beforeBreadcrumb)

### DIFF
--- a/instrumentation-client.ts
+++ b/instrumentation-client.ts
@@ -24,6 +24,8 @@
  * non-prefixed `IS_SENTRY_ENABLED`.
  */
 import * as Sentry from '@sentry/nextjs';
+// SEC-55: strip OAuth secrets / PII from events + breadcrumbs before they ship.
+import { scrubSentryEvent, scrubSentryBreadcrumb } from '@/lib/sentry-scrub';
 
 const dsn = process.env.NEXT_PUBLIC_SENTRY_DSN;
 
@@ -39,6 +41,8 @@ if (dsn) {
     replaysSessionSampleRate: 0,
     replaysOnErrorSampleRate: 0,
     sendDefaultPii: false,
+    beforeSend: (event) => scrubSentryEvent(event),
+    beforeBreadcrumb: (breadcrumb) => scrubSentryBreadcrumb(breadcrumb),
     release: process.env.NEXT_PUBLIC_RELEASE_SHA || undefined,
   });
 }

--- a/instrumentation.ts
+++ b/instrumentation.ts
@@ -31,6 +31,12 @@ export async function register() {
     return;
   }
 
+  // SEC-55: strip OAuth secrets / PII from events + breadcrumbs before they
+  // leave the process. Complements (does not replace) sendDefaultPii:false.
+  const { scrubSentryEvent, scrubSentryBreadcrumb } = await import(
+    '@/lib/sentry-scrub'
+  );
+
   if (process.env.NEXT_RUNTIME === 'nodejs') {
     const Sentry = await import('@sentry/nextjs');
     Sentry.init({
@@ -43,6 +49,8 @@ export async function register() {
       // Sensitive params (search queries, slugs of private profiles)
       // shouldn't end up in Sentry events.
       sendDefaultPii: false,
+      beforeSend: (event) => scrubSentryEvent(event),
+      beforeBreadcrumb: (breadcrumb) => scrubSentryBreadcrumb(breadcrumb),
       release: process.env.NEXT_PUBLIC_RELEASE_SHA || undefined,
     });
   }
@@ -54,6 +62,8 @@ export async function register() {
       environment: process.env.VERCEL_ENV || process.env.NODE_ENV,
       tracesSampleRate: parseFloat(process.env.SENTRY_TRACES_SAMPLE_RATE || '0.1'),
       sendDefaultPii: false,
+      beforeSend: (event) => scrubSentryEvent(event),
+      beforeBreadcrumb: (breadcrumb) => scrubSentryBreadcrumb(breadcrumb),
       release: process.env.NEXT_PUBLIC_RELEASE_SHA || undefined,
     });
   }

--- a/src/lib/sentry-scrub.ts
+++ b/src/lib/sentry-scrub.ts
@@ -1,0 +1,211 @@
+/**
+ * SEC-55: OAuth-secret & PII scrubbing for Sentry events + breadcrumbs.
+ *
+ * `sendDefaultPii:false` stops Sentry attaching cookies/IP by default, but it
+ * does NOT strip application-level secrets that end up in request URLs, query
+ * strings, bodies or breadcrumb URLs — PKCE verifiers, single-use auth codes,
+ * `state`, refresh/access tokens and client secrets. The MCP OAuth design
+ * (docs/MCP_OAUTH_DESIGN.md) mandates a `beforeSend` scrubbing layer; this
+ * module is that layer, shared by all three web Sentry inits (server + edge in
+ * `instrumentation.ts`, browser in `instrumentation-client.ts`). An identical
+ * copy lives in `lyra-mcp-server/src/sentry-scrub.ts` for the MCP server.
+ *
+ * The functions mutate the event/breadcrumb in place (the Sentry-idiomatic
+ * pattern) and also return it, so a call site can write
+ * `beforeSend: (event) => scrubSentryEvent(event)`.
+ *
+ * Design notes:
+ * - Sensitive KEYS are deleted outright (not masked) so "the key is removed
+ *   from the captured event" is literally true — see SEC-55 acceptance.
+ * - `/oauth/*` and `/api/convene/oauth/*` URLs have their ENTIRE query string
+ *   redacted, because the auth code / state / token live there and enumerating
+ *   every possible param name is fragile.
+ * - All other URLs only drop the enumerated sensitive params, preserving
+ *   benign query context (pagination, etc.) for debugging.
+ */
+
+/** Parameter / body-field / header names whose values must never reach Sentry. */
+const SENSITIVE_KEYS: ReadonlySet<string> = new Set([
+  'code',
+  'code_verifier',
+  'state',
+  'refresh_token',
+  'access_token',
+  'client_secret',
+  'token',
+]);
+
+/** Header names that carry credentials wholesale and are dropped entirely. */
+const SENSITIVE_HEADERS: ReadonlySet<string> = new Set([
+  'authorization',
+  'cookie',
+  'set-cookie',
+  'x-api-key',
+]);
+
+/** Paths whose query string is redacted in full (auth code / state / token live here). */
+const OAUTH_PATH_RE = /\/(?:oauth|api\/convene\/oauth)(?:\/|$|\?)/i;
+
+const FILTERED = '[Filtered]';
+const MAX_DEPTH = 8;
+
+function isPlainObject(v: unknown): v is Record<string, unknown> {
+  return typeof v === 'object' && v !== null && !Array.isArray(v);
+}
+
+/** Delete enumerated sensitive keys anywhere in a nested plain-object/array tree. */
+function scrubObjectInPlace(obj: Record<string, unknown>, depth: number): void {
+  if (depth > MAX_DEPTH) return;
+  for (const key of Object.keys(obj)) {
+    if (SENSITIVE_KEYS.has(key.toLowerCase())) {
+      delete obj[key];
+      continue;
+    }
+    const val = obj[key];
+    if (Array.isArray(val)) {
+      for (const el of val) {
+        if (isPlainObject(el)) scrubObjectInPlace(el, depth + 1);
+      }
+    } else if (isPlainObject(val)) {
+      scrubObjectInPlace(val, depth + 1);
+    }
+  }
+}
+
+/** Strip sensitive params from a raw `a=b&c=d` query string. */
+function scrubQueryStringValue(qs: string): string {
+  const params = new URLSearchParams(qs);
+  let mutated = false;
+  for (const key of [...params.keys()]) {
+    if (SENSITIVE_KEYS.has(key.toLowerCase())) {
+      params.delete(key);
+      mutated = true;
+    }
+  }
+  return mutated ? params.toString() : qs;
+}
+
+/**
+ * Redact a URL string. OAuth paths lose their whole query; every other URL
+ * only loses the enumerated sensitive params. Fragment/host/path are kept.
+ */
+export function scrubUrl(url: string): string {
+  const qIdx = url.indexOf('?');
+  if (qIdx === -1) return url;
+  const path = url.slice(0, qIdx);
+  const query = url.slice(qIdx + 1);
+
+  if (OAUTH_PATH_RE.test(path)) {
+    return `${path}?${FILTERED}`;
+  }
+
+  const params = new URLSearchParams(query);
+  let mutated = false;
+  for (const key of [...params.keys()]) {
+    if (SENSITIVE_KEYS.has(key.toLowerCase())) {
+      params.delete(key);
+      mutated = true;
+    }
+  }
+  if (!mutated) return url;
+  const rebuilt = params.toString();
+  return rebuilt ? `${path}?${rebuilt}` : path;
+}
+
+function scrubHeaders(headers: Record<string, unknown>): void {
+  for (const key of Object.keys(headers)) {
+    const lower = key.toLowerCase();
+    if (SENSITIVE_HEADERS.has(lower) || SENSITIVE_KEYS.has(lower)) {
+      delete headers[key];
+    }
+  }
+}
+
+/** Scrub a JSON-encoded request body; non-JSON strings are returned unchanged. */
+function scrubJsonString(body: string): string {
+  try {
+    const parsed: unknown = JSON.parse(body);
+    if (isPlainObject(parsed)) {
+      scrubObjectInPlace(parsed, 0);
+      return JSON.stringify(parsed);
+    }
+    if (Array.isArray(parsed)) {
+      for (const el of parsed) if (isPlainObject(el)) scrubObjectInPlace(el, 0);
+      return JSON.stringify(parsed);
+    }
+  } catch {
+    // Not JSON — leave untouched (form bodies are handled as objects upstream).
+  }
+  return body;
+}
+
+function scrubRequest(req: Record<string, unknown>): void {
+  if (typeof req.url === 'string') req.url = scrubUrl(req.url);
+
+  if (typeof req.query_string === 'string') {
+    req.query_string = scrubQueryStringValue(req.query_string);
+  } else if (isPlainObject(req.query_string)) {
+    scrubObjectInPlace(req.query_string, 0);
+  } else if (Array.isArray(req.query_string)) {
+    req.query_string = req.query_string.filter(
+      (pair) =>
+        !(
+          Array.isArray(pair) &&
+          typeof pair[0] === 'string' &&
+          SENSITIVE_KEYS.has(pair[0].toLowerCase())
+        ),
+    );
+  }
+
+  if (isPlainObject(req.data)) scrubObjectInPlace(req.data, 0);
+  else if (typeof req.data === 'string') req.data = scrubJsonString(req.data);
+
+  if (isPlainObject(req.headers)) scrubHeaders(req.headers);
+  if (isPlainObject(req.cookies)) scrubObjectInPlace(req.cookies, 0);
+}
+
+/** Redact any URL-shaped tokens embedded in a breadcrumb message. */
+function scrubMessageUrls(message: string): string {
+  return message
+    .split(' ')
+    .map((token) => (token.includes('?') ? scrubUrl(token) : token))
+    .join(' ');
+}
+
+function scrubBreadcrumbInPlace(bc: Record<string, unknown>): void {
+  if (typeof bc.message === 'string' && bc.message.includes('?')) {
+    bc.message = scrubMessageUrls(bc.message);
+  }
+  if (isPlainObject(bc.data)) {
+    if (typeof bc.data.url === 'string') bc.data.url = scrubUrl(bc.data.url);
+    scrubObjectInPlace(bc.data, 0);
+  }
+}
+
+/**
+ * `beforeSend` hook. Scrubs request URL/query/body/headers/cookies and any
+ * breadcrumbs carried on the event. Mutates in place and returns the event.
+ */
+export function scrubSentryEvent<T>(event: T): T {
+  if (!isPlainObject(event)) return event;
+
+  if (isPlainObject(event.request)) scrubRequest(event.request);
+
+  const bc = event.breadcrumbs;
+  if (Array.isArray(bc)) {
+    for (const crumb of bc) if (isPlainObject(crumb)) scrubBreadcrumbInPlace(crumb);
+  } else if (isPlainObject(bc) && Array.isArray(bc.values)) {
+    for (const crumb of bc.values) if (isPlainObject(crumb)) scrubBreadcrumbInPlace(crumb);
+  }
+
+  return event;
+}
+
+/**
+ * `beforeSendBreadcrumb` hook. Scrubs a single breadcrumb's message + data URL.
+ * Mutates in place and returns the breadcrumb.
+ */
+export function scrubSentryBreadcrumb<T>(breadcrumb: T): T {
+  if (isPlainObject(breadcrumb)) scrubBreadcrumbInPlace(breadcrumb);
+  return breadcrumb;
+}

--- a/tests/unit/sentry-scrub.test.ts
+++ b/tests/unit/sentry-scrub.test.ts
@@ -1,0 +1,229 @@
+/**
+ * SEC-55: verify the Sentry scrubbing layer strips OAuth secrets / PII from
+ * events and breadcrumbs before they ship. Acceptance: the enumerated keys are
+ * removed from captured events and `/oauth/*` URLs are redacted.
+ */
+import {
+  scrubSentryEvent,
+  scrubSentryBreadcrumb,
+  scrubUrl,
+} from '@/lib/sentry-scrub';
+
+const SENSITIVE_KEYS = [
+  'code',
+  'code_verifier',
+  'state',
+  'refresh_token',
+  'access_token',
+  'client_secret',
+  'token',
+];
+
+describe('scrubUrl', () => {
+  it('redacts the entire query string on /oauth/* URLs', () => {
+    const out = scrubUrl(
+      'https://checklyra.com/oauth/token?code=abc123&code_verifier=xyz&state=nonce',
+    );
+    expect(out).toBe('https://checklyra.com/oauth/token?[Filtered]');
+    expect(out).not.toContain('abc123');
+    expect(out).not.toContain('xyz');
+    expect(out).not.toContain('nonce');
+  });
+
+  it('redacts /api/convene/oauth/* URLs in full', () => {
+    const out = scrubUrl('/api/convene/oauth/callback?code=secretcode&next=/home');
+    expect(out).toBe('/api/convene/oauth/callback?[Filtered]');
+    expect(out).not.toContain('secretcode');
+  });
+
+  it('drops only sensitive params on non-oauth URLs, keeping benign context', () => {
+    const out = scrubUrl(
+      'https://checklyra.com/search?q=teachers&access_token=leaked&page=2',
+    );
+    expect(out).not.toContain('leaked');
+    expect(out).not.toContain('access_token');
+    expect(out).toContain('q=teachers');
+    expect(out).toContain('page=2');
+  });
+
+  it('leaves URLs without a query string untouched', () => {
+    expect(scrubUrl('https://checklyra.com/oauth/authorize')).toBe(
+      'https://checklyra.com/oauth/authorize',
+    );
+    expect(scrubUrl('/dashboard')).toBe('/dashboard');
+  });
+
+  it('is case-insensitive on param names', () => {
+    const out = scrubUrl('/callback?Refresh_Token=x&keep=1');
+    expect(out).not.toContain('x');
+    expect(out).toContain('keep=1');
+  });
+});
+
+describe('scrubSentryEvent — request URL / query / body', () => {
+  it('redacts the request URL for an oauth token exchange', () => {
+    const event = {
+      request: {
+        url: 'https://checklyra.com/oauth/token?code=authcode&client_secret=shh',
+      },
+    };
+    const out = scrubSentryEvent(event)!;
+    expect(out.request.url).toBe('https://checklyra.com/oauth/token?[Filtered]');
+    expect(JSON.stringify(out)).not.toContain('authcode');
+    expect(JSON.stringify(out)).not.toContain('shh');
+  });
+
+  it('removes every enumerated key from a JSON request body (object form)', () => {
+    const event = {
+      request: {
+        url: '/api/convene/oauth/token',
+        data: {
+          grant_type: 'authorization_code',
+          code: 'AUTH_CODE',
+          code_verifier: 'PKCE_VERIFIER',
+          refresh_token: 'RT',
+          access_token: 'AT',
+          client_secret: 'CS',
+          token: 'TOK',
+          state: 'STATE',
+          redirect_uri: 'https://app/cb',
+        },
+      },
+    };
+    const out = scrubSentryEvent(event)!;
+    const data = out.request.data as Record<string, unknown>;
+    for (const key of SENSITIVE_KEYS) {
+      expect(data).not.toHaveProperty(key);
+    }
+    // Benign fields survive.
+    expect(data.grant_type).toBe('authorization_code');
+    expect(data.redirect_uri).toBe('https://app/cb');
+    // No secret value anywhere in the serialised event.
+    const serialised = JSON.stringify(out);
+    for (const secret of ['AUTH_CODE', 'PKCE_VERIFIER', 'RT', 'AT', 'CS', 'TOK', 'STATE']) {
+      expect(serialised).not.toContain(secret);
+    }
+  });
+
+  it('scrubs a JSON string request body', () => {
+    const event = {
+      request: {
+        data: JSON.stringify({ code: 'SECRET', foo: 'bar' }),
+      },
+    };
+    const out = scrubSentryEvent(event)!;
+    expect(out.request.data).not.toContain('SECRET');
+    expect(out.request.data).toContain('bar');
+  });
+
+  it('strips sensitive params from request.query_string (raw string form)', () => {
+    const event = {
+      request: { query_string: 'code=SECRET&page=1&refresh_token=RT' },
+    };
+    const out = scrubSentryEvent(event)!;
+    expect(out.request.query_string).not.toContain('SECRET');
+    expect(out.request.query_string).not.toContain('RT');
+    expect(out.request.query_string).toContain('page=1');
+  });
+
+  it('drops Authorization / Cookie headers wholesale', () => {
+    const event = {
+      request: {
+        headers: {
+          Authorization: 'Bearer leaked.jwt.token',
+          Cookie: 'sb-access-token=leaked',
+          'Content-Type': 'application/json',
+          token: 'raw-token',
+        },
+      },
+    };
+    const out = scrubSentryEvent(event)!;
+    const headers = out.request.headers as Record<string, unknown>;
+    expect(headers).not.toHaveProperty('Authorization');
+    expect(headers).not.toHaveProperty('Cookie');
+    expect(headers).not.toHaveProperty('token');
+    expect(headers['Content-Type']).toBe('application/json');
+    expect(JSON.stringify(out)).not.toContain('leaked');
+  });
+
+  it('scrubs nested secrets inside the body tree', () => {
+    const event = {
+      request: {
+        data: { outer: { inner: { refresh_token: 'DEEP', keep: 'ok' } } },
+      },
+    };
+    const out = scrubSentryEvent(event)!;
+    const inner = (out.request.data as { outer: { inner: Record<string, unknown> } })
+      .outer.inner;
+    expect(inner).not.toHaveProperty('refresh_token');
+    expect(inner.keep).toBe('ok');
+  });
+});
+
+describe('scrubSentryEvent — breadcrumbs', () => {
+  it('redacts oauth URLs in breadcrumb data + strips sensitive keys', () => {
+    const event = {
+      breadcrumbs: [
+        {
+          category: 'fetch',
+          data: {
+            url: 'https://checklyra.com/oauth/token?code=BCRUMB',
+            access_token: 'AT_IN_CRUMB',
+          },
+        },
+      ],
+    };
+    const out = scrubSentryEvent(event)!;
+    const crumb = out.breadcrumbs[0] as { data: Record<string, unknown> };
+    expect(crumb.data.url).toBe('https://checklyra.com/oauth/token?[Filtered]');
+    expect(crumb.data).not.toHaveProperty('access_token');
+    expect(JSON.stringify(out)).not.toContain('BCRUMB');
+    expect(JSON.stringify(out)).not.toContain('AT_IN_CRUMB');
+  });
+
+  it('handles the { breadcrumbs: { values: [] } } envelope shape', () => {
+    const event = {
+      breadcrumbs: {
+        values: [{ data: { url: '/search?token=SECRET&q=x' } }],
+      },
+    };
+    const out = scrubSentryEvent(event)!;
+    const crumb = out.breadcrumbs.values[0] as { data: Record<string, unknown> };
+    expect(crumb.data.url).not.toContain('SECRET');
+    expect(crumb.data.url).toContain('q=x');
+  });
+});
+
+describe('scrubSentryBreadcrumb', () => {
+  it('redacts a URL embedded in a breadcrumb message', () => {
+    const bc = {
+      category: 'xhr',
+      message: 'GET https://checklyra.com/oauth/authorize?code=MSGCODE',
+    };
+    const out = scrubSentryBreadcrumb(bc)!;
+    expect(out.message).not.toContain('MSGCODE');
+    expect(out.message).toContain('[Filtered]');
+  });
+
+  it('scrubs sensitive keys in breadcrumb data', () => {
+    const bc = { data: { client_secret: 'CS_CRUMB', ok: 1 } };
+    const out = scrubSentryBreadcrumb(bc)!;
+    expect(out.data).not.toHaveProperty('client_secret');
+    expect(out.data.ok).toBe(1);
+  });
+});
+
+describe('robustness', () => {
+  it('returns null / undefined / primitives unchanged', () => {
+    expect(scrubSentryEvent(null)).toBeNull();
+    expect(scrubSentryEvent(undefined)).toBeUndefined();
+    expect(scrubSentryBreadcrumb(null)).toBeNull();
+    expect(scrubSentryEvent(42 as unknown)).toBe(42);
+  });
+
+  it('does not throw on an event with no request/breadcrumbs', () => {
+    const event = { message: 'boom', level: 'error' };
+    expect(() => scrubSentryEvent(event)).not.toThrow();
+    expect(scrubSentryEvent(event)).toBe(event);
+  });
+});


### PR DESCRIPTION
## What & Why

Sentry init had no `beforeSend` scrubbing — PKCE verifiers, single-use auth codes, `state`, refresh/access tokens, client secrets and PII could leak into events / breadcrumbs / transaction URLs (visible to anyone with Sentry access + sub-processors). `sendDefaultPii:false` alone does not strip app-level secrets that end up in request URLs, query strings, bodies or breadcrumb URLs. The MCP OAuth design mandates this scrubbing layer; it was absent. (SEC-55, epic KAN-350.)

## Changes

- **New `src/lib/sentry-scrub.ts`** — framework-agnostic, no imports. Pure `scrubSentryEvent` / `scrubSentryBreadcrumb` (+ exported `scrubUrl`) that mutate in place:
  - Delete enumerated sensitive keys — `code, code_verifier, state, refresh_token, access_token, client_secret, token` — from request bodies (object **and** JSON-string form), query strings, breadcrumb data, and headers; **case-insensitive**, recursive (depth-guarded).
  - Drop `Authorization / Cookie / Set-Cookie / x-api-key` headers wholesale.
  - Redact `/oauth/*` and `/api/convene/oauth/*` URL query strings **in full**; strip only the sensitive params from every other URL (benign context like `q=`, `page=` is kept for debugging).
- Wired as `beforeSend` + `beforeBreadcrumb` into all three web inits: nodejs + edge in `instrumentation.ts`, browser in `instrumentation-client.ts`. `sendDefaultPii:false` unchanged.

## Tests

`tests/unit/sentry-scrub.test.ts` — 17 tests asserting the enumerated keys are **removed** from captured events (URL, query_string, JSON body, nested body, headers, breadcrumbs in both `[]` and `{values:[]}` shapes) and `/oauth/*` redaction. tsc + eslint clean; full unit suite **163 suites / 2030 tests** green; no existing test touched.

## Security Review

Defence-in-depth on the egress path; no new inputs, no auth/RLS surface. Fails safe — non-object events pass through untouched; unknown fields are preserved.

## Architecture Impact

No env vars / deps / schema. Paired MCP half (same scrub logic + init wiring): **luisa-sys/lyra-mcp-server** `claude/sec-55-sentry-scrub`. Observability/infra change (MCP-main lockstep n/a), cross-linked for parity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V8NyfFkDSjptS94FFpmSCL

---
_Generated by [Claude Code](https://claude.ai/code/session_01V8NyfFkDSjptS94FFpmSCL)_