### PR TITLE
feat(KAN-410): "See example profiles" gallery + fix(BUGS-68) accented-slug 404

### DIFF
--- a/src/app/[slug]/page.tsx
+++ b/src/app/[slug]/page.tsx
@@ -19,6 +19,7 @@ import { getRecommendations } from '@/lib/recommend';
 import RecommendationsSection from './recommendations-section';
 import V2RecommendationsSection from './v2-recommendations-section';
 import ReportButton from './report-button';
+import { decodeSlug } from './slug-utils';
 import { headers } from 'next/headers';
 import { isIsoAlpha2, normaliseDeliveryCountry } from '@/lib/affiliate/country-codes';
 import { buildV2Recommendations } from '@/lib/recommender/v2/pipeline';
@@ -81,7 +82,9 @@ type Props = {
 };
 
 export async function generateMetadata({ params }: Props): Promise<Metadata> {
-  const { slug } = await params;
+  const { slug: rawSlug } = await params;
+  // Decode + NFC-normalise to match the stored slug (see PublicProfilePage).
+  const slug = decodeSlug(rawSlug);
 
   const { data: profile } = await getSupabase()
     .from('profiles')
@@ -170,7 +173,13 @@ function CardSection({ heading, items }: { heading: string; items: ProfileItem[]
 }
 
 export default async function PublicProfilePage({ params }: Props) {
-  const { slug } = await params;
+  const { slug: rawSlug } = await params;
+  // The dynamic route param arrives PERCENT-ENCODED for any non-ASCII slug
+  // (e.g. "rosa-martínez" → "rosa-mart%C3%ADnez"), so it must be decoded before
+  // the lookup — an undecoded "%C3%AD" never matches the stored "í" and the
+  // profile 404s. Slugs are stored in Unicode NFC, so normalise to NFC too so a
+  // decomposed (NFD) form still matches. ASCII slugs are unaffected (no-op).
+  const slug = decodeSlug(rawSlug);
 
   const { data: profile } = await getSupabase()
     .from('profiles')

--- a/src/app/[slug]/slug-utils.ts
+++ b/src/app/[slug]/slug-utils.ts
@@ -1,0 +1,27 @@
+/**
+ * Helpers for resolving a public profile's dynamic `[slug]` route param.
+ *
+ * Kept in a sibling module (not `page.tsx`) so the logic can be unit-tested in
+ * isolation without importing the full server component and its dependencies.
+ */
+
+/**
+ * Normalise a `[slug]` route param for lookup against the stored slug.
+ *
+ * The param can arrive PERCENT-ENCODED for any non-ASCII slug (e.g.
+ * "rosa-martínez" → "rosa-mart%C3%ADnez"). The profile lookup compares text
+ * byte-for-byte (`.eq('slug', …)`), so an undecoded value never matches the
+ * stored "í" and the profile 404s. We URL-decode, then NFC-normalise (slugs are
+ * stored in Unicode NFC) so a decomposed (NFD) request still matches. Pure-ASCII
+ * slugs are unaffected — both steps are no-ops. Malformed `%` sequences (which
+ * throw in decode) fall back to the raw value, which simply won't match → 404.
+ */
+export function decodeSlug(rawSlug: string): string {
+  let decoded = rawSlug;
+  try {
+    decoded = decodeURIComponent(rawSlug);
+  } catch {
+    // Malformed percent-encoding — keep the raw value (will 404).
+  }
+  return decoded.normalize('NFC');
+}

--- a/src/app/examples/page.tsx
+++ b/src/app/examples/page.tsx
@@ -2,8 +2,7 @@ import Link from "next/link";
 import Image from "next/image";
 import { redirect } from "next/navigation";
 import type { Metadata } from "next";
-import { createClient } from "@supabase/supabase-js";
-import { env } from "@/lib/env";
+import { createServiceRoleClient } from "@/lib/supabase-service";
 import { isProdDeploy } from "@/lib/beta-access/flow";
 
 /**
@@ -45,7 +44,8 @@ interface ExampleProfile {
 }
 
 function getSupabase() {
-  return createClient(env.supabaseUrl(), env.supabaseServiceRoleKey());
+  // KAN-352: the service-role client must come from the one hardened factory.
+  return createServiceRoleClient();
 }
 
 async function getExampleProfiles(): Promise<ExampleProfile[]> {

--- a/src/app/examples/page.tsx
+++ b/src/app/examples/page.tsx
@@ -75,7 +75,7 @@ function ProfileCard({ profile }: { profile: ExampleProfile }) {
       <div className="flex items-start gap-4">
         <div className="w-12 h-12 rounded-full bg-[var(--color-sage)] flex items-center justify-center text-lg text-white font-[family-name:var(--font-serif)] shrink-0 overflow-hidden">
           {profile.avatar_url ? (
-            // eslint-disable-next-line @next/next/no-img-element -- avatar lives in Supabase Storage, not the Vercel image pipeline
+            // eslint-disable-next-line @next/next/no-img-element -- KAN-410: avatar lives in Supabase Storage, not the Vercel image pipeline
             <img
               src={profile.avatar_url}
               alt={profile.display_name}

--- a/src/app/examples/page.tsx
+++ b/src/app/examples/page.tsx
@@ -1,0 +1,175 @@
+import Link from "next/link";
+import Image from "next/image";
+import { redirect } from "next/navigation";
+import type { Metadata } from "next";
+import { createClient } from "@supabase/supabase-js";
+import { env } from "@/lib/env";
+import { isProdDeploy } from "@/lib/beta-access/flow";
+
+/**
+ * "See example profiles" gallery.
+ *
+ * The homepage hero's ghost CTA ("See example profiles") points here. This page
+ * lists EVERY curated example profile (the "A few people to meet" band on the
+ * homepage only shows the first 6) so a visitor can browse the full set of
+ * demo profiles and see what a finished Lyra profile looks like.
+ *
+ * Like the homepage band, this is gated to `is_homepage_example` profiles only
+ * — a DB-trigger-enforced allowlist restricted to @seed.checklyra.com demo
+ * accounts (KAN-334), so no real user (incl. Ben/Luisa) can ever appear here.
+ *
+ * Prod front-door parity (KAN-273): on the real production deploy
+ * (checklyra.com) the public site is the waitlist doorway and deliberately
+ * surfaces NO browseable directory, so this page redirects home there — exactly
+ * as the homepage renders the waitlist landing instead of the product home.
+ * Beta/dev/stage (where isProdDeploy() is false) show the full gallery. To lift
+ * this once prod launches publicly, remove the redirect guard below.
+ */
+
+export const dynamic = "force-dynamic";
+
+export const metadata: Metadata = {
+  title: "Example profiles — Lyra",
+  description:
+    "Browse example Lyra profiles — honest pages about people, in their own words. See what a finished profile looks like before you create your own.",
+};
+
+interface ExampleProfile {
+  id: string;
+  display_name: string;
+  slug: string;
+  headline: string | null;
+  city: string | null;
+  country: string | null;
+  avatar_url: string | null;
+}
+
+function getSupabase() {
+  return createClient(env.supabaseUrl(), env.supabaseServiceRoleKey());
+}
+
+async function getExampleProfiles(): Promise<ExampleProfile[]> {
+  try {
+    const supabase = getSupabase();
+    const { data } = await supabase
+      .from("profiles")
+      .select("id, display_name, slug, headline, city, country, avatar_url")
+      .eq("is_published", true)
+      .eq("is_homepage_example", true)
+      .order("homepage_example_order", { ascending: true })
+      .limit(60);
+    return (data || []) as ExampleProfile[];
+  } catch {
+    // The page must still render if the DB is briefly unreachable — the grid
+    // just shows the empty state rather than 500-ing.
+    return [];
+  }
+}
+
+function ProfileCard({ profile }: { profile: ExampleProfile }) {
+  return (
+    <Link
+      href={`/${profile.slug}`}
+      className="block bg-white rounded-xl border border-[var(--color-border)] p-5 hover:shadow-sm hover:border-[var(--color-sage)] transition-all group"
+    >
+      <div className="flex items-start gap-4">
+        <div className="w-12 h-12 rounded-full bg-[var(--color-sage)] flex items-center justify-center text-lg text-white font-[family-name:var(--font-serif)] shrink-0 overflow-hidden">
+          {profile.avatar_url ? (
+            // eslint-disable-next-line @next/next/no-img-element -- avatar lives in Supabase Storage, not the Vercel image pipeline
+            <img
+              src={profile.avatar_url}
+              alt={profile.display_name}
+              className="w-full h-full object-cover"
+            />
+          ) : (
+            profile.display_name.charAt(0).toUpperCase()
+          )}
+        </div>
+        <div className="min-w-0">
+          <h3 className="font-medium text-[var(--color-ink)] group-hover:text-[var(--color-sage)] transition-colors truncate">
+            {profile.display_name}
+          </h3>
+          {profile.headline && (
+            <p className="text-sm text-[var(--color-muted)] mt-0.5 line-clamp-2">
+              {profile.headline}
+            </p>
+          )}
+          {profile.city && (
+            <p className="text-xs text-[var(--color-muted)] mt-1">
+              {profile.city}
+              {profile.country ? `, ${profile.country}` : ""}
+            </p>
+          )}
+        </div>
+      </div>
+    </Link>
+  );
+}
+
+export default async function ExamplesPage() {
+  // Prod (checklyra.com) is the public waitlist doorway — no browseable
+  // directory pre-launch. LYRA_FORCE_WAITLIST lets a non-prod env mirror that.
+  if (isProdDeploy() || process.env.LYRA_FORCE_WAITLIST === "true") {
+    redirect("/");
+  }
+
+  const people = await getExampleProfiles();
+
+  return (
+    <main className="min-h-screen bg-[var(--color-paper)]">
+      {/* Nav — matches the /search public page */}
+      <nav
+        aria-label="Examples navigation"
+        className="border-b border-[var(--color-border)]/60 bg-[var(--color-paper)]/80 backdrop-blur-md"
+      >
+        <div className="max-w-3xl mx-auto px-6 h-14 flex items-center justify-between">
+          <Link href="/" className="flex items-center" aria-label="Lyra home">
+            <Image
+              src="/lyra-logo.png"
+              alt="Lyra"
+              width={32}
+              height={32}
+              className="h-8 w-auto"
+              priority
+            />
+          </Link>
+          <Link
+            href="/signup"
+            className="text-xs font-medium px-4 py-1.5 rounded-full bg-[var(--color-sage)] text-white hover:opacity-90 transition-opacity"
+          >
+            Create yours
+          </Link>
+        </div>
+      </nav>
+
+      <div className="max-w-3xl mx-auto px-6 pt-10 pb-16">
+        <h1 className="text-3xl font-[family-name:var(--font-serif)] text-[var(--color-ink)] mb-2">
+          Example profiles
+        </h1>
+        <p className="text-[var(--color-muted)] mb-8 max-w-xl">
+          A few example profiles to show what Lyra looks like &mdash; honest
+          pages about people, in their own words. Open any one to see the whole
+          thing.
+        </p>
+
+        {people.length > 0 ? (
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+            {people.map((p) => (
+              <ProfileCard key={p.id} profile={p} />
+            ))}
+          </div>
+        ) : (
+          <div className="text-center py-16">
+            <p className="text-4xl mb-4">👤</p>
+            <h3 className="text-lg font-medium text-[var(--color-ink)] mb-2">
+              No example profiles yet
+            </h3>
+            <p className="text-sm text-[var(--color-muted)]">
+              Check back soon.
+            </p>
+          </div>
+        )}
+      </div>
+    </main>
+  );
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -234,9 +234,10 @@ export default async function Home({
   }
 
   const people = await getPublishedProfiles();
-  // Ghost CTA — "See example profiles" — points at the first published
-  // profile when one exists, otherwise falls back to search.
-  const exampleHref = people.length > 0 ? `/${people[0].slug}` : "/search";
+  // Ghost CTA — "See example profiles" — leads to the full gallery of curated
+  // example profiles (/examples). The band below only previews the first 6;
+  // the gallery lists them all.
+  const exampleHref = "/examples";
 
   const jsonLd = {
     "@context": "https://schema.org",

--- a/src/lib/features/global-switches-service.ts
+++ b/src/lib/features/global-switches-service.ts
@@ -16,8 +16,7 @@
  * gates remain the hard, fail-closed layer. (An admin-driven OFF is a written
  * row, which we DO honour.)
  */
-import { createClient as createServiceClient } from '@supabase/supabase-js';
-import { env } from '@/lib/env';
+import { createServiceRoleClient } from '@/lib/supabase-service';
 import { getDeployEnv, type DeployEnv } from '@/lib/deploy-env';
 import {
   resolveGlobalSwitches,
@@ -25,9 +24,10 @@ import {
 } from './global-features';
 
 function serviceClient() {
-  return createServiceClient(env.supabaseUrl(), env.supabaseServiceRoleKey(), {
-    auth: { persistSession: false },
-  });
+  // KAN-352: route through the one hardened service-role factory (bakes in
+  // persistSession:false + autoRefreshToken:false — a superset of the prior
+  // inline options, so behaviour is unchanged).
+  return createServiceRoleClient();
 }
 
 /**

--- a/tests/unit/examples-page.test.js
+++ b/tests/unit/examples-page.test.js
@@ -1,0 +1,85 @@
+/**
+ * Example-profiles gallery page tests
+ *
+ * The homepage hero's ghost CTA ("See example profiles") now leads to a
+ * dedicated /examples gallery that lists EVERY curated example profile, instead
+ * of jumping to the single first profile. The homepage "A few people to meet"
+ * band still previews only the first 6.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const root = path.join(__dirname, '../..');
+const examplesPath = path.join(root, 'src/app/examples/page.tsx');
+const homepagePath = path.join(root, 'src/app/page.tsx');
+
+describe('Example profiles gallery (/examples)', () => {
+  let content;
+
+  beforeAll(() => {
+    content = fs.readFileSync(examplesPath, 'utf8');
+  });
+
+  test('examples page file exists', () => {
+    expect(fs.existsSync(examplesPath)).toBe(true);
+  });
+
+  test('page has metadata with title', () => {
+    expect(content).toContain('title: "Example profiles');
+  });
+
+  test('renders fresh so newly-published examples appear without a redeploy', () => {
+    expect(content).toContain('export const dynamic = "force-dynamic"');
+  });
+
+  test('queries published curated example profiles, ordered', () => {
+    expect(content).toContain('.from("profiles")');
+    expect(content).toContain('.eq("is_published", true)');
+    expect(content).toContain('.eq("is_homepage_example", true)');
+    expect(content).toContain('homepage_example_order');
+  });
+
+  test('lists ALL examples — not just the homepage band\'s 6', () => {
+    // The homepage band caps at .limit(6); the gallery must NOT reuse that cap.
+    expect(content).not.toContain('.limit(6)');
+    expect(content).toContain('.limit(60)');
+  });
+
+  test('KAN-334: gated to curated examples only (never real users)', () => {
+    expect(content).toContain('is_homepage_example');
+  });
+
+  test('KAN-273: prod front door surfaces no browseable directory — redirects home', () => {
+    expect(content).toContain('isProdDeploy');
+    expect(content).toContain('LYRA_FORCE_WAITLIST');
+    expect(content).toContain('redirect("/")');
+  });
+
+  test('cards link to each profile by slug', () => {
+    expect(content).toContain('href={`/${profile.slug}`}');
+    expect(content).toContain('profile.display_name');
+    expect(content).toContain('profile.headline');
+  });
+
+  test('has an empty state when no examples are present', () => {
+    expect(content).toContain('No example profiles yet');
+  });
+});
+
+describe('Homepage "See example profiles" CTA targets the gallery', () => {
+  let content;
+
+  beforeAll(() => {
+    content = fs.readFileSync(homepagePath, 'utf8');
+  });
+
+  test('ghost CTA no longer jumps to the first profile slug', () => {
+    expect(content).not.toContain('`/${people[0].slug}`');
+  });
+
+  test('ghost CTA points at the /examples gallery', () => {
+    expect(content).toContain('const exampleHref = "/examples"');
+    expect(content).toContain('See example profiles');
+  });
+});

--- a/tests/unit/slug-utils.test.ts
+++ b/tests/unit/slug-utils.test.ts
@@ -1,0 +1,46 @@
+/**
+ * decodeSlug — resolving the public profile [slug] route param.
+ *
+ * Regression: a percent-encoded non-ASCII slug (e.g. an accented "í") reached
+ * the profile lookup undecoded, so `.eq('slug', …)` never matched the stored
+ * value and the profile 404'd (surfaced by the /examples gallery via
+ * "rosa-martínez"). decodeSlug URL-decodes + NFC-normalises the param.
+ */
+
+import { decodeSlug } from '@/app/[slug]/slug-utils';
+
+describe('decodeSlug', () => {
+  test('leaves a pure-ASCII slug unchanged', () => {
+    expect(decodeSlug('olu-adebayo-a0000000')).toBe('olu-adebayo-a0000000');
+  });
+
+  test('URL-decodes a percent-encoded accented slug to the stored NFC form', () => {
+    // "rosa-mart%C3%ADnez-a0000000" → "rosa-martínez-a0000000" (NFC "í").
+    const decoded = decodeSlug('rosa-mart%C3%ADnez-a0000000');
+    expect(decoded).toBe('rosa-martínez-a0000000');
+    expect(Buffer.from(decoded, 'utf8').toString('hex')).toContain('c3ad'); // NFC í
+  });
+
+  test('decodes the raw (already-decoded) accented form to the same NFC value', () => {
+    expect(decodeSlug('rosa-martínez-a0000000')).toBe('rosa-martínez-a0000000');
+  });
+
+  test('normalises a decomposed (NFD) accented slug to NFC', () => {
+    // NFD "í" = "i" + combining acute (U+0301). Percent-encoded combining mark.
+    const nfd = 'rosa-marti%CC%81nez-a0000000';
+    const decoded = decodeSlug(nfd);
+    expect(decoded).toBe('rosa-martínez-a0000000');
+    expect(Buffer.from(decoded, 'utf8').toString('hex')).toContain('c3ad'); // collapsed to NFC í
+  });
+
+  test('leaves an apostrophe slug intact (apostrophes are not percent-encoded in paths)', () => {
+    expect(decodeSlug("michael-o'connor-a0000000")).toBe("michael-o'connor-a0000000");
+  });
+
+  test('falls back to the raw value on malformed percent-encoding (no throw)', () => {
+    // A lone "%" is invalid percent-encoding; decodeURIComponent throws — we
+    // must not crash the route, just return a value that won't match → 404.
+    expect(() => decodeSlug('bad-%-slug')).not.toThrow();
+    expect(decodeSlug('bad-%-slug')).toBe('bad-%-slug');
+  });
+});


### PR DESCRIPTION
## What & Why
The homepage hero's ghost CTA **"See example profiles"** linked to `/${people[0].slug}` — it only ever opened the *first* curated example (Olu Adebayo). The founder expected all the curated example profiles. This adds a dedicated **`/examples`** gallery listing every published `is_homepage_example` profile and repoints the CTA to it. (`/search` can't host them — KAN-334 excludes homepage examples from real-member discovery.)

While verifying, one of the 24 example cards (`rosa-martínez`) **404'd**. Root cause: the `[slug]` route param arrives **percent-encoded** for non-ASCII slugs (`%C3%AD`), and the byte-exact `.eq('slug', …)` never matched the stored `í`. This affects **real users** with accented names too, so it's fixed here (BUGS-68).

## Changes
- **`src/app/examples/page.tsx`** (new) — gallery of all `is_homepage_example` profiles, ordered by `homepage_example_order`, no `.limit(6)` cap. `force-dynamic`. Prod (checklyra.com) / `LYRA_FORCE_WAITLIST` → redirects to `/` (keeps the KAN-273 no-directory front door); beta/dev/stage show the gallery.
- **`src/app/page.tsx`** — CTA now `href="/examples"`; "A few people to meet" band still previews the first 6.
- **`src/app/[slug]/slug-utils.ts`** (new) — `decodeSlug()` = `decodeURIComponent` (guarded) + `.normalize('NFC')`.
- **`src/app/[slug]/page.tsx`** — use `decodeSlug` in `generateMetadata` + `PublicProfilePage`.

## Tests
- `tests/unit/examples-page.test.js`, `tests/unit/slug-utils.test.ts` (new) + homepage CTA assertions.
- Full unit suite: **2459 passing** (the only red is `check-fix-only-promote` — a local macOS `bash 3.2 / mapfile` env quirk, unrelated; green in CI).
- Verified on dev: `/examples` renders **all 24** cards (24 links + 24 headings, 200); `rosa-martínez` now 200 in NFC/raw/NFD and renders; 23 controls stay 200; unknown slug still 404.

## Checklist
- **MCP coverage: N/A** — pure UI over existing published-profile reads + a read-route bugfix; no new data/tools (`lyra_get_profile`/`lyra_search_profiles` already cover it).
- **Docs / system map:** N/A — no new service/table/env/security boundary (one new public read-only route).
- Tickets: KAN-410 (feature), BUGS-68 (bug), linked.