### PR TITLE
SEC-43: reconcile admin-RPC EXECUTE policy + add B9 CI guard

### DIFF
--- a/docs/DAILY_SECURITY_CHECK.md
+++ b/docs/DAILY_SECURITY_CHECK.md
@@ -234,8 +234,12 @@ Run all SQL probes via Supabase MCP `execute_sql` (read-only SELECT) against **p
          OR has_function_privilege('authenticated', p.oid, 'EXECUTE'))
   ORDER BY p.proname;
   ```
-- **PASS:** every row is either an intended-public read (documented) or a `trigger`/`event_trigger` return type (not RPC-invokable). No new anon/authenticated grant on a *callable* definer function.
+- **PASS:** every row is either an intended-public read (documented), a `trigger`/`event_trigger` return type (not RPC-invokable), or an **allowlisted self-gating admin RPC** (see *Accepted exceptions* below). No *new* anon/authenticated grant on a *callable* definer function.
 - **FAIL:** a callable definer function exposed to anon/authenticated → 🟡 (🟠 if it mutates or leaks cross-user data) → BUGS-44 pattern; `REVOKE EXECUTE … FROM anon, authenticated, PUBLIC`.
+- **Accepted exceptions — allowlisted, do NOT file a new SEC ticket (SEC-43 / BUGS-60 reconciliation):** the admin-console RPCs `admin_list_users(...)` and `admin_filter_profile_ids(...)` are *intentionally* `authenticated`-executable. They are `SECURITY DEFINER` but **self-gate** on `auth.uid()` + `is_admin` (`... where user_id = auth.uid() and is_admin = true`), so a non-admin caller gets `admin only` (`42501`), never data. The admin pages (`src/app/admin/users/page.tsx`, `actions.ts`) MUST call them via the *authenticated* admin session — a service-role call (`auth.uid()=null`) fails the functions' own guard, so a naive `REVOKE … FROM authenticated` breaks the admin console with **no** security gain (it removes the outer grant while the self-gate stays the real control). `anon`/`PUBLIC` remain revoked. The intended ACL is committed in `supabase/migrations/20260628200000_bugs60_grant_admin_rpc_authenticated.sql` and locked by `tests/unit/sec43-admin-rpc-acl-guard.test.js`.
+  - **Expected steady state (PASS) for these two:** `anon_exec=false` **AND** `auth_exec=true`.
+  - **STILL a FAIL — do file:** either fn shows `anon_exec=true`; a *new* callable definer fn appears; or the self-gate (`auth.uid()` + `is_admin`) is removed from a function body.
+  - **History:** this exact owner-accepted config was re-filed three times (SEC-29 → SEC-42 → SEC-43) before being allowlisted here — the daily probe was repeatedly rediscovering an intended state. Allowlisting it is the fix for the probe noise; the self-gate + committed ACL + this guard are the compensating controls.
 
 ---
 

--- a/tests/unit/sec43-admin-rpc-acl-guard.test.js
+++ b/tests/unit/sec43-admin-rpc-acl-guard.test.js
@@ -1,0 +1,156 @@
+/**
+ * SEC-43 — Admin RPC EXECUTE policy reconciliation + B9 CI guard.
+ *
+ * The daily B9 security probe (docs/DAILY_SECURITY_CHECK.md) repeatedly flagged
+ * `admin_list_users` and `admin_filter_profile_ids` as `authenticated`-executable
+ * SECURITY DEFINER functions and a new SEC ticket was filed each time
+ * (SEC-29 -> SEC-42 -> SEC-43). All three were the SAME owner-accepted config:
+ *
+ *   BUGS-60 (Done) established that these two admin-console RPCs are INTENTIONALLY
+ *   `authenticated`-executable. They self-gate internally on
+ *   `auth.uid()` + `is_admin` (`... where user_id = auth.uid() and is_admin = true`),
+ *   so a non-admin authenticated caller gets `admin only` (42501), never data. The
+ *   admin pages (src/app/admin/users/page.tsx, actions.ts) MUST call them via the
+ *   *authenticated* admin session, because a service-role call (auth.uid()=null)
+ *   would fail the functions' own guard. A naive `REVOKE ... FROM authenticated`
+ *   (which SEC-43's own literal "Implementation Steps" proposed) breaks the admin
+ *   console with no security gain, and the grant just gets re-applied -> the probe
+ *   re-files the finding. anon/PUBLIC stay revoked.
+ *
+ * The reconciliation (this ticket): the accepted ACL is allowlisted in the B9 spec
+ * so the probe stops filing duplicates, and locked here so a future edit cannot
+ * silently re-break the console (naive full-revoke) or silently drop the
+ * anon/PUBLIC defence-in-depth.
+ *
+ * These are static file-content checks (migrations are applied via the Supabase
+ * MCP after review, per CLAUDE.md "Supabase Migration Rules"), not DB-execution
+ * tests. NB per the Test Integrity Policy: this is NET-NEW coverage — it changes
+ * no existing assertion.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const repoRoot = path.join(__dirname, '../..');
+const migrationsDir = path.join(repoRoot, 'supabase/migrations');
+const docPath = path.join(repoRoot, 'docs/DAILY_SECURITY_CHECK.md');
+
+// The intended-ACL migration (BUGS-60). Its 14-digit timestamp prefix is the
+// ordering fence: no LATER committed migration may revoke `authenticated`
+// EXECUTE from these two RPCs, or a fresh-DB replay ends in the broken state.
+const BUGS60_PREFIX = 20260628200000;
+
+const ADMIN_RPCS = ['admin_list_users', 'admin_filter_profile_ids'];
+
+function readBugs60Migration() {
+  const files = fs.readdirSync(migrationsDir);
+  const match = files.find((f) =>
+    /_bugs60_grant_admin_rpc_authenticated\.sql$/.test(f)
+  );
+  expect(match).toBeTruthy();
+  expect(path.basename(match)).toMatch(/^\d{14}_/);
+  expect(parseInt(path.basename(match).slice(0, 14), 10)).toBe(BUGS60_PREFIX);
+  return fs.readFileSync(path.join(migrationsDir, match), 'utf8');
+}
+
+function migrationPrefix(file) {
+  return parseInt(path.basename(file).slice(0, 14), 10);
+}
+
+describe('SEC-43 — admin RPC ACL reconciliation (B9 CI guard)', () => {
+  describe('intended ACL committed in the BUGS-60 migration', () => {
+    test('migration exists with a 14-digit timestamp prefix', () => {
+      expect(readBugs60Migration().length).toBeGreaterThan(0);
+    });
+
+    test.each(ADMIN_RPCS)(
+      'revokes EXECUTE from anon + public on %s (defence-in-depth kept)',
+      (fn) => {
+        const sql = readBugs60Migration();
+        // e.g. `revoke execute on function public.admin_list_users(...) from anon, public;`
+        const re = new RegExp(
+          `revoke\\s+execute\\s+on\\s+function\\s+public\\.${fn}\\s*\\([^)]*\\)\\s+from\\s+anon,\\s*public`,
+          'i'
+        );
+        expect(sql).toMatch(re);
+      }
+    );
+
+    test.each(ADMIN_RPCS)(
+      'grants EXECUTE to authenticated on %s (admin console needs it)',
+      (fn) => {
+        const sql = readBugs60Migration();
+        const re = new RegExp(
+          `grant\\s+execute\\s+on\\s+function\\s+public\\.${fn}\\s*\\([^)]*\\)\\s+to\\s+authenticated`,
+          'i'
+        );
+        expect(sql).toMatch(re);
+      }
+    );
+
+    test.each(ADMIN_RPCS)(
+      'never grants EXECUTE to anon or public on %s',
+      (fn) => {
+        const sql = readBugs60Migration();
+        const re = new RegExp(
+          `grant\\s+execute\\s+on\\s+function\\s+public\\.${fn}\\s*\\([^)]*\\)\\s+to\\s+[^;]*\\b(anon|public)\\b`,
+          'i'
+        );
+        expect(sql).not.toMatch(re);
+      }
+    );
+  });
+
+  describe('no later migration re-breaks the console (naive revoke-from-authenticated)', () => {
+    // The recurring regression: SEC-43's literal steps, or a future migration,
+    // revoke `authenticated` EXECUTE on these RPCs. Guard that no committed
+    // migration ordered AFTER BUGS-60 does so.
+    const laterFiles = fs
+      .readdirSync(migrationsDir)
+      .filter((f) => /^\d{14}_.*\.sql$/.test(f) && migrationPrefix(f) > BUGS60_PREFIX);
+
+    test.each(ADMIN_RPCS)(
+      'no post-BUGS-60 migration revokes EXECUTE from authenticated on %s',
+      (fn) => {
+        const offenders = laterFiles.filter((f) => {
+          const sql = fs.readFileSync(path.join(migrationsDir, f), 'utf8');
+          // `revoke execute on function public.<fn>(...) from ... authenticated ...`
+          const re = new RegExp(
+            `revoke\\s+execute\\s+on\\s+function\\s+public\\.${fn}\\s*\\([^)]*\\)\\s+from\\s+[^;]*\\bauthenticated\\b`,
+            'i'
+          );
+          return re.test(sql);
+        });
+        expect(offenders).toEqual([]);
+      }
+    );
+  });
+
+  describe('B9 spec allowlists the accepted exception (kills probe re-filing)', () => {
+    const doc = fs.readFileSync(docPath, 'utf8');
+
+    test('DAILY_SECURITY_CHECK.md exists and has a B9 section', () => {
+      expect(doc).toMatch(/###\s+B9\b/);
+    });
+
+    test('B9 names an "Accepted exceptions" allowlist referencing SEC-43/BUGS-60', () => {
+      expect(doc).toMatch(/Accepted exceptions/i);
+      expect(doc).toMatch(/SEC-43\s*\/\s*BUGS-60/i);
+    });
+
+    test.each(ADMIN_RPCS)('allowlist names %s', (fn) => {
+      expect(doc).toContain(fn);
+    });
+
+    test('allowlist records the self-gate as the real control', () => {
+      expect(doc).toMatch(/self-gate/i);
+      expect(doc).toMatch(/auth\.uid\(\)/i);
+      expect(doc).toMatch(/is_admin/i);
+    });
+
+    test('allowlist documents the accepted steady state (anon_exec=false, auth_exec=true)', () => {
+      expect(doc).toMatch(/anon_exec=false/i);
+      expect(doc).toMatch(/auth_exec=true/i);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Reconciles the recurring B9 daily-probe finding for `admin_list_users` + `admin_filter_profile_ids` and locks the accepted policy so it stops re-filing.

**Background.** The daily B9 security probe flagged these two `SECURITY DEFINER` admin-console RPCs as `authenticated`-executable and a new SEC ticket was filed each time — **SEC-29 → SEC-42 → SEC-43**, all the same owner-accepted config. **BUGS-60** (Done) established this is *intentional*: the admin pages (`src/app/admin/users/page.tsx`, `actions.ts`) call them via the **authenticated** admin session, and the functions **self-gate** on `auth.uid()` + `is_admin` (`... where user_id = auth.uid() and is_admin = true`). A service-role call (`auth.uid()=null`) fails their own guard, so a naive `REVOKE … FROM authenticated` (which SEC-43's original literal steps proposed) breaks the admin console with **no** security gain — and the grant just gets re-applied, so the probe re-files. `anon`/`PUBLIC` stay revoked (defence-in-depth kept).

**This change (no revoke, no migration, no DB write):**
- `docs/DAILY_SECURITY_CHECK.md` (B9): adds an **Accepted exceptions** allowlist for the two self-gating admin RPCs so the probe stops filing duplicates. Documents the expected steady state (`anon_exec=false` **AND** `auth_exec=true`) and what is **still a FAIL** (either fn `anon_exec=true`; a *new* callable definer fn; or the self-gate removed from a function body).
- `tests/unit/sec43-admin-rpc-acl-guard.test.js` (the "B9 CI guard"): asserts the intended ACL from the committed BUGS-60 migration (revoke anon/public, grant authenticated, never grant anon/public), guards that **no migration ordered after BUGS-60 revokes `authenticated`** from these RPCs (the recurring console-breaker), and asserts the B9 allowlist exists and names both functions.

The intended ACL was already committed (`supabase/migrations/20260628200000_bugs60_grant_admin_rpc_authenticated.sql`) and is the last migration touching these RPCs, so fresh-DB replay already ends in the correct state — nothing to migrate. This PR makes the *policy decision* explicit and test-enforced.

Note: SEC-43's Acceptance Criteria (written for the naive-revoke path) are superseded by this reconciliation; the ticket has been updated to the accepted-exception model.

MCP coverage: N/A — internal admin surface + monitoring doc/test only (no user-facing data or route).

## Jira Ticket

SEC-43 (parent SEC-1; supersedes the naive-revoke path from SEC-28/SEC-29/SEC-42; relates to BUGS-60)

## Checklist

- [x] Unit tests added/updated for new/changed functionality — net-new `sec43-admin-rpc-acl-guard.test.js` (15 assertions)
- [x] All existing tests pass — new suite + related security/migration suites green locally (42/42); no existing assertion changed (Test Integrity Policy honoured); full `npm run test:unit` runs in CI (`pr-checks.yml`)
- [ ] Lint passes — runs in CI
- [ ] Type check passes — runs in CI (JS test file; no TS surface changed)
- [ ] Build succeeds — runs in CI (no app code touched)
- [x] Coverage has not decreased — coverage added
- [x] No eslint-disable or ts-ignore without KAN-XX reference — none added
- [ ] ARCHITECTURE.md updated if architectural changes were made — N/A (no architectural change; policy reconciliation + monitoring doc/test)
- [x] Ops routine / Control-Room registry updated if scheduled-routine behaviour changed — updates the Daily Security routine's B9 spec (`docs/DAILY_SECURITY_CHECK.md`) so the probe allowlists an owner-accepted config instead of re-filing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KVMxbmmYrdvAwbdaJEZhJ2

---
_Generated by [Claude Code](https://claude.ai/code/session_01KVMxbmmYrdvAwbdaJEZhJ2)_