### PR TITLE
fix(SEC-79): watchdog FAILs on a disabled registry-owner workflow

### DIFF
--- a/docs/OPS_ROUTINES_CONTROL_ROOM.md
+++ b/docs/OPS_ROUTINES_CONTROL_ROOM.md
@@ -123,8 +123,20 @@ bash scripts/routine-watchdog.sh \
   'weekly-health|11520|2026-06-29T06:30:00Z|PASS' \
   'doc-sync|2000|2026-07-04T08:15:00Z|PASS|weekday' \
   'doc-producer|2000|2026-07-04T08:00:00Z|PASS|weekday' \
-  'health-check|540|2026-07-04T06:00:00Z|PASS'
+  'health-check|540|2026-07-04T06:00:00Z|PASS||active'
 ```
+
+**Workflow-state (optional 6th field — SEC-79).** For a routine OWNED by a
+GitHub-Actions workflow (`health-check.yml` = liveness; `weekly-report.yml` =
+reporting), pass the workflow's enabled-state as the 6th field — leave the 5th
+(weekday) empty if unused: `…|PASS||active`. Values come from
+`gh workflow list --all --json name,state`: `active`, `disabled_manually`, or
+`disabled_inactivity`. A **disabled** state is a **FAIL** ("monitoring is DARK")
+regardless of heartbeat freshness — this makes a silently-disabled owner
+workflow self-detecting instead of a 20-day blind spot (the SEC-79 failure
+mode). An unrecognised state string is `UNVERIFIED`, never a silent pass. The
+Daily Security routine gathers the states with `gh workflow list --all` and
+feeds them for `health-check.yml` and `weekly-report.yml`.
 
 **Where it runs.** The watchdog is folded into the **Daily Security routine**
 (trigger #1 — it already has the Atlassian + GitHub connectors). For any routine

--- a/scripts/routine-watchdog.sh
+++ b/scripts/routine-watchdog.sh
@@ -12,7 +12,7 @@
 #
 # Input model — one CHECK per routine, passed as a positional argument of the
 # form (fields are PIPE-delimited so ISO-8601 timestamps keep their colons):
-#   <name>|<max_age_minutes>|<last_iso8601_or_->|<last_outcome>[|<weekday_only>]
+#   <name>|<max_age_minutes>|<last_iso8601_or_->|<last_outcome>[|<weekday_only>[|<workflow_state>]]
 #
 #   name           routine label (no pipes), e.g. daily-security
 #   max_age_minutes cadence + grace in minutes; a heartbeat older than this is
@@ -26,8 +26,20 @@
 #   weekday_only    optional; "weekday" or "1" means the routine only runs
 #                   Mon–Fri, so an overdue heartbeat on Sat/Sun is OK (grace),
 #                   mirroring doc-sync-healthcheck.sh's weekend-grace idea.
+#   workflow_state  optional; for a routine OWNED by a GitHub-Actions workflow
+#                   (per the Ops Routines Control Room registry — e.g.
+#                   health-check.yml = liveness), the workflow's enabled-state
+#                   from `gh workflow list`: active | disabled_manually |
+#                   disabled_inactivity. A "disabled" state is a FAIL regardless
+#                   of freshness — the monitoring/backstop is DARK, which is
+#                   strictly worse than a missed heartbeat (SEC-79: an owner
+#                   workflow can sit silently off for weeks). Empty/active =
+#                   evaluate freshness as normal. To pass state WITHOUT a
+#                   weekday, leave the weekday field empty:
+#                   'health-check|540|-|-||disabled_manually'.
 #
 #   Example: 'daily-security|1800|2026-07-04T07:00:00Z|PASS'
+#            'health-check|540|2026-07-06T12:00:00Z|PASS||active'
 #
 # Output: one tab-separated line per routine — "<STATUS>\t<name>\t<detail>" —
 # STATUS ∈ PASS | FAIL | UNVERIFIED. Then a machine-readable summary line.
@@ -97,13 +109,33 @@ if [ -z "$NOW_EPOCH" ]; then
   exit 1
 fi
 
-check_one() { # $1 = the raw <name>|<max>|<last>|<outcome>[|weekday] token
+check_one() { # $1 = the raw <name>|<max>|<last>|<outcome>[|weekday[|state]] token
   local raw="$1"
-  local name max last outcome weekday
-  IFS='|' read -r name max last outcome weekday <<EOF
+  local name max last outcome weekday state
+  IFS='|' read -r name max last outcome weekday state <<EOF
 $raw
 EOF
   name="${name:-<unnamed>}"
+
+  # SEC-79 — a registry-named OWNER workflow reported DISABLED means the
+  # monitoring/backstop is DARK: strictly worse than a missed heartbeat (the
+  # exact silent-off-for-weeks failure mode). This is a FAIL regardless of
+  # freshness or recorded outcome, so it is evaluated first. The optional 6th
+  # field carries the workflow's enabled-state, fed from `gh workflow list`.
+  local st; st="$(lower "${state:-}")"
+  case "$st" in
+    ''|active|enabled) : ;;  # not disabled — fall through to freshness eval
+    disabled_manually|disabled_inactivity|disabled|off)
+      echo "FAIL	$name	registry-named owner workflow is DISABLED ($state) — the monitoring/backstop is DARK, not merely a missed heartbeat; re-enable it (SEC-79)"
+      FAIL=$((FAIL+1)); return
+      ;;
+    *)
+      # Unrecognised state — never silently ignore it (a typo must not mask a
+      # real disable). UNVERIFIED, never a silent PASS.
+      echo "UNVERIFIED	$name	unrecognised workflow_state '$state' — expected active|disabled_manually|disabled_inactivity (or empty)"
+      UNV=$((UNV+1)); return
+      ;;
+  esac
 
   # Guard the numeric cadence — a non-integer is a config error, UNVERIFIED.
   if ! printf '%s' "${max:-}" | grep -qE '^[0-9]+$'; then

--- a/scripts/routine-watchdog.sh
+++ b/scripts/routine-watchdog.sh
@@ -30,7 +30,9 @@
 #                   (per the Ops Routines Control Room registry — e.g.
 #                   health-check.yml = liveness), the workflow's enabled-state
 #                   from `gh workflow list`: active | disabled_manually |
-#                   disabled_inactivity. A "disabled" state is a FAIL regardless
+#                   disabled_inactivity (the synonyms `enabled`→active and
+#                   `disabled`/`off`→disabled are also accepted defensively, in
+#                   case GitHub's state strings change). A "disabled" state is a FAIL regardless
 #                   of freshness — the monitoring/backstop is DARK, which is
 #                   strictly worse than a missed heartbeat (SEC-79: an owner
 #                   workflow can sit silently off for weeks). Empty/active =
@@ -91,7 +93,7 @@ FAIL=0; UNV=0; PASS=0
 echo "# routine-watchdog $NOW_ISO ($DOW)"
 
 if [ "$#" -eq 0 ]; then
-  echo "UNVERIFIED	args	no routine checks supplied — pass '<name>|<max_age_min>|<last_iso|->|<outcome>[|weekday]' per routine"
+  echo "UNVERIFIED	args	no routine checks supplied — pass '<name>|<max_age_min>|<last_iso|->|<outcome>[|weekday[|workflow_state]]' per routine"
   echo "# ---"
   echo "# summary	PASS=0	FAIL=0	UNVERIFIED=1	day=$DOW"
   echo "# RESULT: UNVERIFIED"

--- a/tests/scripts/routine-watchdog.test.js
+++ b/tests/scripts/routine-watchdog.test.js
@@ -147,4 +147,54 @@ describe('scripts/routine-watchdog.sh', () => {
     const wed = run(['daily-security|1800|2026-07-01T07:00:00Z|PASS'], WED_NOON);
     expect(wed.out).toMatch(/\(Wednesday\)/);
   });
+
+  // --- SEC-79: registry-named owner-workflow disabled detection (optional 6th field) ---
+
+  it('exit 2 + FAIL when an owner workflow is disabled_manually, even if the heartbeat is fresh', () => {
+    // health-check is fresh + last outcome PASS, but the WORKFLOW is disabled →
+    // the liveness backstop is DARK. Must FAIL, not report a green PASS.
+    const { code, out } = run(['health-check|540|2026-07-04T11:00:00Z|PASS||disabled_manually']);
+    expect(out).toMatch(/FAIL\thealth-check/);
+    expect(out).toMatch(/DISABLED \(disabled_manually\)/);
+    expect(out).toMatch(/DARK/);
+    expect(out).toMatch(/# RESULT: FAIL/);
+    expect(code).toBe(2);
+  });
+
+  it('flags disabled_inactivity as FAIL too', () => {
+    const { code, out } = run(['health-check|540|2026-07-04T11:00:00Z|PASS||disabled_inactivity']);
+    expect(out).toMatch(/FAIL\thealth-check/);
+    expect(out).toMatch(/DISABLED \(disabled_inactivity\)/);
+    expect(code).toBe(2);
+  });
+
+  it('the disabled check wins over freshness — a stale AND disabled workflow reports DISABLED, not OVERDUE', () => {
+    const { code, out } = run(['health-check|540|2026-06-01T00:00:00Z|PASS||disabled_manually']);
+    expect(out).toMatch(/FAIL\thealth-check/);
+    expect(out).toMatch(/DISABLED/);
+    expect(out).not.toMatch(/OVERDUE/);
+    expect(code).toBe(2);
+  });
+
+  it('treats an active workflow_state as normal — fresh still PASSes', () => {
+    const { code, out } = run(['health-check|540|2026-07-04T11:00:00Z|PASS||active']);
+    expect(out).toMatch(/PASS\thealth-check/);
+    expect(out).toMatch(/# RESULT: PASS/);
+    expect(code).toBe(0);
+  });
+
+  it('exit 1 + UNVERIFIED on an unrecognised workflow_state (a typo must not mask a real disable)', () => {
+    const { code, out } = run(['health-check|540|2026-07-04T11:00:00Z|PASS||disabledd']);
+    expect(out).toMatch(/UNVERIFIED\thealth-check/);
+    expect(out).toMatch(/unrecognised workflow_state/);
+    expect(code).toBe(1);
+  });
+
+  it('is backward-compatible: a 5-field token (weekday, no state field) still weekend-graces', () => {
+    // Proves adding the 6th field did not shift weekday parsing.
+    const { code, out } = run(['doc-sync|2000|2026-07-02T08:15:00Z|PASS|weekday'], SAT_NOON);
+    expect(out).toMatch(/UNVERIFIED\tdoc-sync/);
+    expect(out).toMatch(/runs weekdays only/);
+    expect(code).toBe(1);
+  });
 });


### PR DESCRIPTION
## What & Why
Closes the SEC-79 failure mode at the source. On 2026-06-16 the `health-check.yml` liveness workflow (a registry-named **owner** in the Ops Control Room) was silently `disabled_manually` and sat dark for **20 days**. The watchdog only judged *heartbeat freshness*, so a disabled owner-workflow read as "missed run", not "monitoring is OFF" — the exact blind spot SEC-79 is about.

## Change
`scripts/routine-watchdog.sh` gains an optional **6th token field**, `workflow_state`, fed from `gh workflow list` (`active` | `disabled_manually` | `disabled_inactivity`):
- A **disabled** state → **FAIL** ("monitoring/backstop is DARK"), evaluated **before** freshness so it wins over any stale/PASS signal.
- An **unrecognised** state → **UNVERIFIED** (a typo must not mask a real disable; never a silent PASS).
- **Empty/active** → freshness eval exactly as before. Fully backward-compatible — existing 4- and 5-field tokens are unchanged.

## Tests
`tests/scripts/routine-watchdog.test.js` +6 cases: `disabled_manually`/`disabled_inactivity` FAIL, disabled-wins-over-overdue, `active` PASS, bad-state UNVERIFIED, and a 5-field backward-compat guard. **21/21 green.** No existing test weakened.

## Integrity
`set -uo pipefail` preserved; no `|| true` / `|| echo` masking; read-only (no mutating verbs) — honours the Workflow & Backup Integrity Policy. Disabled/unknown are loud (FAIL/UNVERIFIED), never a silent green.

## Docs
`docs/OPS_ROUTINES_CONTROL_ROOM.md` documents the field + how the Daily Security routine feeds workflow states.

## Follow-up (not in this PR)
Wire the Daily Security routine prompt (RemoteTrigger, main-session) to pass the live states for `health-check.yml` + `weekly-report.yml`. Tracked on SEC-79.

MCP coverage: not applicable — ops tooling.