### PR TITLE
SEC-74: enforce affiliate-click raw-event retention (purge job)

### DIFF
--- a/docs/compliance/RETENTION_SCHEDULE.md
+++ b/docs/compliance/RETENTION_SCHEDULE.md
@@ -19,7 +19,7 @@
 | Gatherings / invitees / RSVPs | Supabase | While the gathering exists; suggest purge ~12 months after the event | Manual/cron purge of past gatherings | ☐ define purge job |
 | **Waitlist emails (DP-04)** | **Cloudflare KV** | **Add a TTL — proposed 12 months**, then auto-expire; bring into the data map | Set KV `expirationTtl` on write in the maintenance worker | ☐ **implement TTL (SEC-2)** |
 | Transactional email logs | Resend | Per Resend default (typically ~30 days) — confirm | Provider-side | ☐ confirm Resend window |
-| Affiliate click events | Supabase | Raw events ~13 months, then aggregate-only | Cron aggregate + purge raw | ☐ define purge job |
+| Affiliate click events | Supabase | Raw events ~13 months, then aggregate-only | Cron purge raw (SEC-74: `affiliate_clicks_purge_expired` via `/api/retention/cron/sweep`, gated by `RETENTION_ENABLED`; window `RETENTION_AFFILIATE_CLICKS_MONTHS`, default 13) | ◑ purge job built (SEC-74); enable + confirm window per env |
 | Moderation / admin audit logs | Supabase | **Retain ≥ 12 months** (security/audit; do not auto-delete short-term) | Reviewed, not auto-purged within the window | ☑ audit-first writes |
 | Operational/web logs (IP, UA) | Cloudflare/Vercel/Railway | Per platform default (short) — confirm | Provider-side | ☐ confirm windows |
 | Encrypted backups (WORM) | Cloudflare R2 | Per DISASTER_RECOVERY.md (object-lock window) | Object-lock expiry | ☑ see DR doc |
@@ -37,4 +37,6 @@ to be immediate where they are securely isolated and expire on schedule).
 1. **Waitlist KV TTL (DP-04)** — set `expirationTtl` in the maintenance worker so waitlist emails expire (proposed 12 months). _Small worker change; two-step Cloudflare deploy._
 2. **Account-deletion purge** — verify the deletion flow demonstrably purges/anonymises in Supabase (not just deactivates).
 3. **Past-gathering + affiliate-raw purge jobs** — define and schedule.
+   - **Affiliate-raw purge — BUILT (SEC-74).** `affiliate_clicks_purge_expired(cutoff)` (SECURITY DEFINER, service_role-only; refuses null/future cutoffs) driven by the retention sweep at `/api/retention/cron/sweep` (Sun 03:00 UTC). Gated behind `RETENTION_ENABLED` (default OFF) so nothing is deleted until the window is confirmed and the flag is enabled per environment. Window is config (`RETENTION_AFFILIATE_CLICKS_MONTHS`, default 13). _Remaining: Luisa confirms the 13-month window, then set `RETENTION_ENABLED=true` per env._
+   - **Past-gathering purge — still to define** (cascade vs anonymise across invitees/RSVPs/messages/events-log is a policy call).
 4. Confirm provider-side windows (Resend, Didit, platform logs) and record them above.

--- a/src/app/api/retention/cron/sweep/route.ts
+++ b/src/app/api/retention/cron/sweep/route.ts
@@ -1,0 +1,48 @@
+/**
+ * /api/retention/cron/sweep — SEC-74 data-retention purge (UK-GDPR Art. 5(1)(e)).
+ *
+ * Scheduled sweep that enforces the deletion windows published in the privacy
+ * policy / RETENTION_SCHEDULE.md. Schedule: `0 3 * * 0` (Sundays 03:00 UTC,
+ * quiet window; see vercel.json). Vercel Cron only fires on the Production
+ * deployment.
+ *
+ * Gate: `RETENTION_ENABLED=true` or 404 — default OFF, so the purge jobs never
+ * run (and delete nothing) until Luisa confirms the retention windows and
+ * enables them per environment. Mirrors the Convene `CONVENE_ENABLED` gate.
+ *
+ * Auth: Vercel Cron sends `Authorization: Bearer ${CRON_SECRET}`; compared in
+ * constant time (reuses the Convene cron-auth helper).
+ *
+ * Honesty: if any retention job errored, the route returns 500 with the errors
+ * surfaced — a partial failure is never reported as a clean success.
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { isRetentionEnabled } from '@/lib/retention/flags';
+import { runRetentionSweep } from '@/lib/retention/sweep';
+import { timingSafeStrEqual } from '@/lib/convene/cron-auth';
+
+export const maxDuration = 60;
+
+export async function GET(req: NextRequest) {
+  if (!isRetentionEnabled()) {
+    return NextResponse.json({ ok: false, error: 'retention_disabled' }, { status: 404 });
+  }
+
+  const expected = process.env.CRON_SECRET;
+  const expectedHeader = `Bearer ${expected}`;
+  if (!expected || !timingSafeStrEqual(req.headers.get('authorization'), expectedHeader)) {
+    return NextResponse.json({ ok: false, error: 'unauthorised' }, { status: 401 });
+  }
+
+  try {
+    const summary = await runRetentionSweep();
+    if (summary.errors.length > 0) {
+      return NextResponse.json({ ok: false, summary }, { status: 500 });
+    }
+    return NextResponse.json({ ok: true, summary });
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : 'unknown';
+    return NextResponse.json({ ok: false, error: msg }, { status: 500 });
+  }
+}

--- a/src/lib/retention/affiliate-clicks.ts
+++ b/src/lib/retention/affiliate-clicks.ts
@@ -1,0 +1,76 @@
+/**
+ * Affiliate-click raw-event retention purge (SEC-74 · finding compliance-06).
+ *
+ * RETENTION_SCHEDULE.md proposes that raw affiliate click events are kept for
+ * ~13 months and then removed (aggregate-only thereafter). This module computes
+ * the cutoff from config and calls the `affiliate_clicks_purge_expired` SQL
+ * function (SECURITY DEFINER, service_role-only) to delete rows older than it.
+ *
+ * The retention *window* is config, not a hardcoded constant, so the policy
+ * number stays Luisa's to set/confirm:
+ *   - RETENTION_AFFILIATE_CLICKS_MONTHS overrides the default of 13.
+ * The cutoff is always in the past (the SQL function additionally refuses a
+ * null or non-past cutoff), so a mis-set window can only ever remove old data.
+ */
+
+import { createClient, type SupabaseClient } from '@supabase/supabase-js';
+import { env } from '@/lib/env';
+
+/** Proposed default window from RETENTION_SCHEDULE.md (raw events ~13 months). */
+export const DEFAULT_AFFILIATE_CLICKS_RETENTION_MONTHS = 13;
+
+export interface AffiliateClicksRetentionSummary {
+  data_type: 'affiliate_clicks';
+  window_months: number;
+  cutoff: string;
+  purged: number;
+}
+
+function admin(): SupabaseClient {
+  return createClient(env.supabaseUrl(), env.supabaseServiceRoleKey(), {
+    auth: { persistSession: false },
+  });
+}
+
+/** Read + validate the configured retention window (months). Falls back to the
+ * proposed default on an unset/blank/invalid value rather than guessing an
+ * unsafe (too-short) window. */
+export function affiliateClicksRetentionMonths(): number {
+  const raw = process.env.RETENTION_AFFILIATE_CLICKS_MONTHS;
+  if (raw == null || raw.trim() === '') return DEFAULT_AFFILIATE_CLICKS_RETENTION_MONTHS;
+  const n = Number(raw);
+  if (!Number.isFinite(n) || n <= 0) return DEFAULT_AFFILIATE_CLICKS_RETENTION_MONTHS;
+  return Math.floor(n);
+}
+
+/** Compute the cutoff instant `months` before `nowMs`. Exported for testing. */
+export function affiliateClicksCutoff(months: number, nowMs: number): Date {
+  const d = new Date(nowMs);
+  d.setUTCMonth(d.getUTCMonth() - months);
+  return d;
+}
+
+/**
+ * Purge raw affiliate click events older than the configured retention window.
+ * Returns a structured summary (never throws for "nothing to purge" — a 0-row
+ * purge is a valid healthy result).
+ */
+export async function runAffiliateClicksRetention(): Promise<AffiliateClicksRetentionSummary> {
+  const months = affiliateClicksRetentionMonths();
+  const cutoff = affiliateClicksCutoff(months, Date.now());
+
+  const sb = admin();
+  const { data, error } = await sb.rpc('affiliate_clicks_purge_expired', {
+    cutoff: cutoff.toISOString(),
+  });
+  if (error) {
+    throw new Error(`affiliate_clicks retention purge failed: ${error.message}`);
+  }
+
+  return {
+    data_type: 'affiliate_clicks',
+    window_months: months,
+    cutoff: cutoff.toISOString(),
+    purged: typeof data === 'number' ? data : 0,
+  };
+}

--- a/src/lib/retention/flags.ts
+++ b/src/lib/retention/flags.ts
@@ -1,0 +1,14 @@
+/**
+ * Data-retention feature flag (SEC-74 · UK-GDPR Art. 5(1)(e)).
+ *
+ * The retention sweep enforces the deletion windows published in the privacy
+ * policy / RETENTION_SCHEDULE.md. It is gated behind this flag and defaults
+ * OFF so the purge jobs never delete anything until Luisa has confirmed the
+ * retention windows and explicitly enables them per environment
+ * (`RETENTION_ENABLED=true`). Same pattern as the Convene flag.
+ *
+ * While off, the retention cron route returns 404 and no rows are ever purged.
+ */
+export function isRetentionEnabled(): boolean {
+  return process.env.RETENTION_ENABLED === 'true';
+}

--- a/src/lib/retention/sweep.ts
+++ b/src/lib/retention/sweep.ts
@@ -1,0 +1,38 @@
+/**
+ * Retention sweep orchestrator (SEC-74 · UK-GDPR Art. 5(1)(e)).
+ *
+ * Runs each enforced retention/purge job and collects a structured summary.
+ * A job that throws is recorded in `errors[]` and does not abort the other jobs
+ * (same resilience pattern as the Convene post-event sweep) — but the sweep
+ * never masks a failure as success: any error is surfaced in the response and
+ * makes the cron route return a non-2xx so the failure is visible, not silent.
+ *
+ * Currently enforced:
+ *   - affiliate_clicks raw events (proposed 13-month window).
+ * Follow-up legs of SEC-74 (decomposed): waitlist KV `expirationTtl`
+ * (Cloudflare maintenance worker — ops/two-step deploy), past-gathering purge
+ * (cascade/anonymise policy call), and the moderation/audit-log retention
+ * window. Add them here as they land.
+ */
+
+import {
+  runAffiliateClicksRetention,
+  type AffiliateClicksRetentionSummary,
+} from './affiliate-clicks';
+
+export interface RetentionSweepSummary {
+  jobs: AffiliateClicksRetentionSummary[];
+  errors: string[];
+}
+
+export async function runRetentionSweep(): Promise<RetentionSweepSummary> {
+  const summary: RetentionSweepSummary = { jobs: [], errors: [] };
+
+  try {
+    summary.jobs.push(await runAffiliateClicksRetention());
+  } catch (e) {
+    summary.errors.push(e instanceof Error ? e.message : 'affiliate_clicks: unknown error');
+  }
+
+  return summary;
+}

--- a/supabase/migrations/20260712033000_sec74_affiliate_clicks_retention_purge.sql
+++ b/supabase/migrations/20260712033000_sec74_affiliate_clicks_retention_purge.sql
@@ -1,0 +1,54 @@
+-- SEC-74 (finding compliance-06, UK-GDPR Art. 5(1)(e) storage limitation).
+--
+-- Retention purge for raw affiliate click events. RETENTION_SCHEDULE.md proposes
+-- "Affiliate click events — raw events ~13 months, then aggregate-only". This
+-- migration adds the deletion mechanism the schedule promises but did not have:
+-- a SECURITY DEFINER purge function the retention cron calls with a caller-supplied
+-- cutoff (the window itself is decided in app config, so the retention *policy*
+-- number stays Luisa's to set/confirm — not hardcoded destructively here).
+--
+-- Safety rails baked into the function:
+--   * NULL cutoff  -> raise (never a blanket delete).
+--   * cutoff >= now() -> raise (refuse to purge current/future rows; a mis-set
+--     window can only ever delete OLD data, never the live table).
+--   * Deletes only rows strictly older than the cutoff; returns the row count so
+--     the caller/cron can log exactly how many rows aged out.
+--
+-- Follows the established purge-fn + BUGS-44 ACL pattern
+-- (oauth_connect_state_purge_expired): security definer, pinned search_path,
+-- EXECUTE revoked from public/anon/authenticated, granted to service_role only.
+-- The cron authenticates with the service role, which bypasses RLS to sweep
+-- across all rows (the purge's whole purpose).
+--
+-- Rollback (one-time, do not include in migration body):
+--   drop function if exists public.affiliate_clicks_purge_expired(timestamptz);
+
+create or replace function public.affiliate_clicks_purge_expired(cutoff timestamptz)
+  returns integer
+  language plpgsql
+  security definer
+  set search_path = public
+as $$
+declare
+  deleted integer;
+begin
+  if cutoff is null then
+    raise exception 'affiliate_clicks_purge_expired: cutoff must not be null';
+  end if;
+  -- Fail closed: never purge rows at/after "now". A retention window is only ever
+  -- allowed to remove data that is already older than the current time.
+  if cutoff >= now() then
+    raise exception 'affiliate_clicks_purge_expired: cutoff (%) must be in the past', cutoff;
+  end if;
+
+  delete from public.affiliate_clicks where created_at < cutoff;
+  get diagnostics deleted = row_count;
+  return deleted;
+end;
+$$;
+
+revoke execute on function public.affiliate_clicks_purge_expired(timestamptz) from public, anon, authenticated;
+grant  execute on function public.affiliate_clicks_purge_expired(timestamptz) to service_role;
+
+comment on function public.affiliate_clicks_purge_expired(timestamptz) is
+  'SEC-74 retention purge — deletes raw affiliate_clicks older than the caller-supplied cutoff (proposed window 13 months, set in app config). service_role only; refuses null/future cutoffs.';

--- a/tests/unit/retention/affiliate-clicks-retention.test.ts
+++ b/tests/unit/retention/affiliate-clicks-retention.test.ts
@@ -1,0 +1,133 @@
+/**
+ * SEC-74 — affiliate-click raw-event retention purge (UK-GDPR Art. 5(1)(e)).
+ *
+ * Behavioural coverage of the pure config/cutoff logic (no DB), plus structural
+ * assertions locking the safety rails in the SQL function, the cron-route gate,
+ * the disabled-by-default flag, and the vercel.json schedule wiring.
+ */
+
+import fs from 'fs';
+import path from 'path';
+import {
+  DEFAULT_AFFILIATE_CLICKS_RETENTION_MONTHS,
+  affiliateClicksRetentionMonths,
+  affiliateClicksCutoff,
+} from '@/lib/retention/affiliate-clicks';
+
+const ROOT = path.join(__dirname, '..', '..', '..');
+const ORIG = process.env.RETENTION_AFFILIATE_CLICKS_MONTHS;
+
+afterEach(() => {
+  if (ORIG === undefined) delete process.env.RETENTION_AFFILIATE_CLICKS_MONTHS;
+  else process.env.RETENTION_AFFILIATE_CLICKS_MONTHS = ORIG;
+});
+
+describe('affiliateClicksRetentionMonths — config window', () => {
+  test('defaults to 13 months (RETENTION_SCHEDULE.md proposal) when unset', () => {
+    delete process.env.RETENTION_AFFILIATE_CLICKS_MONTHS;
+    expect(DEFAULT_AFFILIATE_CLICKS_RETENTION_MONTHS).toBe(13);
+    expect(affiliateClicksRetentionMonths()).toBe(13);
+  });
+
+  test('honours a valid override', () => {
+    process.env.RETENTION_AFFILIATE_CLICKS_MONTHS = '24';
+    expect(affiliateClicksRetentionMonths()).toBe(24);
+  });
+
+  test('falls back to the default (never a too-short/unsafe window) on blank or invalid input', () => {
+    for (const bad of ['', '   ', 'abc', '0', '-5', 'NaN']) {
+      process.env.RETENTION_AFFILIATE_CLICKS_MONTHS = bad;
+      expect(affiliateClicksRetentionMonths()).toBe(13);
+    }
+  });
+
+  test('floors a fractional override to a whole month count', () => {
+    process.env.RETENTION_AFFILIATE_CLICKS_MONTHS = '13.9';
+    expect(affiliateClicksRetentionMonths()).toBe(13);
+  });
+});
+
+describe('affiliateClicksCutoff — always strictly in the past', () => {
+  test('subtracts the given months from now', () => {
+    const now = Date.UTC(2026, 6, 12, 3, 0, 0); // 2026-07-12T03:00:00Z
+    const cutoff = affiliateClicksCutoff(13, now);
+    // 13 months before 2026-07 is 2025-06.
+    expect(cutoff.getUTCFullYear()).toBe(2025);
+    expect(cutoff.getUTCMonth()).toBe(5); // June (0-indexed)
+    expect(cutoff.getTime()).toBeLessThan(now);
+  });
+
+  test('the default window produces a cutoff comfortably in the past', () => {
+    const now = Date.now();
+    const cutoff = affiliateClicksCutoff(DEFAULT_AFFILIATE_CLICKS_RETENTION_MONTHS, now);
+    expect(cutoff.getTime()).toBeLessThan(now);
+  });
+});
+
+describe('SQL purge function — safety rails (structural)', () => {
+  const sql = fs.readFileSync(
+    path.join(ROOT, 'supabase/migrations/20260712033000_sec74_affiliate_clicks_retention_purge.sql'),
+    'utf8',
+  );
+
+  test('is SECURITY DEFINER with a pinned search_path', () => {
+    expect(sql).toMatch(/security definer/i);
+    expect(sql).toMatch(/set search_path = public/i);
+  });
+
+  test('refuses a null cutoff and a non-past cutoff', () => {
+    expect(sql).toMatch(/cutoff is null/i);
+    expect(sql).toMatch(/cutoff >= now\(\)/i);
+    expect(sql).toMatch(/raise exception/i);
+  });
+
+  test('deletes only rows strictly older than the cutoff', () => {
+    expect(sql).toMatch(/delete from public\.affiliate_clicks where created_at < cutoff/i);
+  });
+
+  test('EXECUTE revoked from public/anon/authenticated, granted to service_role only', () => {
+    expect(sql).toMatch(/revoke execute on function public\.affiliate_clicks_purge_expired\(timestamptz\) from public, anon, authenticated/i);
+    expect(sql).toMatch(/grant\s+execute on function public\.affiliate_clicks_purge_expired\(timestamptz\) to service_role/i);
+  });
+});
+
+describe('retention cron route + flag (structural)', () => {
+  const route = fs.readFileSync(
+    path.join(ROOT, 'src/app/api/retention/cron/sweep/route.ts'),
+    'utf8',
+  );
+  const flag = fs.readFileSync(path.join(ROOT, 'src/lib/retention/flags.ts'), 'utf8');
+
+  test('flag is disabled by default (opt-in via RETENTION_ENABLED=true)', () => {
+    expect(flag).toMatch(/process\.env\.RETENTION_ENABLED === 'true'/);
+  });
+
+  test('route 404s when retention is disabled', () => {
+    expect(route).toMatch(/isRetentionEnabled\(\)/);
+    expect(route).toMatch(/retention_disabled/);
+    expect(route).toMatch(/status:\s*404/);
+  });
+
+  test('route requires the CRON_SECRET bearer, compared in constant time', () => {
+    expect(route).toMatch(/CRON_SECRET/);
+    expect(route).toMatch(/timingSafeStrEqual/);
+    expect(route).toMatch(/status:\s*401/);
+  });
+
+  test('a job error is surfaced as a non-2xx (no false-green)', () => {
+    expect(route).toMatch(/summary\.errors\.length > 0/);
+    expect(route).toMatch(/status:\s*500/);
+  });
+});
+
+describe('vercel.json — retention sweep scheduled', () => {
+  const vercel = JSON.parse(fs.readFileSync(path.join(ROOT, 'vercel.json'), 'utf8'));
+
+  test('registers the retention sweep cron', () => {
+    const cron = (vercel.crons || []).find(
+      (c: { path: string }) => c.path === '/api/retention/cron/sweep',
+    );
+    expect(cron).toBeDefined();
+    expect(cron.schedule).toBe('0 3 * * 0');
+  });
+});

--- a/vercel.json
+++ b/vercel.json
@@ -14,6 +14,10 @@
     {
       "path": "/api/convene/cron/post-event",
       "schedule": "0 4 * * *"
+    },
+    {
+      "path": "/api/retention/cron/sweep",
+      "schedule": "0 3 * * 0"
     }
   ]
 }


### PR DESCRIPTION
## Summary

One bounded, dev-safe leg of **SEC-74** (finding compliance-06, UK-GDPR Art. 5(1)(e) storage limitation). The privacy policy / `RETENTION_SCHEDULE.md` promise raw affiliate click events are kept ~13 months then removed, but no deletion backed that. This adds the missing mechanism:

- **Migration `20260712033000`** — `affiliate_clicks_purge_expired(cutoff timestamptz)`: SECURITY DEFINER, pinned `search_path`, EXECUTE **service_role-only** (revoked from public/anon/authenticated, per the `oauth_connect_state_purge_expired` / BUGS-44 pattern). **Fail-closed:** refuses a `null` or non-past cutoff, so a mis-set window can only ever delete *old* data — never the live table.
- **`src/lib/retention/`** — affiliate-clicks purge (window from `RETENTION_AFFILIATE_CLICKS_MONTHS`, default **13**; the policy number stays config, not hardcoded destructively), a sweep orchestrator scaffolded for the remaining legs, and a disabled-by-default flag.
- **`/api/retention/cron/sweep`** — gated by `RETENTION_ENABLED` (404 when off, so nothing is ever deleted until Luisa confirms the window and enables per-env) + `CRON_SECRET` bearer (constant-time). Any job error surfaces as **500** — no false-green.
- **`vercel.json`** — Sunday 03:00 UTC sweep, inert until `RETENTION_ENABLED=true` on the relevant Vercel scope. Vercel cron only fires on Production.
- **`RETENTION_SCHEDULE.md`** — affiliate-raw purge marked *built*; waitlist-KV-TTL and past-gathering legs noted as remaining.

**Verified on dev + staging** (no prod DB writes): ACLs correct (`service_role` yes; `anon`/`authenticated` no); both guards raise; a synthetic 2020 row is purged while the live 2026 rows are preserved.

**Left for Luisa:** confirm the 13-month window, then set `RETENTION_ENABLED=true` (and optionally `RETENTION_AFFILIATE_CLICKS_MONTHS`) per environment to activate.

## Jira Ticket

SEC-74 (stays **In Progress** — remaining legs: waitlist KV TTL [Cloudflare worker, ops/two-step deploy]; past-gathering purge [cascade-vs-anonymise policy call]; moderation-log window).

MCP coverage: deferred — internal scheduled retention job, not user-facing data an agent reads/writes (KAN-222 "doesn't apply: scheduled jobs / audit pipelines").

## Checklist

- [x] Unit tests added/updated for new/changed functionality (15 new: behavioural window/cutoff + structural safety-rail/gate/schedule)
- [x] All existing tests pass (`npm run test:unit` — 175 suites / 2156 tests green)
- [x] Lint passes (eslint clean on new files)
- [x] Type check passes (`tsc --noEmit` exit 0)
- [ ] Build succeeds (`npm run build`) — not run in this environment; CI covers
- [x] Coverage has not decreased (net-new tests only)
- [x] No eslint-disable or ts-ignore without KAN-XX reference (none added)
- [ ] ARCHITECTURE.md updated if architectural changes were made — N/A (new internal cron; `RETENTION_SCHEDULE.md` updated instead)
- [x] Ops routine / Control-Room registry updated if scheduled-routine behaviour changed — N/A (new inert-by-default cron; not an existing routine)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K9fVLchBn454aF9c4mrFV6

---
_Generated by [Claude Code](https://claude.ai/code/session_01K9fVLchBn454aF9c4mrFV6)_