### PR TITLE
docs(SEC-75): Art.17(3)(b) retention exception for moderation-audit actor (Option 3)

### DIFF
--- a/docs/compliance/DSAR_BREACH_COMPLAINTS.md
+++ b/docs/compliance/DSAR_BREACH_COMPLAINTS.md
@@ -63,7 +63,11 @@ requester within the first month, with reasons.
    — request via the provider). Use the ROPA as the checklist.
 4. **Action** the right: access → export the user's data in a portable format
    (JSON/CSV); erasure → run the deletion/anonymisation per RETENTION_SCHEDULE.md
-   (note the time-limited backup exception); rectification → correct + confirm.
+   (note the time-limited **backup** exception, and — only for accounts that have
+   taken moderation/admin actions — the **moderation-audit actor** Art.17(3)(b)
+   retention exception: erase everything lawful, retain the audit trail + the
+   account it references for the audit-retention window, and record this with its
+   expiry in the response); rectification → correct + confirm.
 5. **Respond** with the data/outcome and signpost the complaints route + ICO.
 6. **Close** the log entry with the outcome date.
 

--- a/docs/compliance/RETENTION_SCHEDULE.md
+++ b/docs/compliance/RETENTION_SCHEDULE.md
@@ -20,7 +20,7 @@
 | **Waitlist emails (DP-04)** | **Cloudflare KV** | **Add a TTL — proposed 12 months**, then auto-expire; bring into the data map | Set KV `expirationTtl` on write in the maintenance worker | ☐ **implement TTL (SEC-2)** |
 | Transactional email logs | Resend | Per Resend default (typically ~30 days) — confirm | Provider-side | ☐ confirm Resend window |
 | Affiliate click events | Supabase | Raw events ~13 months, then aggregate-only | Cron aggregate + purge raw | ☐ define purge job |
-| Moderation / admin audit logs | Supabase | **Retain ≥ 12 months** (security/audit; do not auto-delete short-term) | Reviewed, not auto-purged within the window | ☑ audit-first writes |
+| Moderation / admin audit logs | Supabase | **Retain ≥ 12 months** (security/audit; do not auto-delete short-term). **Actor identity is an Art.17(3)(b) erasure exception — see note below.** | Reviewed, not auto-purged within the window; append-only + tamper-evident (SEC-64) | ☑ audit-first writes |
 | Operational/web logs (IP, UA) | Cloudflare/Vercel/Railway | Per platform default (short) — confirm | Provider-side | ☐ confirm windows |
 | Encrypted backups (WORM) | Cloudflare R2 | Per DISASTER_RECOVERY.md (object-lock window) | Object-lock expiry | ☑ see DR doc |
 | OAuth token registry / auth codes | Supabase | Access tokens: until expiry; auth codes: ≤10 min one-time; refresh: 30-day rotation | Expiry + rotation (migration `oauth_2_1_server`) | ☑ enforced in schema |
@@ -32,6 +32,34 @@ waitlist KV entry if present; note that **encrypted, object-locked backups** wil
 age out per the DR retention window (document this in the DSAR response as a
 lawful, time-limited exception — erasure from immutable backups is not required
 to be immediate where they are securely isolated and expire on schedule).
+
+### Erasure exception — moderation/admin audit actor identity (Art.17(3)(b))
+**Who this affects:** the narrow class of users who have ever taken a moderation
+or admin action (an `is_admin`/moderator account) and therefore appear as
+`moderation_logs.actor_user_id`. Ordinary members are unaffected — their account
+deletes and cascades in full.
+
+**What we retain and why:** the moderation/admin audit trail is retained for
+security and accountability, and — because `moderation_logs.actor_user_id` is
+`ON DELETE RESTRICT` and the table is append-only + tamper-evident (SEC-64) —
+the audit rows cannot be deleted or rewritten, so the `auth.users` account they
+reference is also retained for the audit-retention window. This is a documented
+**Art.17(3)(b)** exception (retention necessary for compliance with a legal
+obligation / for the establishment, exercise or defence of legal claims), not a
+failure of the deletion flow. It is **time-limited**: once the audit-retention
+window (≥ 12 months) elapses and the rows are eligible for purge, the account is
+erased in the ordinary course.
+
+**In practice:** the self-service deletion flow declines for this class with a
+clear message and routes the person to `privacy@checklyra.com`; the DSR log
+records the request, what was erased, and what is retained under this exception
+with its expiry. A future co-designed change (tracked on SEC-75 / SEC-64) may
+allow anonymising just the actor identity while preserving the hash-chain — until
+then, retention under this exception is the operative behaviour.
+
+> **Decision (Luisa, 2026-07-12):** adopt the Art.17(3)(b) retention exception
+> above (SEC-75 "Option 3") rather than an anonymisation/tombstone schema change,
+> which is coupled to the SEC-64 tamper-evidence design.
 
 ## Open implementation items (tracked under SEC-2)
 1. **Waitlist KV TTL (DP-04)** — set `expirationTtl` in the maintenance worker so waitlist emails expire (proposed 12 months). _Small worker change; two-step Cloudflare deploy._

--- a/src/app/dashboard/settings/actions.ts
+++ b/src/app/dashboard/settings/actions.ts
@@ -71,14 +71,20 @@ export async function deleteAccount() {
   const admin = getAdminServiceClient();
   const { error } = await admin.auth.admin.deleteUser(userId);
   if (error) {
-    // The only expected failure is an account with non-deletable audit
-    // rows (a moderator's moderation_logs are ON DELETE RESTRICT). Don't
-    // half-delete anything — leave the account intact and ask them to
-    // contact us.
+    // The only expected failure is an account that has performed moderation/
+    // admin actions: moderation_logs.actor_user_id is ON DELETE RESTRICT and
+    // the log is append-only + tamper-evident (SEC-64), so the auth-user
+    // delete is blocked by those audit rows. Per SEC-75 (UK-GDPR Art.17(3)(b),
+    // retention for a legal obligation), the moderation audit trail — and the
+    // actor identity it references — is retained as a documented, time-limited
+    // erasure exception (see docs/compliance/RETENTION_SCHEDULE.md +
+    // DSAR_BREACH_COMPLAINTS.md). Don't half-delete anything; route the person
+    // to the privacy inbox, which erases everything lawful and records what
+    // must be retained and why.
     return redirect(
       '/dashboard/settings?error=' +
         encodeURIComponent(
-          "We couldn't delete your account automatically. Please contact us and we'll remove it for you.",
+          'Your account includes moderation/admin audit records we are legally required to keep, so it cannot be deleted automatically. Please email privacy@checklyra.com — we will erase everything we lawfully can and explain what must be retained.',
         ),
     );
   }


### PR DESCRIPTION
## What & Why
SEC-75 **leg (a)** — ex-moderator erasure edge-case. `moderation_logs.actor_user_id` is `ON DELETE RESTRICT` and the table is append-only + tamper-evident (SEC-64), so `auth.users` deletion is blocked for anyone who has taken a moderation/admin action, and `deleteAccount()` currently dead-ends on a vague "contact us".

Per **Luisa's decision (2026-07-12)** this is resolved as **Option 3**: adopt a documented **UK-GDPR Art.17(3)(b)** retention exception (legal-obligation / audit integrity) rather than an anonymisation/tombstone schema change. The schema route is genuinely coupled to the SEC-64 hash-chain design (the append-only trigger already live on the dev DB rejects the anonymisation UPDATE, and nulling the actor would break the row hash) and must be co-designed with PR #470 — see the SEC-75 / SEC-64 comments dated 2026-07-12.

## Changes
- **`docs/compliance/RETENTION_SCHEDULE.md`** — document the moderation-audit actor-identity erasure exception: who it affects (only accounts that took moderation/admin actions; ordinary members unaffected), what is retained and why, that it is time-limited to the audit-retention window, and Luisa's decision.
- **`docs/compliance/DSAR_BREACH_COMPLAINTS.md`** — the erasure step now notes this exception alongside the existing backup exception, so the DSR response records what is retained and its expiry.
- **`src/app/dashboard/settings/actions.ts`** — make the ex-moderator `deleteAccount()` message honest: explain the legal-obligation retention and route to `privacy@checklyra.com`. Redirect path unchanged.

## Tests Required
No behavioural logic changed (message string + docs). Existing `account-deletion.test.ts` (asserts the `/dashboard/settings?error=` path + no-partial-delete) + `gdpr.test.js` / `gdpr-settings.test.js` stay green: **32 tests pass**, `tsc --noEmit` exit 0, `check-server-action-exports.sh` passes. No test was modified.

## Security Review
No schema, RLS, or auth change. No new data collected. The message no longer implies full erasure is always possible; it accurately states the legal-retention basis. No prod DB writes.

## Architecture Impact
Docs-only + one user-facing string. No env vars, dependencies, or migrations. **Follow-up:** SEC-75 **leg (b)** (record-only processor/KV erasure obligations) is queued separately; and a future co-designed anonymise-just-the-actor path may supersede this exception in lockstep with SEC-64 / PR #470.

## Acceptance Criteria
- [x] Ex-moderator erasure behaviour is documented as an Art.17(3)(b) exception with scope + time-limit.
- [x] DSAR response procedure records what is retained and why.
- [x] User-facing deletion message is accurate.
- [ ] Founder/legal review of the compliance-doc wording (this PR is draft).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01XcNQKadkEdNRRDPNF77QfT)_