### PR TITLE
fix(SEC-86): document prod-promote merge-flow gate residual + integrity assertion (Finding A)

### DIFF
--- a/.github/workflows/promote-to-production.yml
+++ b/.github/workflows/promote-to-production.yml
@@ -139,6 +139,21 @@ jobs:
           echo "::error::Could not verify beta CI for $BETA_SHORT after $MAX_ATTEMPTS attempts."
           exit 1
 
+  # SEC-86 Finding A (release-flow gate) — DOCUMENTED RESIDUAL, decision pending Luisa.
+  # This job runs the irreversible beta -> main merge + push. It intentionally carries
+  # NO `environment:` block, so the GitHub required-reviewers gate (attached to the
+  # `production` Environment, which is referenced only by the DOWNSTREAM
+  # deploy-production.yml) does NOT guard the merge itself — only the later Vercel deploy.
+  # The sole gate on the merge today is the typed workflow_dispatch confirm input
+  # (== "PRODUCTION"), backed by verify-source (beta CI green), SHA-matched smoke tests,
+  # and auto-rollback. Whether to upgrade to a merge-time reviewer gate (add
+  # `environment: production` to this job) or accept the residual for the solo-maintainer
+  # release flow is Luisa's call; the production Environment's required-reviewers setting
+  # must also be confirmed in GitHub repo settings (not visible from workflow files).
+  # See docs/RELEASE_POLICY.md -> "Release-flow gate (SEC-86 Finding A)".
+  # check-workflow-integrity.sh Pattern 5 keeps this gap explicit and pins the
+  # typed-confirm control so it can never be silently removed.
+  # integrity-ok: sec-86 residual documented in docs/RELEASE_POLICY.md; typed-confirm gate preserved; merge-time reviewer upgrade is a pending Luisa decision.
   merge-and-push:
     name: Merge beta → main
     needs: verify-source

--- a/docs/RELEASE_POLICY.md
+++ b/docs/RELEASE_POLICY.md
@@ -65,6 +65,24 @@ The reasoning is asymmetric:
 - Auto-promote to **staging** is safe — staging is gated by Vercel SSO, no real users see it
 - Auto-promote to **production** has the same false-positive risk class KAN-167 spent days dismantling — a "green" CI run that's actually broken would auto-ship to users
 
+## Release-flow gate (SEC-86 Finding A)
+
+The `beta → main` merge in `promote-to-production.yml` is the highest-blast-radius, effectively irreversible action in the project. It is worth being precise about what gates it today:
+
+- The **`merge-and-push` job** performs the `git merge beta` + `git push origin main` (pushed with `LYRA_RELEASE_PAT` so the downstream `deploy-production.yml` fires — see CLAUDE.md gotcha #16). This job declares **no `environment:` block**.
+- The **`production` GitHub Environment** — the only place GitHub *required-reviewers* can attach — is referenced solely by `deploy-production.yml`'s `deploy-production` job, which runs **after** the merge to `main`.
+
+**Net residual:** any required-reviewers configured on the `production` Environment guard the Vercel *deploy*, not the *merge*. The sole gate on the irreversible merge is the typed `workflow_dispatch` input (`Type "PRODUCTION"`). Anyone with repo-write who can dispatch the workflow can land `beta` on `main` by typing the fixed string, with no second pair of eyes on the merge itself. Compensating controls that remain in force: `verify-source` (beta CI must be green at HEAD), SHA-matched production smoke tests, and `auto-rollback` on smoke failure.
+
+**Decision pending (Luisa):** either
+
+1. **Add a merge-time reviewer gate** — put `environment: production` on the `merge-and-push` job so required-reviewers fire *before* the merge. This adds a manual approval step to the solo-maintainer release flow (you approve your own dispatch), which may or may not be worth the friction; **or**
+2. **Accept the residual** — keep the typed-confirm gate as the merge control and rely on the compensating controls above.
+
+Either way, the `production` Environment's *required-reviewers* setting must be confirmed in **GitHub repo settings** (it is not verifiable from the workflow files).
+
+Until this is decided, the gap is kept **explicit and non-regressing** by `scripts/check-workflow-integrity.sh` **Pattern 5**, which fails CI if a workflow pushes to `main` without either `environment: production` or an `# integrity-ok: sec-86` waiver, and *separately* fails if the typed-confirm compensating control is ever removed.
+
 ## Reference
 
 - KAN-173 (this policy): <https://checklyra.atlassian.net/browse/KAN-173>

--- a/scripts/check-workflow-integrity.sh
+++ b/scripts/check-workflow-integrity.sh
@@ -138,6 +138,52 @@ for f in "$WORKFLOW_DIR"/*.yml; do
 done
 rm -f /tmp/rb_hits
 
+# ── Pattern 5: prod-promote merge-to-main gate (SEC-86 Finding A) ──
+# The beta -> main promote merge is the highest-blast-radius, effectively
+# irreversible action in the project. Two invariants must hold for any
+# workflow that runs `git push origin main`:
+#
+#   (5a) A reviewer/approval checkpoint on the merge itself. The merge job
+#        must declare `environment: production` (the GitHub Environment where
+#        required-reviewers attach) OR the residual "the merge lands before
+#        any reviewer" must be an EXPLICIT, documented decision — allow-listed
+#        with `# integrity-ok: sec-86 <reason>`. Without one of these, the
+#        merge can be landed on main by anyone with repo write who types the
+#        confirm string, with no second pair of eyes. The reviewer gate that
+#        DOES exist today (production Environment) is referenced only by the
+#        downstream deploy-production.yml, which runs AFTER the merge, so it
+#        guards the deploy, not the merge. See
+#        docs/RELEASE_POLICY.md -> "Release-flow gate (SEC-86 Finding A)".
+#
+#   (5b) The typed-confirm compensating control must be preserved. The
+#        workflow must still gate on `inputs.confirm == "PRODUCTION"`. That
+#        typed confirmation is the ONE gate that currently guards the merge;
+#        a change that silently removes it (leaving the merge with no gate at
+#        all) must fail CI. This half is decision-neutral — it only pins an
+#        existing control and never blocks a future upgrade to a real
+#        reviewer gate.
+for f in "$WORKFLOW_DIR"/*.yml; do
+  [ -f "$f" ] || continue
+
+  if grep -qE 'git push origin main([^a-zA-Z0-9_-]|$)' "$f"; then
+    # (5a) reviewer checkpoint OR documented residual
+    if ! grep -qE '^[[:space:]]*environment:[[:space:]]*production' "$f" \
+       && ! grep -qiE '# integrity-ok:.*sec-86' "$f"; then
+      echo "::error file=$f::Pattern 5a: pushes to main (prod promote) but the merge job has no 'environment: production' reviewer gate and no documented residual."
+      echo "    Add 'environment: production' to the merge job so required-reviewers fire BEFORE the merge,"
+      echo "    OR document the residual in docs/RELEASE_POLICY.md and allow-list with '# integrity-ok: sec-86 <reason>'."
+      PROBLEMS=$((PROBLEMS + 1))
+    fi
+
+    # (5b) typed-confirm compensating control must survive
+    if ! grep -qE 'inputs\.confirm' "$f" || ! grep -qE '"PRODUCTION"' "$f"; then
+      echo "::error file=$f::Pattern 5b: pushes to main but the typed-confirm gate (inputs.confirm == \"PRODUCTION\") is missing or weakened."
+      echo "    The typed confirmation is the sole gate on the irreversible beta->main merge — it must not be removed."
+      PROBLEMS=$((PROBLEMS + 1))
+    fi
+  fi
+done
+
 echo ""
 if [ "$PROBLEMS" -eq 0 ]; then
   echo "✓ No workflow integrity issues found"

--- a/tests/scripts/check-workflow-integrity.test.js
+++ b/tests/scripts/check-workflow-integrity.test.js
@@ -1,0 +1,166 @@
+const { execSync } = require('child_process');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const REPO_ROOT = path.resolve(__dirname, '../../');
+const SCRIPT = path.resolve(REPO_ROOT, 'scripts/check-workflow-integrity.sh');
+
+// Run the integrity script with a given working directory. Returns
+// { status, output }. status 0 == clean; non-zero == integrity problem(s).
+// The script echoes its ::error:: annotations to stdout, so we capture both.
+function runIn(cwd) {
+  try {
+    const output = execSync(`bash "${SCRIPT}"`, { cwd, stdio: 'pipe' }).toString();
+    return { status: 0, output };
+  } catch (err) {
+    return {
+      status: err.status || 1,
+      output: `${err.stdout || ''}${err.stderr || ''}`,
+    };
+  }
+}
+
+// Build a throwaway repo root containing only .github/workflows/<name>.yml
+// with the supplied contents, then run the script against it.
+function runWithWorkflow(name, contents) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'wfint-'));
+  const wfDir = path.join(dir, '.github', 'workflows');
+  fs.mkdirSync(wfDir, { recursive: true });
+  fs.writeFileSync(path.join(wfDir, name), contents);
+  try {
+    return runIn(dir);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+describe('scripts/check-workflow-integrity.sh', () => {
+  let source = '';
+
+  beforeAll(() => {
+    source = fs.readFileSync(SCRIPT, 'utf8');
+  });
+
+  it('exists and is a bash script', () => {
+    expect(fs.existsSync(SCRIPT)).toBe(true);
+    expect(source.startsWith('#!/usr/bin/env bash')).toBe(true);
+  });
+
+  it('is syntactically valid (bash -n)', () => {
+    expect(() => execSync(`bash -n "${SCRIPT}"`, { stdio: 'pipe' })).not.toThrow();
+  });
+
+  it('is hardened with set -euo pipefail', () => {
+    expect(source).toMatch(/set -euo pipefail/);
+  });
+
+  it('passes cleanly against the real .github/workflows tree', () => {
+    // Integration guard: the repo's actual workflows (including the SEC-86
+    // documented residual on promote-to-production.yml) must be clean.
+    const { status, output } = runIn(REPO_ROOT);
+    expect(output).toContain('No workflow integrity issues found');
+    expect(status).toBe(0);
+  });
+
+  describe('Pattern 5 — prod-promote merge-to-main gate (SEC-86 Finding A)', () => {
+    it('defines Pattern 5 keyed on the push-to-main promote action', () => {
+      expect(source).toMatch(/Pattern 5/);
+      expect(source).toMatch(/git push origin main/);
+      expect(source).toMatch(/sec-86/i);
+    });
+
+    // A promote-style workflow: pushes to main, typed-confirm gate present.
+    const confirmGate =
+      "        run: |\n" +
+      '          if [ "${{ github.event.inputs.confirm }}" != "PRODUCTION" ]; then\n' +
+      '            exit 1\n' +
+      '          fi\n' +
+      '          git config user.name ci\n';
+    const pushMain = '          git push origin main\n';
+
+    it('5a: FAILS when the merge job has no environment gate and no waiver', () => {
+      const wf =
+        'name: Promote\n' +
+        'on: { workflow_dispatch: { inputs: { confirm: { description: \'Type "PRODUCTION"\' } } } }\n' +
+        'jobs:\n' +
+        '  merge:\n' +
+        '    runs-on: ubuntu-latest\n' +
+        '    steps:\n' +
+        '      - name: merge\n' +
+        confirmGate +
+        pushMain;
+      const { status, output } = runWithWorkflow('promote.yml', wf);
+      expect(status).not.toBe(0);
+      expect(output).toMatch(/Pattern 5a/);
+    });
+
+    it('5a: PASSES when the residual is documented via an integrity-ok sec-86 waiver', () => {
+      const wf =
+        'name: Promote\n' +
+        'on: { workflow_dispatch: { inputs: { confirm: { description: \'Type "PRODUCTION"\' } } } }\n' +
+        'jobs:\n' +
+        '  # integrity-ok: sec-86 residual documented in RELEASE_POLICY.md\n' +
+        '  merge:\n' +
+        '    runs-on: ubuntu-latest\n' +
+        '    steps:\n' +
+        '      - name: merge\n' +
+        confirmGate +
+        pushMain;
+      const { status, output } = runWithWorkflow('promote.yml', wf);
+      expect(output).not.toMatch(/Pattern 5a/);
+      expect(status).toBe(0);
+    });
+
+    it('5a: PASSES when the merge job carries environment: production', () => {
+      const wf =
+        'name: Promote\n' +
+        'on: { workflow_dispatch: { inputs: { confirm: { description: \'Type "PRODUCTION"\' } } } }\n' +
+        'jobs:\n' +
+        '  merge:\n' +
+        '    runs-on: ubuntu-latest\n' +
+        '    environment: production\n' +
+        '    steps:\n' +
+        '      - name: merge\n' +
+        confirmGate +
+        pushMain;
+      const { status, output } = runWithWorkflow('promote.yml', wf);
+      expect(output).not.toMatch(/Pattern 5a/);
+      expect(status).toBe(0);
+    });
+
+    it('5b: FAILS when the typed-confirm gate is removed (merge left ungated)', () => {
+      // Environment gate present (so 5a is satisfied) but no inputs.confirm /
+      // "PRODUCTION" typed-confirm control — 5b must catch the regression.
+      const wf =
+        'name: Promote\n' +
+        'on: { workflow_dispatch: {} }\n' +
+        'jobs:\n' +
+        '  merge:\n' +
+        '    runs-on: ubuntu-latest\n' +
+        '    environment: production\n' +
+        '    steps:\n' +
+        '      - name: merge\n' +
+        '        run: |\n' +
+        '          git config user.name ci\n' +
+        pushMain;
+      const { status, output } = runWithWorkflow('promote.yml', wf);
+      expect(status).not.toBe(0);
+      expect(output).toMatch(/Pattern 5b/);
+    });
+
+    it('does not fire on workflows that never push to main', () => {
+      const wf =
+        'name: CI\n' +
+        'on: { push: { branches: [develop] } }\n' +
+        'jobs:\n' +
+        '  test:\n' +
+        '    runs-on: ubuntu-latest\n' +
+        '    steps:\n' +
+        '      - run: npm test\n';
+      const { status, output } = runWithWorkflow('ci.yml', wf);
+      expect(output).not.toMatch(/Pattern 5/);
+      expect(status).toBe(0);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Bounded, dev-safe leg of **SEC-86 Finding A** (KAN-295 exit-gate, runbook step D).

The `beta → main` merge in `promote-to-production.yml` (`merge-and-push` job) runs the irreversible `git merge beta` + `git push origin main` with **no `environment:` block**. The `production` GitHub Environment — the only place GitHub *required-reviewers* attach — is referenced solely by the **downstream** `deploy-production.yml`, so any reviewer gate protects the Vercel *deploy*, not the *merge*. The sole gate on the merge today is the typed `confirm=PRODUCTION` `workflow_dispatch` input.

This PR makes that residual **explicit and non-regressing** without changing the release flow:

- **`scripts/check-workflow-integrity.sh`** — new **Pattern 5**:
  - **(5a)** any workflow that runs `git push origin main` must carry `environment: production` **or** an explicit `# integrity-ok: sec-86 <reason>` documented-residual waiver.
  - **(5b)** decision-neutral pin of the typed-confirm compensating control (`inputs.confirm == "PRODUCTION"`) so it can never be silently removed, leaving the merge with no gate at all.
- **`.github/workflows/promote-to-production.yml`** — comment-only `# integrity-ok: sec-86` waiver documenting the residual + pending decision. **No behavioural change.**
- **`docs/RELEASE_POLICY.md`** — new "Release-flow gate (SEC-86 Finding A)" subsection: the residual, the compensating controls still in force (`verify-source` beta-CI-green, SHA-matched smoke, `auto-rollback`), and the two options.
- **`tests/scripts/check-workflow-integrity.test.js`** — new suite (10 tests): behavioural coverage of 5a (fail with no gate/no waiver; pass with waiver; pass with `environment: production`) and 5b (fail when typed-confirm removed), non-firing on non-main-push workflows, plus an integration pass against the real workflow tree.

### ⚠️ Decision required (Luisa) — this PR does NOT resolve SEC-86 on its own

The *real* fix is a merge-flow change that is your call:
1. **Add a merge-time reviewer gate** — put `environment: production` on the `merge-and-push` job so required-reviewers fire *before* the merge (adds a manual approval step to the solo-maintainer release flow — you approve your own dispatch); **or**
2. **Accept the residual** — keep the typed-confirm gate + compensating controls as-is.

Either way, the `production` Environment's *required-reviewers* setting must be confirmed in **GitHub repo settings** (not verifiable from workflow files). SEC-86 stays **In Progress** until you decide.

> Note: the `promote-to-production.yml` change is a comment only; per CLAUDE.md gotcha #1, workflow-file changes only take effect once on `main`, but a comment has no runtime effect regardless. The `check-workflow-integrity.sh` change runs from `pr-checks.yml` and takes effect on PRs immediately.

## Jira Ticket

SEC-86

## Checklist

- [x] Unit tests added/updated for new/changed functionality (10 new tests)
- [x] All existing tests pass (`tests/scripts/` 100/100; `promote-to-production-bugs11` 8/8; new suite 10/10)
- [ ] Lint passes (`npm run lint`) — not run in this slice (no app/TS code changed; shell + md + a JS test file)
- [x] Type check passes — N/A (no TS source changed)
- [x] Build succeeds — N/A (no app code changed)
- [x] Coverage has not decreased (net-new tests only)
- [x] No eslint-disable or ts-ignore without KAN-XX reference
- [x] ARCHITECTURE.md updated if architectural changes were made — N/A
- [x] Ops routine / Control-Room registry updated if scheduled-routine behaviour changed — N/A (no routine cadence/ownership change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TZfXqtujaqqFnqjkaciXfR)_