### PR TITLE
SEC-57: refuse credential issuance for suspended accounts

### DIFF
--- a/src/app/dashboard/settings/actions.ts
+++ b/src/app/dashboard/settings/actions.ts
@@ -2,6 +2,7 @@
 
 import { createClient } from '@/lib/supabase-server';
 import { getAdminServiceClient } from '@/lib/admin';
+import { getAccountStanding, shouldRefuseIssuance } from '@/lib/account-status';
 import { redirect } from 'next/navigation';
 import { randomBytes, createHash } from 'crypto';
 
@@ -104,6 +105,15 @@ export async function generateApiKey(name: string = 'Default'): Promise<{ key?: 
   const supabase = await createClient();
   const { data: { user } } = await supabase.auth.getUser();
   if (!user) return { error: 'Not authenticated' };
+
+  // SEC-57: refuse to mint credentials for a suspended (or unverifiable)
+  // account. Fail closed — a suspended user must not be able to obtain a new
+  // MCP API key even if they reach this action directly (the middleware
+  // redirect that normally catches them fails open on a lookup error).
+  const standing = await getAccountStanding(supabase, user.id);
+  if (shouldRefuseIssuance(standing)) {
+    return { error: 'Your account is suspended. API keys cannot be generated.' };
+  }
 
   // Generate a secure random API key
   const rawKey = `lyra_${randomBytes(24).toString('base64url')}`;

--- a/src/app/oauth/authorize/actions.ts
+++ b/src/app/oauth/authorize/actions.ts
@@ -16,6 +16,7 @@
 
 import { redirect } from 'next/navigation';
 import { createClient as createSupabaseServer } from '@/lib/supabase-server';
+import { getAccountStanding, shouldRefuseIssuance } from '@/lib/account-status';
 import { issueAuthCode } from '@/lib/oauth/codes';
 import { recordConsent } from '@/lib/oauth/consents';
 import { getOauthClient } from '@/lib/oauth/clients';
@@ -80,6 +81,15 @@ export async function submitConsent(input: DecideInput): Promise<void> {
 
   if (input.decision === 'deny') {
     redirect(buildErrorRedirect(input.redirect_uri, 'access_denied', 'user denied authorization', state));
+  }
+
+  // SEC-57: refuse to issue an authorization code for a suspended (or
+  // unverifiable) account. Fail closed — a suspended user must not be able to
+  // complete an OAuth grant even by POSTing directly to this action. Send them
+  // to the in-app suspended page rather than back to the client with a code.
+  const standing = await getAccountStanding(sb, user!.id);
+  if (shouldRefuseIssuance(standing)) {
+    redirect('/suspended');
   }
 
   // Allow path — record consent + issue code + redirect.

--- a/src/app/oauth/authorize/page.tsx
+++ b/src/app/oauth/authorize/page.tsx
@@ -12,6 +12,7 @@
 import { redirect } from 'next/navigation';
 import { createClient as createSupabaseServer } from '@/lib/supabase-server';
 import { validateAuthorizeRequest, buildErrorRedirect } from '@/lib/oauth/authorize';
+import { getAccountStanding } from '@/lib/account-status';
 import { getConsent } from '@/lib/oauth/consents';
 import { submitConsent, switchAccountAndContinue } from './actions';
 import type { Metadata } from 'next';
@@ -80,6 +81,16 @@ export default async function AuthorizePage({ searchParams }: PageProps) {
     next.searchParams.set('code_challenge', req.codeChallenge);
     next.searchParams.set('code_challenge_method', req.codeChallengeMethod);
     redirect(`/login?next=${encodeURIComponent(next.pathname + next.search)}`);
+  }
+
+  // SEC-57: don't even show the consent screen to a suspended user (the
+  // middleware normally catches this on navigation; this is defence-in-depth).
+  // Only redirect on a POSITIVE suspension — a transient lookup error must not
+  // send a good-standing user to /suspended. The actual code mint in
+  // submitConsent still fails closed on 'unknown'.
+  const standing = await getAccountStanding(sb, user!.id);
+  if (standing === 'suspended') {
+    redirect('/suspended');
   }
 
   // Auto-skip consent if user has already granted the same (or wider)

--- a/src/lib/account-status.ts
+++ b/src/lib/account-status.ts
@@ -1,0 +1,67 @@
+/**
+ * SEC-57: account-standing check for credential-issuance paths.
+ *
+ * A suspended/moderated user must not be able to mint NEW MCP credentials —
+ * neither an API key (dashboard settings) nor an OAuth authorization code
+ * (the /oauth/authorize consent flow). Suspension was previously forward-looking
+ * only at the middleware layer (KAN-319), which redirects a suspended user to
+ * /suspended on navigation but *fails open* on a lookup error (by design — that
+ * gate governs ALL authenticated navigation and must not lock out the whole
+ * userbase on a transient profiles read).
+ *
+ * This helper is the narrow, security-sensitive counterpart used at the exact
+ * points where a credential is minted. Because its blast radius is a single
+ * mint (a false refusal costs one retried key generation; a false allow hands a
+ * suspended account live credentials), the issuance paths fail CLOSED: they
+ * refuse unless the account is positively confirmed to be in good standing.
+ *
+ * The tri-state return lets each caller choose its own posture:
+ *   - the mint paths refuse on anything other than 'ok' (fail closed);
+ *   - the consent-screen render redirects only on a confirmed 'suspended', so a
+ *     transient error never shows a good-standing user a misleading
+ *     "account suspended" page (the mint in submitConsent still fails closed).
+ */
+
+import type { SupabaseClient } from '@supabase/supabase-js';
+
+export type AccountStanding = 'ok' | 'suspended' | 'unknown';
+
+/**
+ * Look up the account standing for the given authenticated user id.
+ *
+ * `unknown` means we could not positively determine standing (lookup error or
+ * no profile row) — callers minting a credential MUST treat it like 'suspended'.
+ */
+export async function getAccountStanding(
+  supabase: SupabaseClient,
+  userId: string,
+): Promise<AccountStanding> {
+  const { data, error } = await supabase
+    .from('profiles')
+    .select('is_suspended')
+    .eq('user_id', userId)
+    .maybeSingle();
+
+  if (error) {
+    // Never fail silently, and never fall through to a permissive default on a
+    // credential path — surface it and let the caller fail closed.
+    console.error('[account-status] suspension lookup failed (treating as unknown):', error.message);
+    return 'unknown';
+  }
+  if (!data) {
+    // Every user has a profile (handle_new_user trigger) by the time they can
+    // reach settings or the OAuth flow, so a missing row is anomalous — treat
+    // it as unknown rather than assuming good standing.
+    console.error('[account-status] no profile row for user (treating as unknown):', userId);
+    return 'unknown';
+  }
+  return data.is_suspended === true ? 'suspended' : 'ok';
+}
+
+/**
+ * Fail-closed predicate for credential-issuance paths: refuse unless the account
+ * is positively in good standing. `suspended` and `unknown` both refuse.
+ */
+export function shouldRefuseIssuance(standing: AccountStanding): boolean {
+  return standing !== 'ok';
+}

--- a/tests/unit/account-status.test.ts
+++ b/tests/unit/account-status.test.ts
@@ -1,0 +1,77 @@
+/**
+ * SEC-57: unit tests for the account-standing helper used to refuse credential
+ * issuance for suspended (or unverifiable) accounts.
+ *
+ * Covers the tri-state contract and the fail-closed predicate:
+ *   - is_suspended === true            -> 'suspended'
+ *   - is_suspended === false / absent  -> 'ok'
+ *   - lookup error                     -> 'unknown'   (fail closed for mints)
+ *   - no profile row                   -> 'unknown'   (fail closed for mints)
+ *   - shouldRefuseIssuance refuses on anything but 'ok'
+ */
+
+import type { SupabaseClient } from '@supabase/supabase-js';
+import { getAccountStanding, shouldRefuseIssuance } from '@/lib/account-status';
+
+/** Build a minimal supabase-shaped client whose profiles read resolves to `res`. */
+function clientReturning(res: { data: unknown; error: unknown }): SupabaseClient {
+  return {
+    from: () => ({
+      select: () => ({
+        eq: () => ({
+          maybeSingle: () => Promise.resolve(res),
+        }),
+      }),
+    }),
+  } as unknown as SupabaseClient;
+}
+
+describe('SEC-57 getAccountStanding', () => {
+  test('returns "suspended" when is_suspended is true', async () => {
+    const c = clientReturning({ data: { is_suspended: true }, error: null });
+    await expect(getAccountStanding(c, 'user-1')).resolves.toBe('suspended');
+  });
+
+  test('returns "ok" when is_suspended is false', async () => {
+    const c = clientReturning({ data: { is_suspended: false }, error: null });
+    await expect(getAccountStanding(c, 'user-1')).resolves.toBe('ok');
+  });
+
+  test('returns "ok" when is_suspended is absent/null (not positively suspended)', async () => {
+    const c = clientReturning({ data: { is_suspended: null }, error: null });
+    await expect(getAccountStanding(c, 'user-1')).resolves.toBe('ok');
+  });
+
+  test('returns "unknown" on a lookup error (fail closed)', async () => {
+    const c = clientReturning({ data: null, error: { message: 'pgrst timeout' } });
+    await expect(getAccountStanding(c, 'user-1')).resolves.toBe('unknown');
+  });
+
+  test('returns "unknown" when no profile row exists (fail closed)', async () => {
+    const c = clientReturning({ data: null, error: null });
+    await expect(getAccountStanding(c, 'user-1')).resolves.toBe('unknown');
+  });
+
+  test('queries profiles by the passed user id', async () => {
+    const eqSpy = jest.fn(() => ({ maybeSingle: () => Promise.resolve({ data: { is_suspended: false }, error: null }) }));
+    const selectSpy = jest.fn(() => ({ eq: eqSpy }));
+    const fromSpy = jest.fn(() => ({ select: selectSpy }));
+    const c = { from: fromSpy } as unknown as SupabaseClient;
+    await getAccountStanding(c, 'user-xyz');
+    expect(fromSpy).toHaveBeenCalledWith('profiles');
+    expect(selectSpy).toHaveBeenCalledWith('is_suspended');
+    expect(eqSpy).toHaveBeenCalledWith('user_id', 'user-xyz');
+  });
+});
+
+describe('SEC-57 shouldRefuseIssuance (fail closed)', () => {
+  test('refuses when suspended', () => {
+    expect(shouldRefuseIssuance('suspended')).toBe(true);
+  });
+  test('refuses when unknown', () => {
+    expect(shouldRefuseIssuance('unknown')).toBe(true);
+  });
+  test('allows only when ok', () => {
+    expect(shouldRefuseIssuance('ok')).toBe(false);
+  });
+});

--- a/tests/unit/sec57-issuance-suspension.test.ts
+++ b/tests/unit/sec57-issuance-suspension.test.ts
@@ -1,0 +1,175 @@
+/**
+ * SEC-57: behavioural tests that a suspended (or unverifiable) account cannot
+ * OBTAIN new MCP credentials at either issuance point:
+ *
+ *   - generateApiKey (dashboard settings) returns an error and never inserts an
+ *     api_keys row.
+ *   - submitConsent (OAuth authorize, Allow path) redirects to /suspended and
+ *     never records consent or issues an authorization code.
+ *
+ * Both paths fail CLOSED: an 'unknown' standing (profiles lookup error) refuses
+ * issuance too. A good-standing account still mints normally.
+ *
+ * A static assertion also pins the defence-in-depth guard on the consent-screen
+ * render (page.tsx) so it can't silently regress.
+ */
+
+import fs from 'fs';
+import path from 'path';
+
+// ── next/navigation: redirect throws so we can assert the target + halt. ──
+const mockRedirect = jest.fn();
+jest.mock('next/navigation', () => ({
+  redirect: (...args: unknown[]) => {
+    mockRedirect(...args);
+    throw new Error('REDIRECT');
+  },
+}));
+
+// ── Shared cookie-auth supabase client (getUser + profiles + api_keys). ──
+const mockGetUser = jest.fn();
+const mockMaybeSingle = jest.fn();
+const mockInsert = jest.fn();
+jest.mock('@/lib/supabase-server', () => ({
+  createClient: jest.fn(async () => ({
+    auth: { getUser: (...a: unknown[]) => mockGetUser(...a) },
+    from: (table: string) => {
+      if (table === 'profiles') {
+        return {
+          select: () => ({ eq: () => ({ maybeSingle: (...a: unknown[]) => mockMaybeSingle(...a) }) }),
+        };
+      }
+      // api_keys
+      return { insert: (...a: unknown[]) => mockInsert(...a) };
+    },
+  })),
+}));
+
+// generateApiKey's module imports getAdminServiceClient (unused here).
+jest.mock('@/lib/admin', () => ({
+  getAdminServiceClient: () => ({}),
+}));
+
+// ── OAuth libs used by submitConsent. ──
+const mockGetOauthClient = jest.fn();
+jest.mock('@/lib/oauth/clients', () => ({
+  getOauthClient: (...a: unknown[]) => mockGetOauthClient(...a),
+}));
+const mockRecordConsent = jest.fn();
+jest.mock('@/lib/oauth/consents', () => ({
+  recordConsent: (...a: unknown[]) => mockRecordConsent(...a),
+}));
+const mockIssueAuthCode = jest.fn();
+jest.mock('@/lib/oauth/codes', () => ({
+  issueAuthCode: (...a: unknown[]) => mockIssueAuthCode(...a),
+}));
+jest.mock('@/lib/oauth/authorize', () => ({
+  buildErrorRedirect: (uri: string, code: string) => `${uri}?error=${code}`,
+  buildSuccessRedirect: (uri: string, code: string) => `${uri}?code=${code}`,
+}));
+
+import { generateApiKey } from '@/app/dashboard/settings/actions';
+import { submitConsent } from '@/app/oauth/authorize/actions';
+
+const VALID_CONSENT_INPUT = {
+  client_id: 'client-1',
+  redirect_uri: 'https://claude.ai/callback',
+  scope: 'lyra:full',
+  state: 'xyz',
+  code_challenge: 'abc123',
+  code_challenge_method: 'S256' as const,
+  decision: 'allow' as const,
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockGetUser.mockResolvedValue({ data: { user: { id: 'user-123' } } });
+  mockMaybeSingle.mockResolvedValue({ data: { is_suspended: false }, error: null });
+  mockInsert.mockResolvedValue({ error: null });
+  mockGetOauthClient.mockResolvedValue({
+    client_id: 'client-1',
+    revoked_at: null,
+    redirect_uris: ['https://claude.ai/callback'],
+  });
+  mockIssueAuthCode.mockResolvedValue({ code: 'authcode-xyz' });
+});
+
+// ── generateApiKey ──────────────────────────────────────────
+describe('SEC-57 generateApiKey suspension gate', () => {
+  test('a good-standing user mints a key', async () => {
+    const res = await generateApiKey('My key');
+    expect(res.key).toMatch(/^lyra_/);
+    expect(res.error).toBeUndefined();
+    expect(mockInsert).toHaveBeenCalledTimes(1);
+  });
+
+  test('a suspended user is refused and NO api_keys row is inserted', async () => {
+    mockMaybeSingle.mockResolvedValue({ data: { is_suspended: true }, error: null });
+    const res = await generateApiKey('My key');
+    expect(res.key).toBeUndefined();
+    expect(res.error).toMatch(/suspended/i);
+    expect(mockInsert).not.toHaveBeenCalled();
+  });
+
+  test('fails closed: a profiles lookup error refuses issuance', async () => {
+    mockMaybeSingle.mockResolvedValue({ data: null, error: { message: 'boom' } });
+    const res = await generateApiKey('My key');
+    expect(res.key).toBeUndefined();
+    expect(res.error).toMatch(/suspended/i);
+    expect(mockInsert).not.toHaveBeenCalled();
+  });
+
+  test('still rejects unauthenticated callers before any suspension read', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: null } });
+    const res = await generateApiKey('My key');
+    expect(res.error).toMatch(/not authenticated/i);
+    expect(mockInsert).not.toHaveBeenCalled();
+  });
+});
+
+// ── submitConsent (OAuth authorize, Allow path) ─────────────
+describe('SEC-57 submitConsent suspension gate', () => {
+  test('a good-standing user gets an authorization code', async () => {
+    await expect(submitConsent({ ...VALID_CONSENT_INPUT })).rejects.toThrow('REDIRECT');
+    expect(mockIssueAuthCode).toHaveBeenCalledTimes(1);
+    expect(mockRecordConsent).toHaveBeenCalledTimes(1);
+    expect(mockRedirect).toHaveBeenCalledWith('https://claude.ai/callback?code=authcode-xyz');
+  });
+
+  test('a suspended user is redirected to /suspended and NO code is issued', async () => {
+    mockMaybeSingle.mockResolvedValue({ data: { is_suspended: true }, error: null });
+    await expect(submitConsent({ ...VALID_CONSENT_INPUT })).rejects.toThrow('REDIRECT');
+    expect(mockRedirect).toHaveBeenCalledWith('/suspended');
+    expect(mockIssueAuthCode).not.toHaveBeenCalled();
+    expect(mockRecordConsent).not.toHaveBeenCalled();
+  });
+
+  test('fails closed: a profiles lookup error blocks code issuance', async () => {
+    mockMaybeSingle.mockResolvedValue({ data: null, error: { message: 'boom' } });
+    await expect(submitConsent({ ...VALID_CONSENT_INPUT })).rejects.toThrow('REDIRECT');
+    expect(mockRedirect).toHaveBeenCalledWith('/suspended');
+    expect(mockIssueAuthCode).not.toHaveBeenCalled();
+  });
+
+  test('the Deny path is unaffected (still an access_denied redirect)', async () => {
+    await expect(
+      submitConsent({ ...VALID_CONSENT_INPUT, decision: 'deny' }),
+    ).rejects.toThrow('REDIRECT');
+    expect(mockRedirect).toHaveBeenCalledWith('https://claude.ai/callback?error=access_denied');
+    expect(mockIssueAuthCode).not.toHaveBeenCalled();
+  });
+});
+
+// ── Defence-in-depth: consent-screen render guard (static pin) ──
+describe('SEC-57 authorize page render guard', () => {
+  const pageSrc = fs.readFileSync(
+    path.join(__dirname, '../../src/app/oauth/authorize/page.tsx'),
+    'utf8',
+  );
+
+  test('page render redirects a confirmed-suspended user to /suspended', () => {
+    expect(pageSrc).toContain('getAccountStanding');
+    expect(pageSrc).toMatch(/standing === 'suspended'/);
+    expect(pageSrc).toContain("redirect('/suspended')");
+  });
+});


### PR DESCRIPTION
## Summary

API-key generation and OAuth authorization did not check `is_suspended`, so a suspended/moderated user could still mint **new** MCP credentials (API keys and OAuth authorization codes) and keep automating reads/exports. The middleware suspension gate (KAN-319) only redirects on navigation and **fails open** on a lookup error, so it is not a sufficient boundary at the point a credential is minted.

This adds a shared account-standing helper (`src/lib/account-status.ts`) with a tri-state result (`ok` / `suspended` / `unknown`) and a fail-closed predicate, wired into every issuance point:

- **`generateApiKey`** (dashboard settings) — returns an error and does not insert an `api_keys` row unless the account is positively in good standing.
- **`submitConsent`** (OAuth authorize, Allow path) — redirects to `/suspended` and does not record consent or issue an authorization code. Fails closed on an `unknown` standing; the **Deny** path is unchanged.
- **authorize page render** — defence-in-depth redirect to `/suspended` on a **confirmed** suspension only (a transient error must not mislead a good-standing user; the mint in `submitConsent` still fails closed).

**Scope / residual:** this ships the *"cannot **obtain**"* half of the acceptance criterion. The retroactive-revocation-on-suspend leg (*"cannot **retain**"* — revoke existing `api_keys` rows + OAuth grants inside the admin suspend action) is deferred: it couples to the bulk-admin flow and the founder-gated **SEC-46** OAuth-revocation work. **SEC-57 stays In Progress** until that leg lands (candidate follow-up slice).

MCP coverage: N/A — this hardens the web app's own issuance paths (auth/authz), not user-facing data an agent mirrors. The MCP server independently validates keys against `api_keys`; refusing issuance and (future) revocation are the correct control points.

## Jira Ticket

SEC-57

## Checklist

- [x] Unit tests added/updated for new/changed functionality — `tests/unit/account-status.test.ts` (tri-state + fail-closed predicate) and `tests/unit/sec57-issuance-suspension.test.ts` (both mint paths refuse `suspended` and `unknown`, still mint for good standing, Deny unaffected, render guard pinned)
- [x] All existing tests pass (`npm run test:unit`) — 166 suites / 2063 tests green
- [x] Lint passes (`npm run lint`) — changed files clean
- [x] Type check passes (`npm run type-check`) — full `tsc --noEmit` clean
- [ ] Build succeeds (`npm run build`) — not run in this slice (no build-surface change; tsc + lint green)
- [x] Coverage has not decreased — net-new tests only
- [x] No eslint-disable or ts-ignore without KAN-XX reference — none added
- [x] ARCHITECTURE.md updated if architectural changes were made — N/A (defence-in-depth authz check, no architectural change)
- [x] Ops routine / Control-Room registry updated if scheduled-routine behaviour changed — N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0187d4zH8gNAdJ7eBtfyYf7z

---
_Generated by [Claude Code](https://claude.ai/code/session_0187d4zH8gNAdJ7eBtfyYf7z)_