### PR TITLE
fix(SEC-59): unify search-term sanitiser strip-set with MCP surfaces

### DIFF
--- a/src/lib/sanitise.ts
+++ b/src/lib/sanitise.ts
@@ -61,10 +61,17 @@ export function sanitiseUrl(input: string, maxLength = 2048): string {
  * that could turn the query into a match-all. Strip those metacharacters (and the
  * backslash) before the term reaches the query builder. Returns '' when nothing
  * usable remains so the caller can skip the query rather than match everything.
+ *
+ * SEC-59 (2026-07-13): unify the strip-set across all three surfaces (web +
+ * lyra-mcp-server + lyra-admin-mcp-server) so a query sanitised on one surface is
+ * sanitised identically on the others. The admin-MCP sanitiser already stripped
+ * the fuller defensive set — `.` and `:` are PostgREST operator separators
+ * (`column.operator.value`, casts/ranges use `:`) and `"` is a quote — so this
+ * strip-set is aligned UP to that superset: `, ( ) * % _ . : " \`.
  */
 export function sanitiseSearchTerm(input: string, maxLength = 100): string {
   return input
-    .replace(/[,()*%_\\]/g, ' ')
+    .replace(/[,()*%_.:"\\]/g, ' ')
     .replace(/\s+/g, ' ')
     .trim()
     .slice(0, maxLength);

--- a/tests/unit/sanitise.test.ts
+++ b/tests/unit/sanitise.test.ts
@@ -229,4 +229,25 @@ describe('sanitiseSearchTerm', () => {
   test('returns empty string when only metacharacters are supplied', () => {
     expect(sanitiseSearchTerm(',(),%_')).toBe('');
   });
+
+  // ── SEC-59 (2026-07-13): strip-set unified with the MCP surfaces ──
+  // `.` and `:` are PostgREST operator separators (column.operator.value; casts
+  // use `:`) and `"` is a quote — the admin-MCP sanitiser already stripped these,
+  // so the web + user-MCP strip-set is aligned UP to the same defensive superset.
+  test('strips PostgREST operator separators . and : (SEC-59 parity)', () => {
+    const out = sanitiseSearchTerm('display_name.ilike:foo');
+    expect(out).not.toContain('.');
+    expect(out).not.toContain(':');
+  });
+
+  test('strips double quotes (SEC-59 parity)', () => {
+    expect(sanitiseSearchTerm('a"b')).toBe('a b');
+  });
+
+  test('the unified strip-set covers exactly , ( ) * % _ . : " and backslash', () => {
+    // every metacharacter collapses to nothing usable
+    expect(sanitiseSearchTerm(',()*%_.:"\\')).toBe('');
+    // a benign name/slug is preserved (letters, digits, spaces, hyphens, apostrophes)
+    expect(sanitiseSearchTerm("O'Brien-Smith 3")).toBe("O'Brien-Smith 3");
+  });
 });


### PR DESCRIPTION
## Summary

Unifies the free-text search sanitiser (`sanitiseSearchTerm`, SEC-09) strip-set across the three Lyra surfaces (web, `lyra-mcp-server`, `lyra-admin-mcp-server`) — the leftover consistency leg after the qs #97 CVE bump (queue row #64).

The strip-set had drifted: web + user-MCP stripped `, ( ) * % _ \`, while admin-MCP already stripped the fuller PostgREST-DSL defensive set — additionally `.` and `:` (operator separators: `column.operator.value`; casts/ranges use `:`) and `"` (quote). This aligns the web strip-set **up** to that superset so a query is sanitised identically everywhere:

```
, ( ) * % _ . : " \
```

Direction is strip-*more* (defensive superset), never removing protection. The existing `[,()*%_` char-class prefix is preserved so the paired structural guards continue to hold.

Paired change: `luisa-sys/lyra-mcp-server#113` (draft → main). `lyra-admin-mcp-server` already strips this set — no change needed there.

## Jira Ticket

SEC-59

## Checklist

- [x] Unit tests added/updated for new/changed functionality — parity tests in `tests/unit/sanitise.test.ts` (`.`/`:`/`"` stripped, benign names/slugs preserved)
- [x] All existing tests pass — `tests/unit/sanitise.test.ts` 42/42; no existing assertion modified or weakened
- [x] Lint passes — `eslint` clean on changed files
- [x] Type check passes — `tsc --noEmit` clean
- [ ] Build succeeds — deferred to CI
- [x] Coverage has not decreased — net-new tests only
- [x] No eslint-disable or ts-ignore
- [x] ARCHITECTURE.md updated if architectural changes were made — N/A (single-function strip-set)
- [x] Ops routine / Control-Room registry updated — N/A (no scheduled-routine behaviour change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)