### PR TITLE
fix(BUGS-67): "See example profiles" opens a gallery, not one profile

### DIFF
--- a/src/app/examples/page.tsx
+++ b/src/app/examples/page.tsx
@@ -1,0 +1,169 @@
+import Link from "next/link";
+import Image from "next/image";
+import { redirect } from "next/navigation";
+import type { Metadata } from "next";
+import { createClient } from "@supabase/supabase-js";
+import { env } from "@/lib/env";
+import { isProdDeploy } from "@/lib/beta-access/flow";
+
+/**
+ * BUGS-67 — "See example profiles" gallery.
+ *
+ * The homepage ghost CTA "See example profiles" used to jump straight to the
+ * FIRST example profile (`/${people[0].slug}`), so a visitor who wanted to
+ * browse the examples only ever saw one person. This page is the real
+ * destination: EVERY curated example profile, as a grid of cards, so people
+ * can pick the ones they want to explore.
+ *
+ * Same curation rule as the homepage band (KAN-334): only
+ * `is_homepage_example = true` published profiles — a DB-trigger-enforced
+ * allowlist of @seed.checklyra.com demo accounts — ever appear here, never a
+ * real user. Unlike the homepage band this page is NOT capped at 6: it shows
+ * the whole curated set.
+ *
+ * Prod parity: checklyra.com is the gated waitlist doorway (KAN-273/278) with
+ * no browseable directory, so on the prod-family deploy this route redirects to
+ * the homepage (which itself renders the waitlist landing), exactly like the
+ * homepage showcase is hidden there.
+ */
+
+// Render fresh so newly-curated examples appear without a redeploy, and so the
+// prod redirect is evaluated per request.
+export const dynamic = "force-dynamic";
+
+export const metadata: Metadata = {
+  title: "Example profiles — Lyra",
+  description:
+    "Browse example Lyra profiles. See what an honest page about a person looks like, then pick any to explore.",
+};
+
+interface ExampleProfile {
+  display_name: string;
+  slug: string;
+  headline: string | null;
+  avatar_url: string | null;
+}
+
+function getSupabase() {
+  return createClient(env.supabaseUrl(), env.supabaseServiceRoleKey());
+}
+
+async function getExampleProfiles(): Promise<ExampleProfile[]> {
+  try {
+    const supabase = getSupabase();
+    const { data } = await supabase
+      .from("profiles")
+      .select("display_name, slug, headline, avatar_url")
+      .eq("is_published", true)
+      .eq("is_homepage_example", true)
+      .order("homepage_example_order", { ascending: true })
+      .limit(60);
+    return (data || []) as ExampleProfile[];
+  } catch {
+    // Never 500 the gallery if the DB is briefly unreachable — render the empty
+    // state instead.
+    return [];
+  }
+}
+
+function ExampleCard({ profile }: { profile: ExampleProfile }) {
+  return (
+    <Link
+      href={`/${profile.slug}`}
+      className="flex items-center gap-3 bg-white border border-[var(--color-border)] rounded-xl px-4 py-3 hover:border-[var(--color-sage)] hover:shadow-sm transition-all group"
+    >
+      <div className="w-11 h-11 rounded-full bg-[var(--color-sage)] flex items-center justify-center text-white font-semibold shrink-0 overflow-hidden">
+        {profile.avatar_url ? (
+          // eslint-disable-next-line @next/next/no-img-element -- KAN-272: avatar lives in Supabase Storage, not the Vercel image pipeline
+          <img
+            src={profile.avatar_url}
+            alt={profile.display_name}
+            className="w-full h-full object-cover"
+          />
+        ) : (
+          profile.display_name.charAt(0).toUpperCase()
+        )}
+      </div>
+      <div className="min-w-0">
+        <span className="block font-medium text-[var(--color-ink)] group-hover:text-[var(--color-sage)] transition-colors truncate">
+          {profile.display_name}
+        </span>
+        {profile.headline && (
+          <span className="block text-[12.5px] text-[var(--color-muted)] truncate">
+            {profile.headline}
+          </span>
+        )}
+      </div>
+    </Link>
+  );
+}
+
+export default async function ExamplesPage() {
+  // Prod (checklyra.com) is the waitlist doorway — no browseable directory.
+  // Mirror the homepage's own guard so /examples is a beta/dev/stage feature.
+  if (isProdDeploy() || process.env.LYRA_FORCE_WAITLIST === "true") {
+    redirect("/");
+  }
+
+  const people = await getExampleProfiles();
+
+  return (
+    <main role="main" className="min-h-screen bg-[var(--color-paper)]">
+      <nav
+        aria-label="Examples navigation"
+        className="border-b border-[var(--color-border)]/60 bg-[var(--color-paper)]/80 backdrop-blur-md"
+      >
+        <div className="max-w-3xl mx-auto px-6 h-14 flex items-center justify-between">
+          <Link href="/" className="flex items-center" aria-label="Lyra home">
+            <Image
+              src="/lyra-logo.png"
+              alt="Lyra"
+              width={32}
+              height={32}
+              className="h-8 w-auto"
+              priority
+            />
+          </Link>
+          <Link
+            href="/signup"
+            className="text-xs font-medium px-4 py-1.5 rounded-full bg-[var(--color-sage)] text-white hover:opacity-90 transition-opacity"
+          >
+            Create yours
+          </Link>
+        </div>
+      </nav>
+
+      <div className="max-w-3xl mx-auto px-6 pt-10 pb-16">
+        <h1 className="text-3xl font-[family-name:var(--font-serif)] text-[var(--color-ink)] mb-2">
+          Example profiles
+        </h1>
+        <p className="text-[var(--color-muted)] mb-8">
+          A few example pages so you can see what Lyra looks like. Pick anyone to
+          explore their profile.
+        </p>
+
+        {people.length > 0 ? (
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+            {people.map((p) => (
+              <ExampleCard key={p.slug} profile={p} />
+            ))}
+          </div>
+        ) : (
+          <div className="text-center py-16">
+            <p className="text-4xl mb-4">👤</p>
+            <h2 className="text-lg font-medium text-[var(--color-ink)] mb-2">
+              No example profiles yet
+            </h2>
+            <p className="text-sm text-[var(--color-muted)]">
+              Check back soon — or{" "}
+              <Link href="/search" className="text-[var(--color-sage)] hover:underline">
+                find someone
+              </Link>
+              .
+            </p>
+          </div>
+        )}
+      </div>
+    </main>
+  );
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -235,9 +235,11 @@ export default async function Home({
   }
 
   const people = await getPublishedProfiles();
-  // Ghost CTA — "See example profiles" — points at the first published
-  // profile when one exists, otherwise falls back to search.
-  const exampleHref = people.length > 0 ? `/${people[0].slug}` : "/search";
+  // Ghost CTA — "See example profiles" — opens the /examples gallery so a
+  // visitor can browse EVERY curated example and pick who to explore. It used
+  // to link to the first example profile's slug, which showed only one person
+  // (BUGS-67).
+  const exampleHref = "/examples";
 
   const jsonLd = {
     "@context": "https://schema.org",

--- a/tests/unit/examples-page.test.js
+++ b/tests/unit/examples-page.test.js
@@ -1,0 +1,80 @@
+/**
+ * BUGS-67: "See example profiles" must open a gallery of ALL curated example
+ * profiles, not jump to a single one.
+ *
+ * The bug: the homepage ghost CTA linked to `/${people[0].slug}` — the first
+ * example only — so "see example profiles" showed exactly one person. These
+ * tests lock in (a) the homepage CTA now targets the /examples gallery, and
+ * (b) the gallery lists the whole curated example set, each card linking to the
+ * individual profile so visitors can pick who to explore.
+ *
+ * Source-level assertions (like homepage-content.test.js): these are
+ * server components that query Supabase, so we assert on the wiring rather than
+ * render them against a live DB.
+ */
+const fs = require('fs');
+const path = require('path');
+
+const root = path.join(__dirname, '../..');
+const homepagePath = path.join(root, 'src/app/page.tsx');
+const examplesPath = path.join(root, 'src/app/examples/page.tsx');
+
+describe('BUGS-67: homepage "See example profiles" CTA', () => {
+  let home;
+  beforeAll(() => {
+    home = fs.readFileSync(homepagePath, 'utf8');
+  });
+
+  test('the CTA label is unchanged', () => {
+    expect(home).toContain('See example profiles');
+  });
+
+  test('the ghost CTA now targets the /examples gallery, not a single profile', () => {
+    expect(home).toContain('const exampleHref = "/examples"');
+    // Regression guard: it must NOT derive the target from a single profile
+    // slug the way the bug did.
+    expect(home).not.toContain('`/${people[0].slug}`');
+  });
+});
+
+describe('BUGS-67: /examples gallery page', () => {
+  let page;
+  beforeAll(() => {
+    page = fs.readFileSync(examplesPath, 'utf8');
+  });
+
+  test('the examples page exists', () => {
+    expect(fs.existsSync(examplesPath)).toBe(true);
+  });
+
+  test('renders fresh (force-dynamic) so newly-curated examples appear', () => {
+    expect(page).toContain('export const dynamic = "force-dynamic"');
+  });
+
+  test('queries ONLY curated example profiles (KAN-334 allowlist)', () => {
+    expect(page).toContain("is_published");
+    expect(page).toContain("is_homepage_example");
+  });
+
+  test('shows the whole set — NOT capped at the homepage band\'s 6', () => {
+    // The homepage band uses .limit(6); the gallery must show more than that.
+    expect(page).not.toContain('.limit(6)');
+    // It maps the fetched profiles into a grid of cards.
+    expect(page).toMatch(/people\.map\(/);
+  });
+
+  test('each example card links to the individual profile so people can pick', () => {
+    expect(page).toContain('href={`/${profile.slug}`}');
+  });
+
+  test('mirrors the homepage prod guard — no browseable directory on prod', () => {
+    // checklyra.com is the gated waitlist doorway; the gallery redirects home
+    // there, exactly like the homepage showcase is hidden on prod.
+    expect(page).toContain('isProdDeploy');
+    expect(page).toContain("redirect(\"/\")");
+  });
+
+  test('degrades to an empty state instead of 500ing if the DB read throws', () => {
+    expect(page).toMatch(/catch\s*\{[\s\S]*return \[\]/);
+  });
+});


### PR DESCRIPTION
## Summary

Founder-reported on dev: *"when I click on a few people to meet it shows me one profile. Can you show all of them and people can pick the ones they want?"*

The homepage ghost CTA **"See example profiles"** linked to the *first* example profile's slug (`exampleHref = people.length > 0 ? ` + "`/${people[0].slug}`" + ` : "/search"`), so it dropped the visitor onto a single person's page. Pointing it at `/search` wasn't an option either — search deliberately **excludes** `is_homepage_example` profiles (KAN-334), so it would show zero examples.

**Fix:**
- New route **`/examples`** (`src/app/examples/page.tsx`) — a gallery of **every** curated example profile as a grid of cards, each linking to the individual profile so people can pick who to explore.
  - Same curation allowlist as the homepage band (KAN-334): `is_published = true AND is_homepage_example = true`, ordered by `homepage_example_order`. **Not** capped at 6 (`.limit(60)`).
  - `force-dynamic`; fails safe to an empty state on DB error (never 500s).
  - Prod parity: mirrors the homepage's own guard — on the prod-family waitlist deploy (`isProdDeploy()` / `LYRA_FORCE_WAITLIST`) it `redirect("/")`, keeping checklyra.com a pure waitlist doorway (KAN-273/278).
- `src/app/page.tsx`: the ghost CTA now points at `/examples`. The "A few people to meet" band (still `.limit(6)`) is unchanged.

Pure UI + one new route. No schema, env, or dependency change, so no MCP-lockstep (KAN-222) obligation.

## Jira Ticket

BUGS-67

## Checklist

- [x] Unit tests added/updated for new/changed functionality — `tests/unit/examples-page.test.js` (new, +9 tests)
- [x] All existing tests pass (`npm run test:unit`) — 2162 passed / 175 suites
- [x] Lint passes (`npm run lint`) — 0 errors
- [x] Type check passes (`npm run type-check`)
- [x] Build succeeds (`npm run build`) — `/examples` present as a dynamic route
- [x] Coverage has not decreased — net-new coverage added
- [x] No eslint-disable or ts-ignore without KAN-XX reference — the one `eslint-disable` on the avatar `<img>` carries its KAN-272 reason, matching the homepage
- [x] ARCHITECTURE.md updated if architectural changes were made — N/A (one UI route)
- [x] Ops routine / Control-Room registry updated if scheduled-routine behaviour changed — N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fm94DhvABfJNkt7SwsP1oN)_