### PR TITLE
docs(KAN-406): add Known Technical Gotcha #22 — Next.js loading.tsx blank-page trap

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -429,6 +429,8 @@ These have caused real bugs. Read before making related changes:
 
     First hit: KAN-209 (2026-05-17) after adding `RESEND_API_KEY` to develop scope — invite dispatcher kept failing with `RESEND_API_KEY not set` until a doc-only chore PR triggered a redeploy. Second hit: KAN-88 (2026-05-17) `OAUTH_JWT_SIGNING_SECRET` — same fix. **Bake the chore-PR-to-redeploy pattern in any time you set a branch-scoped env var as part of getting a feature live on dev.**
 
+22. **Next.js `loading.tsx` can permanently hide streamed content on a hard load**: A route segment's `loading.tsx` creates a Suspense boundary whose streamed content can fail to reveal on a hard page load (direct URL visit or refresh) on some deployed builds (confirmed on Next 16.2.6) — the real page content stays inside React's hidden streaming holder (`<div hidden>`) while the loading skeleton shows, so the page renders blank except the site-wide footer. Client-side navigation into the same route is unaffected (no fresh Suspense boundary), which makes the bug easy to miss in normal manual testing. Discovered 2026-07-03: this blanked the ENTIRE `/dashboard` segment (not just widget-specific code) on hard load/refresh — confirmed in-browser; service worker, CSP, and PPR were ruled out as causes. Tracked under BUGS-63, fixed in PR #424 by removing the segment's `loading.tsx` (trade-off: no instant skeleton during the async render, acceptable vs. a blank dashboard). **If a route with a `loading.tsx` renders blank on a hard load but works fine via client-side navigation, suspect this first.** Deeper root cause (likely a Next 16 streaming / `@sentry/nextjs` interaction) is an open follow-up.
+
 ## Supabase Migration Rules
 
 - Always test migrations on dev first, then staging, then production


### PR DESCRIPTION
Folds the gotcha note from #426 (which targeted `main`) onto `develop` so it reaches prod via the normal promote — no standalone prod redeploy. Documents the BUGS-63 `loading.tsx` Suspense-reveal trap. Doc-only (+2 lines to CLAUDE.md). Supersedes #426 (being closed). MCP coverage: n/a (docs).