### PR TITLE
ci(KAN-411): UI/copy founder-ownership guard for PR Quality Gate

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -17,6 +17,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6
+        with:
+          fetch-depth: 0 # KAN-411: full history so the UI/copy-ownership guard can diff against the base branch
       - name: Workflow integrity check (BUGS-4)
         # Static scan of .github/workflows/*.yml for known false-positive
         # patterns (GITHUB_TOKEN+push, --limit 1 deploy verification, 401
@@ -76,6 +78,16 @@ jobs:
         # the PR if more than one exists (or none, or the winning file has no
         # default `* @owner`). See SEC-3 / GOV-01.
         run: bash scripts/check-codeowners-single.sh
+      - name: UI/copy founder-ownership guard (KAN-411)
+        # Machine backstop for "LOOK AND TEXT belong to Luisa". If a PR changes a
+        # founder-owned UI/copy path — src/app/**/*.tsx (except src/app/admin/**),
+        # src/components/**, globals.css/design tokens, public/ brand assets, and the
+        # named copy modules — it must carry a `UI-Change-Approved: <KEY>` (Luisa-
+        # initiated) or `UI-Bugfix-Only: <KEY>` (text/rendering-error fix) commit
+        # trailer, else the PR fails. Mirrors the Backlog Autopilot protected-surface
+        # list so guard and robot agree. Fail-open ONLY when the diff base can't be
+        # resolved (CODEOWNERS still hard-gates these paths). See KAN-411.
+        run: BASE_REF="origin/${{ github.base_ref }}" bash scripts/check-ui-copy-ownership.sh
       - name: macOS Finder-duplicate file check (KAN-357)
         # Reject any committed " <n>"-suffixed file/dir (e.g. "[slug] 2/" or
         # "profile-sections 2.cjs"). These Finder-copy duplicates shadow the

--- a/scripts/check-ui-copy-ownership.sh
+++ b/scripts/check-ui-copy-ownership.sh
@@ -1,0 +1,126 @@
+#!/usr/bin/env bash
+# scripts/check-ui-copy-ownership.sh
+#
+# KAN-411 — machine backstop for the "LOOK AND TEXT belong to Luisa" rule.
+#
+# The look and text of Lyra's user-facing pages are Luisa's to own: such work
+# must be FOUNDER-INITIATED, and the Backlog Autopilot must skip it (see
+# CLAUDE.md "LOOK AND TEXT", the autopilot House rules 9/10 on Confluence
+# Control Room 33554434, and the `ui-approval-required` Jira label). Until now
+# that rule lived only in prompts, policy docs and CODEOWNERS. This guard makes
+# it a mechanical PR gate.
+#
+# What it does: over the PR's change range it classifies every changed file
+# against the FOUNDER-OWNED UI/COPY surface (mirrored 1:1 from the autopilot's
+# protected-surface list so the guard and the robot agree). If any protected
+# path is touched, it requires an approval trailer on a commit in the range:
+#   * UI-Change-Approved: <JIRA-KEY>  — a Luisa-initiated design/copy change.
+#   * UI-Bugfix-Only:     <JIRA-KEY>  — a fix STRICTLY limited to a text error
+#                                       (typo/wrong/stale string) or a rendering
+#                                       error (blank page, broken layout, styling
+#                                       regression), which *restores* the intended
+#                                       design rather than changing it.
+# No trailer → HARD FAIL (a false positive only forces a human to add a trailer;
+# a false negative would let the product's voice/look drift silently, which is
+# the case we bias hard against).
+#
+# Fail-OPEN only on infrastructure failure: if the diff base cannot be resolved
+# (shallow/detached CI history), we emit a ::warning:: and pass, because
+# CODEOWNERS still requires Luisa's review on every one of these paths — a git
+# hiccup must not block every unrelated PR. When the base IS resolvable the gate
+# is strict.
+#
+# Range: merge-base(BASE_REF, HEAD_REF)..HEAD_REF.
+#   BASE_REF defaults to origin/develop; HEAD_REF defaults to HEAD. Both are
+#   overridable via env so the unit tests can drive crafted histories.
+set -euo pipefail
+
+BASE_REF="${BASE_REF:-origin/develop}"
+HEAD_REF="${HEAD_REF:-HEAD}"
+
+if ! git rev-parse --verify --quiet "$BASE_REF" >/dev/null; then
+  echo "::warning::check-ui-copy-ownership: base ref '$BASE_REF' not found — cannot compute the diff; skipping (CODEOWNERS still gates every UI/copy path)."
+  exit 0
+fi
+MERGE_BASE="$(git merge-base "$BASE_REF" "$HEAD_REF" 2>/dev/null || true)"
+if [ -z "$MERGE_BASE" ]; then
+  echo "::warning::check-ui-copy-ownership: no merge-base for ${BASE_REF}..${HEAD_REF} — skipping (CODEOWNERS still gates)."
+  exit 0
+fi
+
+# Founder-owned UI/copy surface. Non-protected carve-outs are checked FIRST and
+# win. In bash [[ == ]] a '*' matches across '/', so 'src/app/*.tsx' catches any
+# nested .tsx page/layout/component under src/app.
+is_protected() {
+  local f="$1"
+  # --- explicit NON-protected carve-outs (these win) ---
+  [[ $f == src/app/admin/* ]] && return 1     # Luisa-only console behind CF Access
+  [[ $f == src/app/api/* ]]   && return 1     # route handlers = logic
+  [[ $f == */route.ts ]]      && return 1     # any route handler = logic
+  [[ $f == src/middleware.ts ]] && return 1
+  # --- named user-facing copy modules ---
+  [[ $f == src/lib/invite-text.ts ]] && return 0
+  [[ $f == src/lib/convene/invites/templates.ts ]] && return 0
+  [[ $f == src/lib/convene/invites/sms-templates.ts ]] && return 0
+  [[ $f == src/lib/beta-access/email.ts ]] && return 0
+  [[ $f == src/app/dashboard/profile/affiliation-fields.ts ]] && return 0
+  [[ $f == src/app/dashboard/convene/organise/organise-fields.ts ]] && return 0
+  # --- design / styling / brand ---
+  [[ $f == src/*.css ]] && return 0           # globals.css + any css under src/
+  [[ $f == postcss.config.* ]] && return 0
+  [[ $f == tailwind.config.* ]] && return 0
+  [[ $f == public/lyra-logo* ]] && return 0
+  [[ $f == public/lyra-icon-* ]] && return 0
+  [[ $f == public/og-image.png ]] && return 0
+  [[ $f == public/manifest.webmanifest ]] && return 0
+  [[ $f == public/offline.html ]] && return 0
+  # --- all page / layout / component TSX under src/app + everything in src/components ---
+  [[ $f == src/app/*.tsx ]] && return 0
+  [[ $f == src/components/* ]] && return 0
+  return 1
+}
+
+CHANGED=()
+while IFS= read -r _line; do CHANGED+=("$_line"); done < <(git diff --name-only "$MERGE_BASE" "$HEAD_REF")
+if [ "${#CHANGED[@]}" -eq 0 ]; then
+  echo "check-ui-copy-ownership: no changed files in range — OK."
+  exit 0
+fi
+
+PROTECTED_HITS=()
+for f in "${CHANGED[@]}"; do
+  [ -z "$f" ] && continue
+  if is_protected "$f"; then PROTECTED_HITS+=("$f"); fi
+done
+
+if [ "${#PROTECTED_HITS[@]}" -eq 0 ]; then
+  echo "check-ui-copy-ownership: no founder-owned UI/copy paths changed — OK."
+  exit 0
+fi
+
+# A UI/copy change is present → require an approval trailer somewhere in range.
+COMMIT_MSGS="$(git log "${MERGE_BASE}..${HEAD_REF}" --format='%B' 2>/dev/null || true)"
+TRAILER_RE='^(UI-Change-Approved|UI-Bugfix-Only):[[:space:]]*[A-Z][A-Z0-9]+-[0-9]+'
+# here-strings (not pipes) so `set -o pipefail` can't SIGPIPE-fail a match.
+if grep -Eq "$TRAILER_RE" <<<"$COMMIT_MSGS"; then
+  TRAILER="$(grep -m1 -Eo "$TRAILER_RE" <<<"$COMMIT_MSGS" || true)"
+  echo "check-ui-copy-ownership: UI/copy paths changed and an approval trailer is present (${TRAILER}). OK."
+  printf '  touched: %s\n' "${PROTECTED_HITS[@]}"
+  exit 0
+fi
+
+echo "::error::check-ui-copy-ownership: this PR changes founder-owned UI/copy paths but carries no approval trailer."
+printf '::error::  founder-owned path changed: %s\n' "${PROTECTED_HITS[@]}"
+cat <<'EOF'
+
+The look and text of Lyra's user-facing pages belong to Luisa (CLAUDE.md
+"LOOK AND TEXT"; autopilot House rule 9). A change to these paths must be
+FOUNDER-INITIATED. Add ONE of these trailers to a commit in this PR:
+
+  UI-Change-Approved: <JIRA-KEY>   # Luisa-initiated design/copy change
+  UI-Bugfix-Only:     <JIRA-KEY>   # fix limited to a text error or rendering error
+
+and label the Jira ticket `ui-approval-required`. If this really is not a
+UI/copy change, the path may need adding to the carve-out list in this script.
+EOF
+exit 1

--- a/tests/scripts/check-ui-copy-ownership.test.js
+++ b/tests/scripts/check-ui-copy-ownership.test.js
@@ -1,0 +1,187 @@
+const { execSync } = require('child_process');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const REPO_ROOT = path.resolve(__dirname, '../../');
+const SCRIPT = path.resolve(REPO_ROOT, 'scripts/check-ui-copy-ownership.sh');
+
+// Build a throwaway git repo with a `develop` branch and a `feature` branch
+// whose commits (ahead of develop) create/modify the supplied files with the
+// supplied messages, then run the guard over develop..feature. Returns
+// { status, output }.
+//
+// `commits` is an array of { files: string[], message: string }. Each file is
+// created (parents made as needed) with unique content so it shows as changed.
+function runOverCommits(commits, { baseRef = 'develop' } = {}) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'uicopy-'));
+  const git = (args, opts = {}) =>
+    execSync(`git ${args}`, { cwd: dir, stdio: 'pipe', ...opts }).toString();
+  try {
+    git('init -q');
+    git('config user.email test@example.com');
+    git('config user.name tester');
+    git('config commit.gpgsign false');
+    git('commit -q --allow-empty -m "chore: repo base"');
+    git('branch -M develop');
+    git('checkout -q -b feature');
+    let n = 0;
+    for (const c of commits) {
+      for (const rel of c.files) {
+        const abs = path.join(dir, rel);
+        fs.mkdirSync(path.dirname(abs), { recursive: true });
+        fs.writeFileSync(abs, `content ${rel} ${n++}\n`);
+      }
+      git('add -A');
+      const msgFile = path.join(dir, `.msg${n}`);
+      fs.writeFileSync(msgFile, c.message);
+      git(`commit -q -F ${JSON.stringify(msgFile)}`);
+      fs.rmSync(msgFile, { force: true });
+    }
+    let status = 0;
+    let output = '';
+    try {
+      output = execSync(`bash "${SCRIPT}"`, {
+        cwd: dir,
+        stdio: 'pipe',
+        env: { ...process.env, BASE_REF: baseRef, HEAD_REF: 'HEAD' },
+      }).toString();
+    } catch (err) {
+      status = err.status || 1;
+      output = `${err.stdout || ''}${err.stderr || ''}`;
+    }
+    return { status, output };
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+describe('scripts/check-ui-copy-ownership.sh', () => {
+  let source = '';
+  beforeAll(() => {
+    source = fs.readFileSync(SCRIPT, 'utf8');
+  });
+
+  it('exists and is a bash script', () => {
+    expect(fs.existsSync(SCRIPT)).toBe(true);
+    expect(source.startsWith('#!/usr/bin/env bash')).toBe(true);
+  });
+
+  it('is syntactically valid (bash -n)', () => {
+    expect(() => execSync(`bash -n "${SCRIPT}"`, { stdio: 'pipe' })).not.toThrow();
+  });
+
+  it('is hardened with set -euo pipefail', () => {
+    expect(source).toMatch(/set -euo pipefail/);
+  });
+
+  it('does not use mapfile (bash-4 only; macOS ships bash 3.2)', () => {
+    expect(source).not.toMatch(/\bmapfile\b/);
+  });
+
+  it('PASSES a non-UI change with no trailer (scripts/docs only)', () => {
+    const { status, output } = runOverCommits([
+      { files: ['scripts/foo.sh', 'docs/NOTES.md'], message: 'chore: infra tweak' },
+    ]);
+    expect(status).toBe(0);
+    expect(output).toMatch(/no founder-owned UI\/copy paths changed/);
+  });
+
+  it('FAILS a src/app page (.tsx) change with no trailer', () => {
+    const { status, output } = runOverCommits([
+      { files: ['src/app/dashboard/page.tsx'], message: 'change the dashboard' },
+    ]);
+    expect(status).not.toBe(0);
+    expect(output).toMatch(/no approval trailer/);
+    expect(output).toMatch(/src\/app\/dashboard\/page\.tsx/);
+  });
+
+  it('PASSES the same .tsx change when a UI-Change-Approved trailer is present', () => {
+    const { status, output } = runOverCommits([
+      {
+        files: ['src/app/dashboard/page.tsx'],
+        message: 'feat: new dashboard hero\n\nUI-Change-Approved: KAN-410',
+      },
+    ]);
+    expect(status).toBe(0);
+    expect(output).toMatch(/approval trailer is present/);
+    expect(output).toMatch(/UI-Change-Approved: KAN-410/);
+  });
+
+  it('PASSES the same .tsx change with a UI-Bugfix-Only trailer (carve-out)', () => {
+    const { status, output } = runOverCommits([
+      {
+        files: ['src/app/dashboard/page.tsx'],
+        message: 'fix: correct a typo in the heading\n\nUI-Bugfix-Only: BUGS-70',
+      },
+    ]);
+    expect(status).toBe(0);
+    expect(output).toMatch(/approval trailer is present/);
+  });
+
+  it('accepts the trailer even when it lands in a LATER commit in the range', () => {
+    const { status } = runOverCommits([
+      { files: ['src/components/Hero.tsx'], message: 'wip: hero' },
+      { files: ['README.md'], message: 'chore: note\n\nUI-Change-Approved: KAN-1' },
+    ]);
+    expect(status).toBe(0);
+  });
+
+  it('PASSES an admin-console change (carve-out) with no trailer', () => {
+    const { status, output } = runOverCommits([
+      { files: ['src/app/admin/features/page.tsx'], message: 'admin: tweak' },
+    ]);
+    expect(status).toBe(0);
+    expect(output).toMatch(/no founder-owned UI\/copy paths changed/);
+  });
+
+  it('PASSES an API route handler change (carve-out) with no trailer', () => {
+    const { status } = runOverCommits([
+      { files: ['src/app/api/search/route.ts'], message: 'api: add route' },
+    ]);
+    expect(status).toBe(0);
+  });
+
+  it('FAILS a named copy module change (src/lib/invite-text.ts) with no trailer', () => {
+    const { status, output } = runOverCommits([
+      { files: ['src/lib/invite-text.ts'], message: 'reword the invite copy' },
+    ]);
+    expect(status).not.toBe(0);
+    expect(output).toMatch(/invite-text\.ts/);
+  });
+
+  it('PASSES a non-copy src/lib logic change with no trailer', () => {
+    const { status } = runOverCommits([
+      { files: ['src/lib/dashboard/resolve-widgets.ts'], message: 'logic: gate a widget' },
+    ]);
+    expect(status).toBe(0);
+  });
+
+  it('FAILS a globals.css / design-token change with no trailer', () => {
+    const { status, output } = runOverCommits([
+      { files: ['src/app/globals.css'], message: 'restyle tokens' },
+    ]);
+    expect(status).not.toBe(0);
+    expect(output).toMatch(/globals\.css/);
+  });
+
+  it('requires a JIRA key on the trailer (bare trailer does not satisfy)', () => {
+    const { status } = runOverCommits([
+      {
+        files: ['src/app/page.tsx'],
+        message: 'change home\n\nUI-Change-Approved: yes please',
+      },
+    ]);
+    expect(status).not.toBe(0);
+  });
+
+  it('WARNS and passes (fail-open) when the base ref cannot be resolved', () => {
+    const { status, output } = runOverCommits(
+      [{ files: ['src/app/page.tsx'], message: 'change home' }],
+      { baseRef: 'origin/does-not-exist-xyz' },
+    );
+    expect(status).toBe(0);
+    expect(output).toMatch(/::warning::/);
+    expect(output).toMatch(/not found/);
+  });
+});


### PR DESCRIPTION
## KAN-411 — CI guard: UI/copy founder-ownership

Adds the mechanical backstop the Backlog Autopilot prompt already references
(`scripts/check-ui-copy-ownership.sh`) for the **"LOOK AND TEXT belong to Luisa"**
rule. Until now that rule lived only in prompts, policy docs and CODEOWNERS.

**What it does:** over the PR's change range, classifies changed files against the
founder-owned UI/copy surface (mirrors the autopilot protected-surface list 1:1):
`src/app/**/*.tsx` (except `src/app/admin/**`), `src/components/**`,
`globals.css` + any `src/**/*.css`, `postcss.config.*`/`tailwind.config.*`,
`public/` brand assets, and the named copy modules. Carve-outs win
(`src/app/api/**`, `**/route.ts`, `src/middleware.ts`). If a protected path is
touched, a commit in range must carry `UI-Change-Approved: <KEY>` (Luisa-initiated)
or `UI-Bugfix-Only: <KEY>` (text/rendering-error fix), else the gate **fails**.
Fail-**open** only when the diff base can't be resolved (CODEOWNERS still gates).

**Files**
- `scripts/check-ui-copy-ownership.sh` — portable (bash 3.2, no `mapfile`; here-strings avoid a `pipefail` SIGPIPE false-fail)
- `tests/scripts/check-ui-copy-ownership.test.js` — 16 cases (temp-git histories); all green locally
- `.github/workflows/pr-checks.yml` — new gate step + `fetch-depth: 0` so the base branch is available for the diff

**Notes**
- This PR touches only `scripts/`, `tests/`, `.github/` — no founder-owned UI/copy paths — so the new guard passes on its own PR (no trailer needed).
- MCP-main lockstep (KAN-222): **N/A** — CI-only, no user-facing data surface.
- Docs DoD (KAN-359): **N/A** — the autopilot prompt + CLAUDE.md already reference this guard by name.
- Needs **@luisa-sys review** (CODEOWNERS owns `/.github/workflows/`).

Closes KAN-411 on merge.
