### PR TITLE
fix(BUGS-69): revoke PUBLIC execute on prevent_global_feature_switch_user_write trigger fn

### DIFF
--- a/supabase/migrations/20260725000500_bugs69_revoke_global_feature_switch_trigger_exec.sql
+++ b/supabase/migrations/20260725000500_bugs69_revoke_global_feature_switch_trigger_exec.sql
@@ -1,0 +1,22 @@
+-- ============================================================================
+-- BUGS-69 (B9 residual, post-BUGS-65) — revoke PUBLIC/anon/authenticated EXECUTE
+-- on the prevent_global_feature_switch_user_write SECURITY DEFINER trigger fn
+-- ============================================================================
+-- public.prevent_global_feature_switch_user_write() was created 2026-07-21 by
+-- 20260721120000_global_feature_switches.sql (trigger
+-- global_feature_switches_no_user_write). It is zero-arg, RETURNS trigger,
+-- SECURITY DEFINER, and inherited the default PUBLIC EXECUTE grant (plus explicit
+-- anon/authenticated grants) — exactly the same B9 class the Supabase advisor
+-- flags under anon_/authenticated_security_definer_function_executable, and the
+-- same shape BUGS-48 (5 fns) and BUGS-65 (2 fns) already remediated.
+--
+-- Trigger functions fire on the caller's privilege for the table operation, not
+-- on EXECUTE of the function, and PostgREST cannot supply TriggerData via
+-- /rest/v1/rpc/<fn> — so revoking EXECUTE does not change the guard's behaviour.
+-- Defense-in-depth / advisor-hygiene, consistent with BUGS-48/BUGS-65.
+--
+-- Rollback: GRANT EXECUTE ON FUNCTION
+--           public.prevent_global_feature_switch_user_write() TO public;
+--           (re-opens the advisor finding — not recommended)
+revoke execute on function public.prevent_global_feature_switch_user_write() from public, anon, authenticated;
+grant execute on function public.prevent_global_feature_switch_user_write() to service_role;


### PR DESCRIPTION
## What & Why
B9-class advisor residual found during the BUGS-65 verification sweep. `public.prevent_global_feature_switch_user_write()` (zero-arg, RETURNS trigger, SECURITY DEFINER; created 2026-07-21 by `20260721120000_global_feature_switches.sql`) inherited the default PUBLIC EXECUTE grant, so the Supabase advisor flagged it under `anon_/authenticated_security_definer_function_executable`. Same class + shape as BUGS-48 (5 fns) and BUGS-65 (2 fns).

## Change
Adds `supabase/migrations/20260725000500_bugs69_revoke_global_feature_switch_trigger_exec.sql`:
- `revoke execute ... from public, anon, authenticated`
- `grant execute ... to service_role`

## Applied + verified
Already applied via `apply_migration` to **dev, staging, prod**; `proacl` on all three is now `{postgres, service_role}` (public/anon/authenticated EXECUTE = false, service_role = true). This PR records the migration in the repo for fresh-rebuild parity (OPS-04).

## Tests / risk
Trigger functions fire on the table-op privilege, not on EXECUTE of the function, and PostgREST cannot supply TriggerData via /rpc — so revoking EXECUTE does not change the `global_feature_switches_no_user_write` guard behaviour. No app/env/dependency change. Docs: N/A (SQL-only hardening).

Closes BUGS-69.

🤖 Generated with [Claude Code](https://claude.com/claude-code)