### PR TITLE
fix(SEC-76): DCR anti-phishing on OAuth consent screen (web-oauth-7)

### DIFF
--- a/src/app/oauth/authorize/page.tsx
+++ b/src/app/oauth/authorize/page.tsx
@@ -14,6 +14,7 @@ import { createClient as createSupabaseServer } from '@/lib/supabase-server';
 import { validateAuthorizeRequest, buildErrorRedirect } from '@/lib/oauth/authorize';
 import { getAccountStanding } from '@/lib/account-status';
 import { getConsent } from '@/lib/oauth/consents';
+import { clientTrust, redirectHost } from '@/lib/oauth/client-trust';
 import { submitConsent, switchAccountAndContinue } from './actions';
 import type { Metadata } from 'next';
 
@@ -125,12 +126,65 @@ export default async function AuthorizePage({ searchParams }: PageProps) {
   currentAuthorizeUrl.searchParams.set('code_challenge_method', req.codeChallengeMethod);
   const authorizePathWithQuery = currentAuthorizeUrl.pathname + currentAuthorizeUrl.search;
 
+  // SEC-76 (web-oauth-7) — DCR anti-phishing. client_name is self-asserted at
+  // registration (RFC 7591), so a phishing client can call itself "Lyra
+  // Official". Surface a verified/unverified badge + the real redirect host so
+  // the user can tell a look-alike apart before granting access.
+  const trust = clientTrust(req.client.is_first_party);
+  const returnHost = redirectHost(req.redirectUri);
+
   // Show the consent screen.
   return (
     <main style={{ maxWidth: 560, margin: '64px auto', padding: '0 24px', fontFamily: 'system-ui' }}>
       <h1 style={{ fontSize: 24, marginBottom: 8 }}>Authorize access</h1>
       <p style={{ color: '#555' }}>
         <strong>{req.client.client_name}</strong> wants access to your Lyra account.
+      </p>
+
+      {/*
+        SEC-76 (web-oauth-7) — DCR anti-phishing badge. client_name above is
+        chosen by the app at registration and does not prove its identity.
+      */}
+      <p style={{ margin: '4px 0 0' }}>
+        <span
+          data-testid="client-trust-badge"
+          style={{
+            display: 'inline-block',
+            fontSize: 12,
+            fontWeight: 600,
+            padding: '2px 10px',
+            borderRadius: 999,
+            background: trust.verified ? '#e7f4ea' : '#fdecea',
+            color: trust.verified ? '#1e5631' : '#a3271b',
+            border: `1px solid ${trust.verified ? '#a6d8b4' : '#e6a6a0'}`,
+          }}
+        >
+          {trust.verified ? `✓ ${trust.label}` : `⚠ ${trust.label}`}
+        </span>
+      </p>
+
+      {!trust.verified && (
+        <div
+          data-testid="unverified-client-warning"
+          style={{
+            background: '#fdecea',
+            border: '1px solid #e6a6a0',
+            padding: 12,
+            borderRadius: 8,
+            margin: '12px 0 0',
+            fontSize: 13,
+            color: '#7a2018',
+          }}
+        >
+          This app registered itself and has not been verified by Lyra. The name
+          above is chosen by the app and does not prove its identity — only
+          continue if you recognise and trust it.
+        </div>
+      )}
+
+      <p style={{ fontSize: 13, color: '#555', margin: '12px 0 0' }}>
+        After you allow, you&apos;ll be returned to{' '}
+        <strong style={{ fontFamily: 'monospace' }}>{returnHost}</strong>.
       </p>
 
       {/*

--- a/src/lib/oauth/client-trust.ts
+++ b/src/lib/oauth/client-trust.ts
@@ -1,0 +1,47 @@
+/**
+ * OAuth client trust surface — SEC-76 (web-oauth-7), DCR anti-phishing.
+ *
+ * Dynamic Client Registration (RFC 7591) lets any party self-register an
+ * OAuth client with an arbitrary client_name. A phishing client can register
+ * as "Lyra Official"; the consent screen renders client_name verbatim, so the
+ * user has no way to tell a look-alike apart from a real first-party app.
+ *
+ * These are pure helpers (no I/O) that drive the anti-phishing UI on
+ * /oauth/authorize: a trust verdict (verified vs unverified) and the redirect
+ * host the user would actually be returned to, so the destination is visible
+ * before they click Allow. Kept in their own module so the logic is unit-
+ * testable independently of the server-component render path.
+ */
+
+export interface ClientTrust {
+  verified: boolean;
+  /** Short label for the consent-screen badge. */
+  label: string;
+}
+
+/**
+ * A client is trusted only when an admin has explicitly marked it first-party.
+ * Every DCR-registered client defaults to unverified. Fail closed: anything
+ * other than a strict boolean `true` is treated as unverified.
+ */
+export function clientTrust(isFirstParty: unknown): ClientTrust {
+  const verified = isFirstParty === true;
+  return {
+    verified,
+    label: verified ? 'Verified app' : 'Unverified app',
+  };
+}
+
+/**
+ * The host (host[:port]) the user would be redirected back to. Surfaced on the
+ * consent screen so a look-alike client cannot hide where the authorization
+ * code is sent. Redirect URIs are validated upstream, but this must never
+ * throw in a render path — fall back to the raw string if it cannot be parsed.
+ */
+export function redirectHost(redirectUri: string): string {
+  try {
+    return new URL(redirectUri).host;
+  } catch {
+    return redirectUri;
+  }
+}

--- a/src/lib/oauth/clients.ts
+++ b/src/lib/oauth/clients.ts
@@ -209,6 +209,11 @@ export async function createOauthClient(input: RegisterClientInput): Promise<Reg
     application_type: input.application_type,
     token_endpoint_auth_method: input.token_endpoint_auth_method,
     scopes: 'lyra:full',
+    // SEC-76 (web-oauth-7): DCR-registered clients are never first-party.
+    // Explicit (the column also defaults false) so the anti-phishing default
+    // survives even if the DB default is ever changed. An admin flips this to
+    // true out-of-band for genuinely first-party clients.
+    is_first_party: false,
   });
 
   if (error) throw new Error(`client registration failed: ${error.message}`);
@@ -238,6 +243,9 @@ export interface ClientRecord {
   token_endpoint_auth_method: string;
   scopes: string;
   revoked_at: string | null;
+  // SEC-76 (web-oauth-7): true only for admin-verified first-party clients.
+  // DCR clients are false and render as "Unverified app" on the consent screen.
+  is_first_party: boolean;
 }
 
 export async function getOauthClient(clientId: string): Promise<ClientRecord | null> {
@@ -245,7 +253,7 @@ export async function getOauthClient(clientId: string): Promise<ClientRecord | n
   const { data } = await sb
     .from('oauth_clients')
     .select(
-      'client_id, client_secret_hash, client_name, redirect_uris, grant_types, response_types, application_type, token_endpoint_auth_method, scopes, revoked_at'
+      'client_id, client_secret_hash, client_name, redirect_uris, grant_types, response_types, application_type, token_endpoint_auth_method, scopes, revoked_at, is_first_party'
     )
     .eq('client_id', clientId)
     .maybeSingle();

--- a/supabase/migrations/20260707193000_sec76_oauth_clients_is_first_party.sql
+++ b/supabase/migrations/20260707193000_sec76_oauth_clients_is_first_party.sql
@@ -1,0 +1,20 @@
+-- SEC-76 (web-oauth-7) — DCR anti-phishing.
+--
+-- Dynamic Client Registration (RFC 7591) lets any party self-register an
+-- OAuth client with an arbitrary client_name. A phishing client can register
+-- as "Lyra Official" and the /oauth/authorize consent screen — which renders
+-- client_name verbatim — gives the user no way to tell it apart from a real
+-- first-party app.
+--
+-- Add an is_first_party flag. Every dynamically-registered client defaults to
+-- FALSE and is surfaced as "Unverified app" on the consent screen. An admin
+-- flips this to TRUE for genuinely first-party clients.
+--
+-- Rollback:
+--   alter table public.oauth_clients drop column if exists is_first_party;
+
+alter table public.oauth_clients
+  add column if not exists is_first_party boolean not null default false;
+
+comment on column public.oauth_clients.is_first_party is
+  'SEC-76 — true only for admin-verified first-party OAuth clients. DCR (RFC 7591) clients default false and render as "Unverified app" on the consent screen.';

--- a/tests/unit/oauth/client-trust.test.ts
+++ b/tests/unit/oauth/client-trust.test.ts
@@ -1,0 +1,53 @@
+/**
+ * SEC-76 (web-oauth-7) — DCR anti-phishing helper tests.
+ *
+ * Pure logic behind the /oauth/authorize consent-screen trust surface:
+ * a verified/unverified verdict (fail-closed) and the redirect host shown
+ * to the user before they grant access.
+ */
+
+import { clientTrust, redirectHost } from '@/lib/oauth/client-trust';
+
+describe('clientTrust (SEC-76 web-oauth-7)', () => {
+  test('a strict boolean true is the ONLY verified state', () => {
+    const t = clientTrust(true);
+    expect(t.verified).toBe(true);
+    expect(t.label).toBe('Verified app');
+  });
+
+  test('false is unverified', () => {
+    const t = clientTrust(false);
+    expect(t.verified).toBe(false);
+    expect(t.label).toBe('Unverified app');
+  });
+
+  test.each([
+    ['undefined', undefined],
+    ['null', null],
+    ['string "true"', 'true'],
+    ['number 1', 1],
+    ['object', {}],
+  ])('fails closed for %s → unverified', (_label, value) => {
+    const t = clientTrust(value);
+    expect(t.verified).toBe(false);
+    expect(t.label).toBe('Unverified app');
+  });
+});
+
+describe('redirectHost (SEC-76 web-oauth-7)', () => {
+  test('returns the host of a valid https redirect URI', () => {
+    expect(redirectHost('https://claude.ai/api/mcp/auth_callback')).toBe('claude.ai');
+  });
+
+  test('includes a non-default port', () => {
+    expect(redirectHost('http://localhost:3000/cb')).toBe('localhost:3000');
+  });
+
+  test('surfaces a look-alike host verbatim (no normalisation that hides it)', () => {
+    expect(redirectHost('https://lyra-official.evil.example/cb')).toBe('lyra-official.evil.example');
+  });
+
+  test('never throws on an unparseable value — falls back to the raw string', () => {
+    expect(redirectHost('not a url')).toBe('not a url');
+  });
+});

--- a/tests/unit/oauth/dcr-anti-phishing.test.ts
+++ b/tests/unit/oauth/dcr-anti-phishing.test.ts
@@ -1,0 +1,76 @@
+/**
+ * SEC-76 (web-oauth-7) — DCR anti-phishing wiring guard.
+ *
+ * Static-source assertions that the consent screen surfaces the trust badge,
+ * the unverified warning, and the real redirect host, and that DCR-registered
+ * clients are persisted (and read back) as NOT first-party. These protect the
+ * anti-phishing controls from silently regressing in a future refactor.
+ */
+import fs from 'fs';
+import path from 'path';
+
+const ROOT = path.join(__dirname, '..', '..', '..');
+
+describe('consent screen wires the trust surface (SEC-76 web-oauth-7)', () => {
+  const src = fs.readFileSync(path.join(ROOT, 'src/app/oauth/authorize/page.tsx'), 'utf8');
+
+  test('imports clientTrust + redirectHost from the helper module', () => {
+    expect(src).toMatch(
+      /import\s+\{[^}]*clientTrust[^}]*redirectHost[^}]*\}\s+from\s+['"]@\/lib\/oauth\/client-trust['"]/
+    );
+  });
+
+  test('computes trust from the client is_first_party flag', () => {
+    expect(src).toMatch(/clientTrust\(req\.client\.is_first_party\)/);
+  });
+
+  test('computes the redirect host from the validated redirect URI', () => {
+    expect(src).toMatch(/redirectHost\(req\.redirectUri\)/);
+  });
+
+  test('renders the trust badge', () => {
+    expect(src).toMatch(/data-testid="client-trust-badge"/);
+  });
+
+  test('renders an unverified-client warning gated on !verified', () => {
+    expect(src).toMatch(/!trust\.verified\s*&&/);
+    expect(src).toMatch(/data-testid="unverified-client-warning"/);
+    expect(src).toMatch(/has not been verified by Lyra/);
+  });
+
+  test('surfaces the redirect host to the user', () => {
+    expect(src).toMatch(/you&apos;ll be returned to/);
+    expect(src).toMatch(/\{returnHost\}/);
+  });
+});
+
+describe('oauth_clients repository treats DCR clients as unverified (SEC-76)', () => {
+  const src = fs.readFileSync(path.join(ROOT, 'src/lib/oauth/clients.ts'), 'utf8');
+
+  test('DCR insert explicitly sets is_first_party: false', () => {
+    expect(src).toMatch(/is_first_party:\s*false/);
+  });
+
+  test('getOauthClient selects is_first_party so the consent screen can read it', () => {
+    expect(src).toMatch(/\.select\(\s*['"][^'"]*is_first_party[^'"]*['"]/);
+  });
+
+  test('ClientRecord type carries is_first_party', () => {
+    expect(src).toMatch(/is_first_party:\s*boolean/);
+  });
+});
+
+describe('migration adds the is_first_party column (SEC-76)', () => {
+  const mig = fs.readFileSync(
+    path.join(ROOT, 'supabase/migrations/20260707193000_sec76_oauth_clients_is_first_party.sql'),
+    'utf8'
+  );
+
+  test('adds is_first_party boolean defaulting false', () => {
+    expect(mig).toMatch(/add column if not exists is_first_party boolean not null default false/i);
+  });
+
+  test('documents a rollback', () => {
+    expect(mig).toMatch(/drop column if exists is_first_party/i);
+  });
+});


### PR DESCRIPTION
## Summary

DCR anti-phishing for the OAuth consent screen — finding **web-oauth-7**, split from SEC-76 batch row #25.

Dynamic Client Registration (RFC 7591) lets any party self-register an OAuth client with an arbitrary `client_name`. The `/oauth/authorize` consent screen rendered `client_name` verbatim with no verified/first-party mark and never showed the `redirect_uri`, so a phishing client could register as **"Lyra Official"** indistinguishably from a real first-party app and the user never saw where the authorization code would go.

Changes:
- **DB**: new `oauth_clients.is_first_party` column (migration `20260707193000`). DCR clients default `false`. Applied + verified on **dev** (`ilprytcrnqyrsbsrfujj`) and **staging** (`uobmlkzrjkptwhttzmmi`). `getOauthClient()` selects it; `createOauthClient()` sets it `false` explicitly.
- **Helper**: new pure module `src/lib/oauth/client-trust.ts` — `clientTrust()` (fail-closed: only a strict boolean `true` is verified) + `redirectHost()` — kept off the server-component render path so the trust logic is unit-testable.
- **Consent screen** (`src/app/oauth/authorize/page.tsx`): a verified/unverified **badge**, an **"unverified app" warning** for self-registered clients, and the real **redirect host** surfaced before the Allow button.
- **Tests**: `client-trust.test.ts` (helper logic incl. fail-closed + look-alike host) and `dcr-anti-phishing.test.ts` (consent-screen + repo + migration static-wiring guards). No existing test modified.

Verification: `tests/unit/oauth` — 11 suites / 121 tests green; `tsc --noEmit` clean; eslint clean on touched files.

## Jira Ticket

SEC-76 (finding web-oauth-7)

MCP coverage: N/A — OAuth consent-screen / auth-server internals, not user-facing profile data an agent would mirror.

## Checklist

- [x] Unit tests added/updated for new/changed functionality
- [x] All existing tests pass (oauth suite; no existing test touched)
- [x] Lint passes (touched files)
- [x] Type check passes (`tsc --noEmit`)
- [ ] Build succeeds (`npm run build`) — CI
- [x] Coverage has not decreased (net-new tests only)
- [x] No eslint-disable or ts-ignore added
- [x] ARCHITECTURE.md — N/A (no architectural change; additive column + UI)
- [x] Ops routine / Control-Room registry — N/A (no routine behaviour change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CKtRwvQJ124mLZkGF2WeJ1

---
_Generated by [Claude Code](https://claude.ai/code/session_01CKtRwvQJ124mLZkGF2WeJ1)_