### PR TITLE
fix(KAN-404): render 'plays' favourites on the public profile

### DIFF
--- a/src/app/[slug]/page.tsx
+++ b/src/app/[slug]/page.tsx
@@ -301,6 +301,7 @@ export default async function PublicProfilePage({ params }: Props) {
     ['favourite_media', 'Favourite films'],
     ['favourite_books', 'Favourite books'],
     ['favourite_tv', 'Favourite TV shows'],
+    ['plays', 'Favourite plays'],
     ['quotes', 'Favourite quotes'],
     ['favourite_places', 'Favourite places'],
     ['favourite_music', 'Favourite music & bands'],

--- a/tests/unit/public-profile.test.js
+++ b/tests/unit/public-profile.test.js
@@ -49,4 +49,13 @@ describe('Public Profile', () => {
     expect(content).not.toContain('createSignedUrl');
     expect(content).not.toContain('object/public/profile-files');
   });
+
+  // KAN-404: Play (🎭) favourites are addable in the editor but were not being
+  // rendered on the public profile (FAV_DEFS had no 'plays' entry, so Play items
+  // saved but never showed). Guard that the public favourites grid includes it.
+  test("public profile renders the 'plays' favourites category (KAN-404)", () => {
+    const content = fs.readFileSync(path.join(root, 'src/app/[slug]/page.tsx'), 'utf8');
+    expect(content).toContain("'plays'");
+    expect(content).toContain('Favourite plays');
+  });
 });


### PR DESCRIPTION
## What
The profile editor lets users add **Play (🎭)** favourites (category `plays`), but the public profile's favourites grid (`FAV_DEFS` in `src/app/[slug]/page.tsx`) had no `plays` entry — so Play items **saved but never showed publicly**. Caught in the founder's pre-promote dev E2E.

## Fix
Add `['plays', 'Favourite plays']` to `FAV_DEFS` (between TV and quotes, matching the editor grouping). The existing filter/map renders it automatically when the user has Play items.

## Tests
Net-new guard in `public-profile.test.js` that the public grid includes the `plays` category. public-profile + section-visibility + profile-sections suites **69/69 green**.

Closes the last pre-promote gap for the KAN-349/404 wave. MCP coverage: n/a (public render only).