### PR TITLE
fix(SEC-77): durable SHA-pin regression guard for third-party actions (ci-pin-1)

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -24,6 +24,14 @@ jobs:
         # workflow re-introduces a banned pattern. See script source for
         # rationale and the # integrity-ok: allow-list mechanism.
         run: bash scripts/check-workflow-integrity.sh
+      - name: Action SHA-pinning check (SEC-77 F-22)
+        # Static scan of .github/workflows/*.yml: every remote action must be
+        # pinned to a full 40-hex commit SHA, never a mutable @tag/@branch.
+        # A mutable ref lets upstream change CI code without our review
+        # (supply-chain vector). The one-time pin already happened (SEC-20
+        # #356); this is the durable regression guard. Exempt local (./)
+        # reusables; escape hatch is '# integrity-ok: pin <reason>'.
+        run: bash scripts/check-action-pinning.sh
       - name: Server-action export check (BUGS-12)
         # Static scan of every `'use server'` file in src/ for non-async
         # exports. Next.js 16+ rejects these at action-invocation time

--- a/scripts/check-action-pinning.sh
+++ b/scripts/check-action-pinning.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# scripts/check-action-pinning.sh
+#
+# SEC-77 finding F-22 (supply-chain) / regression guard for SEC-20 (#356):
+# every remote GitHub Action referenced by a workflow must be pinned to a
+# full 40-hex commit SHA, never a mutable tag or branch.
+#
+# Why: a mutable ref (e.g. `@v4`, `@main`) lets the upstream owner — or anyone
+# who compromises the tag/branch — change the code that runs in our CI without
+# our review. That is the classic third-party-action supply-chain vector.
+# Pinning to an immutable commit SHA closes it. Pinning does NOT freeze the
+# version: Dependabot still bumps the SHA as long as a trailing `# vX.Y.Z`
+# comment records the human-readable version, so provenance stays honest and
+# updates keep flowing.
+#
+# The one-time SHA-pin across the tree already happened (SEC-20 #356). This
+# script is the DURABLE guard that stops a future PR from silently
+# re-introducing an un-pinned action. It only inspects this repo's own
+# workflow files — it never resolves or changes a SHA itself.
+#
+# Run from pr-checks.yml so any PR that (re)introduces a mutable ref fails CI.
+#
+# What counts as pinned:
+#   uses: actions/checkout@<40-hex-sha>   # v4        ✓ pinned
+#   uses: docker://image@sha256:<64-hex>              ✓ pinned (image digest)
+#   uses: ./.github/workflows/reusable.yml            ✓ local (in-repo, exempt)
+#   uses: actions/checkout@v4                         ✗ mutable tag
+#   uses: some/action@main                            ✗ mutable branch
+#
+# Escape hatch (rare, must be justified): append
+#   # integrity-ok: pin <reason>
+# to the offending `uses:` line if a non-SHA ref is genuinely intentional.
+
+set -euo pipefail
+
+WORKFLOW_DIR=".github/workflows"
+PROBLEMS=0
+
+if [ ! -d "$WORKFLOW_DIR" ]; then
+  echo "::error::No $WORKFLOW_DIR directory found"
+  exit 1
+fi
+
+echo "Scanning $WORKFLOW_DIR for un-pinned (mutable-ref) actions..."
+echo ""
+
+for f in "$WORKFLOW_DIR"/*.yml; do
+  [ -f "$f" ] || continue
+
+  # Candidate lines: a `uses:` referencing a remote action `owner/repo[...]@ref`.
+  # Local reusable workflows (`uses: ./...`) are in-repo and exempt.
+  while IFS= read -r line; do
+    [ -n "$line" ] || continue
+    lineno="${line%%:*}"
+    body="${line#*:}"
+
+    # Already pinned? A full 40-hex commit SHA, or a docker image sha256
+    # digest, immediately followed by end-of-token (space, '#', or EOL).
+    if printf '%s' "$body" | grep -qE '@([0-9a-f]{40}|sha256:[0-9a-f]{64})([[:space:]#]|$)'; then
+      continue
+    fi
+    # Intentional, documented exception on the same line?
+    if printf '%s' "$body" | grep -qiE '#[[:space:]]*integrity-ok:[[:space:]]*pin'; then
+      continue
+    fi
+    echo "::error file=$f,line=$lineno::un-pinned action (mutable ref) — pin to a full 40-hex commit SHA with a trailing '# vX.Y.Z' comment:$body"
+    PROBLEMS=$((PROBLEMS + 1))
+  done < <(grep -nE '^[[:space:]]*(-[[:space:]]+)?uses:[[:space:]]*[A-Za-z0-9_.-]+/[A-Za-z0-9_./-]+@' "$f" \
+             | grep -vE 'uses:[[:space:]]*\.' || true)
+done
+
+echo ""
+if [ "$PROBLEMS" -eq 0 ]; then
+  echo "✓ All workflow actions are SHA-pinned"
+  exit 0
+fi
+echo "::error::Found $PROBLEMS un-pinned action reference(s). Pin to a commit SHA before merging."
+echo "    A mutable tag/branch ref lets upstream change CI code without review (supply-chain risk)."
+echo "    Dependabot keeps SHA pins current when a trailing '# vX.Y.Z' comment is present."
+echo "    Intentional exception: append '# integrity-ok: pin <reason>' to the uses: line."
+exit 1

--- a/tests/scripts/check-action-pinning.test.js
+++ b/tests/scripts/check-action-pinning.test.js
@@ -1,0 +1,166 @@
+const { execSync } = require('child_process');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const REPO_ROOT = path.resolve(__dirname, '../../');
+const SCRIPT = path.resolve(REPO_ROOT, 'scripts/check-action-pinning.sh');
+
+// Run the guard with a given working directory. Returns { status, output }.
+// status 0 == all actions pinned; non-zero == at least one un-pinned action.
+// The script echoes ::error:: annotations to stdout, so capture both streams.
+function runIn(cwd) {
+  try {
+    const output = execSync(`bash "${SCRIPT}"`, { cwd, stdio: 'pipe' }).toString();
+    return { status: 0, output };
+  } catch (err) {
+    return {
+      status: err.status || 1,
+      output: `${err.stdout || ''}${err.stderr || ''}`,
+    };
+  }
+}
+
+// Build a throwaway repo root containing only .github/workflows/<name>.yml
+// with the supplied contents, then run the script against it.
+function runWithWorkflow(name, contents) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'pin-'));
+  const wfDir = path.join(dir, '.github', 'workflows');
+  fs.mkdirSync(wfDir, { recursive: true });
+  fs.writeFileSync(path.join(wfDir, name), contents);
+  try {
+    return runIn(dir);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+// A real 40-hex commit SHA (actions/checkout, as pinned across the tree).
+const SHA = 'de0fac2e4500dabe0009e67214ff5f5447ce83dd';
+
+function wf(steps) {
+  return (
+    'name: T\n' +
+    'on: { push: {} }\n' +
+    'jobs:\n' +
+    '  a:\n' +
+    '    runs-on: ubuntu-latest\n' +
+    '    steps:\n' +
+    steps
+  );
+}
+
+describe('scripts/check-action-pinning.sh', () => {
+  let source = '';
+
+  beforeAll(() => {
+    source = fs.readFileSync(SCRIPT, 'utf8');
+  });
+
+  it('exists and is a bash script', () => {
+    expect(fs.existsSync(SCRIPT)).toBe(true);
+    expect(source.startsWith('#!/usr/bin/env bash')).toBe(true);
+  });
+
+  it('is syntactically valid (bash -n)', () => {
+    expect(() => execSync(`bash -n "${SCRIPT}"`, { stdio: 'pipe' })).not.toThrow();
+  });
+
+  it('is hardened with set -euo pipefail', () => {
+    expect(source).toMatch(/set -euo pipefail/);
+  });
+
+  it('passes cleanly against the real .github/workflows tree', () => {
+    // Integration guard: every action in the repo's real workflows is already
+    // SHA-pinned (SEC-20 #356), so the guard must be green on the live tree.
+    const { status, output } = runIn(REPO_ROOT);
+    expect(output).toContain('All workflow actions are SHA-pinned');
+    expect(status).toBe(0);
+  });
+
+  it('FAILS on a mutable tag ref (@v4)', () => {
+    const { status, output } = runWithWorkflow(
+      't.yml',
+      wf('      - uses: actions/checkout@v4\n')
+    );
+    expect(status).not.toBe(0);
+    expect(output).toMatch(/un-pinned action/);
+    expect(output).toMatch(/actions\/checkout@v4/);
+  });
+
+  it('FAILS on a mutable branch ref (@main)', () => {
+    const { status, output } = runWithWorkflow(
+      't.yml',
+      wf('      - uses: some/action@main\n')
+    );
+    expect(status).not.toBe(0);
+    expect(output).toMatch(/un-pinned action/);
+  });
+
+  it('FAILS on a nested-path action pinned to a tag (github/codeql-action/init@v4)', () => {
+    const { status, output } = runWithWorkflow(
+      't.yml',
+      wf('      - uses: github/codeql-action/init@v4\n')
+    );
+    expect(status).not.toBe(0);
+    expect(output).toMatch(/codeql-action\/init@v4/);
+  });
+
+  it('PASSES on a full 40-hex commit SHA (with a version comment)', () => {
+    const { status, output } = runWithWorkflow(
+      't.yml',
+      wf(`      - uses: actions/checkout@${SHA} # v6\n`)
+    );
+    expect(output).not.toMatch(/un-pinned action/);
+    expect(status).toBe(0);
+  });
+
+  it('PASSES on a full 40-hex commit SHA with no trailing comment', () => {
+    const { status } = runWithWorkflow(
+      't.yml',
+      wf(`      - uses: actions/checkout@${SHA}\n`)
+    );
+    expect(status).toBe(0);
+  });
+
+  it('PASSES on a docker image sha256 digest', () => {
+    const digest = '0'.repeat(64);
+    const { status } = runWithWorkflow(
+      't.yml',
+      wf(`      - uses: docker://alpine@sha256:${digest}\n`)
+    );
+    expect(status).toBe(0);
+  });
+
+  it('exempts a local (./) reusable workflow', () => {
+    const { status, output } = runWithWorkflow(
+      't.yml',
+      wf('      - uses: ./.github/workflows/reusable.yml\n')
+    );
+    expect(output).not.toMatch(/un-pinned action/);
+    expect(status).toBe(0);
+  });
+
+  it('honours an explicit # integrity-ok: pin waiver on the offending line', () => {
+    const { status, output } = runWithWorkflow(
+      't.yml',
+      wf('      - uses: foo/bar@v9 # integrity-ok: pin intentional floating tag\n')
+    );
+    expect(output).not.toMatch(/un-pinned action/);
+    expect(status).toBe(0);
+  });
+
+  it('counts every un-pinned reference, not just the first', () => {
+    const { status, output } = runWithWorkflow(
+      't.yml',
+      wf(
+        '      - uses: actions/checkout@v4\n' +
+          '      - uses: some/action@main\n' +
+          `      - uses: actions/setup-node@${SHA} # v6\n`
+      )
+    );
+    expect(status).not.toBe(0);
+    // Two mutable refs; the SHA-pinned one is not counted.
+    expect(output).toMatch(/Found 2 un-pinned action reference\(s\)/);
+  });
+});


### PR DESCRIPTION
## Summary

The **ci-pin-1** leg of **SEC-77** (Phase-4 / KAN-350, supply-chain finding F-22). Confirmed at claim that the finding's *one-time* work — SHA-pinning the third-party actions the 2026-06-30 review flagged (checkout/setup-node/setup-python/upload-artifact/codeql) — **already landed** via SEC-20 (#356). All **82** remote `uses:` on `develop` are 40-hex pinned; there are **no un-pinned actions left to resolve**, and the ticket's framed approach (resolve `actions/*` tag→SHA via the github MCP) can't run here because those repos are outside this session's allowed scope.

What was still missing is the **durable regression guard** so a future PR can't silently re-introduce a mutable `@tag`/`@branch` ref — the actual F-22 risk (a mutable ref lets upstream change CI code without our review). This PR adds it.

- **`scripts/check-action-pinning.sh`** — static scan of `.github/workflows/*.yml`. Every remote action must be pinned to a full 40-hex commit SHA (or a docker `sha256:` image digest). Local (`./`) reusables are exempt; escape hatch is a trailing `# integrity-ok: pin <reason>`. **Clean on the real tree** (all 82 already pinned) — it does not resolve or change any SHA itself.
- **`.github/workflows/pr-checks.yml`** — new step running the guard, mirroring the project's one-concern-per-`check-*.sh` house pattern (`check-workflow-integrity` / `check-server-action-exports` / `check-macos-duplicate-files` / `check-doc-mirror-manifest`).
- **`tests/scripts/check-action-pinning.test.js`** — 13 net-new tests: tag/branch/nested-path refs FAIL; SHA + docker digest + local reusable + `# integrity-ok: pin` waiver PASS; multi-count; and the real-tree-is-clean integration guard.

**Design note:** implemented as a *standalone* guard rather than a new pattern inside `check-workflow-integrity.sh` on purpose — that keeps it off the in-flight SEC-86/SEC-66 pattern stack (#516/#520, which edit that script + its test harness) and avoids tripping that harness's convenience un-pinned `@v6` fixtures. This PR therefore targets `develop` directly, no stacking.

Per CLAUDE.md gotcha #1, the workflow-file change only takes effect once it reaches `main`; the guard itself runs from `pr-checks.yml` on PRs immediately.

## Jira Ticket

SEC-77 (stays **In Progress** — closes finding ci-pin-1; the machine-checked fix-only auto-promote guard noted on #494 remains a separate SEC-77 follow-up).

## Checklist

- [x] Unit tests added/updated for new/changed functionality (13 net-new)
- [x] All existing tests pass (`tests/scripts` 9 suites/103; the two pr-checks-referencing unit suites 40/40) — **no existing test modified/weakened/deleted**
- [ ] Lint passes — not run in this slice (shell + a CommonJS test file + a workflow yaml; no app/TS source changed), mirroring #494/#516/#520
- [x] Type check passes — N/A (no TS source changed)
- [ ] Build succeeds — N/A (no app code changed)
- [x] Coverage has not decreased (net-new tests only)
- [x] No eslint-disable or ts-ignore added
- [x] ARCHITECTURE.md — N/A (CI hygiene, no architectural change)
- [x] Ops routine / Control-Room registry — N/A (no scheduled-routine behaviour/cadence/ownership change)

## MCP-main lockstep

N/A — CI/supply-chain hygiene only, no user-facing data-model change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KWPCBBfZjh8wRe4auAPECy

---
_Generated by [Claude Code](https://claude.ai/code/session_01KWPCBBfZjh8wRe4auAPECy)_