### PR TITLE
fix(SEC-80): exclude suspended profiles from search_by_contact_hash

### DIFF
--- a/supabase/migrations/20260713093000_sec80_contact_hash_suspended_guard.sql
+++ b/supabase/migrations/20260713093000_sec80_contact_hash_suspended_guard.sql
@@ -1,0 +1,67 @@
+-- =====================================================================
+-- SEC-80 (KAN-295 audit 2026-07-11, label security-audit-2026-07-11):
+-- search_by_contact_hash must not return SUSPENDED profiles.
+--
+-- The SECURITY DEFINER function public.search_by_contact_hash(text, text)
+-- bypasses RLS and filters only is_published = true, so a published+suspended
+-- profile is still discoverable (id + slug) by phone/postcode hash even though
+-- the canonical public-read RLS policy on profiles requires
+--   is_published = true AND is_suspended = false.
+-- This deviates from the F-13 / SEC-44 suspended-guard contract and is
+-- safeguarding-relevant (the platform includes under-18 profiles).
+--
+-- Fix: re-create the function with `AND p.is_suspended = false` added to BOTH
+-- the phone and postcode branches, mirroring the profiles RLS policy. Tightens
+-- (never loosens) exposure; callers are unchanged (no app-code change).
+--
+-- Guarded so it is a no-op where the function is absent (e.g. production,
+-- pre-Convene/pre-discovery). CREATE OR REPLACE preserves the existing EXECUTE
+-- ACL from 20260621090300 (authenticated, service_role) — grants are NOT reset.
+--
+-- Apply order: dev -> staging -> prod (prod founder-gated).
+-- Applied to dev (ilprytcrnqyrsbsrfujj) + staging (uobmlkzrjkptwhttzmmi) 2026-07-13.
+--
+-- ROLLBACK: re-create the function without the `AND p.is_suspended = false`
+-- predicates (i.e. the 20260514100000 / pre-SEC-80 body).
+-- =====================================================================
+do $$
+begin
+  if exists (
+    select 1
+    from pg_proc p
+    join pg_namespace n on n.oid = p.pronamespace
+    where n.nspname = 'public'
+      and p.proname = 'search_by_contact_hash'
+  ) then
+    execute $fn$
+      create or replace function public.search_by_contact_hash(p_kind text, p_hash text)
+        returns table(id uuid, slug text)
+        language plpgsql
+        security definer
+        set search_path to 'public', 'pg_temp'
+      as $body$
+      begin
+        if p_kind = 'phone' then
+          return query
+            select p.id, p.slug
+            from public.profiles p
+            where p.discoverable_by_phone = true
+              and p.phone_search_hash = p_hash
+              and p.is_published = true
+              and p.is_suspended = false;
+        elsif p_kind = 'postcode' then
+          return query
+            select p.id, p.slug
+            from public.profiles p
+            where p.discoverable_by_postcode = true
+              and p.postcode_search_hash = p_hash
+              and p.is_published = true
+              and p.is_suspended = false;
+        else
+          return;
+        end if;
+      end;
+      $body$;
+    $fn$;
+  end if;
+end $$;

--- a/tests/unit/sec80-contact-hash-suspended-guard.test.js
+++ b/tests/unit/sec80-contact-hash-suspended-guard.test.js
@@ -1,0 +1,86 @@
+/**
+ * SEC-80 — search_by_contact_hash must exclude suspended profiles.
+ *
+ * Finding from the KAN-295 audit re-run (label security-audit-2026-07-11):
+ * the SECURITY DEFINER function public.search_by_contact_hash(text, text)
+ * bypasses RLS and filtered only is_published = true, so a published+suspended
+ * profile was still discoverable (id + slug) by phone/postcode hash — a
+ * deviation from the profiles public-read RLS contract
+ * (is_published = true AND is_suspended = false) and from the SEC-44 suspended
+ * guard. Safeguarding-relevant (the platform includes under-18 profiles).
+ *
+ * The fix (migration 20260713093000_sec80_contact_hash_suspended_guard.sql)
+ * re-creates the function with `AND p.is_suspended = false` on BOTH the phone
+ * and postcode branches. These are static file-content checks (migrations are
+ * applied via the Supabase MCP after review, per CLAUDE.md "Supabase Migration
+ * Rules") — they fail CI if the migration is dropped or a future edit weakens
+ * the suspended guard on either branch.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const migrationsDir = path.join(__dirname, '../../supabase/migrations');
+
+function readMigration() {
+  const files = fs.readdirSync(migrationsDir);
+  const match = files.find((f) =>
+    /_sec80_contact_hash_suspended_guard\.sql$/.test(f)
+  );
+  expect(match).toBeTruthy();
+  expect(path.basename(match)).toMatch(/^\d{14}_/);
+  return fs.readFileSync(path.join(migrationsDir, match), 'utf8');
+}
+
+describe('SEC-80 — search_by_contact_hash suspended guard migration', () => {
+  test('migration file exists with a 14-digit timestamp prefix', () => {
+    expect(readMigration().length).toBeGreaterThan(0);
+  });
+
+  test('re-creates the search_by_contact_hash function', () => {
+    expect(readMigration()).toMatch(
+      /create or replace function\s+public\.search_by_contact_hash\s*\(\s*p_kind text\s*,\s*p_hash text\s*\)/i
+    );
+  });
+
+  test('keeps the function SECURITY DEFINER with a pinned search_path', () => {
+    const sql = readMigration();
+    expect(sql).toMatch(/security definer/i);
+    expect(sql).toMatch(/set search_path to 'public', 'pg_temp'/i);
+  });
+
+  test('is guarded so it is a no-op where the function is absent (prod-safe)', () => {
+    const sql = readMigration();
+    expect(sql).toMatch(/if exists\s*\(/i);
+    expect(sql).toMatch(/proname\s*=\s*'search_by_contact_hash'/i);
+  });
+
+  describe('suspended guard is present on BOTH discovery branches', () => {
+    test('adds is_suspended = false exactly twice (phone + postcode)', () => {
+      const sql = readMigration();
+      // Count only inside the executable block; the header comments also mention
+      // the predicate in prose (What/Fix/ROLLBACK) and must not inflate the count.
+      const body = sql.slice(sql.indexOf('do $$'));
+      const matches = body.match(/is_suspended\s*=\s*false/gi) || [];
+      expect(matches.length).toBe(2);
+    });
+
+    test('phone branch filters discoverable_by_phone AND is_suspended = false', () => {
+      const sql = readMigration();
+      // the phone branch: from discoverable_by_phone up to (but not into) the elsif
+      const phoneBranch = sql.slice(
+        sql.indexOf('discoverable_by_phone'),
+        sql.indexOf('elsif')
+      );
+      expect(phoneBranch).toMatch(/is_published\s*=\s*true/i);
+      expect(phoneBranch).toMatch(/is_suspended\s*=\s*false/i);
+    });
+
+    test('postcode branch filters discoverable_by_postcode AND is_suspended = false', () => {
+      const sql = readMigration();
+      const postcodeBranch = sql.slice(sql.indexOf('discoverable_by_postcode'));
+      expect(postcodeBranch).toMatch(/is_published\s*=\s*true/i);
+      expect(postcodeBranch).toMatch(/is_suspended\s*=\s*false/i);
+    });
+  });
+});


### PR DESCRIPTION
## What & Why

The `SECURITY DEFINER` function `public.search_by_contact_hash(text, text)` returns `(id, slug)` for profiles matching a phone/postcode discovery hash. Because it is SECURITY DEFINER it **bypasses RLS** and ran its own query filtering only `is_published = true` (+ `discoverable_by_phone/postcode = true`). It did **not** filter `is_suspended = false`.

The canonical public-read contract on `profiles` (RLS policy "Anyone can read published non-suspended profiles") requires `is_published = true AND is_suspended = false`. So a **published + suspended** profile — correctly hidden from the normal public read path — was **still returned (id + slug)** by contact-hash discovery. This deviates from the F-13 / SEC-44 suspended-guard pattern and is **safeguarding-relevant** (the platform includes under-18 profiles).

Finding from the KAN-295 audit re-run (label `security-audit-2026-07-11`). Severity Low–Medium (full profile render is already blocked for suspended profiles by SEC-44/KAN-355; the residual leak was existence + slug + opt-in-to-discovery).

## Implementation

- Migration `20260713093000_sec80_contact_hash_suspended_guard.sql`: `CREATE OR REPLACE` the function with `AND p.is_suspended = false` added to **both** the phone and postcode branches, mirroring the RLS policy.
- Guarded so it is a **no-op where the function is absent** (prod pre-discovery), matching the `20260621090300` convention. `CREATE OR REPLACE` preserves the existing EXECUTE ACL (`authenticated`, `service_role`) — grants are not reset.
- No app-code change — callers are unchanged.

## Tests Required

- New static guard test `tests/unit/sec80-contact-hash-suspended-guard.test.js` (7 tests): asserts the migration re-creates the function, stays SECURITY DEFINER with a pinned `search_path`, is guarded (no-op where absent), and carries `is_suspended = false` on **both** branches while keeping `is_published = true`.
- Regression: existing discovery/suspension suites stay green (`discoverability-actions`, `discoverability-helpers`, `public-profile-suspended-gating` — 45/45 with the new test).

## Security Review

Read-path consistency fix; **tightens, never loosens** exposure. Aligns the SECDEF discovery path with the RLS contract. No new attack surface, no auth-model change. EXECUTE ACL unchanged (no `anon`).

## Architecture Impact

One migration altering a SECURITY DEFINER function on `profiles`. No env vars / dependencies. Applied + verified on **dev** (`ilprytcrnqyrsbsrfujj`) + **staging** (`uobmlkzrjkptwhttzmmi`): predicate present on both branches (2/2), `is_published` preserved (2/2), grants unchanged, function executes clean. **No prod DB writes** — prod promote is founder-gated.

## Acceptance Criteria

- [x] `search_by_contact_hash` excludes suspended profiles on dev + staging (predicate present on both branches; verified).
- [x] Test coverage added in the same PR.
- [ ] Prod migration applied after founder-gated promote.
- [ ] KAN-295 baseline notes SEC-80 remediated (non-regressed on next audit run).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QSBwziLEXPfgBaWkW2xrDD

---
_Generated by [Claude Code](https://claude.ai/code/session_01QSBwziLEXPfgBaWkW2xrDD)_