### PR TITLE
fix(e2e): run authed-journey harness on Node 22 (KAN-348)

### DIFF
--- a/.github/workflows/e2e-authed.yml
+++ b/.github/workflows/e2e-authed.yml
@@ -81,7 +81,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'npm'
 
       - name: Install dependencies


### PR DESCRIPTION
## What & Why

Luisa provisioned the `E2E_SUPABASE_URL` / `E2E_SUPABASE_SERVICE_ROLE_KEY` secrets (2026-07-21), so the KAN-348 authed-journey E2E harness could finally run. But a `workflow_dispatch` run on `develop` (run 29818041111) still failed — **before any test executed** — in `global-setup`:

```
Error: Node.js detected but native WebSocket not found.
Suggested solution: Ensure you are running Node.js 22+ ...
   at adminClient (tests/e2e/support/supabase-admin.ts:97)
   at seedJourneyUser (tests/e2e/support/seed-user.ts:62)
   at globalSetup (tests/e2e/global-setup.ts:74)
```

`@supabase/supabase-js` (realtime-js) now resolves a **native global `WebSocket`** at client-construction time. That global is stable only on **Node 22+**; the workflow pinned `node-version: '20'`, so `createClient()` threw while seeding the deterministic journey user. supabase-js's own deprecation notice in the same log says: *"Please upgrade to Node.js 22 or later."*

## Change

One line in `.github/workflows/e2e-authed.yml`: `node-version: '20'` → `'22'`. CI-config only — **no test file touched, no assertion changed** (Test Integrity Policy respected). The prod hard-guards (code guard in `supabase-admin.ts` + the shell guard step) are unchanged; the suite still targets dev/staging only.

## Verification

Dispatched against this branch to confirm the harness now gets past `global-setup` and runs the real journey. See the linked run in the PR checks / Jira comment.

## Tests

The KAN-348 authed journey **is** the test; this PR only fixes the runtime it executes on. No new unit coverage applicable to a workflow Node-version bump.

Jira: KAN-348

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JnhBVR3ANQ4scoxDB6HNgL)_