### PR TITLE
fix(profile): SEC-52 — enforce magic-byte validation on avatar upload via shared preflight

### DIFF
--- a/src/app/dashboard/profile/actions.ts
+++ b/src/app/dashboard/profile/actions.ts
@@ -16,6 +16,7 @@ import {
   isControllableSectionKey,
   type SectionVisibility,
 } from './section-visibility';
+import { preflightUpload } from '@/lib/file-magic-bytes';
 
 async function getAuthenticatedUser() {
   const supabase = await createClient();
@@ -658,29 +659,34 @@ export async function uploadAvatar(formData: FormData): Promise<ActionResult> {
   if (!rl.allowed) return rl.result;
 
   const file = formData.get('avatar') as File | null;
-  if (!file || file.size === 0) return { success: false, error: 'No file provided' };
 
-  // Validate MIME type server-side
-  if (!ALLOWED_IMAGE_TYPES.includes(file.type)) {
-    return { success: false, error: 'Invalid file type. Allowed: JPEG, PNG, WebP, GIF' };
-  }
-
-  // Validate file size
-  if (file.size > MAX_FILE_SIZE) {
-    return { success: false, error: 'File too large. Maximum size is 5MB' };
-  }
+  // SEC-52 — shared preflight: presence, 5MB cap, allowed image MIME AND
+  // magic-byte signature. The declared MIME is browser-controlled and
+  // trivially spoofable, so a spoofed-MIME/polyglot must be rejected here
+  // before it reaches the world-readable profile-photos bucket. This is the
+  // SAME helper uploadProfileFile uses so the two paths can't drift.
+  const preflightError = await preflightUpload(file, {
+    allowedMimes: ALLOWED_IMAGE_TYPES,
+    maxBytes: MAX_FILE_SIZE,
+    emptyMessage: 'No file provided',
+    typeMessage: 'Invalid file type. Allowed: JPEG, PNG, WebP, GIF',
+    sizeMessage: 'File too large. Maximum size is 5MB',
+  });
+  if (preflightError) return { success: false, error: preflightError };
+  // preflightUpload guarantees a present, valid File past this point.
+  const avatar = file as File;
 
   // Determine extension from MIME type
   const extMap: Record<string, string> = {
     'image/jpeg': 'jpg', 'image/png': 'png', 'image/webp': 'webp', 'image/gif': 'gif',
   };
-  const ext = extMap[file.type] || 'jpg';
+  const ext = extMap[avatar.type] || 'jpg';
   const filePath = `${user!.id}/avatar.${ext}`;
 
   // Upload to Supabase Storage (upsert to overwrite existing)
   const { error: uploadError } = await supabase.storage
     .from('profile-photos')
-    .upload(filePath, file, { upsert: true, contentType: file.type });
+    .upload(filePath, avatar, { upsert: true, contentType: avatar.type });
 
   if (uploadError) return { success: false, error: uploadError.message };
 

--- a/src/app/dashboard/profile/files-actions.ts
+++ b/src/app/dashboard/profile/files-actions.ts
@@ -6,7 +6,7 @@ import { sanitiseText, type ActionResult } from '@/lib/sanitise';
 import { checkProfileWriteRateLimit } from '@/lib/profile-rate-limit';
 import { coerceVisibility } from './visibility';
 import {
-  validateFileMagicBytes,
+  preflightUpload,
   ALLOWED_MIMES,
   extensionForMime,
   type AllowedMime,
@@ -77,23 +77,19 @@ export async function uploadProfileFile(formData: FormData): Promise<ActionResul
   if (!(file instanceof File)) {
     return { success: false, error: 'No file supplied' };
   }
-  if (file.size === 0) {
-    return { success: false, error: 'File is empty' };
-  }
-  if (file.size > MAX_BYTES) {
-    return { success: false, error: `File exceeds 10 MB limit (got ${file.size} bytes)` };
-  }
-  if (!ALLOWED_MIMES.has(file.type as AllowedMime)) {
-    return {
-      success: false,
-      error: `Disallowed type ${file.type}. Allowed: ${[...ALLOWED_MIMES].join(', ')}`,
-    };
-  }
 
-  // Magic-byte check — never trust the declared MIME alone.
-  const magicError = await validateFileMagicBytes(file, file.type);
-  if (magicError) {
-    return { success: false, error: magicError };
+  // SEC-52 — shared preflight: presence, 10MB cap, allowed MIME AND magic-byte
+  // signature (never trust the declared MIME alone). Same helper as
+  // uploadAvatar so the two upload paths can't drift apart.
+  const preflightError = await preflightUpload(file, {
+    allowedMimes: ALLOWED_MIMES,
+    maxBytes: MAX_BYTES,
+    emptyMessage: 'File is empty',
+    sizeMessage: `File exceeds 10 MB limit (got ${file.size} bytes)`,
+    typeMessage: `Disallowed type ${file.type}. Allowed: ${[...ALLOWED_MIMES].join(', ')}`,
+  });
+  if (preflightError) {
+    return { success: false, error: preflightError };
   }
 
   const displayName = sanitiseText(

--- a/src/lib/file-magic-bytes.ts
+++ b/src/lib/file-magic-bytes.ts
@@ -129,6 +129,60 @@ export async function validateFileMagicBytes(
 }
 
 /**
+ * SEC-52: shared upload preflight so the avatar path and the profile-files
+ * path enforce the SAME validation and can't silently drift. The avatar
+ * uploader historically validated only the browser-declared MIME + size and
+ * skipped the magic-byte check that `uploadProfileFile` enforced — letting a
+ * spoofed-MIME / polyglot file land in the (world-readable) profile-photos
+ * bucket. Routing both callers through one helper closes that gap and keeps
+ * them in lockstep.
+ *
+ * Runs, in order:
+ *   1. presence + non-empty
+ *   2. size cap
+ *   3. declared MIME is in the caller's allow-list
+ *   4. magic-byte signature match (the anti-spoofing check)
+ *
+ * Returns `null` when the file is safe to upload, or a human-readable error
+ * string (mirrors `validateFileMagicBytes`' contract). Callers pass their own
+ * allow-list, size cap, and messages so existing wording stays stable — but
+ * every path is now guaranteed to run the magic-byte check.
+ */
+export interface UploadPreflightOptions {
+  /** MIME types this caller accepts (a subset of ALLOWED_MIMES). */
+  allowedMimes: ReadonlySet<string> | readonly string[];
+  /** Hard byte cap for this caller. */
+  maxBytes: number;
+  emptyMessage?: string;
+  sizeMessage?: string;
+  typeMessage?: string;
+}
+
+export async function preflightUpload(
+  file: File | null | undefined,
+  opts: UploadPreflightOptions,
+): Promise<string | null> {
+  if (!file || file.size === 0) {
+    return opts.emptyMessage ?? 'No file provided';
+  }
+  if (file.size > opts.maxBytes) {
+    return opts.sizeMessage ?? `File exceeds the ${opts.maxBytes}-byte limit`;
+  }
+  const allowed =
+    opts.allowedMimes instanceof Set
+      ? (opts.allowedMimes as ReadonlySet<string>)
+      : new Set<string>(opts.allowedMimes as readonly string[]);
+  if (!allowed.has(file.type)) {
+    return (
+      opts.typeMessage ??
+      `Disallowed type ${file.type}. Allowed: ${[...allowed].join(', ')}`
+    );
+  }
+  // Never trust the declared MIME alone — verify the file's actual bytes.
+  return validateFileMagicBytes(file, file.type);
+}
+
+/**
  * Extension guess from a MIME type. Used to build storage paths since
  * the original filename isn't trusted.
  */

--- a/tests/unit/sec52-upload-preflight.test.ts
+++ b/tests/unit/sec52-upload-preflight.test.ts
@@ -1,0 +1,149 @@
+/**
+ * SEC-52: shared upload preflight — magic-byte enforcement on the avatar path.
+ *
+ * The avatar uploader (`uploadAvatar`) historically validated only the
+ * browser-declared MIME + size and skipped `validateFileMagicBytes`, which the
+ * sibling profile-files path enforced. A spoofed-MIME / polyglot file
+ * (e.g. an EXE served with `Content-Type: image/png`) therefore landed in the
+ * world-readable `profile-photos` bucket. `finding web-input-01`.
+ *
+ * These tests lock two things:
+ *   1. `preflightUpload` behaviour — the shared helper both paths now use:
+ *      presence, size cap, MIME allow-list, and (critically) the magic-byte
+ *      signature check.
+ *   2. Source guards — that BOTH `uploadAvatar` and `uploadProfileFile` route
+ *      through `preflightUpload` BEFORE the storage `.upload(` call, so the two
+ *      paths can't drift apart again.
+ */
+
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+import { preflightUpload } from '@/lib/file-magic-bytes';
+
+const ROOT = resolve(__dirname, '../..');
+
+/** Build a File with a known byte prefix and declared MIME. */
+function fileWith(prefix: number[], type: string, totalLen = 32): File {
+  const bytes = new Uint8Array(totalLen);
+  bytes.set(prefix);
+  return new File([bytes], 'upload.bin', { type });
+}
+
+const PNG_SIG = [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a];
+const JPEG_SIG = [0xff, 0xd8, 0xff, 0xe0];
+const EXE_SIG = [0x4d, 0x5a]; // "MZ" — PE/COFF header, not an image
+
+const IMAGE_MIMES = ['image/jpeg', 'image/png', 'image/webp', 'image/gif'];
+
+describe('SEC-52 preflightUpload', () => {
+  const opts = {
+    allowedMimes: IMAGE_MIMES,
+    maxBytes: 5 * 1024 * 1024,
+    emptyMessage: 'No file provided',
+    typeMessage: 'Invalid file type. Allowed: JPEG, PNG, WebP, GIF',
+    sizeMessage: 'File too large. Maximum size is 5MB',
+  };
+
+  test('accepts a genuine PNG (bytes match declared MIME)', async () => {
+    const err = await preflightUpload(fileWith(PNG_SIG, 'image/png'), opts);
+    expect(err).toBeNull();
+  });
+
+  test('accepts a genuine JPEG', async () => {
+    const err = await preflightUpload(fileWith(JPEG_SIG, 'image/jpeg'), opts);
+    expect(err).toBeNull();
+  });
+
+  test('REJECTS a spoofed MIME — EXE bytes declared as image/png', async () => {
+    // This is the core SEC-52 vulnerability: declared MIME passes the
+    // allow-list, but the actual bytes are not a PNG.
+    const err = await preflightUpload(fileWith(EXE_SIG, 'image/png'), opts);
+    expect(err).not.toBeNull();
+    expect(err).toMatch(/don['']t match/i);
+  });
+
+  test('REJECTS a spoofed MIME — PNG bytes declared as image/jpeg', async () => {
+    const err = await preflightUpload(fileWith(PNG_SIG, 'image/jpeg'), opts);
+    expect(err).not.toBeNull();
+    expect(err).toMatch(/don['']t match/i);
+  });
+
+  test('rejects a disallowed declared type before the byte check', async () => {
+    // PDF has valid magic bytes but is not in the avatar allow-list.
+    const err = await preflightUpload(
+      fileWith([0x25, 0x50, 0x44, 0x46, 0x2d], 'application/pdf'),
+      opts,
+    );
+    expect(err).toBe(opts.typeMessage);
+  });
+
+  test('rejects an oversize file', async () => {
+    const big = new File([new Uint8Array(6 * 1024 * 1024)], 'big.png', {
+      type: 'image/png',
+    });
+    const err = await preflightUpload(big, opts);
+    expect(err).toBe(opts.sizeMessage);
+  });
+
+  test('rejects a null / missing file', async () => {
+    expect(await preflightUpload(null, opts)).toBe(opts.emptyMessage);
+  });
+
+  test('rejects an empty (zero-byte) file', async () => {
+    const empty = new File([], 'empty.png', { type: 'image/png' });
+    expect(await preflightUpload(empty, opts)).toBe(opts.emptyMessage);
+  });
+
+  test('honours a distinct allow-list + messages per caller (files path)', async () => {
+    // The profile-files path allows PDFs and uses its own wording.
+    const fileOpts = {
+      allowedMimes: ['image/jpeg', 'image/png', 'image/webp', 'image/gif', 'application/pdf'],
+      maxBytes: 10 * 1024 * 1024,
+      emptyMessage: 'File is empty',
+    };
+    const ok = await preflightUpload(
+      fileWith([0x25, 0x50, 0x44, 0x46, 0x2d], 'application/pdf'),
+      fileOpts,
+    );
+    expect(ok).toBeNull();
+    const empty = new File([], 'x.pdf', { type: 'application/pdf' });
+    expect(await preflightUpload(empty, fileOpts)).toBe('File is empty');
+  });
+});
+
+describe('SEC-52 source guards — both upload paths enforce the shared preflight', () => {
+  test('uploadAvatar runs preflightUpload before the profile-photos upload', () => {
+    const src = readFileSync(
+      resolve(ROOT, 'src/app/dashboard/profile/actions.ts'),
+      'utf-8',
+    );
+    const fn = src.slice(src.indexOf('export async function uploadAvatar'));
+    const preflightIdx = fn.indexOf('preflightUpload(');
+    const uploadIdx = fn.indexOf("from('profile-photos')");
+    expect(preflightIdx).toBeGreaterThan(-1);
+    expect(uploadIdx).toBeGreaterThan(-1);
+    // The magic-byte-bearing preflight must run BEFORE the storage upload.
+    expect(preflightIdx).toBeLessThan(uploadIdx);
+  });
+
+  test('uploadProfileFile runs preflightUpload before the profile-files upload', () => {
+    const src = readFileSync(
+      resolve(ROOT, 'src/app/dashboard/profile/files-actions.ts'),
+      'utf-8',
+    );
+    const fn = src.slice(src.indexOf('export async function uploadProfileFile'));
+    const preflightIdx = fn.indexOf('preflightUpload(');
+    const uploadIdx = fn.indexOf("from('profile-files')");
+    expect(preflightIdx).toBeGreaterThan(-1);
+    expect(uploadIdx).toBeGreaterThan(-1);
+    expect(preflightIdx).toBeLessThan(uploadIdx);
+  });
+
+  test('preflightUpload always reaches the magic-byte validator', () => {
+    // Guard the helper itself: it must call validateFileMagicBytes so a future
+    // edit can't quietly drop the anti-spoofing check.
+    const src = readFileSync(resolve(ROOT, 'src/lib/file-magic-bytes.ts'), 'utf-8');
+    const fn = src.slice(src.indexOf('export async function preflightUpload'));
+    expect(fn).toMatch(/validateFileMagicBytes\(/);
+  });
+});


### PR DESCRIPTION
## Summary

`uploadAvatar` (`src/app/dashboard/profile/actions.ts`) validated only the browser-declared MIME + size and **skipped** `validateFileMagicBytes` — the anti-spoofing check that the sibling `uploadProfileFile` path already enforced (**finding web-input-01**). A spoofed-MIME / polyglot file (e.g. an EXE served with `Content-Type: image/png`) could therefore land in the **world-readable `profile-photos` bucket**. The two upload paths had drifted.

**Fix:**
- New shared **`preflightUpload()`** helper in `src/lib/file-magic-bytes.ts`: presence → size cap → MIME allow-list → **magic-byte signature check**. Callers pass their own allow-list, size cap, and error messages, so existing user-facing wording is unchanged — but every path now runs the magic-byte check.
- **`uploadAvatar`** and **`uploadProfileFile`** both route through `preflightUpload`, so they can no longer drift apart.

No schema/RLS change; single-repo web change. `preflightUpload`/its interface live in a plain `.ts` module (not the `'use server'` action files), per Gotcha #18.

## Jira Ticket

SEC-52

## MCP coverage

N/A — this is a server-side input-validation hardening on an existing form action; no new user-facing entity or API surface for an agent to mirror.

## Test evidence

- New `tests/unit/sec52-upload-preflight.test.ts`: behavioural coverage of `preflightUpload` (spoofed EXE-as-PNG rejected, PNG-as-JPEG rejected, disallowed type, oversize, empty, null, per-caller allow-list/messages) + source guards that **both** upload paths call `preflightUpload` before the storage `.upload(`.
- Affected existing suites still green: `photo-upload`, `file-magic-bytes`, `feature-entitlements`, `profile-rate-limit-wiring`.
- Full `tests/(unit|scripts)` suite: **172 suites / 2118 tests green**. `tsc --noEmit` clean; eslint clean on changed files. No existing test modified.

## Checklist

- [x] Unit tests added for new/changed functionality
- [x] All existing tests pass (`npm run test:unit`)
- [x] Lint passes
- [x] Type check passes
- [ ] Build succeeds — not run in this environment (CI covers it)
- [x] Coverage has not decreased (net-new tests only)
- [x] No eslint-disable / ts-ignore added
- [ ] ARCHITECTURE.md — N/A (no architectural change)
- [ ] Ops routine / Control-Room — N/A (no scheduled-routine change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P1tQLxfd7dC5XTpsvMFbZu

---
_Generated by [Claude Code](https://claude.ai/code/session_01P1tQLxfd7dC5XTpsvMFbZu)_