### PR TITLE
fix(SEC-81): enforce SEC-57 account-standing guard on Convene invite paths

### DIFF
--- a/src/app/dashboard/convene/gatherings/[id]/actions.ts
+++ b/src/app/dashboard/convene/gatherings/[id]/actions.ts
@@ -21,6 +21,7 @@ import { adapterFor } from '@/lib/convene/calendar';
 import { getConnectionForUser } from '@/lib/convene/oauth-connections';
 import { generateRsvpToken, persistQueuedInvite, setInviteeRsvpToken } from '@/lib/convene/invites/repository';
 import { dispatchQueuedInvites } from '@/lib/convene/invites/dispatch';
+import { getAccountStanding, shouldRefuseIssuance } from '@/lib/account-status';
 
 type Result = { ok: true } | { ok: false; error: string };
 type SendSummary = { queued: number; sent: number; blocked_by_allowlist: number; failed: number };
@@ -228,6 +229,14 @@ export async function sendInvites(
   const userId = a.userId;
 
   const sb = admin();
+
+  // SEC-81 / SEC-57: a suspended host must not be able to emit invite emails.
+  // Mirror the credential-issuance guard (dashboard/settings/actions.ts) — fail
+  // CLOSED on anything other than a positively-confirmed good-standing account.
+  if (shouldRefuseIssuance(await getAccountStanding(sb, userId))) {
+    return { ok: false, error: 'Your account is suspended. Invites cannot be sent.' };
+  }
+
   // ownership-ok: host_user_id filter (KAN-306)
   const { data: g } = await sb
     .from('gatherings')
@@ -292,6 +301,12 @@ export async function resendInvite(inviteeId: string): Promise<Result> {
   const userId = a.userId;
 
   const sb = admin();
+
+  // SEC-81 / SEC-57: refuse a resend for a suspended host (fail closed).
+  if (shouldRefuseIssuance(await getAccountStanding(sb, userId))) {
+    return { ok: false, error: 'Your account is suspended. Invites cannot be sent.' };
+  }
+
   const { data: inv } = await sb
     .from('gathering_invitees')
     .select('id, gathering_id, status')

--- a/src/lib/convene/invites/dispatch.ts
+++ b/src/lib/convene/invites/dispatch.ts
@@ -25,6 +25,7 @@ import {
 } from './templates';
 import { renderSmsBody } from './sms-templates';
 import { isFeatureEnabledByUserId } from '@/lib/features/entitlements-service';
+import { getAccountStanding, shouldRefuseIssuance } from '@/lib/account-status';
 
 const SITE_URL = process.env.LYRA_SITE_URL ?? 'https://checklyra.com';
 const DEFAULT_BATCH_SIZE = 25;
@@ -389,6 +390,17 @@ export async function dispatchQueuedInvites(
   // When hostUserId is given, narrow to that user's gatherings only.
   // The MCP admin tool relies on this so one user can't drain another's queue.
   let queuedRows: QueuedRow[];
+  if (opts.hostUserId) {
+    // SEC-81 / SEC-57 defence-in-depth: refuse to drain a suspended host's
+    // queued invites (this is the per-host path used by the web actions and the
+    // MCP drain tool). Fail CLOSED — a lookup error also refuses. The global
+    // cron drain (no hostUserId) is unaffected; per-host refusal at the two
+    // server actions is the primary gate.
+    if (shouldRefuseIssuance(await getAccountStanding(sb, opts.hostUserId))) {
+      summary.errors.push('host suspended — dispatch refused (SEC-81)');
+      return summary;
+    }
+  }
   if (opts.hostUserId) {
     const { data: gatherings, error: gErr } = await sb
       .from('gatherings')

--- a/tests/unit/convene/dispatch-suspension-guard.test.ts
+++ b/tests/unit/convene/dispatch-suspension-guard.test.ts
@@ -1,0 +1,110 @@
+/**
+ * SEC-81 / SEC-57 — defence-in-depth: the invite dispatcher must refuse to
+ * drain a suspended host's queued invites on the per-host path (the path used
+ * by the web `sendInvites`/`resendInvite` actions and by the MCP
+ * `lyra_drain_invite_queue` tool). Fail CLOSED: a standing-lookup error also
+ * refuses. The global cron drain (no hostUserId) keeps its existing behaviour.
+ *
+ * This file mocks the Supabase client just enough to exercise the new early
+ * guard; the real getAccountStanding/shouldRefuseIssuance helpers run against
+ * the mock. The happy path uses a host with zero gatherings so the dispatcher
+ * returns immediately after the standing check without touching the send path.
+ */
+
+// ── Mutable mock state ─────────────────────────────────────
+let profileRow: Record<string, unknown> | null = { is_suspended: false };
+let profileError: unknown = null;
+let gatheringIds: { id: string }[] = [];
+const calls = { gatheringsQueried: false, messagesQueried: false };
+
+function makeQuery(result: { data: unknown; error: unknown }) {
+  const c: Record<string, unknown> = {};
+  c.select = () => c;
+  c.eq = () => c;
+  c.is = () => c;
+  c.in = () => c;
+  c.order = () => c;
+  c.limit = () => c;
+  c.maybeSingle = async () => result;
+  // Thenable so `await sb.from(...).select(...).eq(...).is(...)` resolves.
+  c.then = (resolve: (v: unknown) => unknown) => resolve(result);
+  return c;
+}
+
+function fromImpl(table: string) {
+  if (table === 'profiles') return makeQuery({ data: profileRow, error: profileError });
+  if (table === 'gatherings') {
+    calls.gatheringsQueried = true;
+    return makeQuery({ data: gatheringIds, error: null });
+  }
+  if (table === 'gathering_invite_messages') {
+    calls.messagesQueried = true;
+    return makeQuery({ data: [], error: null });
+  }
+  return makeQuery({ data: [], error: null });
+}
+
+jest.mock('@supabase/supabase-js', () => ({
+  createClient: jest.fn(() => ({ from: (t: string) => fromImpl(t) })),
+}));
+
+jest.mock('@/lib/env', () => ({
+  env: { supabaseUrl: () => 'http://localhost', supabaseServiceRoleKey: () => 'svc', supabaseAnonKey: () => 'anon' },
+}));
+
+import { dispatchQueuedInvites } from '@/lib/convene/invites/dispatch';
+
+beforeEach(() => {
+  profileRow = { is_suspended: false };
+  profileError = null;
+  gatheringIds = [];
+  calls.gatheringsQueried = false;
+  calls.messagesQueried = false;
+});
+
+describe('dispatchQueuedInvites — SEC-81 suspended-host guard', () => {
+  test('refuses a suspended host before scanning the queue', async () => {
+    profileRow = { is_suspended: true };
+    const summary = await dispatchQueuedInvites({ hostUserId: 'host-suspended' });
+    expect(summary.scanned).toBe(0);
+    expect(summary.sent).toBe(0);
+    expect(summary.errors.join(' ')).toMatch(/suspended/i);
+    // Guard short-circuits before any gathering/message scan.
+    expect(calls.gatheringsQueried).toBe(false);
+    expect(calls.messagesQueried).toBe(false);
+  });
+
+  test('fails closed when the standing lookup errors', async () => {
+    profileError = { message: 'transient read failure' };
+    profileRow = null;
+    const summary = await dispatchQueuedInvites({ hostUserId: 'host-unknown' });
+    expect(summary.errors.join(' ')).toMatch(/suspended/i);
+    expect(calls.gatheringsQueried).toBe(false);
+  });
+
+  test('fails closed when the host has no profile row', async () => {
+    profileRow = null;
+    const summary = await dispatchQueuedInvites({ hostUserId: 'host-noprofile' });
+    expect(summary.errors.join(' ')).toMatch(/suspended/i);
+    expect(calls.gatheringsQueried).toBe(false);
+  });
+
+  test('a good-standing host passes the guard and proceeds to scan', async () => {
+    profileRow = { is_suspended: false };
+    gatheringIds = []; // no gatherings → dispatcher returns after the scan
+    const summary = await dispatchQueuedInvites({ hostUserId: 'host-ok' });
+    expect(summary.errors).toHaveLength(0);
+    // Passed the standing check and reached the per-host gathering scan.
+    expect(calls.gatheringsQueried).toBe(true);
+  });
+
+  test('global cron drain (no hostUserId) does not invoke the standing check', async () => {
+    // With no hostUserId, the guard block is skipped entirely and the global
+    // queue scan runs. profiles must never be consulted on this path.
+    profileRow = { is_suspended: true }; // would refuse IF it were consulted
+    const summary = await dispatchQueuedInvites({});
+    // No per-host refusal error was emitted → the guard was not applied.
+    expect(summary.errors.join(' ')).not.toMatch(/suspended/i);
+    expect(calls.messagesQueried).toBe(true);
+  });
+});

--- a/tests/unit/convene/invites-actions.test.ts
+++ b/tests/unit/convene/invites-actions.test.ts
@@ -20,6 +20,11 @@ let inviteeSingle: Record<string, unknown> | null = { id: 'i1', gathering_id: 'g
 let messageRows: { invitee_id: string; delivery_status: string }[] = [];
 let venueRow: { id: string } | null = { id: 'v1' };
 let updateError: unknown = null;
+// SEC-81 / SEC-57: the invite actions now look up the host's account standing
+// via profiles.is_suspended. Default is good-standing so the happy paths are
+// unchanged; individual tests flip is_suspended / the row / the error.
+let profileRow: Record<string, unknown> | null = { is_suspended: false };
+let profileError: unknown = null;
 
 const captured = {
   gatheringUpdate: [] as Record<string, unknown>[],
@@ -88,6 +93,17 @@ function adminFrom(table: string) {
   if (table === 'gathering_events_log') {
     return { insert: (row: Record<string, unknown>) => (captured.events.push(row), Promise.resolve({ error: null })) };
   }
+  if (table === 'profiles') {
+    // SEC-81 / SEC-57 account-standing lookup (getAccountStanding).
+    return {
+      select: () => {
+        const c: Record<string, unknown> = {};
+        c.eq = () => c;
+        c.maybeSingle = async () => ({ data: profileRow, error: profileError });
+        return c;
+      },
+    };
+  }
   return { select: () => ({ then: (r: (v: unknown) => unknown) => r({ data: [], error: null }) }) };
 }
 
@@ -146,6 +162,8 @@ beforeEach(() => {
   messageRows = [];
   venueRow = { id: 'v1' };
   updateError = null;
+  profileRow = { is_suspended: false };
+  profileError = null;
   captured.gatheringUpdate = [];
   captured.inviteeUpdate = [];
   captured.events = [];
@@ -227,6 +245,32 @@ describe('sendInvites', () => {
     const res = await sendInvites('g1');
     expect(res.ok).toBe(false);
   });
+
+  // SEC-81 / SEC-57 — a suspended host must not be able to emit invite emails.
+  test('refuses a suspended host, queues nothing, never dispatches', async () => {
+    profileRow = { is_suspended: true };
+    const res = await sendInvites('g1');
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.error).toMatch(/suspended/i);
+    expect(mockPersist).not.toHaveBeenCalled();
+    expect(mockDispatch).not.toHaveBeenCalled();
+  });
+
+  test('fails closed when the standing lookup errors (treated as suspended)', async () => {
+    profileError = { message: 'transient read failure' };
+    profileRow = null;
+    const res = await sendInvites('g1');
+    expect(res.ok).toBe(false);
+    expect(mockPersist).not.toHaveBeenCalled();
+    expect(mockDispatch).not.toHaveBeenCalled();
+  });
+
+  test('fails closed when no profile row exists (unknown standing)', async () => {
+    profileRow = null;
+    const res = await sendInvites('g1');
+    expect(res.ok).toBe(false);
+    expect(mockPersist).not.toHaveBeenCalled();
+  });
 });
 
 describe('resendInvite', () => {
@@ -252,6 +296,24 @@ describe('resendInvite', () => {
     mockUserId = null;
     const res = await resendInvite('i1');
     expect(res.ok).toBe(false);
+  });
+
+  // SEC-81 / SEC-57 — suspended host cannot resend either.
+  test('refuses a suspended host and never re-queues', async () => {
+    profileRow = { is_suspended: true };
+    const res = await resendInvite('i1');
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.error).toMatch(/suspended/i);
+    expect(mockPersist).not.toHaveBeenCalled();
+    expect(mockDispatch).not.toHaveBeenCalled();
+  });
+
+  test('fails closed on a standing-lookup error', async () => {
+    profileError = { message: 'transient read failure' };
+    profileRow = null;
+    const res = await resendInvite('i1');
+    expect(res.ok).toBe(false);
+    expect(mockPersist).not.toHaveBeenCalled();
   });
 });
 


### PR DESCRIPTION
## Summary

A suspended host retaining a valid session could still queue and dispatch invite emails from their gatherings — an outbound-email abuse / impersonation surface (safeguarding-relevant given the under-18 posture). SEC-57 established that issuance paths must refuse a suspended caller and explicitly names "send invites" as such a path, but the guard was never applied to Convene.

This PR closes that parity gap:

- **`sendInvites` / `resendInvite`** (`src/app/dashboard/convene/gatherings/[id]/actions.ts`) — call `getAccountStanding` + `shouldRefuseIssuance` after resolving the authed user, **failing CLOSED** (a lookup error or missing profile row also refuses), mirroring the API-key-generation guard in `dashboard/settings/actions.ts`.
- **`dispatchQueuedInvites`** (`src/lib/convene/invites/dispatch.ts`) — defence-in-depth standing check on the per-host path (used by the web actions and the MCP drain tool). The global cron drain (no `hostUserId`) keeps its existing behaviour.
- **Tests** — suspended-host refusal + fail-closed (lookup error / missing row) cases for both actions and the dispatcher (new `tests/unit/convene/dispatch-suspension-guard.test.ts`; extended `invites-actions.test.ts`).

No schema change. No existing test assertion weakened — the only test-infra change is a new `profiles` branch in the existing action mock (default good-standing preserves every prior happy path).

**MCP coverage (KAN-222):** `lyra_send_invite` (via `conveneAuthedUser`) and `lyra_drain_invite_queue` both route through `requireFeatures`, whose suspended-actor refusal is the SEC-83 workstream (in-flight PR `lyra-mcp-server#116`). Parity is already covered there — no new follow-up required.

## Jira Ticket

SEC-81 (found by the KAN-295 exit-gate app-route/server-action audit)

## Checklist

- [x] Unit tests added/updated for new/changed functionality
- [x] All existing tests pass (`npm run test:unit` — 175 suites / 2151 tests green)
- [x] Lint passes (changed files clean)
- [x] Type check passes (`tsc --noEmit` clean)
- [ ] Build succeeds (`npm run build`) — not run in this slice; CI gate covers it
- [x] Coverage has not decreased (net-new tests only)
- [x] No eslint-disable or ts-ignore without KAN-XX reference
- [x] ARCHITECTURE.md updated if architectural changes were made (N/A — no schema/arch change)
- [x] Ops routine / Control-Room registry updated if scheduled-routine behaviour changed (N/A)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JUhtVMtCDLa6dEmbDMszJt)_