### PR TITLE
fix(BUGS-23): distinguish bot-blocked from down in affiliate smoke monitor

### DIFF
--- a/docs/AFFILIATE_MONETIZATION.md
+++ b/docs/AFFILIATE_MONETIZATION.md
@@ -1,0 +1,82 @@
+# Affiliate monetisation — smoke monitor & triage runbook
+
+Internal ops doc. Covers the hourly **Affiliate link smoke** monitor
+(KAN-194) and what to do when it fires. Referenced by
+`.github/workflows/affiliate-link-smoke.yml` and
+`scripts/smoke-affiliate-links.ts`.
+
+## What the monitor does
+
+For every `(merchant × buyer-country)` in `SMOKE_PROBES`
+(`src/lib/affiliate/smoke.ts`), the hourly workflow probes the merchant's
+representative URL and asserts the final landing host is the correct
+localised storefront for that country. It exits non-zero (red workflow +
+admin email) when `shouldAlert` is true.
+
+### Probe logic (BUGS-23)
+
+Each probe is a **bounded HEAD with a single bounded GET fallback**
+(`probeUrl()`), 5s per attempt:
+
+| HEAD result | Action | Classified as |
+|---|---|---|
+| `2xx` | — | **reachable** (assert host) |
+| `403` / `405` / `429` | retry with GET | see GET row |
+| timeout (abort) | retry with GET | see GET row |
+| `5xx`, `404`, `410`, other 4xx | — | **genuine failure** (pages) |
+| DNS / connection / TLS error | — | **genuine failure** (pages) |
+
+| GET result (only after a HEAD bot-wall/timeout) | Classified as |
+|---|---|
+| `2xx` | **reachable** (assert host) |
+| `403` / `429` | **inconclusive — bot-walled** (does NOT page) |
+| timeout (abort) | **inconclusive — bot-walled** (does NOT page) |
+| `5xx` / `404` / `405` / other | **genuine failure** (pages) |
+| wrong final host (any 2xx) | **genuine failure** (pages) |
+
+**Why the inconclusive bucket exists.** GitHub Actions runner IPs are
+data-centre IPs that some merchants (notably **John Lewis**, behind Akamai)
+tarpit or 403 regardless of HTTP method — see gotcha #7. From such an IP we
+cannot distinguish "merchant is down" from "merchant is refusing our bot".
+Paging on that is a false positive, and (per the Workflow & Backup Integrity
+Policy) a monitor that cries wolf destroys trust. So a merchant that
+bot-walls **both** HEAD and GET is reported as `INCONCLUSIVE` and does **not**
+page — while a *determinate* outage (5xx, connection refused, wrong host)
+still pages. The monitor is not weakened; it is honest about what a
+data-centre probe can prove.
+
+## When the smoke monitor fires
+
+The workflow only exits non-zero when `shouldAlert` is true, which now means
+**a genuine failure** — never an inconclusive bot-wall. Triage:
+
+1. **Open the run's artifact** (`smoke-summary.json`) or read the job log.
+   - `Merchants fully down:` — a merchant with zero passes and ≥1 *genuine*
+     failure. This is the real signal.
+   - `INCONCLUSIVE (bot-walled, not alerting):` — merchants we couldn't
+     verify from CI. These did **not** cause the alert; they're logged so a
+     long-term merchant loss can't hide behind "bot-blocked" forever.
+2. **For a fully-down merchant**, check the `failureReason`:
+   - `head_http_5xx` / `get_http_5xx` → merchant outage. Confirm from a
+     normal browser; if genuinely down, it's an upstream incident — no code
+     change, note it and re-check next hour.
+   - `unexpected_host` → the redirect chain landed on the wrong domain. This
+     is a real monetisation defect (Sovrn misconfig, wrong representative
+     URL, merchant domain change). Investigate the link service / probe URL.
+   - `error:*` (DNS/connection/TLS) → DNS or cert problem at the merchant.
+3. **For an inconclusive merchant that stays inconclusive for days**, decide
+   with the founder whether that merchant is still worth carrying in the
+   matrix, or whether it needs a residential-egress probe. Do **not** silence
+   it by deleting the probe or treating timeouts as passes.
+
+## What NOT to do
+
+- Do **not** bump the per-attempt timeout to make johnlewis "pass".
+- Do **not** treat a timeout or 403 as a success.
+- Do **not** drop johnlewis (or any merchant) from `SMOKE_PROBES` to quiet
+  the alert.
+- Do **not** weaken or delete the smoke unit tests
+  (`tests/unit/affiliate-smoke.test.ts`).
+
+Any of the above would mask a real "merchant unreachable" condition — the
+exact false-negative the Workflow & Backup Integrity Policy forbids.

--- a/scripts/smoke-affiliate-links.ts
+++ b/scripts/smoke-affiliate-links.ts
@@ -7,10 +7,17 @@
  *      via /api/affiliate/link (when that endpoint exists — for MVP we call
  *      the Sovrn-stubbed flow inline, i.e. the link service returns the raw
  *      URL with monetised:false)
- *   2. Follow the returned URL with HEAD (or GET on HEAD-unsupported hosts)
- *      with a 5s timeout, country-spoofed Accept-Language
+ *   2. Follow the returned URL with a bounded HEAD, falling back to a single
+ *      bounded GET when HEAD is bot-walled (403/405/429) or times out — see
+ *      probeUrl() in src/lib/affiliate/smoke.ts (BUGS-23). Country-spoofed
+ *      Accept-Language, 5s per attempt.
  *   3. Assert the final hostname matches the expected merchant for that
  *      country (assertLocalisedDomain)
+ *
+ * A merchant that bot-walls both HEAD and GET from the CI runner IP (Akamai
+ * tarpit — gotcha #7) is reported as INCONCLUSIVE and does NOT page; a genuine
+ * outage (5xx / connection error / wrong host) still pages. The monitor is not
+ * weakened — only made honest about what a datacenter probe can determine.
  *
  * Today's behaviour (pre-Sovrn): all links resolve to raw merchant URLs,
  * so the assertion just verifies the merchant's own domain is reachable.
@@ -24,7 +31,13 @@
  * into a notification (Slack / Resend email).
  */
 
-import { buildSmokeMatrix, assertLocalisedDomain, summariseResults, type ProbeOutcome } from '../src/lib/affiliate/smoke';
+import {
+  buildSmokeMatrix,
+  assertLocalisedDomain,
+  summariseResults,
+  probeUrl,
+  type ProbeOutcome,
+} from '../src/lib/affiliate/smoke';
 
 const LYRA_APP_URL = process.env.LYRA_APP_URL || 'https://checklyra.com';
 const PROBE_TIMEOUT_MS = 5000;
@@ -34,67 +47,50 @@ type ProbeInput = ReturnType<typeof buildSmokeMatrix>[number];
 
 async function probeOne(entry: ProbeInput): Promise<ProbeOutcome> {
   const start = Date.now();
-  try {
-    // For MVP we directly probe the representativeUrl. Once the lyra app
-    // exposes /api/affiliate/link as a server-side endpoint, this should
-    // first call that to obtain the monetised URL, then probe THAT —
-    // exercising the link service path end-to-end. Leaving the inline
-    // probe here keeps the smoke check independently useful for upstream-
-    // merchant uptime.
-    const _appUrl = LYRA_APP_URL; // referenced for future expansion
-    void _appUrl;
 
-    const controller = new AbortController();
-    const timeout = setTimeout(() => controller.abort(), PROBE_TIMEOUT_MS);
+  // For MVP we directly probe the representativeUrl. Once the lyra app
+  // exposes /api/affiliate/link as a server-side endpoint, this should
+  // first call that to obtain the monetised URL, then probe THAT —
+  // exercising the link service path end-to-end. Leaving the inline
+  // probe here keeps the smoke check independently useful for upstream-
+  // merchant uptime.
+  const _appUrl = LYRA_APP_URL; // referenced for future expansion
+  void _appUrl;
 
-    const headRes = await fetch(entry.representativeUrl, {
-      method: 'HEAD',
-      redirect: 'follow',
-      signal: controller.signal,
-      headers: { 'Accept-Language': languageHintFor(entry.buyerCountry) },
-    });
-    clearTimeout(timeout);
+  // BUGS-23: bounded HEAD with a single GET retry when HEAD is bot-walled or
+  // times out. The pure logic (and its three-way classification) lives in the
+  // lib so it can be unit-tested with an injected fetch.
+  const result = await probeUrl(fetch, entry.representativeUrl, {
+    timeoutMs: PROBE_TIMEOUT_MS,
+    acceptLanguage: languageHintFor(entry.buyerCountry),
+  });
 
-    if (!headRes.ok && headRes.status !== 405) {
-      // 405 (method not allowed) is normal — fall through to GET. Anything
-      // else is a failure: the merchant is down or geo-blocking us.
-      return {
-        merchantId: entry.merchantId,
-        buyerCountry: entry.buyerCountry,
-        ok: false,
-        finalUrl: headRes.url || null,
-        failureReason: `head_http_${headRes.status}`,
-        durationMs: Date.now() - start,
-      };
-    }
-
-    const finalUrl = headRes.url || entry.representativeUrl;
-    const assertion = assertLocalisedDomain(finalUrl, entry.expectedHosts);
-
-    return {
-      merchantId: entry.merchantId,
-      buyerCountry: entry.buyerCountry,
-      ok: assertion.ok,
-      finalUrl,
-      failureReason: assertion.ok ? null : assertion.reason,
-      durationMs: Date.now() - start,
-    };
-  } catch (err: unknown) {
-    const reason =
-      err instanceof Error && err.name === 'AbortError'
-        ? 'timeout'
-        : err instanceof Error
-          ? `error:${err.message.slice(0, 60)}`
-          : 'unknown_error';
+  if (!result.ok) {
+    // Reachability failed OR was inconclusive (bot-walled). Propagate the
+    // botBlocked flag so summariseResults can exclude inconclusive probes from
+    // the alert without masking a genuine outage.
     return {
       merchantId: entry.merchantId,
       buyerCountry: entry.buyerCountry,
       ok: false,
-      finalUrl: null,
-      failureReason: reason,
+      finalUrl: result.finalUrl,
+      failureReason: result.reason,
+      botBlocked: result.botBlocked,
       durationMs: Date.now() - start,
     };
   }
+
+  // Reachable — now enforce the localised-storefront assertion on the final
+  // host. A wrong host is a GENUINE failure (never bot-blocked).
+  const assertion = assertLocalisedDomain(result.finalUrl, entry.expectedHosts);
+  return {
+    merchantId: entry.merchantId,
+    buyerCountry: entry.buyerCountry,
+    ok: assertion.ok,
+    finalUrl: result.finalUrl,
+    failureReason: assertion.ok ? null : assertion.reason,
+    durationMs: Date.now() - start,
+  };
 }
 
 /** Per-country Accept-Language hint. Some sites localise based on this
@@ -152,6 +148,22 @@ async function main(): Promise<void> {
         (f.finalUrl ? ` (final=${f.finalUrl})` : '') +
         ` [${f.durationMs}ms]`,
     );
+  }
+  // BUGS-23: surface inconclusive (bot-walled) probes as warnings — they do NOT
+  // page (we can't tell up-from-down from a datacenter IP; gotcha #7), but they
+  // must be visible so a genuine long-term merchant loss isn't hidden behind
+  // "bot-blocked" forever.
+  if (summary.botBlocked > 0) {
+    console.warn(
+      `[smoke] INCONCLUSIVE (bot-walled, not alerting): ${summary.merchantsInconclusive.join(', ') || '(mixed)'}`,
+    );
+    for (const b of summary.inconclusive) {
+      console.warn(
+        `[smoke] BOT-BLOCKED ${b.merchantId} ${b.buyerCountry}: ${b.failureReason}` +
+          (b.finalUrl ? ` (final=${b.finalUrl})` : '') +
+          ` [${b.durationMs}ms]`,
+      );
+    }
   }
 
   // Optional: write a summary JSON file the GH workflow uploads as an

--- a/src/lib/affiliate/smoke.ts
+++ b/src/lib/affiliate/smoke.ts
@@ -225,6 +225,127 @@ export function assertLocalisedDomain(
   return { ok: false, reason: 'unexpected_host', actualHost: host };
 }
 
+// ── Network probe: HEAD → GET fallback, bot-block aware (BUGS-23) ─────────
+//
+// John Lewis (and any Akamai-fronted merchant) tarpits datacenter/CI-IP HEAD
+// requests (gotcha #7: "GitHub Actions runner IPs are blocked by Cloudflare
+// bot protection"). A single HEAD that aborts at the timeout was being scored
+// as "merchant fully down" → a false page. But we must NOT mask a real outage.
+//
+// probeUrl() therefore distinguishes THREE outcomes:
+//   - reachable (ok:true)         — HEAD or the GET retry returned 2xx.
+//   - inconclusive (botBlocked)   — BOTH HEAD and GET hit a bot-wall signal
+//                                   (timeout / 403 / 429). From a datacenter
+//                                   IP we cannot tell up-from-down, so this is
+//                                   surfaced but does NOT page.
+//   - genuine failure (ok:false)  — a determinate error (5xx, 4xx that isn't a
+//                                   bot-wall, wrong host, connection/DNS error).
+//                                   This still pages.
+// A timeout is never treated as a pass; only a real 2xx flips to ok:true.
+
+/** Injectable fetch so the probe is unit-testable without the network. */
+export type FetchLike = (url: string, init: RequestInit) => Promise<Response>;
+
+/** HEAD statuses that trigger a single GET retry (host up but hostile to HEAD). */
+const HEAD_RETRY_STATUSES = new Set([403, 405, 429]);
+/** Statuses that, when they ALSO come back on the GET retry, mean "bot-walled"
+ *  (inconclusive) rather than a confirmed outage. 405 is deliberately excluded
+ *  here — a GET that is Method-Not-Allowed on a storefront homepage is a real
+ *  misconfiguration, not a bot wall. */
+const BOT_WALL_STATUSES = new Set([403, 429]);
+
+export type ProbeResult =
+  | { ok: true; finalUrl: string }
+  | { ok: false; botBlocked: boolean; reason: string; finalUrl: string | null };
+
+async function attemptFetch(
+  fetchImpl: FetchLike,
+  url: string,
+  method: 'HEAD' | 'GET',
+  timeoutMs: number,
+  acceptLanguage: string,
+): Promise<{ status: number; ok: boolean; finalUrl: string }> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    const res = await fetchImpl(url, {
+      method,
+      redirect: 'follow',
+      signal: controller.signal,
+      // On GET, ask for only the first byte so we don't drain a full page body.
+      headers:
+        method === 'GET'
+          ? { 'Accept-Language': acceptLanguage, Range: 'bytes=0-0' }
+          : { 'Accept-Language': acceptLanguage },
+    });
+    // We only care about status + final URL; release the body promptly.
+    try {
+      await res.body?.cancel?.();
+    } catch {
+      /* body already consumed / unsupported — ignore */
+    }
+    return { status: res.status, ok: res.ok, finalUrl: res.url || url };
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+/**
+ * Probe a merchant URL with a bounded HEAD, falling back to a single bounded
+ * GET when HEAD is blocked or times out. See the section comment above for the
+ * three-way classification. `fetchImpl` is injected so this is unit-testable.
+ */
+export async function probeUrl(
+  fetchImpl: FetchLike,
+  url: string,
+  opts: { timeoutMs: number; acceptLanguage: string },
+): Promise<ProbeResult> {
+  // ── Attempt 1: HEAD ──
+  try {
+    const h = await attemptFetch(fetchImpl, url, 'HEAD', opts.timeoutMs, opts.acceptLanguage);
+    if (h.ok) return { ok: true, finalUrl: h.finalUrl };
+    if (!HEAD_RETRY_STATUSES.has(h.status)) {
+      // 5xx, 404, 410, … — a determinate problem, not a bot wall. Do not rescue.
+      return { ok: false, botBlocked: false, reason: `head_http_${h.status}`, finalUrl: h.finalUrl };
+    }
+    // 403/405/429 → fall through to a single GET retry.
+  } catch (e) {
+    if (!(e instanceof Error && e.name === 'AbortError')) {
+      // A non-timeout error (DNS, connection refused, TLS) is a real failure.
+      return {
+        ok: false,
+        botBlocked: false,
+        reason: e instanceof Error ? `error:${e.message.slice(0, 60)}` : 'unknown_error',
+        finalUrl: null,
+      };
+    }
+    // HEAD timed out (tarpit) → fall through to the GET retry.
+  }
+
+  // ── Attempt 2: GET (single bounded retry) ──
+  try {
+    const g = await attemptFetch(fetchImpl, url, 'GET', opts.timeoutMs, opts.acceptLanguage);
+    if (g.ok) return { ok: true, finalUrl: g.finalUrl };
+    if (BOT_WALL_STATUSES.has(g.status)) {
+      // Still bot-walled on GET → inconclusive from a datacenter IP, not down.
+      return { ok: false, botBlocked: true, reason: `bot_blocked_http_${g.status}`, finalUrl: g.finalUrl };
+    }
+    // GET returned a determinate error (5xx / 404 / 405 / …) → genuine failure.
+    return { ok: false, botBlocked: false, reason: `get_http_${g.status}`, finalUrl: g.finalUrl };
+  } catch (e) {
+    if (e instanceof Error && e.name === 'AbortError') {
+      // Both HEAD and GET timed out → datacenter tarpit; inconclusive, not down.
+      return { ok: false, botBlocked: true, reason: 'bot_blocked_timeout', finalUrl: null };
+    }
+    return {
+      ok: false,
+      botBlocked: false,
+      reason: e instanceof Error ? `error:${e.message.slice(0, 60)}` : 'unknown_error',
+      finalUrl: null,
+    };
+  }
+}
+
 // ── Probe result + summary ──────────────────────────────────────────────
 
 export type ProbeOutcome = {
@@ -235,6 +356,13 @@ export type ProbeOutcome = {
   finalUrl: string | null;
   /** Why it failed, if it failed. */
   failureReason: string | null;
+  /**
+   * BUGS-23: true when the probe was INCONCLUSIVE because the merchant
+   * bot-walled both HEAD and GET (timeout / 403 / 429) — up-vs-down cannot be
+   * determined from a datacenter/CI IP (gotcha #7). Such a probe is surfaced
+   * but does NOT count toward the alert. Absent/false for a genuine failure.
+   */
+  botBlocked?: boolean;
   /** Total wall-clock ms for the probe. */
   durationMs: number;
 };
@@ -242,53 +370,89 @@ export type ProbeOutcome = {
 export type SmokeRunSummary = {
   totalProbes: number;
   passed: number;
+  /** Count of GENUINE failures (excludes inconclusive bot-walled probes). */
   failed: number;
-  failureRate: number; // 0-1
+  /** BUGS-23: count of INCONCLUSIVE (bot-walled) probes — surfaced, not paged. */
+  botBlocked: number;
+  /** Genuine-failure rate over the ASSESSABLE probes (bot-walled excluded from
+   *  both numerator and denominator). 0-1. */
+  failureRate: number;
+  /** Genuine failures only — the outcomes the alert is based on. */
   failures: ProbeOutcome[];
-  /** Whether this run should trigger an alert (failure rate over threshold OR any merchant fully down). */
+  /** BUGS-23: inconclusive (bot-walled) probes, surfaced for visibility. */
+  inconclusive: ProbeOutcome[];
+  /** Whether this run should trigger an alert (genuine failure rate over threshold OR any merchant genuinely fully down). */
   shouldAlert: boolean;
-  /** Per-merchant uptime: was every country probe for this merchant a pass? */
+  /** Per-merchant: zero passes AND at least one GENUINE failure (a real outage). */
   merchantsFullyDown: readonly string[];
+  /** BUGS-23: per-merchant zero passes with ONLY bot-walled probes — unverifiable, not paged. */
+  merchantsInconclusive: readonly string[];
 };
 
 /**
  * Roll up a flat list of probe outcomes into a summary. The alert decision
- * is conservative: if ANY merchant has zero successful probes across all
- * its countries, that's a structural failure (e.g. the merchant program
- * has been pulled) and should page on-call. A 1-in-50 transient blip
- * across the full matrix shouldn't.
+ * is conservative: if ANY merchant has zero successful probes AND at least one
+ * GENUINE (determinate) failure across its countries, that's a structural
+ * failure (e.g. the merchant program has been pulled) and should page on-call.
+ * A 1-in-50 transient blip across the full matrix shouldn't.
+ *
+ * BUGS-23: probes that came back INCONCLUSIVE because the merchant bot-walled
+ * both HEAD and GET (timeout / 403 / 429 from a datacenter IP — gotcha #7) are
+ * NOT counted as failures for the alert decision. They are surfaced separately
+ * (`inconclusive` / `merchantsInconclusive`) so a human can see them, but they
+ * do not page — because we genuinely cannot tell up-from-down from CI. A real
+ * outage (5xx, connection refused, wrong host) is still a genuine failure and
+ * still pages: the monitor is not weakened, only made honest.
  */
 export function summariseResults(outcomes: readonly ProbeOutcome[]): SmokeRunSummary {
   const total = outcomes.length;
-  const failures = outcomes.filter((o) => !o.ok);
-  const passed = total - failures.length;
-  const failureRate = total > 0 ? failures.length / total : 0;
+  const botBlocked = outcomes.filter((o) => !o.ok && o.botBlocked === true);
+  const genuineFailures = outcomes.filter((o) => !o.ok && o.botBlocked !== true);
+  const passed = outcomes.filter((o) => o.ok).length;
 
-  // Per-merchant pass/fail.
-  const perMerchantTotals = new Map<string, { passed: number; total: number }>();
+  // Failure rate is over ASSESSABLE probes only — an inconclusive bot-wall is
+  // neither a pass nor a fail, so it must not inflate (or deflate) the rate.
+  const assessable = total - botBlocked.length;
+  const failureRate = assessable > 0 ? genuineFailures.length / assessable : 0;
+
+  // Per-merchant tally.
+  const perMerchant = new Map<
+    string,
+    { passed: number; genuineFail: number; botBlocked: number; total: number }
+  >();
   for (const o of outcomes) {
-    let bucket = perMerchantTotals.get(o.merchantId);
+    let bucket = perMerchant.get(o.merchantId);
     if (!bucket) {
-      bucket = { passed: 0, total: 0 };
-      perMerchantTotals.set(o.merchantId, bucket);
+      bucket = { passed: 0, genuineFail: 0, botBlocked: 0, total: 0 };
+      perMerchant.set(o.merchantId, bucket);
     }
     bucket.total += 1;
     if (o.ok) bucket.passed += 1;
+    else if (o.botBlocked === true) bucket.botBlocked += 1;
+    else bucket.genuineFail += 1;
   }
-  const merchantsFullyDown = [...perMerchantTotals.entries()]
-    .filter(([, t]) => t.total > 0 && t.passed === 0)
+  // Fully down = zero passes AND at least one genuine failure (a real outage).
+  const merchantsFullyDown = [...perMerchant.entries()]
+    .filter(([, t]) => t.passed === 0 && t.genuineFail > 0)
+    .map(([m]) => m);
+  // Inconclusive = zero passes, no genuine failures, only bot-walls.
+  const merchantsInconclusive = [...perMerchant.entries()]
+    .filter(([, t]) => t.passed === 0 && t.genuineFail === 0 && t.botBlocked > 0)
     .map(([m]) => m);
 
-  // Alert if any merchant is fully down OR failure rate > 10% overall.
+  // Alert if any merchant is genuinely fully down OR genuine failure rate > 10%.
   const shouldAlert = merchantsFullyDown.length > 0 || failureRate > 0.1;
 
   return {
     totalProbes: total,
     passed,
-    failed: failures.length,
+    failed: genuineFailures.length,
+    botBlocked: botBlocked.length,
     failureRate,
-    failures,
+    failures: genuineFailures,
+    inconclusive: botBlocked,
     shouldAlert,
     merchantsFullyDown,
+    merchantsInconclusive,
   };
 }

--- a/tests/unit/affiliate-smoke.test.ts
+++ b/tests/unit/affiliate-smoke.test.ts
@@ -11,7 +11,9 @@ import {
   buildSmokeMatrix,
   assertLocalisedDomain,
   summariseResults,
+  probeUrl,
   type ProbeOutcome,
+  type FetchLike,
 } from '@/lib/affiliate/smoke';
 
 // ── SMOKE_PROBES shape ─────────────────────────────────────────────────
@@ -275,5 +277,203 @@ describe('KAN-194 summariseResults', () => {
     const failed = failing('amazon', 'GB', 'unexpected_host');
     const out = summariseResults([passing('etsy', 'GB'), failed]);
     expect(out.failures).toContain(failed);
+  });
+});
+
+// ── BUGS-23: probeUrl (HEAD → GET fallback, bot-block aware) ─────────────
+
+type FetchBehavior = { status: number; url?: string } | 'timeout' | { error: string };
+
+/**
+ * Build a fake fetch that plays a queued list of behaviours (one per call,
+ * so [HEAD-behaviour, GET-behaviour]). 'timeout' honours the AbortController
+ * signal so attemptFetch's real timer produces a realistic AbortError.
+ */
+function makeFetch(behaviours: FetchBehavior[]): {
+  impl: FetchLike;
+  calls: Array<{ url: string; method: string }>;
+} {
+  const calls: Array<{ url: string; method: string }> = [];
+  let i = 0;
+  const impl: FetchLike = (url, init) => {
+    calls.push({ url, method: (init.method as string) || 'GET' });
+    const b = behaviours[i++] ?? { status: 200 };
+    if (b === 'timeout') {
+      return new Promise<Response>((_resolve, reject) => {
+        const signal = init.signal as AbortSignal | undefined;
+        signal?.addEventListener('abort', () => {
+          const err = new Error('The operation was aborted');
+          err.name = 'AbortError';
+          reject(err);
+        });
+      });
+    }
+    if ('error' in b) return Promise.reject(new Error(b.error));
+    const status = b.status;
+    return Promise.resolve({
+      ok: status >= 200 && status < 300,
+      status,
+      url: b.url ?? url,
+      body: undefined,
+    } as unknown as Response);
+  };
+  return { impl, calls };
+}
+
+const OPTS = { timeoutMs: 20, acceptLanguage: 'en-GB' };
+const URL_UNDER_TEST = 'https://www.johnlewis.com/';
+
+describe('BUGS-23 probeUrl — HEAD→GET fallback, bot-block aware', () => {
+  test('HEAD 200 → ok, single request (no GET)', async () => {
+    const { impl, calls } = makeFetch([{ status: 200 }]);
+    const r = await probeUrl(impl, URL_UNDER_TEST, OPTS);
+    expect(r.ok).toBe(true);
+    expect(calls).toHaveLength(1);
+    expect(calls[0].method).toBe('HEAD');
+  });
+
+  test('HEAD timeout → GET 200 → ok, exactly two requests (the johnlewis rescue)', async () => {
+    const { impl, calls } = makeFetch(['timeout', { status: 200 }]);
+    const r = await probeUrl(impl, URL_UNDER_TEST, OPTS);
+    expect(r.ok).toBe(true);
+    expect(calls.map((c) => c.method)).toEqual(['HEAD', 'GET']);
+  });
+
+  test('HEAD timeout → GET timeout → inconclusive (botBlocked), never a pass', async () => {
+    const { impl, calls } = makeFetch(['timeout', 'timeout']);
+    const r = await probeUrl(impl, URL_UNDER_TEST, OPTS);
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      expect(r.botBlocked).toBe(true);
+      expect(r.reason).toBe('bot_blocked_timeout');
+    }
+    expect(calls).toHaveLength(2);
+  });
+
+  test('HEAD 403 → GET 200 → ok (bot-hostile HEAD rescued by GET)', async () => {
+    const { impl } = makeFetch([{ status: 403 }, { status: 200 }]);
+    const r = await probeUrl(impl, URL_UNDER_TEST, OPTS);
+    expect(r.ok).toBe(true);
+  });
+
+  test('HEAD 429 → GET 200 → ok', async () => {
+    const { impl } = makeFetch([{ status: 429 }, { status: 200 }]);
+    const r = await probeUrl(impl, URL_UNDER_TEST, OPTS);
+    expect(r.ok).toBe(true);
+  });
+
+  test('HEAD 405 (method not allowed) → GET 200 → ok', async () => {
+    const { impl, calls } = makeFetch([{ status: 405 }, { status: 200 }]);
+    const r = await probeUrl(impl, URL_UNDER_TEST, OPTS);
+    expect(r.ok).toBe(true);
+    expect(calls.map((c) => c.method)).toEqual(['HEAD', 'GET']);
+  });
+
+  test('HEAD 500 → genuine failure, NOT rescued, single request (real outage still detected)', async () => {
+    const { impl, calls } = makeFetch([{ status: 500 }]);
+    const r = await probeUrl(impl, URL_UNDER_TEST, OPTS);
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      expect(r.botBlocked).toBe(false);
+      expect(r.reason).toBe('head_http_500');
+    }
+    expect(calls).toHaveLength(1);
+  });
+
+  test('HEAD 403 → GET 403 → inconclusive (bot wall never yields)', async () => {
+    const { impl } = makeFetch([{ status: 403 }, { status: 403 }]);
+    const r = await probeUrl(impl, URL_UNDER_TEST, OPTS);
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      expect(r.botBlocked).toBe(true);
+      expect(r.reason).toBe('bot_blocked_http_403');
+    }
+  });
+
+  test('HEAD 403 → GET 500 → GENUINE failure (a determinate error on GET is not a bot wall)', async () => {
+    const { impl } = makeFetch([{ status: 403 }, { status: 500 }]);
+    const r = await probeUrl(impl, URL_UNDER_TEST, OPTS);
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      expect(r.botBlocked).toBe(false);
+      expect(r.reason).toBe('get_http_500');
+    }
+  });
+
+  test('HEAD network error (non-abort) → genuine failure, single request', async () => {
+    const { impl, calls } = makeFetch([{ error: 'ECONNREFUSED' }]);
+    const r = await probeUrl(impl, URL_UNDER_TEST, OPTS);
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      expect(r.botBlocked).toBe(false);
+      expect(r.reason).toMatch(/^error:/);
+    }
+    expect(calls).toHaveLength(1);
+  });
+
+  test('returns the final URL so the caller can assert the localised host', async () => {
+    const { impl } = makeFetch([{ status: 200, url: 'https://www.johnlewis.com/home' }]);
+    const r = await probeUrl(impl, URL_UNDER_TEST, OPTS);
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.finalUrl).toBe('https://www.johnlewis.com/home');
+  });
+});
+
+// ── BUGS-23: summariseResults treats bot-walled probes as inconclusive ───
+
+function botBlockedOutcome(merchantId: string, country: string): ProbeOutcome {
+  return {
+    merchantId,
+    buyerCountry: country,
+    ok: false,
+    finalUrl: null,
+    failureReason: 'bot_blocked_timeout',
+    botBlocked: true,
+    durationMs: 5000,
+  };
+}
+
+describe('BUGS-23 summariseResults — inconclusive (bot-walled) handling', () => {
+  test('a merchant that is ONLY bot-walled is inconclusive, NOT fully-down, and does NOT alert', () => {
+    const out = summariseResults([botBlockedOutcome('johnlewis', 'GB')]);
+    expect(out.merchantsFullyDown).toEqual([]);
+    expect(out.merchantsInconclusive).toEqual(['johnlewis']);
+    expect(out.botBlocked).toBe(1);
+    expect(out.failed).toBe(0);
+    expect(out.failureRate).toBe(0);
+    expect(out.shouldAlert).toBe(false);
+  });
+
+  test('a GENUINE johnlewis failure still pages (monitor not weakened)', () => {
+    const out = summariseResults([failing('johnlewis', 'GB', 'head_http_503')]);
+    expect(out.merchantsFullyDown).toEqual(['johnlewis']);
+    expect(out.shouldAlert).toBe(true);
+  });
+
+  test('bot-walled probes are excluded from the failure rate denominator', () => {
+    // 1 pass + 1 bot-walled → assessable = 1, genuine failures = 0 → rate 0.
+    const out = summariseResults([passing('amazon', 'GB'), botBlockedOutcome('johnlewis', 'GB')]);
+    expect(out.failureRate).toBe(0);
+    expect(out.shouldAlert).toBe(false);
+    expect(out.botBlocked).toBe(1);
+  });
+
+  test('a merchant with a pass AND a bot-wall is neither fully-down nor inconclusive', () => {
+    const out = summariseResults([
+      passing('bookshop_org', 'GB'),
+      botBlockedOutcome('bookshop_org', 'US'),
+    ]);
+    expect(out.merchantsFullyDown).toEqual([]);
+    expect(out.merchantsInconclusive).toEqual([]);
+  });
+
+  test('genuine failure + bot-wall on the SAME merchant → fully-down wins (pages)', () => {
+    const out = summariseResults([
+      failing('johnlewis', 'GB', 'head_http_500'),
+      botBlockedOutcome('johnlewis', 'GB'),
+    ]);
+    expect(out.merchantsFullyDown).toEqual(['johnlewis']);
+    expect(out.merchantsInconclusive).toEqual([]);
+    expect(out.shouldAlert).toBe(true);
   });
 });


### PR DESCRIPTION
## What & Why
The hourly **Affiliate link smoke** monitor pages every hour because `johnlewis` (GB-only in the matrix) is behind Akamai, which tarpits datacenter/CI-IP HEAD requests (gotcha #7). A single 5s HEAD timeout was scored `merchant fully down` → `shouldAlert` → red workflow + admin email. But we must **not** mask a real outage.

## Change
`probeUrl()` in `src/lib/affiliate/smoke.ts` now does a bounded **HEAD → single GET fallback** with a three-way classification:

| Situation | Outcome | Pages? |
|---|---|---|
| HEAD or GET returns 2xx | reachable (host asserted) | — |
| BOTH HEAD and GET bot-walled (timeout / 403 / 429) | **inconclusive_bot_blocked** | **no** (surfaced only) |
| 5xx, 404, connection/DNS error, wrong final host | **genuine failure** | **yes** |

`summariseResults` excludes inconclusive probes from the alert decision and the failure-rate denominator, and reports them separately (`inconclusive` / `merchantsInconclusive`). `merchantsFullyDown` now means *zero passes **and** ≥1 genuine failure* — so a real johnlewis outage (5xx/refused) still pages.

**A timeout is never treated as a pass; only a real 2xx flips to reachable.** Per-attempt timeout stays 5s (not bumped); johnlewis is not dropped.

## Tests
+15 net-new unit tests (injected fetch, no network) covering HEAD-200, HEAD-timeout→GET-200 rescue, HEAD+GET timeout→inconclusive, 403/405/429 rescue, HEAD-500 not-rescued, GET-500 genuine, network-error, and the summariseResults inconclusive/fully-down/failure-rate handling. **No existing test weakened.** 44/44 pass in the suite.

## Docs
Creates `docs/AFFILIATE_MONETIZATION.md` — the "When the smoke monitor fires" triage runbook that the workflow + script already referenced but which didn't exist.

## Monitor-integrity note (for founder review)
This changes what the monitor pages on. It aligns the affiliate smoke with the project-wide gotcha #7 stance (CI IPs get bot-blocked; accept that as inconclusive, not down). It does **not** weaken the monitor — 5xx / connection-refused / wrong-host still page. Per the Workflow & Backup Integrity Policy the classification change is called out here explicitly.

Closes BUGS-23.

🤖 Generated with [Claude Code](https://claude.com/claude-code)