### PR TITLE
fix(SEC-77): CI hygiene — upload-artifact version-comment fix + auto-promote doc/code reconciliation

### DIFF
--- a/.github/workflows/backup-complete.yml
+++ b/.github/workflows/backup-complete.yml
@@ -174,7 +174,7 @@ jobs:
       # ── 6. GitHub artifact (encrypted) — forensics / second copy ───────────
       - name: Upload encrypted artifact
         if: always()
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v4
         with:
           name: lyra-complete-backup-${{ github.run_id }}
           path: backups/

--- a/.github/workflows/backup-database.yml
+++ b/.github/workflows/backup-database.yml
@@ -206,7 +206,7 @@ jobs:
       # NOT a silent-skip — the workflow still goes red on integrity failure.
       - name: Upload backup artifact
         if: always()
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v4
         with:
           name: lyra-db-backup-${{ github.run_id }}
           path: backups/

--- a/docs/RELEASE_POLICY.md
+++ b/docs/RELEASE_POLICY.md
@@ -8,7 +8,7 @@
 |---|---|---|---|
 | `develop` → `staging` | **Weekly, automatic** | Sunday 23:00 UTC | Forces the staging chain to run every week so `deploy-staging.yml` doesn't go a month without exercise. |
 | `staging` → `beta` | Manual | When ready to expose changes to beta testers | Beta hits real prod data, so the move beyond staging is a deliberate decision. |
-| `beta` → `main` | Manual | When beta has been exercised against real users | Highest blast radius. Always human-supervised. |
+| `beta` → `main` | Manual (narrow fix-only exception) | When beta has been exercised against real users | Highest blast radius. Human-supervised by default; a single owner-authorised exception lets the weekly routine auto-promote **fix-only** releases — see "What stays manual". |
 
 **The chain MUST be exercised at least weekly.** If `auto-promote-to-staging.yml` skips for any reason, the weekly report flags it red — see "Skip behaviour" below.
 
@@ -59,11 +59,21 @@ A skip is **not the same as a failure**. We never want a green-looking workflow 
 ## What stays manual
 
 - **`staging` → `beta`** — `gh workflow run promote-staging-to-beta.yml -f confirm=promote`. No cron. Decision made when beta-testable changes have soaked on staging.
-- **`beta` → `main` (production)** — `gh workflow run promote-to-production.yml -f confirm=PRODUCTION`. No cron, ever. This is the highest-blast-radius decision in the entire project.
+- **`beta` → `main` (production)** — `gh workflow run promote-to-production.yml -f confirm=PRODUCTION`. This is the highest-blast-radius decision in the entire project. **There is no scheduled/auto-promote-to-production workflow** — production is only ever promoted by an explicit `workflow_dispatch` of `promote-to-production.yml` (typing `PRODUCTION` to confirm).
 
 The reasoning is asymmetric:
 - Auto-promote to **staging** is safe — staging is gated by Vercel SSO, no real users see it
-- Auto-promote to **production** has the same false-positive risk class KAN-167 spent days dismantling — a "green" CI run that's actually broken would auto-ship to users
+- Auto-promote to **production** has the same false-positive risk class KAN-167 spent days dismantling — a "green" CI run that's actually broken would auto-ship to users. This is why there is no cron and no standalone auto-promote-to-production workflow.
+
+### The one owner-authorised exception (fix-only, 2026-06-21)
+
+The default above ("features are manual, always human-supervised") has a single narrow exception, authorised by Luisa on 2026-06-21 and canonical in `CLAUDE.md` → Deployment Pipeline and `docs/WEEKLY_HEALTH_REGRESSION_ROUTINE.md`:
+
+- The **weekly health + regression routine** MAY drive a `beta` → `main` promotion **only when *every* change pending on `develop` ahead of `main` is a bug-FIX** (a BUGS/SEC defect, `fix:`-type — no new feature, user-facing capability, route, table, MCP tool, or migration), with the full suite green through staging + beta.
+- If **any** pending change is a feature, or fix-vs-feature is ambiguous → the routine **STOPS and requires manual sign-off**.
+- Even in the exception, promotion still runs through the same `promote-to-production.yml` `workflow_dispatch` (built-in smoke + auto-rollback). The routine never pushes to `main`/`beta`/`staging` directly and there is still no scheduled auto-promote-to-production workflow.
+
+**Doc/code reconciliation (SEC-77, finding ci-drift-1):** the fix-only gate is **procedural** — it is applied by the routine agent reading the pending commit range, *not* by a machine-checked guard inside the workflow. `promote-to-production.yml` itself does not yet hard-fail on a pending `feat:` commit. Implementing that machine-checked fix-only guard (hard-fail on any non-`fix:` change in `main..beta`) is tracked as a follow-up hardening on SEC-77; until it lands, the exception's safety depends on the routine's own fix-only judgement plus the manual-dispatch confirmation.
 
 ## Reference
 


### PR DESCRIPTION
## Summary

Two **dev-safe legs** of **SEC-77** (CI hygiene, Phase-4 · KAN-350). No behaviour change — comment + docs only.

## Jira

SEC-77 (severity low, effort S). Autopilot slice; SEC-77 → In Progress (the third leg is deferred, see below).

## What changed

**`ci-label-1` — version-comment mislabel (provenance accuracy):**
- `actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a` is **v4** — labelled correctly in `mutation-testing.yml`, `backup-platform.yml`, `weekly-report.yml`, but mis-commented `# v7` in `backup-database.yml:209` and `backup-complete.yml:177`. Both corrected to `# v4`. Comment-only; the pinned SHA is unchanged, so Dependabot now tracks the correct major and provenance reads honestly.

**`ci-drift-1` — auto-promote doc/code drift:**
- `docs/RELEASE_POLICY.md` stated `beta → main` was *"Manual / No cron, ever"* — **stale**, directly contradicting the 2026-06-21 owner-authorised **fix-only** auto-promote exception already canonical in `CLAUDE.md` → Deployment Pipeline and `docs/WEEKLY_HEALTH_REGRESSION_ROUTINE.md`.
- Reconciled the doc to the canonical position:
  - Documented the narrow fix-only exception (weekly routine may auto-promote **only** when *every* pending `develop`-ahead-of-`main` change is a `fix:`/BUGS/SEC defect — never a feature; stop + manual sign-off otherwise).
  - Stated plainly there is **no scheduled / standalone auto-promote-to-production workflow** — production is only ever promoted by an explicit `workflow_dispatch` of `promote-to-production.yml` (typing `PRODUCTION`).
  - Flagged that the fix-only gate is **procedural** (routine-agent judgement reading the commit range), *not* a machine-checked guard inside the workflow. The machine-checked guard (hard-fail on any non-`fix:` change in `main..beta`) is noted as a tracked SEC-77 follow-up.

**Deferred — `ci-pin-1`** (SHA-pin the remaining mutable-tag third-party actions): the sandbox cannot resolve third-party action SHAs (same limitation hit on the SEC-51 leg-3 deferral). Needs a supervised/local session with network SHA resolution.

## Verification

- Both edited workflows validate as YAML (`yaml.safe_load` OK); the SHA pins are unchanged, only the trailing `# vX` comment differs.
- No test asserts on the changed lines: `tests/unit/backup.test.js:39` checks only `content.toContain('upload-artifact')` (still true); no test references `docs/RELEASE_POLICY.md`. Full suite runs in `pr-checks.yml` CI on this PR.

## MCP-main lockstep

N/A — CI/docs hygiene only, no user-facing data model change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01K5Mx7sLJR4MZSBk9dsXLJ8)_