### PR TITLE
docs(KAN-360): point Claude sessions at the Confluence wiki index as mandatory pre-work reading

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,7 +37,7 @@ This file contains instructions and policies that Claude must follow when workin
 Before starting any task, Claude must:
 
 1. **Check Jira** — confirm a ticket exists for the work, or create one. Never start work without a tracked ticket.
-2. **Check docs/** — read relevant documentation before acting on architecture, ops, deployment, or infrastructure questions. Key docs: ARCHITECTURE.md, RUNBOOK.md, JIRA_TICKET_STANDARD.md, SECURITY_ROTATION.md.
+2. **Check the wiki index first, then docs/** — the Confluence wiki index **_Lyra — System Documentation_** (space TWC, page `19922947`) is the **definitive source of truth** for architecture, operations, security, and compliance. **Read it FIRST** before any architecture, ops, deployment, infrastructure, or security work — it is the sectioned map to every authoritative page (System & Architecture, Operations & Runbooks, Security & Risk, Data Protection & Compliance, Routines & Automation). The repo `docs/` holds _mirrored copies_ of the critical runbook/compliance elements for CI and offline use — key docs: ARCHITECTURE.md, RUNBOOK.md, JIRA_TICKET_STANDARD.md, SECURITY_ROTATION.md. If the code and a wiki page disagree, fix the page (the KAN-359 Documentation Definition-of-Done). Wiki professionalisation is tracked under KAN-360.
 3. **Check for existing work** — search the codebase and recent PRs to avoid duplicating effort.
 4. **Run tests before and after** — every change must leave tests green.
 5. **Check the surface** — confirm this is Claude Code, not chat. See "Editing the environment: Claude Code only" above.


### PR DESCRIPTION
## Summary

One bounded, dev-safe slice of KAN-360 (Confluence wiki reorganisation & professionalisation, effort L): the repo-side **"Claude remembers to look at the wiki"** requirement.

`CLAUDE.md` Pre-Work Checklist item 2 previously said only "Check docs/". It now names the Confluence wiki index **_Lyra — System Documentation_** (space TWC, page `19922947`) as the **definitive source of truth** to read FIRST before architecture/ops/deployment/infrastructure/security work, with the repo `docs/` reframed as the mirrored copies for CI/offline use. Also restates the "if code and wiki disagree, fix the page" rule (ties to the KAN-359 Documentation DoD).

The Confluence side of this acceptance criterion is already in place — the index page self-describes as the definitive source of truth and tells Claude Code sessions to start there. This PR closes the repo-side gap so sessions are pointed at it from `CLAUDE.md`.

**Scope note:** the remaining KAN-360 legs (Confluence index completeness/per-page headers, DPIA/ROPA/compliance-pack dedupe, clutter archival, and the Claude-*memory* persistence) are NOT in this PR — the compliance-pack dedupe is founder/compliance-sensitive (touches the pending SEC-70 DPIA sign-off) and the rest is Confluence-only work. Decomposition recorded on the ticket.

## Jira Ticket

KAN-360

## Checklist

- [ ] Unit tests added/updated for new/changed functionality — N/A: documentation-only prose change to `CLAUDE.md`; no automated test exercises its content (verified: the only `CLAUDE.md` references under `tests/`/`scripts/` are comments, no assertion-style reads).
- [x] All existing tests pass — no code path touched; no test reads this file's prose.
- [x] Lint passes — root Markdown file, not linted by the JS/TS toolchain.
- [x] Type check passes — no TypeScript changed.
- [x] Build succeeds — no build input changed.
- [x] Coverage has not decreased — no code changed.
- [x] No eslint-disable or ts-ignore without KAN-XX reference — none added.
- [ ] ARCHITECTURE.md updated if architectural changes were made — N/A: no architectural change.
- [ ] Ops routine / Control-Room registry updated — N/A: no routine behaviour/cadence/ownership change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NXGT9ARZRn3nqhDnAZB42f

---
_Generated by [Claude Code](https://claude.ai/code/session_01NXGT9ARZRn3nqhDnAZB42f)_