### PR TITLE
fix(profile): batch public-profile section reads + surface DB errors (KAN-351)

### DIFF
--- a/src/app/[slug]/page.tsx
+++ b/src/app/[slug]/page.tsx
@@ -23,6 +23,7 @@ import { headers } from 'next/headers';
 import { isIsoAlpha2, normaliseDeliveryCountry } from '@/lib/affiliate/country-codes';
 import { buildV2Recommendations } from '@/lib/recommender/v2/pipeline';
 import type { ConceptInput } from '@/lib/recommender/v2/types';
+import * as Sentry from '@sentry/nextjs';
 
 // BUGS-14: profile pages render dynamically per-request (cookie read for the
 // members-only visibility decision; force-dynamic also makes notFound() emit a
@@ -190,39 +191,76 @@ export default async function PublicProfilePage({ params }: Props) {
   const { data: { user: viewer } } = await cookieClient.auth.getUser();
   const isAuthenticated = viewer !== null;
 
-  const { data: items } = await getSupabase()
-    .from('profile_items')
-    .select('*')
-    .eq('profile_id', typedProfile.id)
-    .order('created_at', { ascending: true });
+  // KAN-351 (web-arch-3): the five per-profile section reads each depend only
+  // on typedProfile.id, so run them in parallel instead of the previous
+  // sequential await-waterfall. Errors are no longer silently dropped — every
+  // read result is inspected below and any failure is surfaced.
+  const [itemsRes, schoolsRes, linksRes, manualOfMeRes, starterRowsRes] = await Promise.all([
+    getSupabase()
+      .from('profile_items')
+      .select('*')
+      .eq('profile_id', typedProfile.id)
+      .order('created_at', { ascending: true }),
+    getSupabase()
+      .from('school_affiliations')
+      .select('*')
+      .eq('profile_id', typedProfile.id),
+    getSupabase()
+      .from('external_links')
+      .select('*')
+      .eq('profile_id', typedProfile.id),
+    getSupabase()
+      .from('profile_manual_of_me')
+      .select('communication_style, working_preferences, energises_me, drains_me, good_to_know, boundaries')
+      .eq('profile_id', typedProfile.id)
+      .maybeSingle(),
+    getSupabase()
+      .from('profile_conversation_starters')
+      .select('id, answer, prompt:conversation_starter_prompts!profile_conversation_starters_prompt_id_fkey(prompt, sort_order)')
+      .eq('profile_id', typedProfile.id)
+      .order('created_at', { ascending: true }),
+  ]);
+
+  // KAN-351 (web-arch-3): previously each `const { data } = await …` dropped
+  // its `error`, so a partial DB outage rendered an incomplete profile as a
+  // clean 200. Capture every failure to Sentry for observability, then fail
+  // loudly rather than silently serve an empty/partial profile. These are
+  // plain/`maybeSingle` reads (no `.single()`), so an error means a genuine
+  // read failure — never the "row legitimately absent" case.
+  const sectionReadErrors = (
+    [
+      ['profile_items', itemsRes.error],
+      ['school_affiliations', schoolsRes.error],
+      ['external_links', linksRes.error],
+      ['profile_manual_of_me', manualOfMeRes.error],
+      ['profile_conversation_starters', starterRowsRes.error],
+    ] as const
+  ).filter((entry) => entry[1] != null);
+
+  if (sectionReadErrors.length > 0) {
+    for (const [table, error] of sectionReadErrors) {
+      Sentry.captureException(error, {
+        tags: { area: 'public-profile', table },
+        extra: { slug, profileId: typedProfile.id },
+      });
+    }
+    throw new Error(
+      `Public profile section reads failed for ${sectionReadErrors
+        .map(([table]) => table)
+        .join(', ')}`,
+    );
+  }
+
+  const items = itemsRes.data;
+  const schools = schoolsRes.data;
+  const links = linksRes.data;
+  const manualOfMe = (manualOfMeRes.data as ManualOfMe | null) ?? null;
+  const starterRowsRaw = starterRowsRes.data;
 
   const sectionVisibility = coerceSectionVisibility(typedProfile.section_visibility);
   const visibleItems = ((items || []) as ProfileItem[]).filter((item) =>
     isItemVisibleUnderHybridModel(item, sectionVisibility, isAuthenticated),
   );
-
-  const { data: schools } = await getSupabase()
-    .from('school_affiliations')
-    .select('*')
-    .eq('profile_id', typedProfile.id);
-
-  const { data: links } = await getSupabase()
-    .from('external_links')
-    .select('*')
-    .eq('profile_id', typedProfile.id);
-
-  const { data: manualOfMeRow } = await getSupabase()
-    .from('profile_manual_of_me')
-    .select('communication_style, working_preferences, energises_me, drains_me, good_to_know, boundaries')
-    .eq('profile_id', typedProfile.id)
-    .maybeSingle();
-  const manualOfMe = (manualOfMeRow as ManualOfMe | null) ?? null;
-
-  const { data: starterRowsRaw } = await getSupabase()
-    .from('profile_conversation_starters')
-    .select('id, answer, prompt:conversation_starter_prompts!profile_conversation_starters_prompt_id_fkey(prompt, sort_order)')
-    .eq('profile_id', typedProfile.id)
-    .order('created_at', { ascending: true });
   const typedStarters = (starterRowsRaw ?? []).map((r) => {
     const promptCandidate = r.prompt as unknown;
     const joined = Array.isArray(promptCandidate)

--- a/tests/unit/kan351-public-profile-data-integrity.test.ts
+++ b/tests/unit/kan351-public-profile-data-integrity.test.ts
@@ -1,0 +1,66 @@
+/**
+ * KAN-351 (finding web-arch-3) — public-profile data-access integrity.
+ *
+ * The public profile Server Component (`src/app/[slug]/page.tsx`) used to run
+ * its per-profile section reads as a sequential await-waterfall and dropped
+ * every Supabase `error` on the floor, so a partial DB outage rendered an
+ * incomplete profile as a clean 200 (a "misleading success").
+ *
+ * This guard locks in the two behavioural fixes that shipped in place (the
+ * larger structural extraction into `src/lib` + JSX component split is deferred
+ * — the repo's source-grep regression guards pin the queries/JSX into
+ * page.tsx, so relocating them needs test-integrity sign-off):
+ *
+ *   1. the five section reads run in ONE `Promise.all(...)` batch, and
+ *   2. any read error is surfaced (Sentry + a thrown error), never swallowed.
+ *
+ * Same cheap static-coverage pattern as the sibling KAN-181 / SEC-44 guards.
+ */
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const ROOT = resolve(__dirname, '../..');
+const PAGE = 'src/app/[slug]/page.tsx';
+
+describe('KAN-351: public profile reads are batched and errors surfaced', () => {
+  const src = readFileSync(resolve(ROOT, PAGE), 'utf8');
+
+  test('imports the Sentry SDK for error surfacing', () => {
+    expect(src).toMatch(/import \* as Sentry from '@sentry\/nextjs'/);
+  });
+
+  test('runs the five section reads in a single Promise.all batch', () => {
+    // Locate the batch and assert all five tables are read inside it (proves
+    // the sequential waterfall is gone).
+    const batchStart = src.indexOf('await Promise.all([');
+    expect(batchStart).toBeGreaterThan(-1);
+    const batchBlock = src.slice(batchStart, src.indexOf('];', batchStart));
+
+    for (const table of [
+      'profile_items',
+      'school_affiliations',
+      'external_links',
+      'profile_manual_of_me',
+      'profile_conversation_starters',
+    ]) {
+      expect(batchBlock).toContain(`.from('${table}')`);
+    }
+  });
+
+  test('captures every read error to Sentry and fails loudly (no silent 200)', () => {
+    expect(src).toMatch(/Sentry\.captureException\(/);
+    // A non-empty error set must throw rather than render an empty profile.
+    expect(src).toMatch(/sectionReadErrors/);
+    expect(src).toMatch(/throw new Error\(/);
+  });
+
+  test('does not reintroduce a sequential per-read await for the batched tables', () => {
+    // The old pattern was `const { data: schools } = await getSupabase()`.
+    // After batching, the section reads are destructured from the Promise.all
+    // result, so no standalone awaited getSupabase() read should remain for
+    // these tables.
+    expect(src).not.toMatch(/const \{ data: schools \} = await getSupabase\(\)/);
+    expect(src).not.toMatch(/const \{ data: links \} = await getSupabase\(\)/);
+    expect(src).not.toMatch(/const \{ data: manualOfMeRow \} = await getSupabase\(\)/);
+  });
+});


### PR DESCRIPTION
## What & why (KAN-351 / finding web-arch-3)

`src/app/[slug]/page.tsx` ran its five per-profile section reads as a **sequential await-waterfall** and **dropped every Supabase `error`** — so a partial DB outage rendered an incomplete profile as a clean `200` (a "misleading success"). This is the sev-high behavioural half of KAN-351.

## Changes

- **Batch the reads** — `profile_items`, `school_affiliations`, `external_links`, `profile_manual_of_me`, `profile_conversation_starters` now run in one `Promise.all(...)` (each depends only on the profile id) instead of five sequential awaits.
- **Surface errors** — every read result is inspected; any error is captured to Sentry (`tags: { area, table }`) and then **thrown**, so a partial read failure fails loudly instead of silently serving an empty/partial profile. These are plain / `maybeSingle` reads (no `.single()`), so an error is a genuine read failure — never the "row legitimately absent" case, so legitimately-empty sections still render normally.
- **New guard** — `tests/unit/kan351-public-profile-data-integrity.test.ts` locks in the batch + error-surfacing.

## Scope / deferral

This slice ships the **behavioural** fix only. The larger structural leg (**web-arch-5**: extract `getPublicProfile` into `src/lib` + split the JSX into section components so the page is orchestration-only) is **deferred** — several existing regression guards source-grep the queries and JSX strings *into* `page.tsx` (`public-profile-suspended-gating` / SEC-44, `phase3-ui-integration` L254, `public-profile`, `conversation-starters`, `affiliations-and-autosave`, `profile-sections`). Relocating the queries/JSX would break those guards, which needs Test-Integrity sign-off to evolve. **Founder decision needed:** (a) approve re-pointing those guards at the extracted module, or (b) keep the queries in `page.tsx` and treat web-arch-3 (this PR) as closing the sev-high risk.

## Tests

- `npm run type-check` clean; `eslint` clean on changed files.
- **175 suites / 2145 tests green.** No existing test modified — behavioural change is additive; new guard added.

MCP coverage: deferred — pure server-render/data-access refactor, no user-facing data-model or API change (no MCP surface).

Left as **draft** for founder review (behavioural change on the public render path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SAGtbwUaQHnfSxk1s1493W

---
_Generated by [Claude Code](https://claude.ai/code/session_01SAGtbwUaQHnfSxk1s1493W)_