### PR TITLE
test(convene): complete SEC-81 dispatch mock for BUGS-62 reclaim path

### DIFF
--- a/tests/unit/convene/dispatch-suspension-guard.test.ts
+++ b/tests/unit/convene/dispatch-suspension-guard.test.ts
@@ -25,6 +25,8 @@ function makeQuery(result: { data: unknown; error: unknown }) {
   c.in = () => c;
   c.order = () => c;
   c.limit = () => c;
+  c.update = () => c;
+  c.lt = () => c;
   c.maybeSingle = async () => result;
   // Thenable so `await sb.from(...).select(...).eq(...).is(...)` resolves.
   c.then = (resolve: (v: unknown) => unknown) => resolve(result);


### PR DESCRIPTION
Fixes the single failing test on `develop` (deploy-dev red) after the BUGS-62 (#464) + SEC-64 (#470) merges.

**Root cause:** BUGS-62 added a stale-claim *reclaim* (`sb.from('gathering_invite_messages').update({...}).eq().lt()`) that runs on the global-cron-drain path. The pre-existing SEC-81 test (#514) mocks the Supabase client with a chainable builder that lacked `.update()` and `.lt()`, so that path threw `TypeError: sb.from(...).update is not a function`.

**Fix:** add the two missing chainable methods to the test's mock builder. **No assertion changed** — this is mock-infrastructure completion for a new code path, per the Test Integrity policy. The suite was 1 failed / 2274 passed; this brings it green.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KP5uMuQ4XGLGhswH1da6Dm)_