### PR TITLE
SEC-62: shared-store rate limiting for OAuth token/revoke/register

### DIFF
--- a/src/app/oauth/register/route.ts
+++ b/src/app/oauth/register/route.ts
@@ -18,7 +18,8 @@
  */
 
 import { NextRequest, NextResponse } from 'next/server';
-import { rateLimit, RATE_LIMITS } from '@/lib/rate-limit';
+import { RATE_LIMITS } from '@/lib/rate-limit';
+import { sharedRateLimit, clientIpFromHeaders } from '@/lib/rate-limit-shared';
 import {
   validateRegisterInput,
   createOauthClient,
@@ -29,12 +30,10 @@ export async function POST(req: NextRequest) {
   // SEC-19 / F-05: per-IP rate limit. DCR is unauthenticated and inserts an
   // oauth_clients row per call — cap it to stop DB-flooding and phishing-client
   // seeding on the Lyra-branded consent screen.
-  const ip =
-    req.headers.get('cf-connecting-ip') ??
-    req.headers.get('x-forwarded-for')?.split(',')[0]?.trim() ??
-    req.headers.get('x-real-ip') ??
-    'unknown';
-  const { limited, retryAfter } = rateLimit(`oauth-register:${ip}`, RATE_LIMITS.oauthRegister);
+  // SEC-62: now backed by the SHARED store so the cap holds across serverless
+  // instances (falls back to the in-memory limiter if the store is down).
+  const ip = clientIpFromHeaders(req.headers);
+  const { limited, retryAfter } = await sharedRateLimit(`oauth-register:${ip}`, RATE_LIMITS.oauthRegister);
   if (limited) {
     return NextResponse.json(
       { error: 'too_many_requests', error_description: 'Too many client registrations. Please try again later.' },

--- a/src/app/oauth/revoke/route.ts
+++ b/src/app/oauth/revoke/route.ts
@@ -23,6 +23,22 @@ import { NextRequest, NextResponse } from 'next/server';
 import { decodeJwt } from 'jose';
 import { getRefreshToken, revokeFamily } from '@/lib/oauth/refresh';
 import { revokeAccessTokenJti, getAccessTokenJti } from '@/lib/oauth/access-tokens';
+import { RATE_LIMITS } from '@/lib/rate-limit';
+import { sharedRateLimit, clientIpFromHeaders } from '@/lib/rate-limit-shared';
+
+function tooManyRequests(retryAfter?: number) {
+  return NextResponse.json(
+    { error: 'too_many_requests', error_description: 'Too many revoke requests. Please slow down.' },
+    {
+      status: 429,
+      headers: {
+        'Cache-Control': 'no-store',
+        Pragma: 'no-cache',
+        'Retry-After': String(retryAfter ?? 60),
+      },
+    }
+  );
+}
 
 interface RevokeRequest {
   token?: string;
@@ -60,6 +76,12 @@ function okEmpty() {
 }
 
 export async function POST(req: NextRequest) {
+  // SEC-62 (web-oauth-4): anti-DoS per-IP cap FIRST, before parsing the body or
+  // touching the DB. Backed by the shared store so it holds across instances.
+  const ip = clientIpFromHeaders(req.headers);
+  const ipLimit = await sharedRateLimit(`oauth-revoke-ip:${ip}`, RATE_LIMITS.oauthRevokeIp);
+  if (ipLimit.limited) return tooManyRequests(ipLimit.retryAfter);
+
   const body = await readBody(req);
   // Per RFC 7009, an unparseable request is an error. But we still avoid
   // leaking — return 400 invalid_request only when shape is wrong, not
@@ -69,6 +91,15 @@ export async function POST(req: NextRequest) {
       { error: 'invalid_request', error_description: 'token is required' },
       { status: 400, headers: { 'Cache-Control': 'no-store', Pragma: 'no-cache' } }
     );
+  }
+
+  // SEC-62: per-client cap when the caller supplies a client_id.
+  if (typeof body.client_id === 'string' && body.client_id) {
+    const clientLimit = await sharedRateLimit(
+      `oauth-revoke-client:${body.client_id}`,
+      RATE_LIMITS.oauthRevokeClient
+    );
+    if (clientLimit.limited) return tooManyRequests(clientLimit.retryAfter);
   }
 
   const hint = body.token_type_hint;

--- a/src/app/oauth/token/route.ts
+++ b/src/app/oauth/token/route.ts
@@ -34,6 +34,8 @@ import {
   revokeFamily,
 } from '@/lib/oauth/refresh';
 import { oauthConfig } from '@/lib/oauth/config';
+import { RATE_LIMITS } from '@/lib/rate-limit';
+import { sharedRateLimit, clientIpFromHeaders } from '@/lib/rate-limit-shared';
 
 function errorJson(error: string, description?: string, status = 400) {
   return NextResponse.json(
@@ -41,6 +43,20 @@ function errorJson(error: string, description?: string, status = 400) {
     {
       status,
       headers: { 'Cache-Control': 'no-store', Pragma: 'no-cache' },
+    }
+  );
+}
+
+function tooManyRequests(retryAfter?: number) {
+  return NextResponse.json(
+    { error: 'too_many_requests', error_description: 'Too many token requests. Please slow down.' },
+    {
+      status: 429,
+      headers: {
+        'Cache-Control': 'no-store',
+        Pragma: 'no-cache',
+        'Retry-After': String(retryAfter ?? 60),
+      },
     }
   );
 }
@@ -141,11 +157,25 @@ async function authenticateClient(
 }
 
 export async function POST(req: NextRequest) {
+  // SEC-62 (web-oauth-4): anti-DoS per-IP cap FIRST, before parsing the body or
+  // touching the DB. Backed by the shared store so it holds across instances.
+  const ip = clientIpFromHeaders(req.headers);
+  const ipLimit = await sharedRateLimit(`oauth-token-ip:${ip}`, RATE_LIMITS.oauthTokenIp);
+  if (ipLimit.limited) return tooManyRequests(ipLimit.retryAfter);
+
   const body = await readTokenRequest(req);
   if (!body) return errorJson('invalid_request', 'body must be form-encoded or JSON');
 
   const auth = await authenticateClient(req, body);
   if (!auth.ok) return errorJson(auth.error, auth.description, auth.status);
+
+  // SEC-62: per-client cap once the client is authenticated — a single client
+  // (compromised or buggy) can't exhaust the token endpoint for everyone.
+  const clientLimit = await sharedRateLimit(
+    `oauth-token-client:${auth.clientId}`,
+    RATE_LIMITS.oauthTokenClient
+  );
+  if (clientLimit.limited) return tooManyRequests(clientLimit.retryAfter);
 
   const grantType = body.grant_type;
   if (grantType === 'authorization_code') {

--- a/src/lib/rate-limit-shared.ts
+++ b/src/lib/rate-limit-shared.ts
@@ -1,0 +1,87 @@
+/**
+ * Shared, cross-instance rate limiter — SEC-62 (web-oauth-4).
+ *
+ * The in-memory `rateLimit()` in `./rate-limit` is per-serverless-instance, so
+ * on Vercel the effective cap is (per-key cap × live instance count). For the
+ * OAuth endpoints that is not good enough: an attacker spraying /oauth/token or
+ * /oauth/register lands across many lambdas and each sees only a fraction of the
+ * traffic. This helper backs the counter with a single Supabase row via the
+ * atomic `rate_limit_hit` RPC (migration 20260708033000), so the cap holds no
+ * matter how many instances serve the requests.
+ *
+ * Failure posture — FAIL OPEN to the in-memory limiter, never fail closed:
+ * if the shared store is unreachable (missing service-role env, network error,
+ * RPC error) we fall back to the per-instance `rateLimit()`. That keeps some
+ * protection (per-instance cap) without ever DoS-ing legitimate callers when the
+ * DB blips, and it makes the helper deterministic under unit tests (which have
+ * no Supabase env, so they exercise the in-memory path). `degraded: true` flags
+ * the fallback for callers that want to log it.
+ */
+
+import { createClient } from '@supabase/supabase-js';
+import { env } from '@/lib/env';
+import { rateLimit, type RateLimitConfig } from '@/lib/rate-limit';
+
+export interface SharedRateLimitResult {
+  /** True when this request is over the cap and should be refused (429). */
+  limited: boolean;
+  /** Seconds until the window resets (for the Retry-After header). */
+  retryAfter?: number;
+  /** True when the shared store was unreachable and we fell back in-memory. */
+  degraded: boolean;
+}
+
+interface RateLimitHitRow {
+  limited: boolean;
+  retry_after: number;
+}
+
+/**
+ * Increment the counter for `key` and report whether the caller is over `config`.
+ * Uses the shared Supabase store; falls back to the in-memory limiter on any
+ * error so it never fails closed.
+ */
+export async function sharedRateLimit(
+  key: string,
+  config: RateLimitConfig
+): Promise<SharedRateLimitResult> {
+  try {
+    const supabase = createClient(env.supabaseUrl(), env.supabaseServiceRoleKey(), {
+      auth: { persistSession: false },
+    });
+    const { data, error } = await supabase.rpc('rate_limit_hit', {
+      p_bucket: key,
+      p_limit: config.limit,
+      p_window_seconds: config.windowSeconds,
+    });
+    if (error) throw error;
+
+    // `RETURNS TABLE (...)` comes back as an array of rows.
+    const row = (Array.isArray(data) ? data[0] : data) as RateLimitHitRow | undefined;
+    if (!row || typeof row.limited !== 'boolean') {
+      throw new Error('rate_limit_hit returned no usable row');
+    }
+    return {
+      limited: row.limited,
+      retryAfter: typeof row.retry_after === 'number' ? row.retry_after : undefined,
+      degraded: false,
+    };
+  } catch {
+    // Shared store unavailable → per-instance best-effort backstop.
+    const local = rateLimit(key, config);
+    return { limited: local.limited, retryAfter: local.retryAfter, degraded: true };
+  }
+}
+
+/**
+ * Extract the best-effort client IP from proxy headers (Cloudflare → Vercel).
+ * Shared by the OAuth route handlers so they bucket consistently.
+ */
+export function clientIpFromHeaders(headers: Headers): string {
+  return (
+    headers.get('cf-connecting-ip') ??
+    headers.get('x-forwarded-for')?.split(',')[0]?.trim() ??
+    headers.get('x-real-ip') ??
+    'unknown'
+  );
+}

--- a/src/lib/rate-limit.ts
+++ b/src/lib/rate-limit.ts
@@ -2,9 +2,17 @@
  * Simple in-memory rate limiter for Next.js middleware (Edge Runtime compatible).
  *
  * ⚠️ Limitation: In-memory store resets on cold starts and is per-instance.
- * On Vercel's serverless/edge, each instance has its own store.
- * This provides basic protection against brute-force attacks but is NOT
- * a distributed rate limiter. For production scale, consider Upstash Redis.
+ * On Vercel's serverless/edge, each instance has its own store, so the
+ * effective cap is (per-key cap × live instance count). This provides basic
+ * per-instance protection against brute-force attacks but is NOT a distributed
+ * rate limiter.
+ *
+ * SEC-62: for the OAuth endpoints (/oauth/token, /oauth/revoke, /oauth/register)
+ * the cap must hold across instances, so those routes go through
+ * `sharedRateLimit()` in `rate-limit-shared.ts` (Supabase-backed, atomic). That
+ * helper falls back to THIS in-memory limiter when the shared store is
+ * unreachable, so this module is still the durable-degradation backstop — never
+ * remove it. Middleware (Edge) keeps using `rateLimit()` directly.
  *
  * KAN-61: Rate limiting on auth endpoints
  */
@@ -31,7 +39,7 @@ function cleanup() {
   }
 }
 
-interface RateLimitConfig {
+export interface RateLimitConfig {
   /** Max requests allowed in the window */
   limit: number;
   /** Window duration in seconds */
@@ -77,4 +85,12 @@ export const RATE_LIMITS = {
   api: { limit: 60, windowSeconds: 60 },
   /** OAuth Dynamic Client Registration: 5 new clients/hour per IP (SEC-19/F-05) */
   oauthRegister: { limit: 5, windowSeconds: 3600 },
+  /** OAuth token endpoint, per source IP (SEC-62/web-oauth-4) — anti-DoS. */
+  oauthTokenIp: { limit: 60, windowSeconds: 60 },
+  /** OAuth token endpoint, per client_id (SEC-62) — allows legit refresh churn. */
+  oauthTokenClient: { limit: 120, windowSeconds: 60 },
+  /** OAuth revoke endpoint, per source IP (SEC-62/web-oauth-4). */
+  oauthRevokeIp: { limit: 60, windowSeconds: 60 },
+  /** OAuth revoke endpoint, per client_id (SEC-62). */
+  oauthRevokeClient: { limit: 120, windowSeconds: 60 },
 } as const;

--- a/supabase/migrations/20260708033000_sec62_oauth_rate_limit_store.sql
+++ b/supabase/migrations/20260708033000_sec62_oauth_rate_limit_store.sql
@@ -1,0 +1,87 @@
+-- SEC-62 (web-oauth-4): shared, cross-instance rate-limit store for the OAuth
+-- endpoints (/oauth/token, /oauth/revoke, /oauth/register).
+--
+-- The in-memory limiter in src/lib/rate-limit.ts is per-serverless-instance:
+-- on Vercel every lambda has its own Map, so an attacker spraying requests
+-- lands on many instances and the effective cap is (per-IP cap × instance
+-- count). This migration adds a single shared counter table + an ATOMIC upsert
+-- RPC so the cap holds no matter how many instances serve the traffic.
+--
+-- Atomicity: rate_limit_hit() does the read-modify-write in ONE
+-- INSERT ... ON CONFLICT DO UPDATE statement. Concurrent callers on the same
+-- bucket serialise on the row lock, so no increment is lost (no read-then-write
+-- race across instances). Fixed-window semantics: the first hit of a window
+-- sets reset_at; expired windows reset the counter to 1 on the next hit.
+--
+-- Rollback:
+--   DROP FUNCTION IF EXISTS public.rate_limit_hit(text, integer, integer);
+--   DROP TABLE IF EXISTS public.rate_limits;
+
+CREATE TABLE IF NOT EXISTS public.rate_limits (
+  bucket    text PRIMARY KEY,
+  hits      integer NOT NULL DEFAULT 0,
+  reset_at  timestamptz NOT NULL
+);
+
+COMMENT ON TABLE public.rate_limits IS
+  'SEC-62: shared fixed-window rate-limit counters. Written only via the service-role rate_limit_hit() RPC. One row per (endpoint,ip|client) bucket.';
+
+-- Lets a periodic sweep / index-scan drop expired rows cheaply. Not required
+-- for correctness (rate_limit_hit resets in-place) — purely for housekeeping.
+CREATE INDEX IF NOT EXISTS rate_limits_reset_at_idx ON public.rate_limits (reset_at);
+
+-- Lock the table down: only the service-role (which BYPASSES RLS) may touch it.
+-- Enabling RLS with no policies denies anon/authenticated entirely — the RPC
+-- below runs SECURITY DEFINER so it still works, and no client can read another
+-- caller's counters or forge/reset their own.
+ALTER TABLE public.rate_limits ENABLE ROW LEVEL SECURITY;
+REVOKE ALL ON public.rate_limits FROM anon, authenticated;
+
+-- Atomic fixed-window increment. Returns whether this hit is over the cap and
+-- how many seconds until the window resets.
+CREATE OR REPLACE FUNCTION public.rate_limit_hit(
+  p_bucket          text,
+  p_limit           integer,
+  p_window_seconds  integer
+)
+RETURNS TABLE (limited boolean, retry_after integer)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+  v_hits     integer;
+  v_reset_at timestamptz;
+BEGIN
+  INSERT INTO public.rate_limits AS r (bucket, hits, reset_at)
+  VALUES (
+    p_bucket,
+    1,
+    now() + make_interval(secs => p_window_seconds)
+  )
+  ON CONFLICT (bucket) DO UPDATE
+    SET hits = CASE
+                 WHEN r.reset_at < now() THEN 1
+                 ELSE r.hits + 1
+               END,
+        reset_at = CASE
+                     WHEN r.reset_at < now()
+                       THEN now() + make_interval(secs => p_window_seconds)
+                     ELSE r.reset_at
+                   END
+  RETURNING r.hits, r.reset_at INTO v_hits, v_reset_at;
+
+  limited := v_hits > p_limit;
+  retry_after := GREATEST(0, ceil(extract(epoch FROM (v_reset_at - now()))))::integer;
+  RETURN NEXT;
+END;
+$$;
+
+COMMENT ON FUNCTION public.rate_limit_hit(text, integer, integer) IS
+  'SEC-62: atomic fixed-window rate-limit increment. Service-role only.';
+
+-- SECURITY DEFINER + no public EXECUTE: only the service-role key (used by the
+-- web app''s server routes) may call it. anon/authenticated cannot enumerate or
+-- reset counters.
+REVOKE ALL ON FUNCTION public.rate_limit_hit(text, integer, integer) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.rate_limit_hit(text, integer, integer) TO service_role;

--- a/tests/unit/oauth/sec62-rate-limit-shared.test.ts
+++ b/tests/unit/oauth/sec62-rate-limit-shared.test.ts
@@ -1,0 +1,178 @@
+/**
+ * SEC-62 (web-oauth-4) — shared, cross-instance rate limiting for the OAuth
+ * endpoints.
+ *
+ * Covers:
+ *   1. sharedRateLimit() uses the Supabase `rate_limit_hit` RPC when the store
+ *      is reachable (env present + RPC ok) and reports its verdict verbatim.
+ *   2. sharedRateLimit() FAILS OPEN to the in-memory limiter on any store
+ *      failure (missing env, RPC error, malformed row) — never fails closed —
+ *      and still enforces a per-instance cap.
+ *   3. clientIpFromHeaders() proxy-header precedence.
+ *   4. /oauth/token + /oauth/revoke enforce a per-IP 429 cap (via the in-memory
+ *      fallback path exercised in unit tests, since there is no Supabase env).
+ */
+
+// Configurable mock for the Supabase client so we can drive the RPC result.
+let mockRpc: jest.Mock;
+jest.mock('@supabase/supabase-js', () => ({
+  createClient: jest.fn(() => ({ rpc: (...args: unknown[]) => mockRpc(...args) })),
+}));
+
+import { sharedRateLimit, clientIpFromHeaders } from '@/lib/rate-limit-shared';
+import { RATE_LIMITS } from '@/lib/rate-limit';
+import { POST as TOKEN_POST } from '@/app/oauth/token/route';
+import { POST as REVOKE_POST } from '@/app/oauth/revoke/route';
+
+const SUPA_ENV_KEYS = ['NEXT_PUBLIC_SUPABASE_URL', 'SUPABASE_SERVICE_ROLE_KEY'] as const;
+const savedEnv: Record<string, string | undefined> = {};
+
+beforeEach(() => {
+  mockRpc = jest.fn();
+  for (const k of SUPA_ENV_KEYS) savedEnv[k] = process.env[k];
+});
+
+afterEach(() => {
+  for (const k of SUPA_ENV_KEYS) {
+    if (savedEnv[k] === undefined) delete process.env[k];
+    else process.env[k] = savedEnv[k];
+  }
+});
+
+function withSupabaseEnv() {
+  process.env.NEXT_PUBLIC_SUPABASE_URL = 'https://example.supabase.co';
+  process.env.SUPABASE_SERVICE_ROLE_KEY = 'service-role-test-key';
+}
+
+function clearSupabaseEnv() {
+  for (const k of SUPA_ENV_KEYS) delete process.env[k];
+}
+
+describe('sharedRateLimit() — shared-store path', () => {
+  test('calls rate_limit_hit with the bucket/limit/window and returns its verdict', async () => {
+    withSupabaseEnv();
+    mockRpc.mockResolvedValue({ data: [{ limited: true, retry_after: 42 }], error: null });
+
+    const res = await sharedRateLimit('unit:key:a', { limit: 5, windowSeconds: 60 });
+
+    expect(res).toEqual({ limited: true, retryAfter: 42, degraded: false });
+    expect(mockRpc).toHaveBeenCalledWith('rate_limit_hit', {
+      p_bucket: 'unit:key:a',
+      p_limit: 5,
+      p_window_seconds: 60,
+    });
+  });
+
+  test('passes through an under-cap verdict', async () => {
+    withSupabaseEnv();
+    mockRpc.mockResolvedValue({ data: [{ limited: false, retry_after: 0 }], error: null });
+
+    const res = await sharedRateLimit('unit:key:b', { limit: 5, windowSeconds: 60 });
+    expect(res.limited).toBe(false);
+    expect(res.degraded).toBe(false);
+  });
+});
+
+describe('sharedRateLimit() — fail-open fallback', () => {
+  test('falls back to the in-memory limiter when the service-role env is missing', async () => {
+    clearSupabaseEnv();
+    const cfg = { limit: 3, windowSeconds: 60 };
+    const key = 'unit:fallback:missing-env';
+
+    const verdicts = [];
+    for (let i = 0; i < 4; i++) verdicts.push(await sharedRateLimit(key, cfg));
+
+    // First 3 within the cap, 4th trips it — enforced by the in-memory backstop.
+    expect(verdicts.slice(0, 3).every((v) => v.limited === false)).toBe(true);
+    expect(verdicts[3].limited).toBe(true);
+    // Every verdict is flagged degraded (store was never reached).
+    expect(verdicts.every((v) => v.degraded === true)).toBe(true);
+    // The RPC was never attempted (env threw before createClient).
+    expect(mockRpc).not.toHaveBeenCalled();
+  });
+
+  test('falls back when the RPC returns an error', async () => {
+    withSupabaseEnv();
+    mockRpc.mockResolvedValue({ data: null, error: { message: 'boom' } });
+
+    const res = await sharedRateLimit('unit:fallback:rpc-error', { limit: 3, windowSeconds: 60 });
+    expect(res.degraded).toBe(true);
+    expect(res.limited).toBe(false); // first hit under cap
+  });
+
+  test('falls back when the RPC returns no usable row', async () => {
+    withSupabaseEnv();
+    mockRpc.mockResolvedValue({ data: [], error: null });
+
+    const res = await sharedRateLimit('unit:fallback:empty-row', { limit: 3, windowSeconds: 60 });
+    expect(res.degraded).toBe(true);
+  });
+});
+
+describe('clientIpFromHeaders()', () => {
+  test('prefers cf-connecting-ip', () => {
+    const h = new Headers({ 'cf-connecting-ip': '1.1.1.1', 'x-forwarded-for': '2.2.2.2' });
+    expect(clientIpFromHeaders(h)).toBe('1.1.1.1');
+  });
+
+  test('uses the first x-forwarded-for hop when cf header is absent', () => {
+    const h = new Headers({ 'x-forwarded-for': '3.3.3.3, 4.4.4.4' });
+    expect(clientIpFromHeaders(h)).toBe('3.3.3.3');
+  });
+
+  test('falls back to "unknown" with no proxy headers', () => {
+    expect(clientIpFromHeaders(new Headers())).toBe('unknown');
+  });
+});
+
+describe('/oauth/token per-IP rate limit (SEC-62)', () => {
+  test('returns 429 with Retry-After once the per-IP cap is exceeded', async () => {
+    clearSupabaseEnv(); // exercise the in-memory fallback deterministically
+    const ip = '198.51.100.20'; // unique bucket for this test
+    const fire = () => {
+      const req = new Request('https://dev.checklyra.com/oauth/token', {
+        method: 'POST',
+        headers: { 'x-forwarded-for': ip }, // no content-type → body parse fails AFTER the IP gate
+        body: 'grant_type=refresh_token',
+      });
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      return TOKEN_POST(req as any);
+    };
+
+    for (let i = 0; i < RATE_LIMITS.oauthTokenIp.limit; i++) {
+      const res = await fire();
+      expect(res.status).not.toBe(429);
+    }
+    const limited = await fire();
+    expect(limited.status).toBe(429);
+    expect(limited.headers.get('retry-after')).toBeTruthy();
+    const j = await limited.json();
+    expect(j.error).toBe('too_many_requests');
+  });
+});
+
+describe('/oauth/revoke per-IP rate limit (SEC-62)', () => {
+  test('returns 429 with Retry-After once the per-IP cap is exceeded', async () => {
+    clearSupabaseEnv();
+    const ip = '198.51.100.21';
+    const fire = () => {
+      const req = new Request('https://dev.checklyra.com/oauth/revoke', {
+        method: 'POST',
+        headers: { 'x-forwarded-for': ip }, // no content-type → invalid_request AFTER the IP gate
+        body: 'token=abc',
+      });
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      return REVOKE_POST(req as any);
+    };
+
+    for (let i = 0; i < RATE_LIMITS.oauthRevokeIp.limit; i++) {
+      const res = await fire();
+      expect(res.status).not.toBe(429);
+    }
+    const limited = await fire();
+    expect(limited.status).toBe(429);
+    expect(limited.headers.get('retry-after')).toBeTruthy();
+    const j = await limited.json();
+    expect(j.error).toBe('too_many_requests');
+  });
+});


### PR DESCRIPTION
## Summary

**Finding web-oauth-4.** `/oauth/token` and `/oauth/revoke` had **no rate limit**, and the DCR limiter on `/oauth/register` used the in-memory limiter — which is per-serverless-instance, so on Vercel the effective cap was `(per-key cap × live instance count)` and reset on every cold start. An attacker spraying requests lands across many lambdas and each sees only a fraction of the traffic.

This backs the OAuth limiters with a **shared Supabase store** so the cap holds across instances, with a **fail-open** fallback to the existing in-memory limiter so a DB blip never DoS-es legitimate callers.

- **Migration `20260708033000_sec62_oauth_rate_limit_store.sql`** — `rate_limits` table + atomic `rate_limit_hit(bucket, limit, window)` RPC. The read-modify-write is a single `INSERT … ON CONFLICT DO UPDATE`, so concurrent instances serialise on the row lock and no increment is lost. Table is RLS-deny-all; the RPC is `SECURITY DEFINER` with `search_path=''` and `EXECUTE` granted **only to `service_role`** (anon/authenticated revoked).
- **`src/lib/rate-limit-shared.ts`** — `sharedRateLimit()` calls the RPC and **fails open** to the existing in-memory `rateLimit()` on any store error (missing env, network, RPC error, malformed row), flagging `degraded: true`. `clientIpFromHeaders()` shared IP extraction.
- **`/oauth/token`** — per-IP cap before body parse (anti-DoS) + per-`client_id` cap after auth.
- **`/oauth/revoke`** — per-IP cap + per-`client_id` cap when a `client_id` is supplied.
- **`/oauth/register`** — switched to the shared store (same 5/hour/IP preset).
- Corrected the F-05 in-memory-durability comments in `rate-limit.ts` and the register route.

## Jira Ticket

SEC-62

## Verification

- **Migration applied + verified on dev (`ilprytcrnqyrsbsrfujj`) and staging (`uobmlkzrjkptwhttzmmi`)**: cap enforcement (Nth+1 call → `limited:true`), fixed-window reset (aged window → `hits` resets to 1), and `anon`/`authenticated` `EXECUTE` denied while `service_role` allowed; RLS on. Test rows cleaned up.
- `get_advisors` (security): no new actionable advisory — `rate_limits` shows only the expected INFO `rls_enabled_no_policy` (intended deny-all, same as every `oauth_*` table); the new RPC does **not** trip the `authenticated_security_definer_function_executable` WARN.

## Checklist

- [x] Unit tests added/updated — new `tests/unit/oauth/sec62-rate-limit-shared.test.ts` (10): RPC verdict pass-through, fail-open fallback (missing env / RPC error / empty row), IP-header precedence, per-IP 429 on `/oauth/token` and `/oauth/revoke`
- [x] All existing tests pass — `175 suites / 2151 tests` green; **no existing test modified**
- [x] Lint passes (changed files)
- [x] Type check passes (`tsc --noEmit`: 0 errors)
- [ ] Build succeeds — not run this session (unit + tsc + lint green)
- [x] Coverage has not decreased (net-new tests only)
- [x] No `eslint-disable`/`ts-ignore` without reference (only the pre-existing test-file `no-explicit-any` disables, matching sibling oauth tests)
- [ ] ARCHITECTURE.md — N/A (no architectural surface change; internal limiter backing store)
- [x] Ops routine / Control-Room registry — N/A (no scheduled-routine behaviour change)

**MCP coverage:** N/A — internal auth-endpoint hardening, not user-facing data (no MCP surface).

**Deploy note:** the shared limiter reads `SUPABASE_SERVICE_ROLE_KEY` (already set in every env). No new env var. Prod migration rides the normal promote wave; until then prod OAuth routes fail open to the in-memory limiter (current behaviour), so there is no ordering hazard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01W2oqPZVuGbuLZ2dpVff1TH)_