### PR TITLE
chore(ci): add macOS Finder-duplicate file guard (KAN-357)

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -30,6 +30,12 @@ jobs:
         # (build does NOT catch it), so without this guard a regression
         # ships green and breaks every form on the affected page.
         run: bash scripts/check-server-action-exports.sh
+      - name: macOS Finder-duplicate file check (KAN-357)
+        # Reject any committed " <n>"-suffixed file/dir (e.g. "[slug] 2/" or
+        # "profile-sections 2.cjs"). These Finder-copy duplicates shadow the
+        # canonical module, are never imported, and confuse audits. Fails the
+        # PR if any tracked path carries the suffix. Allow-list in the script.
+        run: bash scripts/check-macos-duplicate-files.sh
       - name: Auto-heal pattern catalogue self-test (KAN-63 Tier 4)
         # Verify every entry in scripts/auto-fix-patterns.json still
         # matches its fixture under tests/fixtures/auto-fix-logs/, and

--- a/scripts/check-macos-duplicate-files.sh
+++ b/scripts/check-macos-duplicate-files.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+# scripts/check-macos-duplicate-files.sh
+#
+# KAN-357: Reject committed macOS Finder-duplicate files/directories.
+#
+# When a file or folder is copied in macOS Finder (or lands via certain
+# sync/merge accidents) it gets a " 2" / " 3" … suffix appended to the base
+# name, e.g.:
+#
+#   src/app/api/recommendations/[slug] 2/route.ts      (duplicated directory)
+#   tests/unit/profile-sections 2.cjs                  (duplicated source file)
+#
+# These shadow the real module, are never imported, silently rot, and confuse
+# audits ("which is canonical?"). They have slipped into worktrees before
+# (KAN-357 / findings cross-repo-05, web-arch-8). This guard fails the PR if
+# any TRACKED path carries the Finder-copy suffix, so the class of regression
+# can never reach develop.
+#
+# Scope: git-tracked paths only (untracked scratch files are ignored). Applies
+# to source-code extensions and to any directory component, since a duplicated
+# route directory ([slug] 2) is the higher-risk case.
+#
+# Allow-list: if a " <n>" suffix is ever legitimate (it currently never is in
+# this repo), add the exact tracked path to the ALLOWLIST array below with a
+# one-line reason. Keep it empty by default.
+
+set -euo pipefail
+
+# Exact tracked paths that are intentionally allowed to carry a " <n>" suffix.
+# Format: one path per line. Keep empty unless there is a real, justified case.
+ALLOWLIST=$(cat <<'EOF'
+EOF
+)
+
+# Code file extensions we care about for the "<name> 2.ext" file case.
+CODE_EXT_RE='\.(ts|tsx|js|jsx|cjs|mjs|json|md|sql|css|scss)$'
+
+# A path component that is a Finder-copy: ends in a space followed by digits,
+# optionally with a trailing extension (files) or nothing (directories).
+#   "foo 2"        -> dir copy
+#   "foo 2.ts"     -> file copy
+#   "[slug] 2"     -> route-dir copy
+DUP_COMPONENT_RE=' [0-9]+($|\.)'
+
+violations=0
+
+# Iterate tracked files; NUL-safe against spaces in paths.
+while IFS= read -r -d '' path; do
+  # Allow-list check (exact match).
+  if [ -n "$ALLOWLIST" ] && printf '%s\n' "$ALLOWLIST" | grep -qxF "$path"; then
+    continue
+  fi
+
+  hit=""
+
+  # 1) Any directory component with a Finder-copy suffix (e.g. "[slug] 2/").
+  #    Strip the final basename, then inspect each remaining segment.
+  dir="${path%/*}"
+  if [ "$dir" != "$path" ]; then
+    IFS='/' read -ra segs <<<"$dir"
+    for seg in "${segs[@]}"; do
+      if printf '%s' "$seg" | grep -qE "$DUP_COMPONENT_RE"; then
+        hit="duplicated directory component: '$seg'"
+        break
+      fi
+    done
+  fi
+
+  # 2) The file basename itself: "<name> 2.<code-ext>".
+  if [ -z "$hit" ]; then
+    base="${path##*/}"
+    if printf '%s' "$base" | grep -qE " [0-9]+$CODE_EXT_RE" \
+      || printf '%s' "$base" | grep -qE " [0-9]+$"; then
+      hit="duplicated file: '$base'"
+    fi
+  fi
+
+  if [ -n "$hit" ]; then
+    echo "::error file=$path::macOS Finder-duplicate committed — $hit. Remove it (the un-suffixed path is canonical), or allow-list with a reason in scripts/check-macos-duplicate-files.sh."
+    violations=$((violations + 1))
+  fi
+done < <(git ls-files -z)
+
+if [ "$violations" -gt 0 ]; then
+  echo ""
+  echo "::error::Found $violations macOS Finder-duplicate path(s). See KAN-357."
+  echo "These ' <n>'-suffixed files/dirs shadow the canonical module and must not be committed."
+  exit 1
+fi
+
+echo "No macOS Finder-duplicate files committed. ✓"

--- a/tests/scripts/check-macos-duplicate-files.test.js
+++ b/tests/scripts/check-macos-duplicate-files.test.js
@@ -1,0 +1,76 @@
+const { execSync } = require('child_process');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const SCRIPT = path.resolve(__dirname, '../../scripts/check-macos-duplicate-files.sh');
+
+// Run the guard from inside `cwd` (a throwaway git repo). Returns { code, out }.
+function run(cwd) {
+  try {
+    const out = execSync(`bash "${SCRIPT}"`, { stdio: 'pipe', cwd }).toString();
+    return { code: 0, out };
+  } catch (e) {
+    return { code: e.status, out: `${(e.stdout || '')}${(e.stderr || '')}` };
+  }
+}
+
+// Build a minimal git repo containing `files` (map of relative path -> contents),
+// all committed so `git ls-files` sees them.
+function makeRepo(files) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'macdup-'));
+  execSync('git init -q && git config user.email t@t && git config user.name t', { cwd: dir });
+  for (const [rel, contents] of Object.entries(files)) {
+    const full = path.join(dir, rel);
+    fs.mkdirSync(path.dirname(full), { recursive: true });
+    fs.writeFileSync(full, contents);
+  }
+  execSync('git add -A && git commit -q -m fixture', { cwd: dir });
+  return dir;
+}
+
+describe('scripts/check-macos-duplicate-files.sh (KAN-357)', () => {
+  const source = fs.readFileSync(SCRIPT, 'utf8');
+
+  it('exists, is bash, and is syntactically valid', () => {
+    expect(fs.existsSync(SCRIPT)).toBe(true);
+    expect(source.startsWith('#!/usr/bin/env bash')).toBe(true);
+    expect(() => execSync(`bash -n "${SCRIPT}"`, { stdio: 'pipe' })).not.toThrow();
+  });
+
+  it('is hardened (set -euo pipefail, no lossy || echo fallback)', () => {
+    expect(source).toMatch(/set -euo pipefail/);
+    expect(source).not.toMatch(/\|\|\s*echo\s*"/);
+  });
+
+  it('PASSES (exit 0) on a clean tree', () => {
+    const dir = makeRepo({ 'src/app/route.ts': 'export const a = 1;\n', 'README.md': '# ok\n' });
+    const { code, out } = run(dir);
+    expect(code).toBe(0);
+    expect(out).toMatch(/No macOS Finder-duplicate files committed/);
+  });
+
+  it('FAILS (exit 1) on a Finder-duplicate FILE ("<name> 2.cjs")', () => {
+    const dir = makeRepo({ 'tests/unit/profile-sections 2.cjs': 'x\n' });
+    const { code, out } = run(dir);
+    expect(code).toBe(1);
+    expect(out).toMatch(/duplicated file: 'profile-sections 2\.cjs'/);
+  });
+
+  it('FAILS (exit 1) on a Finder-duplicate DIRECTORY ("[slug] 2/")', () => {
+    const dir = makeRepo({ 'src/app/api/recommendations/[slug] 2/route.ts': 'export const x = 1;\n' });
+    const { code, out } = run(dir);
+    expect(code).toBe(1);
+    expect(out).toMatch(/duplicated directory component: '\[slug\] 2'/);
+  });
+
+  it('does NOT false-positive on legitimate names without a space-before-digit suffix', () => {
+    const dir = makeRepo({
+      'src/lib/step2.ts': 'export const a = 1;\n',
+      'src/lib/v2/index.ts': 'export const b = 2;\n',
+      'docs/RFC-2119.md': '# terms\n',
+    });
+    const { code } = run(dir);
+    expect(code).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary

Adds a CI guard that rejects committed macOS Finder-duplicate files/directories — any path whose component carries a `" <n>"` copy-suffix, e.g. `src/app/api/recommendations/[slug] 2/route.ts` or `tests/unit/profile-sections 2.cjs`. These Finder-copy duplicates shadow the canonical module, are never imported, silently rot, and confuse audits. They have leaked into worktrees before (KAN-357 findings cross-repo-05 / web-arch-8).

- **`scripts/check-macos-duplicate-files.sh`** — scans `git ls-files` (tracked paths only; NUL-safe), fails on a Finder-copy suffix in any directory component or code-file basename. Hardened (`set -euo pipefail`), no lossy fallbacks, with an in-script allow-list mechanism (currently empty — no legitimate cases exist).
- **`.github/workflows/pr-checks.yml`** — new "macOS Finder-duplicate file check (KAN-357)" step, alongside the existing static guards (`check-workflow-integrity.sh`, `check-server-action-exports.sh`).
- **`tests/scripts/check-macos-duplicate-files.test.js`** (6 tests) — clean tree passes; a dup file and a dup dir each fail exit 1; no false-positive on legitimate `step2.ts` / `v2/` / `RFC-2119.md` names; script is hardened & syntactically valid.

**Scope note:** the canonical `develop` tree currently has **zero** such files, so this is a *preventive* guard — the deletion leg of KAN-357 is already realised on develop. The worktree/branch-prune + canonical-tree (lyra vs lyra-sec33) reconcile legs are ops-only and cannot run in a fresh cloud clone; they remain for a supervised/local session.

MCP coverage: N/A — CI/infra guard, no user-facing data (per KAN-222 "When it doesn't apply").

## Jira Ticket

KAN-357

## Checklist

- [x] Unit tests added for new functionality (6 tests, `tests/scripts/check-macos-duplicate-files.test.js`)
- [x] New guard passes on the current tree; workflow-integrity guard passes on the edited workflow
- [ ] Full `npm run test:unit` / lint / type-check / build — CI to confirm
- [x] No `eslint-disable` / `ts-ignore`
- [x] Ops routine / Control-Room: N/A (no scheduled-routine behaviour change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0137xXQqtF8r2N3an7ZU7Ck4

---
_Generated by [Claude Code](https://claude.ai/code/session_0137xXQqtF8r2N3an7ZU7Ck4)_