### PR TITLE
docs(KAN-359): Documentation Definition-of-Done + guard test

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -17,3 +17,4 @@ KAN-XX
 - [ ] No eslint-disable or ts-ignore without KAN-XX reference
 - [ ] ARCHITECTURE.md updated if architectural changes were made
 - [ ] Ops routine / Control-Room registry updated if scheduled-routine behaviour, cadence, or ownership changed — `docs/OPS_ROUTINES_CONTROL_ROOM.md` + the Confluence Control Room (or N/A) (KAN-359)
+- [ ] Docs / system map updated — Architecture & Infrastructure and/or Data Model & Security (+ ADR for any design decision), or N/A with reason (KAN-359 Documentation Definition-of-Done; see `docs/RUNBOOK.md` and `docs/DOC_SYNC_HEALTHCHECK_ROUTINE.md`)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,6 +42,19 @@ Before starting any task, Claude must:
 4. **Run tests before and after** — every change must leave tests green.
 5. **Check the surface** — confirm this is Claude Code, not chat. See "Editing the environment: Claude Code only" above.
 6. **Confirm working-tree isolation** — if Luisa might be running other Claude Code instances against this repo, this session MUST be in its own git worktree (see "Parallel Claude sessions" below). Verify with `git branch --show-current` at the start of work AND right before every `git add` / `git commit`. If HEAD switched unexpectedly, stop and recover per BUGS-17.
+7. **Plan the doc footprint** — identify up front which system-map / wiki pages the work will touch (Architecture & Infrastructure, Data Model & Security) per the **Documentation Definition-of-Done** below. Docs are part of "done", not a follow-up ticket.
+
+## Documentation Definition-of-Done (KAN-359)
+
+Docs are part of "done", not a separate ticket. **Before closing any epic — and on every feature PR — confirm:**
+
+- [ ] Live **system map** updated where affected — Confluence **Architecture & Infrastructure** and/or **Data Model & Security** (+ repo `docs/` mirrors such as `ARCHITECTURE.md`): any new/changed service, table, env var, route, scheduled job, or security boundary.
+- [ ] Any **design decision** recorded as an ADR and linked from the epic.
+- [ ] **Jira ↔ wiki** cross-linked — the epic cites the wiki page(s); the page cites the Jira key.
+- [ ] **`docs/TEST_AUDIT_2026Q2.md`** refreshed if test gates, floors, or coverage changed.
+- [ ] PR-template item _"Docs / system map updated — or N/A with reason"_ ticked honestly.
+
+`N/A` is acceptable for pure logic/test/infra-only changes, but must state why. Full runbook version: `docs/RUNBOOK.md` → "Documentation Definition-of-Done". Watched by the `DOC_SYNC_HEALTHCHECK_ROUTINE` and guarded by `tests/unit/doc-dod.test.js`.
 
 ## Parallel Claude sessions — use git worktrees
 

--- a/docs/RUNBOOK.md
+++ b/docs/RUNBOOK.md
@@ -447,3 +447,38 @@ When deploying a feature with MCP changes:
 4. End-to-end test exercises the MCP tool from a real agent on `dev.checklyra.com`.
 
 Reverse the order on rollback (web first, then MCP).
+
+## Documentation Definition-of-Done (KAN-359)
+
+Documentation drifts from code unless keeping it current is part of "done". This
+Definition of Done (DoD) is mandatory for every epic and every feature PR — it is
+how the live system map, the design docs, and `docs/` stay in step with what
+actually ships.
+
+**Before an epic can be closed, it must:**
+
+1. Update the live **system map** — the Confluence **Architecture & Infrastructure**
+   and/or **Data Model & Security** pages (and their repo mirrors under `docs/`,
+   e.g. `ARCHITECTURE.md`) — to reflect any new/changed service, table, env var,
+   route, scheduled job, or security boundary.
+2. Record any **design decision** as a short ADR ("context → decision →
+   consequences") and link it from the epic.
+3. **Link Jira ↔ wiki** — the epic references the wiki page(s) it updated, and
+   those pages reference the epic/Jira key.
+4. Refresh **`docs/TEST_AUDIT_2026Q2.md`** (or the current quarter's audit) when
+   test gates, floors, or coverage change.
+
+**Per-PR gate:** every PR ticks the PR-template checklist item _"Docs / system map
+updated — or N/A with reason"_. `N/A` is a valid answer for pure logic/test/infra
+changes, but it must state why.
+
+**Enforcement / watchers:**
+
+- The `DOC_SYNC_HEALTHCHECK_ROUTINE` (weekday Claude routine) catches the failure
+  mode where the doc-sync log claims "in sync" but a repo's real `main` has moved
+  ahead. See `docs/DOC_SYNC_HEALTHCHECK_ROUTINE.md`.
+- `tests/unit/doc-dod.test.js` guards the presence of this DoD across
+  `docs/RUNBOOK.md`, `CLAUDE.md`, and the PR template so it cannot be silently
+  removed.
+
+Source: KAN-359 · Epic KAN-350 (Phase-4 documentation hygiene).

--- a/docs/TEST_AUDIT_2026Q2.md
+++ b/docs/TEST_AUDIT_2026Q2.md
@@ -89,8 +89,28 @@ The `lyra-mcp-server` repo has no `.github/workflows/` directory — Railway aut
 - [ ] lyra-mcp-server CI gate — deferred to follow-up (cross-repo)
 - [ ] Workflow loop-closure tests — deferred to a coordinated session
 
+## 2026-07 update — Documentation Definition-of-Done gate (KAN-359)
+
+KAN-359 (Phase-4 documentation hygiene, epic KAN-350) adds a **Documentation
+Definition-of-Done**: every epic must update the live system map (Architecture &
+Infrastructure / Data Model & Security), record ADRs for design decisions, and
+cross-link Jira ↔ wiki before it closes; every PR ticks a _"Docs / system map
+updated — or N/A with reason"_ checklist item. Gates recorded here:
+
+- **`tests/unit/doc-dod.test.js`** — asserts the DoD is present in
+  `docs/RUNBOOK.md`, `CLAUDE.md`, and `.github/PULL_REQUEST_TEMPLATE.md`, so the
+  guardrail cannot be silently deleted.
+- **PR-template checklist item** — _"Docs / system map updated — or N/A with
+  reason"_ (complements the existing ops-routine / Control-Room registry item).
+- **`DOC_SYNC_HEALTHCHECK_ROUTINE`** — weekday watcher for doc-sync drift
+  (`docs/DOC_SYNC_HEALTHCHECK_ROUTINE.md`).
+
+These are process/documentation gates; they add net-new coverage and do **not**
+change any existing test assertion.
+
 ## Refs
 
 - KAN-167 (parent — workflow-side false-positive elimination)
 - KAN-110 (original regression guard)
 - KAN-114 (Playwright E2E expansion — unchanged scope here)
+- KAN-359 (Documentation Definition-of-Done gate — added 2026-07-08)

--- a/tests/unit/doc-dod.test.js
+++ b/tests/unit/doc-dod.test.js
@@ -1,0 +1,40 @@
+/**
+ * KAN-359 — Documentation Definition-of-Done guard.
+ *
+ * Asserts the Documentation DoD is present across the runbook, CLAUDE.md, the PR
+ * template, and the quarterly test audit so the guardrail cannot be silently
+ * removed. Pure file-content assertions (same style as backup.test.js /
+ * security-rotation-doc.test.ts). Net-new coverage; changes no existing test.
+ */
+const fs = require('fs');
+const path = require('path');
+
+const root = path.join(__dirname, '../..');
+const read = (p) => fs.readFileSync(path.join(root, p), 'utf8');
+
+describe('KAN-359: Documentation Definition-of-Done is documented', () => {
+  test('docs/RUNBOOK.md has the Documentation Definition-of-Done section', () => {
+    const content = read('docs/RUNBOOK.md');
+    expect(content).toContain('Documentation Definition-of-Done');
+    expect(content).toContain('system map');
+    expect(content).toContain('DOC_SYNC_HEALTHCHECK_ROUTINE');
+  });
+
+  test('CLAUDE.md carries the Documentation Definition-of-Done close-out checklist', () => {
+    const content = read('CLAUDE.md');
+    expect(content).toContain('Documentation Definition-of-Done');
+    expect(content).toContain('Docs are part of "done"');
+  });
+
+  test('PR template has the docs/system-map DoD checklist item', () => {
+    const content = read('.github/PULL_REQUEST_TEMPLATE.md');
+    expect(content).toMatch(/Docs \/ system map updated/);
+    expect(content).toContain('KAN-359');
+  });
+
+  test('TEST_AUDIT_2026Q2 records the doc-DoD gate', () => {
+    const content = read('docs/TEST_AUDIT_2026Q2.md');
+    expect(content).toContain('Documentation Definition-of-Done');
+    expect(content).toContain('doc-dod.test.js');
+  });
+});


### PR DESCRIPTION
## Summary

Phase-4 documentation hygiene (epic KAN-350). Establishes a **Documentation Definition-of-Done (DoD)** so the live system map and design docs stay in step with shipped code, and guards it with a test so it can't be silently removed.

- **`docs/RUNBOOK.md`** — new "Documentation Definition-of-Done" section: every epic must update the system map (Architecture & Infrastructure / Data Model & Security + repo `docs/` mirrors), record ADRs for design decisions, and cross-link Jira ↔ wiki before it closes.
- **`CLAUDE.md`** — pre-work "plan the doc footprint" item + a close-out DoD checklist so Claude Code sessions enforce it.
- **`.github/PULL_REQUEST_TEMPLATE.md`** — adds a "Docs / system map updated — or N/A with reason" checklist item (complements the existing ops-routine / Control-Room registry item already tagged KAN-359).
- **`docs/TEST_AUDIT_2026Q2.md`** — records the new doc-DoD gate.
- **`tests/unit/doc-dod.test.js`** (new) — asserts the DoD is present across RUNBOOK, CLAUDE.md, the PR template, and the test audit.

## Jira Ticket

KAN-359

## Deliberately deferred (KAN-359 stays In Progress)

Two acceptance items are **not** in this PR and remain on the ticket:
- The Confluence **Operations & Support Runbook** mirror of the DoD section.
- The "live system map is current as of this review" sweep (a broader currency pass across the Confluence Architecture / Data-Model pages).

This PR delivers the enforceable, code-reviewed core (the process docs + guard) that Claude Code sessions read on every task.

## Checklist

- [x] Unit tests added/updated for new/changed functionality (`tests/unit/doc-dod.test.js`)
- [x] All existing tests pass (`npm run test:unit` — 175 suites / 2145 tests green)
- [x] Lint passes (new test file `eslint` clean)
- [x] No eslint-disable or ts-ignore without KAN-XX reference
- [x] Docs / system map updated — this PR *is* the DoD documentation (Confluence mirror deferred, see above) (KAN-359)
- N/A: type-check / build (docs + one plain-JS test; no TS/runtime surface), ARCHITECTURE.md (no architectural change)

MCP coverage: not applicable — documentation / process change, no user-facing data surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NZASMqVBuK29mHXR6VapFd

---
_Generated by [Claude Code](https://claude.ai/code/session_01NZASMqVBuK29mHXR6VapFd)_