### PR TITLE
fix(BUGS-71): read /admin/monitoring metrics via service-role client

### DIFF
--- a/src/app/admin/monitoring/page.tsx
+++ b/src/app/admin/monitoring/page.tsx
@@ -13,7 +13,7 @@
 
 import Link from 'next/link';
 import { getAdminServiceClient } from '@/lib/admin';
-import { getAnomalyWindow, type AnomalyWindowKey, type MetricsSnapshot } from '@/lib/metrics';
+import { getAnomalyWindowAdmin, type AnomalyWindowKey, type MetricsSnapshot } from '@/lib/metrics';
 
 export const dynamic = 'force-dynamic';
 
@@ -21,7 +21,10 @@ const WINDOWS: AnomalyWindowKey[] = ['1h', '24h', '7d'];
 
 async function safeWindow(key: AnomalyWindowKey): Promise<MetricsSnapshot | null> {
   try {
-    return await getAnomalyWindow(key);
+    // BUGS-71: read via the service-role variant — get_metrics_for_window is
+    // EXECUTE-able only by service_role since the BUGS-44/SEC-07 lockdown, so
+    // the anon SSR client would 42501 here and collapse to "data unavailable".
+    return await getAnomalyWindowAdmin(key);
   } catch (e) {
     console.error(`[admin/monitoring] metrics ${key} failed`, e);
     return null;

--- a/src/lib/metrics.ts
+++ b/src/lib/metrics.ts
@@ -11,6 +11,7 @@
  */
 
 import { createClient } from '@/lib/supabase-server';
+import { createServiceRoleClient } from '@/lib/supabase-service';
 
 export interface MetricsSnapshot {
   profile_signups: number;
@@ -69,6 +70,39 @@ export async function getMetricsForWindow(
   });
   if (error) {
     throw new Error(`get_metrics_for_window failed: ${error.message}`);
+  }
+  return data as MetricsSnapshot;
+}
+
+/**
+ * BUGS-71: service-role variant of {@link getAnomalyWindow} for the admin
+ * monitoring dashboard.
+ *
+ * `get_metrics_for_window` is SECURITY DEFINER and — since the BUGS-44 / SEC-07
+ * (F-14) lockdown migration `20260621120000` — EXECUTE is granted to
+ * `service_role` ONLY (revoked from public/anon/authenticated). The
+ * `/admin/monitoring` page reads it through the request-scoped anon SSR client,
+ * so every window came back as "data unavailable" (a swallowed 42501
+ * permission-denied). Route the admin read through the hardened service-role
+ * client instead — exactly like that page's `getCounts()` already does.
+ *
+ * Do NOT "fix" this by re-granting EXECUTE to `authenticated`: that would let
+ * any logged-in user call a SECURITY DEFINER counts function and re-open
+ * F-14 / SEC-07. Keep the grant `service_role`-only.
+ *
+ * Server-only + admin-gated usage (the service-role client bypasses RLS).
+ * Mirrors `getAnomalyWindow`'s shape/contract so callers are interchangeable.
+ */
+export async function getAnomalyWindowAdmin(window: AnomalyWindowKey): Promise<MetricsSnapshot> {
+  const supabase = createServiceRoleClient();
+  const end = new Date();
+  const start = new Date(end.getTime() - WINDOW_MS[window]);
+  const { data, error } = await supabase.rpc('get_metrics_for_window', {
+    p_start_at: start.toISOString(),
+    p_end_at: end.toISOString(),
+  });
+  if (error) {
+    throw new Error(`get_metrics_for_window(${window}) [admin] failed: ${error.message}`);
   }
   return data as MetricsSnapshot;
 }

--- a/tests/unit/metrics-admin-window.test.ts
+++ b/tests/unit/metrics-admin-window.test.ts
@@ -1,0 +1,70 @@
+/**
+ * BUGS-71: the admin monitoring dashboard reads window metrics through the
+ * SERVICE-ROLE client, because `get_metrics_for_window` is EXECUTE-able only by
+ * `service_role` since the BUGS-44 / SEC-07 (F-14) lockdown. These tests pin
+ * that contract so a future refactor can't silently route it back through the
+ * anon SSR client (which throws 42501 -> the page renders "data unavailable").
+ */
+
+const rpcSpy = jest.fn();
+const serviceClientSpy = jest.fn(() => ({ rpc: rpcSpy }));
+const anonCreateClientSpy = jest.fn();
+
+jest.mock('@/lib/supabase-service', () => ({
+  createServiceRoleClient: () => serviceClientSpy(),
+}));
+
+// metrics.ts imports createClient from supabase-server at module load; mock it
+// both to prove getAnomalyWindowAdmin never touches it AND to avoid pulling in
+// next/headers (cookies) in the node test env.
+jest.mock('@/lib/supabase-server', () => ({
+  createClient: (...args: unknown[]) => anonCreateClientSpy(...args),
+}));
+
+import { getAnomalyWindowAdmin } from '@/lib/metrics';
+
+const SNAPSHOT = {
+  profile_signups: 3,
+  profile_publishes: 1,
+  profile_items_added: 7,
+  reports_filed: 0,
+  window_start_at: '2026-07-25T00:00:00.000Z',
+  window_end_at: '2026-07-25T01:00:00.000Z',
+};
+
+describe('getAnomalyWindowAdmin (BUGS-71 service-role metrics read)', () => {
+  beforeEach(() => {
+    rpcSpy.mockReset();
+    serviceClientSpy.mockClear();
+    anonCreateClientSpy.mockClear();
+  });
+
+  it('reads via the service-role client, never the anon SSR client', async () => {
+    rpcSpy.mockResolvedValue({ data: SNAPSHOT, error: null });
+    await getAnomalyWindowAdmin('24h');
+    expect(serviceClientSpy).toHaveBeenCalledTimes(1);
+    expect(anonCreateClientSpy).not.toHaveBeenCalled();
+  });
+
+  it('calls get_metrics_for_window with ISO window bounds and returns the snapshot', async () => {
+    rpcSpy.mockResolvedValue({ data: SNAPSHOT, error: null });
+    const result = await getAnomalyWindowAdmin('1h');
+    expect(rpcSpy).toHaveBeenCalledTimes(1);
+    const [fn, args] = rpcSpy.mock.calls[0] as [string, { p_start_at: string; p_end_at: string }];
+    expect(fn).toBe('get_metrics_for_window');
+    expect(typeof args.p_start_at).toBe('string');
+    expect(typeof args.p_end_at).toBe('string');
+    // 1h window: end - start === 3_600_000 ms
+    const delta = new Date(args.p_end_at).getTime() - new Date(args.p_start_at).getTime();
+    expect(delta).toBe(60 * 60 * 1000);
+    expect(result).toEqual(SNAPSHOT);
+  });
+
+  it('throws on an RPC error (e.g. permission denied) so safeWindow can degrade to "data unavailable"', async () => {
+    rpcSpy.mockResolvedValue({
+      data: null,
+      error: { message: 'permission denied for function get_metrics_for_window' },
+    });
+    await expect(getAnomalyWindowAdmin('7d')).rejects.toThrow(/permission denied/);
+  });
+});


### PR DESCRIPTION
Fixes the `/admin/monitoring` **Activity** table showing "data unavailable" for Last 1h/24h/7d on prod (**BUGS-71**).

### Root cause (prod-confirmed)
`get_metrics_for_window` is `SECURITY DEFINER`; the BUGS-44 / SEC-07 (F-14) lockdown migration `20260621120000` revoked EXECUTE from public/anon/authenticated and granted it to `service_role` only. The page read it via the request-scoped **anon SSR client** (`getAnomalyWindow` → `createClient`), so every window threw `42501 permission denied`, which `safeWindow()` swallowed to "data unavailable". `getCounts()` worked because it already uses the service-role client.

Read-only prod probe (2026-07-25): `has_function_privilege('authenticated', 'get_metrics_for_window…')` = **false**, `service_role` = **true**.

### Change
- `src/lib/metrics.ts`: add `getAnomalyWindowAdmin(window)` using the hardened `createServiceRoleClient()` (`@/lib/supabase-service`); identical RPC + return shape to `getAnomalyWindow`, which is kept for any anon caller.
- `src/app/admin/monitoring/page.tsx`: `safeWindow()` now calls `getAnomalyWindowAdmin`.
- **DB grant unchanged** — stays `service_role`-only. Re-granting EXECUTE to `authenticated` would let any logged-in user call a SECURITY DEFINER counts function and re-open F-14 / SEC-07; explicitly avoided (noted in code comment).

### Tests
- New `tests/unit/metrics-admin-window.test.ts` (3 tests): reads via the service-role client and **never** the anon SSR client; calls `get_metrics_for_window` with correct ISO window bounds and returns the snapshot; throws on RPC error so `safeWindow` still degrades to "data unavailable".
- `npx jest` (new + `supabase-service-factory`) → **6/6 pass**; `tsc --noEmit` clean; eslint clean on changed files. No existing test modified or weakened.

### Notes
- **Docs / system map:** N/A — internal ops page; no user-facing/schema/env/route change.
- **MCP coverage:** N/A — internal `/admin/monitoring` route (KAN-222 exemption).
- ⚠️ This PR's `npm audit` gate will be **red** due to the pre-existing `brace-expansion` advisory tracked in **SEC-94** (not introduced here) — the same gate currently blocking all deploys/PRs.

Fixes BUGS-71.

🤖 Generated with [Claude Code](https://claude.com/claude-code)