### PR TITLE
fix(SEC-94): postcss path-traversal + brace-expansion v5 DoS overrides

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3588,15 +3588,15 @@
       }
     },
     "node_modules/@sentry/bundler-plugin-core/node_modules/brace-expansion": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/@sentry/bundler-plugin-core/node_modules/glob": {
@@ -5363,16 +5363,16 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
@@ -13401,9 +13401,9 @@
       "license": "ISC"
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
       "funding": [
         {
           "type": "github",
@@ -14221,9 +14221,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.14",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
-      "integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
+      "version": "8.5.23",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.23.tgz",
+      "integrity": "sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==",
       "funding": [
         {
           "type": "opencollective",
@@ -14240,7 +14240,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.11",
+        "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },

--- a/package.json
+++ b/package.json
@@ -49,10 +49,11 @@
     "typescript": "^5"
   },
   "overrides": {
-    "postcss": "^8.5.10",
+    "postcss": "^8.5.18",
     "tmp": "^0.2.7",
     "brace-expansion@^1.0.0": "1.1.16",
     "brace-expansion@^2.0.0": "2.1.2",
+    "brace-expansion@^5.0.0": "5.0.8",
     "js-yaml@^3.0.0": "3.15.0",
     "js-yaml@^4.0.0": "4.3.0",
     "fast-uri@^3.0.0": "3.1.4",


### PR DESCRIPTION
## Summary

Weekly Health+Regression routine (2026-07-25) found `npm audit --audit-level=high` red again — 37 advisories (1 moderate, 36 high) — one day after the 2026-07-24 run reported it clean. Two (newly surfaced) advisories, both fixed via `package.json` `overrides`, no app code touched:

1. **postcss path traversal** (GHSA-r28c-9q8g-f849, high) — `postcss <=8.5.17`, via `next`/`@sentry/nextjs`/`@vercel/analytics`/`@vercel/speed-insights`/`next-router-mock`. The existing override (`^8.5.10`) had drifted to a vulnerable resolved version (8.5.14). Widened to `^8.5.18` → resolves 8.5.23. **Fully clears this chain.**
2. **brace-expansion DoS** (GHSA-mh99-v99m-4gvg, high) — **supersedes SEC-89** (SEC-89 fixed a *different* advisory by bumping to 5.0.7; this new one's vulnerable range is `<=5.0.7`, so 5.0.7 is still vulnerable to it). Added `brace-expansion@^5.0.0: 5.0.8` for the newly-appeared v5 line (`@sentry/bundler-plugin-core`'s `glob@13`, `typescript-eslint`'s `minimatch@10`). **Partial fix** — see below.

**Known residual (tracked in SEC-94, not silently dropped):** the advisory's range also numerically covers the pre-existing `brace-expansion@^1.0.0: 1.1.16` / `@^2.0.0: 2.1.2` overrides (SEC-89). `eslint@9.39.4` pins `minimatch: "^3.1.5"` with no non-major eslint release on a fixed brace-expansion — npm's own `fixAvailable` says `eslint@10.8.0, isSemVerMajor: true`. Forcing that override would swap a major version under eslint's own `minimatch` with no compatibility guarantee — not a safe mechanical fix, so `npm audit --audit-level=high` will still report this one advisory until a deliberate eslint 9→10 upgrade lands (scoped as a follow-up in SEC-94). Low real-world exploitability: brace-expansion here only processes developer-supplied glob patterns in eslint/jest config, not attacker-reachable production input.

## Jira Ticket

SEC-94

## Checklist

- [ ] Unit tests added/updated for new/changed functionality — N/A, dependency-override-only change, no app code
- [x] All existing tests pass (`npm run test:unit`) — 209 suites / 2482 tests, 0 regressions
- [x] Lint passes (`npm run lint`) — 0 errors (pre-existing warnings only)
- [x] Type check passes (`npm run type-check`)
- [x] Build succeeds (`npm run build`)
- [x] Coverage has not decreased — no code changed
- [x] No eslint-disable or ts-ignore without KAN-XX reference — none added
- [ ] ARCHITECTURE.md updated if architectural changes were made — N/A, no architectural change
- [ ] Ops routine / Control-Room registry updated — N/A, no routine behaviour/cadence/ownership changed
- [x] Docs / system map updated — or N/A with reason — N/A: dependency-security patch only, no service/table/env var/route/scheduled-job/security-boundary change; full context recorded in SEC-94

---
_Generated by [Claude Code](https://claude.ai/code/session_015LjQ7HCMTucgBQFgzDmw3Q)_