### PR TITLE
docs: correct stale cross-repo test-floor counts in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -259,7 +259,7 @@ The pipeline is: **develop → staging → beta → main** (promotion-based, fou
 - New features must have unit and functional tests in the same PR/commit — never defer to a separate ticket
 - E2E functional testing must be built as new features are created
 - Claude must actively look for missing coverage and flag it
-- Current test floor: **2118 tests** (172 suites) in lyra (unit + scripts; E2E + integration not counted), **91 tests** (5 suites) in lyra-mcp-server
+- Current test floor: **2466 tests** (208 suites) in lyra (unit + scripts; E2E + integration not counted), **638 tests** (41 suites) in lyra-mcp-server
 
 ## Test Integrity Policy
 


### PR DESCRIPTION
## Summary

Found during the daily Confluence documentation-sync routine (2026-07-24): `CLAUDE.md`'s "Current test floor" line was stale for both repos it cites.

- **lyra**: documented as 2118 tests / 172 suites. Verified via `npx jest --listTests` + a full run on main HEAD (`2c9c3a3`, later rebased onto `c9cbdd6`): **2466 tests / 208 suites** (unit + scripts; excludes the 5 Playwright specs jest mis-discovers, consistent with the doc's existing "E2E + integration not counted" scope).
- **lyra-mcp-server**: documented as 91 tests / 5 suites — already badly stale even before today. Verified via `npx tsc && npx jest` on that repo's main HEAD (`20a316f`): **638 tests / 41 suites**. A companion fix is in `luisa-sys/lyra-mcp-server` (branch `claude/brave-ramanujan-ucl0oz`) correcting the same number in that repo's own `CLAUDE.md` (which separately said 217/13).

No test behaviour changed — this is a documentation-only correction of the reported counts.

## Jira Ticket

**Pending.** The Atlassian (Confluence + Jira) MCP connector was unreachable for this entire routine run (all calls timed out after repeated retries over several minutes), so the KAN ticket this PR would normally reference could not be created, and the Confluence Doc Sync Log / Ops Routines Control Room heartbeat could not be written either. This routine run will be reported as UNVERIFIED. A follow-up run (or manual retry) should create/link the KAN ticket here once Atlassian is reachable again — flagging so this doesn't get lost.

## Checklist

- [ ] Unit tests added/updated for new/changed functionality — N/A, doc-only change
- [x] All existing tests pass (`npm run test:unit`) — ran full suite locally, 2466/2466 pass (pre-existing, unaffected by this change)
- [ ] Lint passes (`npm run lint`) — not run (doc-only change, single line)
- [ ] Type check passes (`npm run type-check`) — N/A, no code changed
- [ ] Build succeeds (`npm run build`) — N/A, no code changed
- [ ] Coverage has not decreased — N/A, no code changed
- [x] No eslint-disable or ts-ignore without KAN-XX reference — N/A, no code changed
- [ ] ARCHITECTURE.md updated if architectural changes were made — N/A, no architectural change
- [ ] Ops routine / Control-Room registry updated if scheduled-routine behaviour, cadence, or ownership changed — N/A, this routine's behaviour/cadence is unchanged
- [x] Docs / system map updated — or N/A with reason — **this PR is itself the doc fix** (test-floor accuracy); no Architecture & Infrastructure / Data Model & Security content changed as a result

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jamdw2g951exLbMUUsByR9)_