### PR TITLE
fix(SEC-77): machine-checked fix-only auto-promote gate

### DIFF
--- a/.github/workflows/promote-to-production.yml
+++ b/.github/workflows/promote-to-production.yml
@@ -30,6 +30,17 @@ on:
       confirm:
         description: 'Type "PRODUCTION" to confirm (case sensitive)'
         required: true
+      # SEC-77: distinguishes a MANUAL feature release (default) from the
+      # SEC-22 weekly routine's AUTO fix-only promote. In 'auto-fix-only' mode
+      # the merge-and-push job runs scripts/check-fix-only-promote.sh, which
+      # HARD-FAILS if any commit in main..beta is a feature (or otherwise not an
+      # unambiguous non-feature change) — converting the previously procedural
+      # fix-only gate into a machine-enforced one. Manual promotes leave this at
+      # 'manual' and are gated by the typed-confirm above (Luisa's sign-off).
+      promote_mode:
+        description: "'manual' (default, Luisa feature release) or 'auto-fix-only' (SEC-22 routine — enforces fix-only)"
+        required: false
+        default: 'manual'
 
 permissions:
   contents: write
@@ -159,6 +170,19 @@ jobs:
           set -euo pipefail
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
+      # SEC-77: machine-checked fix-only gate. Runs BEFORE the irreversible
+      # beta -> main merge, so a blocked auto-promote leaves main untouched. In
+      # 'manual' mode the script is a no-op (Luisa's typed-confirm is the gate);
+      # in 'auto-fix-only' mode it hard-fails if any commit in origin/main..
+      # origin/beta is a feature / breaking / ambiguous change. This is an
+      # explicit mode branch, NOT a silent-skip on a missing secret (KAN-167).
+      - name: Fix-only auto-promote gate (SEC-77)
+        env:
+          PROMOTE_MODE: ${{ github.event.inputs.promote_mode }}
+        run: |
+          set -euo pipefail
+          git fetch --quiet origin main beta
+          BASE=origin/main HEAD=origin/beta bash scripts/check-fix-only-promote.sh "${PROMOTE_MODE:-manual}"
       - name: Merge beta into main
         id: merge
         env:

--- a/docs/RELEASE_POLICY.md
+++ b/docs/RELEASE_POLICY.md
@@ -65,6 +65,18 @@ The reasoning is asymmetric:
 - Auto-promote to **staging** is safe — staging is gated by Vercel SSO, no real users see it
 - Auto-promote to **production** has the same false-positive risk class KAN-167 spent days dismantling — a "green" CI run that's actually broken would auto-ship to users
 
+## Machine-checked fix-only auto-promote gate (SEC-77)
+
+There is one owner-authorised exception (2026-06-21) to "no cron, ever" on `beta → main`: the SEC-22 weekly health/regression routine MAY auto-promote to production **only when every change pending on `beta` ahead of `main` is a bug-FIX — never a feature** (see `CLAUDE.md` → Deployment Pipeline and `docs/WEEKLY_HEALTH_REGRESSION_ROUTINE.md`). Until SEC-77 this "every pending change is a fix" condition was **procedural** — enforced only by the routine-agent's judgement, with nothing in the workflow to stop a feature slipping through and auto-shipping to a minors' platform unattended.
+
+It is now **machine-enforced**:
+
+- `promote-to-production.yml` takes a `promote_mode` input (`manual` default, or `auto-fix-only`). Both the manual feature release and the SEC-22 auto path share the one workflow; the input is what tells them apart.
+- In **`manual`** mode the gate is a no-op — a manual feature release is authorised by Luisa's typed `PRODUCTION` confirm, and features are expected.
+- In **`auto-fix-only`** mode the `merge-and-push` job runs `scripts/check-fix-only-promote.sh` **before** the irreversible `git merge beta` + `git push origin main`. The script inspects every non-merge commit in `origin/main..origin/beta` and **hard-fails** (blocking the merge, leaving `main` untouched) if any is a **feature** (`feat`), a **breaking change** (`<type>!:`), or **anything without an unambiguous non-feature conventional-commit type**. Merge commits are skipped; an empty range fails closed.
+- The fallback on a hard fail is exactly the policy's prescribed one: **stop the auto-promote and require manual sign-off** (re-dispatch without `promote_mode=auto-fix-only`). A false positive therefore only forces a human — safe — while a false negative (a feature auto-ships) is the failure mode the gate biases hard against.
+- **Allow-list (the one policy knob):** the non-feature types treated as fix-only live in `ALLOWED_TYPES` at the top of `scripts/check-fix-only-promote.sh` (`fix revert docs chore ci build test style`). It deliberately errs strict — `perf`/`refactor` are treated as feature-class (they can change runtime behaviour) and force manual sign-off. Widen or narrow it only as a reviewed policy decision.
+
 ## Reference
 
 - KAN-173 (this policy): <https://checklyra.atlassian.net/browse/KAN-173>
@@ -75,3 +87,4 @@ The reasoning is asymmetric:
 - `.github/workflows/promote-to-staging.yml` — the manual workflow (auto-promote calls the same logic)
 - `.github/workflows/promote-to-production.yml` — direct-merge flow as of 2026-05-15 (BUGS-16 fix)
 - `.github/workflows/auto-promote-to-staging.yml` — the scheduled wrapper
+- `scripts/check-fix-only-promote.sh` — SEC-77 machine-checked fix-only gate for the `auto-fix-only` production promote (unit-tested in `tests/scripts/check-fix-only-promote.test.js`)

--- a/docs/WEEKLY_HEALTH_REGRESSION_ROUTINE.md
+++ b/docs/WEEKLY_HEALTH_REGRESSION_ROUTINE.md
@@ -78,7 +78,13 @@ log everything, and rehearse the release pipeline up to (not through) the prod g
      user-facing capability, route, table, MCP tool, or migration) -> you are AUTHORISED to ship:
        a. Bump package.json: npm version patch --no-git-tag-version (per KAN-166), commit on a claude/ PR.
        b. Promote the chain: promote-to-staging.yml -> verify staging green + healthy ->
-          promote-staging-to-beta.yml -> verify beta -> promote-to-production.yml -f confirm=PRODUCTION.
+          promote-staging-to-beta.yml -> verify beta ->
+          promote-to-production.yml -f confirm=PRODUCTION -f promote_mode=auto-fix-only.
+          The `-f promote_mode=auto-fix-only` flag is REQUIRED for the auto path: the workflow then
+          runs scripts/check-fix-only-promote.sh and HARD-FAILS the promote if any commit in
+          origin/main..origin/beta is a feature / breaking / ambiguous change (SEC-77 — the fix-only
+          gate is now machine-enforced, not just your judgement). If it fails, treat as "release holds
+          a feature" -> STOP and require manual sign-off (see the ambiguous branch below).
        c. The prod workflow runs smoke tests + AUTO-ROLLBACK. If it rolls back, treat as FAIL,
           open a Highest-priority BUGS ticket, and STOP.
        d. Verify prod after: curl https://checklyra.com/api/health and https://mcp.checklyra.com/health.

--- a/scripts/check-fix-only-promote.sh
+++ b/scripts/check-fix-only-promote.sh
@@ -1,0 +1,140 @@
+#!/usr/bin/env bash
+# scripts/check-fix-only-promote.sh
+#
+# SEC-77 (finding: auto-promote doc/code drift → machine-checked fix-only gate).
+#
+# Converts the previously PROCEDURAL "fix-only" gate on the production
+# auto-promote path into a MACHINE-ENFORCED one.
+#
+# Background: promote-to-production.yml (beta -> main) is dispatched two ways
+# that share the same workflow:
+#   * MANUAL feature releases — Luisa dispatches with a typed "PRODUCTION"
+#     confirm. Her sign-off IS the authorisation; features are expected.
+#   * AUTO fix-only releases — the SEC-22 weekly health/regression routine MAY
+#     auto-promote, but ONLY when every change pending on beta ahead of main is
+#     a bug-FIX, never a feature (owner-authorised 2026-06-21; see CLAUDE.md ->
+#     Deployment Pipeline and docs/WEEKLY_HEALTH_REGRESSION_ROUTINE.md).
+#
+# Until now the "every pending change is a fix" condition was enforced only by
+# the routine-agent's judgement. This script makes the workflow itself verify
+# the claim: in auto-fix-only mode it inspects every commit in the promote
+# range and HARD-FAILS if any is a feature (or anything that is not an
+# unambiguous non-feature change). A hard fail here means "stop the auto-promote
+# and require manual sign-off" — exactly the policy's prescribed fallback, so a
+# false positive is SAFE (it only forces a human) while a false negative (a
+# feature slips through to a minors' platform unattended) is the dangerous case
+# we bias hard against.
+#
+# Usage:
+#   check-fix-only-promote.sh <mode>
+#     <mode>  promote mode. Anything other than "auto-fix-only" is treated as a
+#             manual promote and the gate is a no-op (exit 0) — manual releases
+#             are gated by Luisa's typed-confirm sign-off, not by this script.
+#
+# Range: BASE..HEAD, defaulting to origin/main..origin/beta. Overridable via the
+# BASE / HEAD env vars purely so the unit tests can drive crafted histories.
+#
+# Classification (conventional-commit type of each NON-merge commit subject):
+#   * merge commits (>=2 parents) are structural and skipped — their semantic
+#     content is represented by the non-merge commits they introduce.
+#   * type in the NON-FEATURE allow-list below -> OK.
+#   * type "feat", any breaking change ("<type>!:"), OR any subject without a
+#     recognised non-feature conventional prefix -> VIOLATION (stop).
+#
+# The allow-list is deliberately the single policy knob. It errs toward
+# STRICT: perf/refactor are treated as feature-class (they can change runtime
+# behaviour) so they force manual sign-off. Widen or narrow it only as a
+# reviewed policy decision.
+set -euo pipefail
+
+MODE="${1:-manual}"
+
+if [ "$MODE" != "auto-fix-only" ]; then
+  echo "Promote mode '${MODE}': fix-only auto-promote guard not applicable."
+  echo "Manual production promotes are gated by the typed-confirm sign-off (Type \"PRODUCTION\"), not by this guard."
+  exit 0
+fi
+
+BASE="${BASE:-origin/main}"
+HEAD="${HEAD:-origin/beta}"
+
+# Non-feature conventional-commit types permitted in an auto-fix-only promote.
+# Everything else (notably "feat", any breaking "!", and unrecognised subjects)
+# is a violation. See header note on the strict bias.
+ALLOWED_TYPES="fix revert docs chore ci build test style"
+
+if ! git rev-parse --verify --quiet "$BASE" >/dev/null; then
+  echo "::error::check-fix-only-promote: base ref '$BASE' not found — cannot verify the promote range. Refusing (fail-closed)."
+  exit 1
+fi
+if ! git rev-parse --verify --quiet "$HEAD" >/dev/null; then
+  echo "::error::check-fix-only-promote: head ref '$HEAD' not found — cannot verify the promote range. Refusing (fail-closed)."
+  exit 1
+fi
+
+# Non-merge commits in BASE..HEAD, hashes only (subjects fetched per-hash so a
+# subject containing '|' or newlines can't desync the parse).
+mapfile -t COMMITS < <(git rev-list --no-merges "${BASE}..${HEAD}")
+
+if [ "${#COMMITS[@]}" -eq 0 ]; then
+  echo "::error::check-fix-only-promote: no non-merge commits in ${BASE}..${HEAD} — nothing to auto-promote. Refusing an empty auto-promote (fail-closed)."
+  exit 1
+fi
+
+VIOLATIONS=0
+echo "Auto-fix-only promote gate: inspecting ${#COMMITS[@]} non-merge commit(s) in ${BASE}..${HEAD}"
+echo ""
+
+for sha in "${COMMITS[@]}"; do
+  subject="$(git show -s --format=%s "$sha")"
+  short="${sha:0:8}"
+
+  # Parse a conventional-commit type: leading word, optional (scope), optional
+  # '!' (breaking), then ':'. Case-insensitive on the type word.
+  if [[ "$subject" =~ ^([a-zA-Z]+)(\([^\)]*\))?(!)?: ]]; then
+    type="$(printf '%s' "${BASH_REMATCH[1]}" | tr '[:upper:]' '[:lower:]')"
+    breaking="${BASH_REMATCH[3]}"
+  else
+    type=""
+    breaking=""
+  fi
+
+  if [ -z "$type" ]; then
+    echo "::error::  ✗ ${short}: no conventional-commit type — ambiguous, cannot confirm it is a fix: ${subject}"
+    VIOLATIONS=$((VIOLATIONS + 1))
+    continue
+  fi
+
+  if [ -n "$breaking" ]; then
+    echo "::error::  ✗ ${short}: breaking change (${type}!:) is not a plain fix: ${subject}"
+    VIOLATIONS=$((VIOLATIONS + 1))
+    continue
+  fi
+
+  if [ "$type" = "feat" ]; then
+    echo "::error::  ✗ ${short}: feature (feat) — features must not auto-promote to production: ${subject}"
+    VIOLATIONS=$((VIOLATIONS + 1))
+    continue
+  fi
+
+  allowed=0
+  for a in $ALLOWED_TYPES; do
+    [ "$type" = "$a" ] && allowed=1 && break
+  done
+
+  if [ "$allowed" -eq 1 ]; then
+    echo "  ✓ ${short}: ${type} — ${subject}"
+  else
+    echo "::error::  ✗ ${short}: type '${type}' is not in the fix-only allow-list (${ALLOWED_TYPES}) — treat as non-fix, require manual sign-off: ${subject}"
+    VIOLATIONS=$((VIOLATIONS + 1))
+  fi
+done
+
+echo ""
+if [ "$VIOLATIONS" -eq 0 ]; then
+  echo "✓ All ${#COMMITS[@]} pending commit(s) are fix-only — auto-promote may proceed."
+  exit 0
+fi
+
+echo "::error::check-fix-only-promote: ${VIOLATIONS} non-fix change(s) in ${BASE}..${HEAD}. Auto-promote to production is BLOCKED — this release requires manual sign-off (dispatch promote-to-production.yml without promote_mode=auto-fix-only)."
+exit 1

--- a/tests/scripts/check-fix-only-promote.test.js
+++ b/tests/scripts/check-fix-only-promote.test.js
@@ -1,0 +1,179 @@
+const { execSync } = require('child_process');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const REPO_ROOT = path.resolve(__dirname, '../../');
+const SCRIPT = path.resolve(REPO_ROOT, 'scripts/check-fix-only-promote.sh');
+
+// Build a throwaway git repo with a `main` branch and a `beta` branch whose
+// commits (ahead of main) are the supplied subjects, then run the guard over
+// the main..beta range. Returns { status, output }.
+//
+// Each entry in `betaCommits` is either a string (a normal commit subject) or
+// { merge: [subjectA, subjectB] } to fabricate a real merge commit (2 parents)
+// on beta — used to prove merge commits are skipped.
+function runOverHistory(mode, betaCommits) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'fixonly-'));
+  const git = (args) =>
+    execSync(`git ${args}`, { cwd: dir, stdio: 'pipe' }).toString();
+  try {
+    git('init -q');
+    git('config user.email test@example.com');
+    git('config user.name tester');
+    git('config commit.gpgsign false');
+    git('commit -q --allow-empty -m "chore: repo base"');
+    git('branch -M main');
+    git('checkout -q -b beta');
+    for (const c of betaCommits) {
+      if (typeof c === 'object' && c.merge) {
+        // Make a side branch with one commit, then merge it into beta with
+        // --no-ff so the merge commit (2 parents) actually materialises.
+        git('checkout -q -b side main');
+        git(`commit -q --allow-empty -m ${JSON.stringify(c.merge[1])}`);
+        git('checkout -q beta');
+        git(
+          `merge --no-ff -q side -m ${JSON.stringify(c.merge[0])}`,
+        );
+        git('branch -q -D side');
+      } else {
+        git(`commit -q --allow-empty -m ${JSON.stringify(c)}`);
+      }
+    }
+    let status = 0;
+    let output = '';
+    try {
+      output = execSync(`bash "${SCRIPT}" ${JSON.stringify(mode)}`, {
+        cwd: dir,
+        stdio: 'pipe',
+        env: { ...process.env, BASE: 'main', HEAD: 'beta' },
+      }).toString();
+    } catch (err) {
+      status = err.status || 1;
+      output = `${err.stdout || ''}${err.stderr || ''}`;
+    }
+    return { status, output };
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+describe('scripts/check-fix-only-promote.sh', () => {
+  let source = '';
+
+  beforeAll(() => {
+    source = fs.readFileSync(SCRIPT, 'utf8');
+  });
+
+  it('exists and is a bash script', () => {
+    expect(fs.existsSync(SCRIPT)).toBe(true);
+    expect(source.startsWith('#!/usr/bin/env bash')).toBe(true);
+  });
+
+  it('is syntactically valid (bash -n)', () => {
+    expect(() => execSync(`bash -n "${SCRIPT}"`, { stdio: 'pipe' })).not.toThrow();
+  });
+
+  it('is hardened with set -euo pipefail', () => {
+    expect(source).toMatch(/set -euo pipefail/);
+  });
+
+  describe('manual mode (the gate is a no-op)', () => {
+    it('exits 0 without inspecting commits when mode != auto-fix-only', () => {
+      const { status, output } = runOverHistory('manual', [
+        'feat(x): a brand new feature',
+      ]);
+      expect(status).toBe(0);
+      expect(output).toMatch(/not applicable/i);
+      // It must NOT have walked the range / flagged the feature.
+      expect(output).not.toMatch(/features must not auto-promote/);
+    });
+
+    it('exits 0 for an unknown mode string too (fail-open only for manual paths)', () => {
+      const { status } = runOverHistory('', ['feat: x']);
+      expect(status).toBe(0);
+    });
+  });
+
+  describe('auto-fix-only mode', () => {
+    it('PASSES when every pending commit is a fix-family change', () => {
+      const { status, output } = runOverHistory('auto-fix-only', [
+        'fix(SEC-1): patch a real bug',
+        'docs: clarify runbook',
+        'chore(deps): bump a patch dependency',
+        'test: add a regression test',
+        'revert: undo a bad fix',
+      ]);
+      expect(status).toBe(0);
+      expect(output).toMatch(/fix-only — auto-promote may proceed/);
+    });
+
+    it('FAILS when any pending commit is a feature (feat)', () => {
+      const { status, output } = runOverHistory('auto-fix-only', [
+        'fix(SEC-1): patch a real bug',
+        'feat(profile): add a shiny new capability',
+      ]);
+      expect(status).not.toBe(0);
+      expect(output).toMatch(/features must not auto-promote/);
+      expect(output).toMatch(/BLOCKED/);
+    });
+
+    it('FAILS on a breaking change even if typed as fix (fix!)', () => {
+      const { status, output } = runOverHistory('auto-fix-only', [
+        'fix!: drop a legacy column',
+      ]);
+      expect(status).not.toBe(0);
+      expect(output).toMatch(/breaking change/);
+    });
+
+    it('FAILS on a commit with no conventional-commit type (ambiguous → stop)', () => {
+      const { status, output } = runOverHistory('auto-fix-only', [
+        'just did some stuff',
+      ]);
+      expect(status).not.toBe(0);
+      expect(output).toMatch(/no conventional-commit type/);
+    });
+
+    it('FAILS on a recognised-but-non-allowlisted type (e.g. perf/refactor → stop)', () => {
+      const { status, output } = runOverHistory('auto-fix-only', [
+        'refactor: reshape a module',
+      ]);
+      expect(status).not.toBe(0);
+      expect(output).toMatch(/not in the fix-only allow-list/);
+    });
+
+    it('SKIPS merge commits — a fix-only release with merge commits still passes', () => {
+      const { status, output } = runOverHistory('auto-fix-only', [
+        'fix(SEC-2): a bug fix',
+        { merge: ['Merge pull request #123 from some/branch', 'fix(SEC-3): another fix'] },
+      ]);
+      expect(status).toBe(0);
+      expect(output).toMatch(/fix-only — auto-promote may proceed/);
+    });
+
+    it('FAILS closed on an empty promote range (nothing to promote)', () => {
+      const { status, output } = runOverHistory('auto-fix-only', []);
+      expect(status).not.toBe(0);
+      expect(output).toMatch(/no non-merge commits/);
+    });
+
+    it('FAILS closed when the base ref does not exist', () => {
+      // Drive the script directly with a bogus BASE so the fail-closed ref
+      // guard fires.
+      let status = 0;
+      let output = '';
+      try {
+        output = execSync(`bash "${SCRIPT}" auto-fix-only`, {
+          cwd: REPO_ROOT,
+          stdio: 'pipe',
+          env: { ...process.env, BASE: 'origin/does-not-exist-xyz', HEAD: 'HEAD' },
+        }).toString();
+      } catch (err) {
+        status = err.status || 1;
+        output = `${err.stdout || ''}${err.stderr || ''}`;
+      }
+      expect(status).not.toBe(0);
+      expect(output).toMatch(/not found/);
+    });
+  });
+});


### PR DESCRIPTION
## What & why

SEC-77 remaining leg (the follow-up flagged on PR #494 / `docs/RELEASE_POLICY.md`): convert the **procedural** fix-only gate on the SEC-22 auto-promote-to-production path into a **machine-enforced** one.

Today `promote-to-production.yml` (`beta → main`) is dispatched two ways that share one workflow: Luisa's **manual feature release** (typed `PRODUCTION` confirm) and the SEC-22 weekly routine's **auto fix-only** promote (owner-authorised 2026-06-21, *only when every pending change is a bug-fix, never a feature*). Until now that "every pending change is a fix" condition was enforced **only by the routine-agent's judgement** — nothing in the workflow stopped a feature slipping through and auto-shipping to a minors' platform unattended.

## What changed

- **`promote-to-production.yml`** — new `promote_mode` input (`manual` default | `auto-fix-only`). In `auto-fix-only` mode the `merge-and-push` job runs the new guard **before** the irreversible `git merge beta` + `git push origin main`, so a blocked auto-promote leaves `main` untouched. `manual` mode is a no-op (Luisa's typed confirm is the gate) — **manual feature releases are unaffected**.
- **`scripts/check-fix-only-promote.sh`** (new) — inspects every non-merge commit in `origin/main..origin/beta`; hard-fails on any `feat`, any breaking `<type>!:`, or any subject without an unambiguous non-feature conventional type. Merge commits skipped; empty range fails closed.
- **`tests/scripts/check-fix-only-promote.test.js`** (new) — 12 net-new tests (all-fix pass; feat/breaking/unknown/non-allowlisted fail; merge-commit skipped; empty-range + missing-ref fail-closed; manual-mode no-op). No existing test modified.
- **Docs** — `RELEASE_POLICY.md` (new "Machine-checked fix-only auto-promote gate (SEC-77)" subsection) and `WEEKLY_HEALTH_REGRESSION_ROUTINE.md` (auto invocation now carries `-f promote_mode=auto-fix-only`).

## Design notes / decisions for review

- **Bias is intentional and safety-oriented:** a false positive only forces **manual sign-off** (the policy's own fallback); a false negative — a feature auto-shipping to prod — is the failure mode this guards against. So the allow-list errs strict.
- **Allow-list is the one policy knob** — `ALLOWED_TYPES="fix revert docs chore ci build test style"` at the top of the script. `perf`/`refactor` are deliberately treated as feature-class (can change runtime behaviour) → they force manual sign-off. **Please confirm this allow-list matches your intent** — widening/narrowing it is a policy call.
- **No collision with the in-flight SEC-86/SEC-66 stack (#516/#520):** those add a comment block above `merge-and-push` + edits to `check-workflow-integrity.sh`/its test; this change adds an input near the top + a step *inside* `merge-and-push` (~20 lines below) + a **new** standalone script/test — different regions/files, so it targets `develop` directly (mirrors #521's standalone choice). One possible trivial markdown add/add conflict in `RELEASE_POLICY.md` (both insert a `##` subsection before `## Reference`) — resolves by keeping both sections.

## Verification

- New suite 12/12; `tests/unit/promote-to-production-bugs11.test.ts` 9/9 (direct-merge shape preserved); full `tests/scripts` 9 suites / 103 green.
- `promote-to-production.yml` valid YAML; develop `scripts/check-workflow-integrity.sh` clean on the real tree; eslint clean; no `if: env.X != ''` silent-skip and no lossy `|| echo` fallback (KAN-167).
- **No existing test modified/weakened.** Repo-only; no DB, no source-app change.

Not self-merged — production-promote-path change, Luisa reviews. **Never** run `promote-to-production.yml` from the autopilot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015naPAS1L94mTogiRdwe9vo

---
_Generated by [Claude Code](https://claude.ai/code/session_015naPAS1L94mTogiRdwe9vo)_