### PR TITLE
fix(SEC-82): low-severity app-route/server-action authz + hardening batch

### DIFF
--- a/src/app/api/recommendations/[slug]/route.ts
+++ b/src/app/api/recommendations/[slug]/route.ts
@@ -103,12 +103,15 @@ export async function GET(
       insights,
     },
     {
-      // Caches well — the underlying data only changes when the user
-      // updates their profile. 5-minute SWR balances freshness against
-      // load. Anyone hitting this URL more often is almost certainly
-      // automation; the cache will keep them off the DB.
+      // SEC-82: private + short TTL, aligned with the V2 route. The previous
+      // `public, s-maxage=300, swr=900` let a shared/edge cache keep serving a
+      // profile's recommendations for up to ~5 min fresh / 15 min stale AFTER
+      // it was suspended — the DB filters `is_suspended=false`, but a fill that
+      // predates the suspension outlives it on the CDN. `private` keeps it off
+      // shared caches and `max-age=60` bounds any per-client staleness to a
+      // minute, matching the suspension posture already chosen for V2.
       headers: {
-        'Cache-Control': 'public, s-maxage=300, stale-while-revalidate=900',
+        'Cache-Control': 'private, max-age=60, stale-while-revalidate=300',
       },
     },
   );

--- a/src/app/api/reports/route.ts
+++ b/src/app/api/reports/route.ts
@@ -112,6 +112,24 @@ export async function POST(request: Request) {
     return NextResponse.json({ error: 'cannot_report_self' }, { status: 400 });
   }
 
+  // 3b. SEC-82: if the report narrows to a specific item, that item must
+  // actually belong to the target profile. `profileItemId` is only
+  // shape-validated as a UUID above; without this check a reporter could
+  // attach an item id from a *different* profile, producing a mismatched
+  // moderation row (profile_id=A, profile_item_id=B) that corrupts the queue
+  // and confuses moderators. Reject the mismatch rather than silently drop the
+  // item id, so the client learns the report was malformed.
+  if (profileItemId !== null) {
+    const { data: item } = await supabase
+      .from('profile_items')
+      .select('id, profile_id')
+      .eq('id', profileItemId)
+      .maybeSingle();
+    if (!item || item.profile_id !== profile.id) {
+      return NextResponse.json({ error: 'item_not_on_profile' }, { status: 400 });
+    }
+  }
+
   // 4. Rate-limit: one report per (reporter, target profile) per 24h.
   const twentyFourHoursAgo = new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString();
   const { count: recentCount } = await supabase

--- a/src/app/dashboard/settings/actions.ts
+++ b/src/app/dashboard/settings/actions.ts
@@ -184,14 +184,23 @@ export async function updatePassword(currentPassword: string, newPassword: strin
 
   if (newPassword.length < 6) return { error: 'New password must be at least 6 characters' };
 
-  // Verify current password by re-authenticating
-  if (user.email) {
-    const { error: signInError } = await supabase.auth.signInWithPassword({
-      email: user.email,
-      password: currentPassword,
-    });
-    if (signInError) return { error: 'Current password is incorrect' };
+  // SEC-82: current-password proof is mandatory. The re-auth below needs an
+  // email (signInWithPassword is email+password), so previously the whole
+  // check was wrapped in `if (user.email)` — meaning an emailless account
+  // (e.g. OAuth-provisioned) could set a new password with ZERO proof of the
+  // old one from any authenticated session. There is no way to prove knowledge
+  // of the current password without an email, so refuse: the user must add an
+  // email first, which routes them back through the proof-carrying path.
+  if (!user.email) {
+    return { error: 'Add an email address to your account before setting a password.' };
   }
+
+  // Verify current password by re-authenticating
+  const { error: signInError } = await supabase.auth.signInWithPassword({
+    email: user.email,
+    password: currentPassword,
+  });
+  if (signInError) return { error: 'Current password is incorrect' };
 
   const { error } = await supabase.auth.updateUser({
     password: newPassword,

--- a/src/app/waitlist/actions.ts
+++ b/src/app/waitlist/actions.ts
@@ -5,6 +5,7 @@ import { createClient as createServiceRoleClient } from '@supabase/supabase-js';
 import { createClient } from '@/lib/supabase-server';
 import { env } from '@/lib/env';
 import { computeAccessTransition } from '@/app/admin/users/users-actions-shared';
+import { getAccountStanding, shouldRefuseIssuance } from '@/lib/account-status';
 
 /**
  * KAN-336 — redeem a skip-the-waitlist code from the /waitlist page.
@@ -39,11 +40,31 @@ export async function redeemWaitlistCode(formData: FormData): Promise<void> {
     redirect('/waitlist?error=invalid');
   }
 
+  // SEC-82: defence-in-depth — a suspended account must not be able to
+  // self-elevate to beta by pasting the code. Mirror the SEC-57 issuance guard
+  // and fail closed on anything other than confirmed good standing. (Middleware
+  // already routes a suspended user to /suspended, but that gate fails open on a
+  // lookup error; this narrow check does not.)
+  const standing = await getAccountStanding(supabase, user.id);
+  if (shouldRefuseIssuance(standing)) {
+    redirect('/waitlist?error=suspended');
+  }
+
   const svc = createServiceRoleClient(env.supabaseUrl(), env.supabaseServiceRoleKey());
   const { update } = computeAccessTransition('enable_beta', {
     now: new Date().toISOString(),
   });
-  await svc.from('profiles').update(update).eq('user_id', user.id);
+  // SEC-82: don't swallow the grant failure. Previously the update error was
+  // ignored and the user was sent to /dashboard as if it had succeeded, so a
+  // failed grant produced a silently-still-waitlisted account with no signal.
+  const { error: grantError } = await svc
+    .from('profiles')
+    .update(update)
+    .eq('user_id', user.id);
+  if (grantError) {
+    console.error('[waitlist] beta grant failed:', grantError.message);
+    redirect('/waitlist?error=grant_failed');
+  }
 
   redirect('/dashboard');
 }

--- a/tests/unit/sec82-recommendations-v1-cache.test.ts
+++ b/tests/unit/sec82-recommendations-v1-cache.test.ts
@@ -1,0 +1,31 @@
+/**
+ * SEC-82 (item 2) — the V1 recommendations route must not serve on a public,
+ * long-lived shared cache. A `public, s-maxage=300, swr=900` header let an edge
+ * cache keep serving a profile's recommendations for minutes after it was
+ * suspended (the DB filters `is_suspended=false`, but a pre-suspension fill
+ * outlives it on the CDN). The route is aligned to the V2 posture:
+ * `private, max-age=60, stale-while-revalidate=300`. Source assertion locks it
+ * against regression.
+ */
+import fs from 'fs';
+import path from 'path';
+
+const root = path.join(__dirname, '../..');
+const v1 = path.join(root, 'src/app/api/recommendations/[slug]/route.ts');
+
+describe('SEC-82: V1 recommendations cache policy', () => {
+  let content: string;
+  beforeAll(() => {
+    content = fs.readFileSync(v1, 'utf8');
+  });
+
+  test('uses a private, short-TTL Cache-Control', () => {
+    expect(content).toMatch(/'Cache-Control':\s*'private,\s*max-age=60,\s*stale-while-revalidate=300'/);
+  });
+
+  test('no longer serves on a public shared cache', () => {
+    // Assert on the actual header value, not comment prose (which references
+    // the old policy for context).
+    expect(content).not.toMatch(/Cache-Control':\s*'public/);
+  });
+});

--- a/tests/unit/sec82-reports-item-ownership.test.ts
+++ b/tests/unit/sec82-reports-item-ownership.test.ts
@@ -1,0 +1,108 @@
+/**
+ * SEC-82 (item 1) — POST /api/reports must verify that a supplied
+ * `profileItemId` actually belongs to the target profile before inserting the
+ * report. `profileItemId` is only UUID-shape-validated; without the ownership
+ * check a reporter could attach an item id from a *different* profile,
+ * producing a mismatched moderation row (profile_id=A, profile_item_id=B).
+ *
+ * Behavioural: a mismatched item id is rejected (400 item_not_on_profile) and
+ * NO report row is inserted; a matching item id (and the no-item case) insert
+ * normally.
+ */
+
+const mockGetUser = jest.fn();
+
+// Mutable fixtures the admin-service mock reads.
+let profileRow: { id: string; user_id: string } | null;
+let itemRow: { id: string; profile_id: string } | null;
+let recentCount: number;
+const insertSpy = jest.fn();
+let insertResult: { data: { id: string; status: string } | null; error: { message: string } | null };
+
+jest.mock('@/lib/supabase-server', () => ({
+  createClient: async () => ({
+    auth: { getUser: (...a: unknown[]) => mockGetUser(...a) },
+  }),
+}));
+
+jest.mock('@/lib/admin', () => ({
+  getAdminServiceClient: () => ({
+    from: (table: string) => {
+      if (table === 'profiles') {
+        return {
+          select: () => ({ eq: () => ({ maybeSingle: async () => ({ data: profileRow }) }) }),
+        };
+      }
+      if (table === 'profile_items') {
+        return {
+          select: () => ({ eq: () => ({ maybeSingle: async () => ({ data: itemRow }) }) }),
+        };
+      }
+      // reports — used for both the rate-limit head-count and the insert.
+      return {
+        select: (_cols: string, opts?: { head?: boolean }) => {
+          if (opts && opts.head) {
+            return { eq: () => ({ eq: () => ({ gte: async () => ({ count: recentCount }) }) }) };
+          }
+          return { single: async () => insertResult };
+        },
+        insert: (payload: Record<string, unknown>) => {
+          insertSpy(payload);
+          return { select: () => ({ single: async () => insertResult }) };
+        },
+      };
+    },
+  }),
+}));
+
+import { POST } from '@/app/api/reports/route';
+
+function req(body: unknown): Request {
+  return new Request('http://localhost/api/reports', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockGetUser.mockResolvedValue({ data: { user: { id: 'reporter-1' } } });
+  profileRow = { id: 'profile-A', user_id: 'owner-A' };
+  itemRow = { id: 'item-1', profile_id: 'profile-A' };
+  recentCount = 0;
+  insertResult = { data: { id: 'report-1', status: 'pending' }, error: null };
+});
+
+describe('SEC-82: reports profileItemId ownership', () => {
+  it('rejects a profileItemId that belongs to a different profile (no insert)', async () => {
+    itemRow = { id: 'item-1', profile_id: 'profile-B' }; // belongs to someone else
+    const res = await POST(req({ profileSlug: 'a', profileItemId: '11111111-1111-1111-1111-111111111111', reason: 'spam' }));
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: 'item_not_on_profile' });
+    expect(insertSpy).not.toHaveBeenCalled();
+  });
+
+  it('rejects a profileItemId that does not exist (no insert)', async () => {
+    itemRow = null;
+    const res = await POST(req({ profileSlug: 'a', profileItemId: '11111111-1111-1111-1111-111111111111', reason: 'spam' }));
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: 'item_not_on_profile' });
+    expect(insertSpy).not.toHaveBeenCalled();
+  });
+
+  it('accepts a profileItemId that belongs to the target profile', async () => {
+    itemRow = { id: 'item-1', profile_id: 'profile-A' };
+    const res = await POST(req({ profileSlug: 'a', profileItemId: '11111111-1111-1111-1111-111111111111', reason: 'spam' }));
+    expect(res.status).toBe(201);
+    expect(insertSpy).toHaveBeenCalledTimes(1);
+    expect(insertSpy.mock.calls[0][0]).toMatchObject({ profile_id: 'profile-A' });
+  });
+
+  it('accepts a report with no profileItemId (item check skipped)', async () => {
+    const res = await POST(req({ profileSlug: 'a', reason: 'spam' }));
+    expect(res.status).toBe(201);
+    expect(insertSpy).toHaveBeenCalledTimes(1);
+    expect(insertSpy.mock.calls[0][0]).toMatchObject({ profile_id: 'profile-A', profile_item_id: null });
+  });
+});

--- a/tests/unit/sec82-update-password-emailless.test.ts
+++ b/tests/unit/sec82-update-password-emailless.test.ts
@@ -1,0 +1,64 @@
+/**
+ * SEC-82 (item 4) — updatePassword must require current-password proof. The
+ * re-auth is email+password (signInWithPassword), so it was wrapped in
+ * `if (user.email)`, letting an emailless (e.g. OAuth-provisioned) account set
+ * a new password with ZERO proof of the old one. There is no way to prove
+ * knowledge of the current password without an email, so the emailless path is
+ * refused rather than silently allowed.
+ */
+
+const mockGetUser = jest.fn();
+const mockSignIn = jest.fn();
+const mockUpdateUser = jest.fn();
+
+jest.mock('@/lib/supabase-server', () => ({
+  createClient: async () => ({
+    auth: {
+      getUser: (...a: unknown[]) => mockGetUser(...a),
+      signInWithPassword: (...a: unknown[]) => mockSignIn(...a),
+      updateUser: (...a: unknown[]) => mockUpdateUser(...a),
+    },
+  }),
+}));
+
+import { updatePassword } from '@/app/dashboard/settings/actions';
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockSignIn.mockResolvedValue({ error: null });
+  mockUpdateUser.mockResolvedValue({ error: null });
+});
+
+describe('SEC-82: updatePassword current-password proof', () => {
+  it('refuses an emailless account and never sets a password', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: 'u1', email: null } } });
+    const res = await updatePassword('whatever', 'newsecret');
+    expect(res.error).toMatch(/add an email/i);
+    expect(mockSignIn).not.toHaveBeenCalled();
+    expect(mockUpdateUser).not.toHaveBeenCalled();
+  });
+
+  it('rejects a wrong current password on an email account (no update)', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: 'u1', email: 'a@b.com' } } });
+    mockSignIn.mockResolvedValue({ error: { message: 'bad creds' } });
+    const res = await updatePassword('wrong', 'newsecret');
+    expect(res.error).toBe('Current password is incorrect');
+    expect(mockSignIn).toHaveBeenCalledWith({ email: 'a@b.com', password: 'wrong' });
+    expect(mockUpdateUser).not.toHaveBeenCalled();
+  });
+
+  it('updates the password when the current password proof succeeds', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: 'u1', email: 'a@b.com' } } });
+    const res = await updatePassword('correct', 'newsecret');
+    expect(res.success).toBe(true);
+    expect(mockSignIn).toHaveBeenCalledWith({ email: 'a@b.com', password: 'correct' });
+    expect(mockUpdateUser).toHaveBeenCalledWith({ password: 'newsecret' });
+  });
+
+  it('still enforces the minimum length before any auth work', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: 'u1', email: 'a@b.com' } } });
+    const res = await updatePassword('correct', 'short');
+    expect(res.error).toMatch(/at least 6/i);
+    expect(mockSignIn).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/waitlist-redeem.test.ts
+++ b/tests/unit/waitlist-redeem.test.ts
@@ -11,6 +11,9 @@
 
 let mockInviteCode = '';
 let mockUser: { id: string } | null = { id: 'u1' };
+// SEC-82: standing lookup (getAccountStanding) + grant-error injection.
+let mockSuspended = false;
+let mockGrantError: { message: string } | null = null;
 const updateSpy = jest.fn();
 const eqSpy = jest.fn();
 
@@ -26,6 +29,15 @@ jest.mock('@/lib/supabase-server', () => ({
   createClient: () =>
     Promise.resolve({
       auth: { getUser: () => Promise.resolve({ data: { user: mockUser } }) },
+      // SEC-82: getAccountStanding reads is_suspended off the cookie client.
+      from: () => ({
+        select: () => ({
+          eq: () => ({
+            maybeSingle: () =>
+              Promise.resolve({ data: { is_suspended: mockSuspended }, error: null }),
+          }),
+        }),
+      }),
     }),
 }));
 
@@ -37,7 +49,7 @@ jest.mock('@supabase/supabase-js', () => ({
         return {
           eq: (col: string, val: string) => {
             eqSpy(col, val);
-            return Promise.resolve({ data: null });
+            return Promise.resolve({ data: null, error: mockGrantError });
           },
         };
       },
@@ -68,6 +80,8 @@ beforeEach(() => {
   jest.clearAllMocks();
   mockInviteCode = 'SECRET-123';
   mockUser = { id: 'u1' };
+  mockSuspended = false;
+  mockGrantError = null;
 });
 
 describe('KAN-336: redeemWaitlistCode', () => {
@@ -108,5 +122,23 @@ describe('KAN-336: redeemWaitlistCode', () => {
     mockUser = null;
     await expect(redeemWaitlistCode(fd('SECRET-123'))).rejects.toThrow('REDIRECT:/login');
     expect(updateSpy).not.toHaveBeenCalled();
+  });
+
+  // SEC-82: defence-in-depth standing check + honest grant-error handling.
+  it('refuses a suspended account (correct code) and never grants beta', async () => {
+    mockSuspended = true;
+    await expect(redeemWaitlistCode(fd('SECRET-123'))).rejects.toThrow(
+      'REDIRECT:/waitlist?error=suspended',
+    );
+    expect(updateSpy).not.toHaveBeenCalled();
+  });
+
+  it('does NOT report success when the beta grant errors', async () => {
+    mockGrantError = { message: 'db down' };
+    await expect(redeemWaitlistCode(fd('SECRET-123'))).rejects.toThrow(
+      'REDIRECT:/waitlist?error=grant_failed',
+    );
+    // The update was attempted, but the flow must not fall through to /dashboard.
+    expect(updateSpy).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
## Summary

Fixes the four LOW-severity findings from the KAN-295 exit-gate audit (app-route / server-action sweep). Each is fixed with a regression test. All web-only, dev-safe, **no schema change**.

1. **reports POST — item ownership** (`src/app/api/reports/route.ts`): a supplied `profileItemId` was only UUID-shape-validated, never checked to belong to the target profile. Now verified against the resolved profile before insert (rejects `item_not_on_profile`, 400) so a reporter can't produce a mismatched moderation row (`profile_id=A`, `profile_item_id=B`).
2. **v1 recommendations cache** (`src/app/api/recommendations/[slug]/route.ts`): was `public, s-maxage=300, swr=900`, so a profile suspended *after* a cache fill kept being served from the edge for minutes (the DB filters `is_suspended=false`, but the fill outlives the suspension on the CDN). Aligned to the V2 posture: `private, max-age=60, stale-while-revalidate=300`.
3. **redeemWaitlistCode** (`src/app/waitlist/actions.ts`): added the SEC-57 `getAccountStanding`/`shouldRefuseIssuance` fail-closed standing check (a suspended account can no longer self-elevate to beta) and stopped swallowing the grant error (surfaces `?error=grant_failed` instead of a silent `/dashboard` redirect).
4. **updatePassword** (`src/app/dashboard/settings/actions.ts`): current-password proof was wrapped in `if (user.email)`, letting an emailless (OAuth-provisioned) session set a password with zero proof. Proof is now mandatory; the emailless path is refused (add an email first).

## Jira Ticket

SEC-82

## Tests

- New suites: `sec82-reports-item-ownership`, `sec82-recommendations-v1-cache`, `sec82-update-password-emailless`.
- Extended `waitlist-redeem` with suspended-refusal + grant-error cases (test infrastructure only — no existing assertion changed).
- Full unit suite: **177 suites / 2153 tests green**; `tsc --noEmit` clean; eslint clean on all changed files.

MCP coverage: N/A — no new user-facing entity or mutation surface; these are hardening fixes to existing web routes/actions.

## Checklist

- [x] Unit tests added/updated for new/changed functionality
- [x] All existing tests pass (`npm run test:unit`)
- [x] Lint passes (`npm run lint`)
- [x] Type check passes (`tsc --noEmit`)
- [ ] Build succeeds (`npm run build`) — not run in this slice
- [x] Coverage has not decreased (net-new tests added)
- [x] No eslint-disable or ts-ignore without KAN-XX reference
- [x] ARCHITECTURE.md updated if architectural changes were made — N/A
- [x] Ops routine / Control-Room registry updated if scheduled-routine behaviour changed — N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W9suicfAue1MhrsnAYX6BE

---
_Generated by [Claude Code](https://claude.ai/code/session_01W9suicfAue1MhrsnAYX6BE)_