### PR TITLE
feat: show what Lyra is on the showcase homepage, not just the waitlist one

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -40,6 +40,24 @@ function getSupabase() {
   return createClient(env.supabaseUrl(), env.supabaseServiceRoleKey());
 }
 
+/**
+ * The one-line answer to "what is this?".
+ *
+ * Shared by BOTH homepage modes deliberately. The waitlist front door (prod)
+ * and the showcase (beta/dev) are separate components, so this sentence used to
+ * exist only on the waitlist side — meaning beta, where people actually land
+ * after being invited, explained nothing at all beyond "Be understood.".
+ *
+ * The waitlist mode appends its own "join the waitlist" line; the showcase must
+ * NOT, because everyone seeing it already has access.
+ */
+const LYRA_DESCRIPTION = (
+  <>
+    Lyra is a place to share who you are &mdash; the things you love, the gifts
+    that land, the boundaries that matter &mdash; with the people in your life.
+  </>
+);
+
 async function getPublishedProfiles(): Promise<HomeProfile[]> {
   try {
     const supabase = getSupabase();
@@ -144,10 +162,8 @@ function WaitlistLanding() {
               We&rsquo;re opening Lyra a few people at a time.
             </h1>
             <p className="text-[15px] sm:text-base text-[var(--color-muted)] leading-relaxed max-w-md mb-8">
-              Lyra is a place to share who you are &mdash; the things you
-              love, the gifts that land, the boundaries that matter &mdash; with
-              the people in your life. Join the waitlist and we&rsquo;ll email
-              you the moment your spot opens up.
+              {LYRA_DESCRIPTION} Join the waitlist and we&rsquo;ll email you the
+              moment your spot opens up.
             </p>
             <Link
               href="/signup"
@@ -256,8 +272,11 @@ export default async function Home({
               className="h-[92px] w-auto"
               priority
             />
-            <p className="text-base sm:text-lg text-[var(--color-muted)] mt-4 mb-7">
+            <p className="text-base sm:text-lg text-[var(--color-muted)] mt-4 mb-5">
               Be understood.
+            </p>
+            <p className="text-[15px] sm:text-base text-[var(--color-muted)] leading-relaxed max-w-md mb-7">
+              {LYRA_DESCRIPTION}
             </p>
             <div className="flex flex-wrap gap-3 justify-center">
               <Link

--- a/tests/unit/homepage-content.test.js
+++ b/tests/unit/homepage-content.test.js
@@ -35,6 +35,26 @@ describe('KAN-272: Minimal homepage (June-2026 redesign)', () => {
     expect(content).toContain('next/image');
   });
 
+  test('explains what Lyra is in BOTH homepage modes', () => {
+    // The homepage renders one of two components: the waitlist front door
+    // (prod) or the showcase (beta/dev). The description used to live only on
+    // the waitlist side, so beta — where invited people actually land — said
+    // nothing beyond "Be understood.". One shared constant, used twice, so the
+    // two modes cannot drift apart again.
+    expect(content).toContain('const LYRA_DESCRIPTION');
+    // JSX wraps the sentence across lines — compare on collapsed whitespace.
+    const flat = content.replace(/\s+/g, ' ');
+    expect(flat).toContain('the gifts that land, the boundaries that matter');
+    expect((content.match(/\{LYRA_DESCRIPTION\}/g) || []).length).toBe(2);
+  });
+
+  test('only the waitlist mode mentions joining the waitlist', () => {
+    // Everyone seeing the showcase already has access — telling them to join a
+    // waitlist would be wrong.
+    expect(content).toContain('Join the waitlist and we');
+    expect((content.match(/Join the waitlist and we/g) || []).length).toBe(1);
+  });
+
   test('shows the "Be understood." tagline', () => {
     expect(content).toContain('Be understood.');
   });


### PR DESCRIPTION
## The problem

The homepage renders one of **two** components:

- `WaitlistLanding` — prod (`checklyra.com`), and dev until now
- the **showcase** — beta (`beta.checklyra.com`) and dev

The sentence that explains what Lyra actually is lived only on the waitlist side. So **beta — where invited people actually land — said nothing beyond "Be understood."** before dropping them into the example profiles. This wasn't a promotion lag; the copy had never existed in that component.

## The change

Extracted to a single `LYRA_DESCRIPTION` constant used by both modes, so they can't drift apart again.

The showcase deliberately does **not** get the trailing "Join the waitlist and we'll email you the moment your spot opens up" sentence — everyone seeing the showcase already has access, so telling them to join a waitlist would be wrong. That sentence stays on the waitlist mode only, and there's a test asserting it appears exactly once.

## Verified locally

**Showcase** (beta/dev): logo → "Be understood." → description → Find someone / See example profiles → *A few people to meet*

**Waitlist** (`?preview=waitlist`, i.e. prod): unchanged — description still followed by the waitlist sentence and CTA.

## Tests

2153 passing. Two new assertions: the description appears in both modes via the shared constant, and the waitlist sentence appears in exactly one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)