### PR TITLE
fix(SEC-96): honest admin External-monitoring badges (Sentry + UptimeRobot)

### DIFF
--- a/src/app/admin/monitoring/integration-status.ts
+++ b/src/app/admin/monitoring/integration-status.ts
@@ -1,0 +1,60 @@
+/**
+ * SEC-96: honest derivation of the admin "External monitoring" badges.
+ *
+ * The prior version derived each badge from raw env-var *presence*, which was
+ * misleading in two ways:
+ *   - Sentry showed "configured" whenever NEXT_PUBLIC_SENTRY_DSN was set, even
+ *     if server-side capture was off. Server/edge Sentry (instrumentation.ts)
+ *     only initialises when BOTH the DSN AND IS_SENTRY_ENABLED === 'true' — so
+ *     the badge now requires both, matching what actually ships errors.
+ *   - UptimeRobot showed "configured" only where UPTIMEROBOT_API_KEY was present
+ *     in that deployment's env. But the key is Production-scoped, so the dev /
+ *     staging admin read "not configured" even though those endpoints ARE
+ *     monitored — UptimeRobot watches the whole platform from one account, with
+ *     the monitor list committed in scripts/uptimerobot/lib.js. "Configured"
+ *     for UptimeRobot is an account-wide SETUP fact, not a per-deployment
+ *     secret-presence fact, so it defaults to true and is decoupled from the
+ *     secret. Set UPTIMEROBOT_ENABLED='false' to reflect a decommissioned
+ *     account.
+ *
+ * `configured === undefined` marks a row that is NOT a configurable integration
+ * (our own public status page) — rendered as a plain link, not a green pill, so
+ * we don't fake a config signal for something that isn't configured (the
+ * /status page's own live health probes are the real signal there).
+ *
+ * Kept as a pure, env-injectable function so it is unit-testable without
+ * rendering the server component.
+ */
+export type MonitoringIntegration = {
+  name: string;
+  href: string;
+  /** true/false renders a configured pill; undefined => link-only (not configurable). */
+  configured?: boolean;
+};
+
+export function getMonitoringIntegrations(
+  env: Record<string, string | undefined> = process.env,
+): MonitoringIntegration[] {
+  // Sentry server/edge capture needs BOTH the DSN and the enable flag (mirrors
+  // instrumentation.ts) — DSN-only would read green while zero server errors
+  // actually ship.
+  const sentryConfigured =
+    Boolean(env.NEXT_PUBLIC_SENTRY_DSN) && env.IS_SENTRY_ENABLED === 'true';
+
+  // UptimeRobot is account-wide: configured by default (monitors are provisioned
+  // + committed), decoupled from the Production-only secret so the dev/staging
+  // admin no longer falsely reads "not configured". Only an explicit
+  // UPTIMEROBOT_ENABLED='false' turns it off.
+  const uptimeConfigured = env.UPTIMEROBOT_ENABLED !== 'false';
+
+  return [
+    { name: 'Sentry (errors)', href: 'https://sentry.io', configured: sentryConfigured },
+    {
+      name: 'UptimeRobot (uptime)',
+      href: 'https://dashboard.uptimerobot.com',
+      configured: uptimeConfigured,
+    },
+    // Our own public status page — not a "configurable" integration; link only.
+    { name: 'Public status page', href: 'https://checklyra.com/status' },
+  ];
+}

--- a/src/app/admin/monitoring/page.tsx
+++ b/src/app/admin/monitoring/page.tsx
@@ -6,14 +6,16 @@
  *     RPC (src/lib/metrics.ts).
  *   - Operational counts (lifecycle stages, suspended, pending reports, recent
  *     flags, admins) via the service-role client.
- *   - External-tools panel: Sentry / UptimeRobot configured-or-not status + a
- *     link out. Status is derived from env presence and labelled explicitly —
- *     never a silent "looks fine" (Workflow Integrity policy).
+ *   - External-tools panel: Sentry / UptimeRobot configured status + a link out.
+ *     Status comes from getMonitoringIntegrations() (SEC-96): Sentry needs the
+ *     DSN AND IS_SENTRY_ENABLED; UptimeRobot is account-wide, not per-env secret
+ *     presence. Never a silent "looks fine" (Workflow Integrity policy).
  */
 
 import Link from 'next/link';
 import { getAdminServiceClient } from '@/lib/admin';
 import { getAnomalyWindowAdmin, type AnomalyWindowKey, type MetricsSnapshot } from '@/lib/metrics';
+import { getMonitoringIntegrations } from './integration-status';
 
 export const dynamic = 'force-dynamic';
 
@@ -66,19 +68,21 @@ function StatCard({ label, value, href }: { label: string; value: number; href?:
   return href ? <Link href={href} className="block hover:shadow-sm transition-shadow">{body}</Link> : body;
 }
 
-function ExternalRow({ name, configured, href }: { name: string; configured: boolean; href: string }) {
+function ExternalRow({ name, configured, href }: { name: string; configured?: boolean; href: string }) {
   return (
     <div className="p-4 flex items-center justify-between gap-4">
       <span className="text-sm text-[var(--color-ink)]">{name}</span>
       <div className="flex items-center gap-3">
-        <span
-          className={
-            'text-xs px-2 py-0.5 rounded-full ' +
-            (configured ? 'bg-green-50 text-green-700' : 'bg-[#f4efe7] text-[var(--color-muted)]')
-          }
-        >
-          {configured ? 'configured' : 'not configured'}
-        </span>
+        {configured !== undefined && (
+          <span
+            className={
+              'text-xs px-2 py-0.5 rounded-full ' +
+              (configured ? 'bg-green-50 text-green-700' : 'bg-[#f4efe7] text-[var(--color-muted)]')
+            }
+          >
+            {configured ? 'configured' : 'not configured'}
+          </span>
+        )}
         <a href={href} target="_blank" rel="noopener noreferrer" className="text-xs text-[var(--color-muted)] hover:text-[var(--color-ink)]">
           Open ↗
         </a>
@@ -93,8 +97,7 @@ export default async function MonitoringPage() {
     Promise.all(WINDOWS.map((w) => safeWindow(w))),
   ]);
 
-  const sentryConfigured = Boolean(process.env.NEXT_PUBLIC_SENTRY_DSN);
-  const uptimeConfigured = Boolean(process.env.UPTIMEROBOT_API_KEY);
+  const integrations = getMonitoringIntegrations();
 
   return (
     <div className="max-w-6xl mx-auto px-6 py-8 space-y-10">
@@ -156,9 +159,9 @@ export default async function MonitoringPage() {
       <section aria-labelledby="external-heading">
         <h2 id="external-heading" className="text-base font-medium text-[var(--color-ink)] mb-3">External monitoring</h2>
         <div className="rounded-xl border border-[var(--color-border)] bg-white divide-y divide-[var(--color-border)]">
-          <ExternalRow name="Sentry (errors)" configured={sentryConfigured} href="https://sentry.io" />
-          <ExternalRow name="UptimeRobot (uptime)" configured={uptimeConfigured} href="https://dashboard.uptimerobot.com" />
-          <ExternalRow name="Public status page" configured href="https://checklyra.com/status" />
+          {integrations.map((i) => (
+            <ExternalRow key={i.name} name={i.name} configured={i.configured} href={i.href} />
+          ))}
         </div>
       </section>
     </div>

--- a/tests/unit/monitoring-status.test.ts
+++ b/tests/unit/monitoring-status.test.ts
@@ -1,0 +1,67 @@
+/**
+ * SEC-96: the admin "External monitoring" badges must reflect real config, not
+ * raw env-var presence. Pin the honest logic:
+ *   - Sentry: green only when the DSN AND IS_SENTRY_ENABLED='true' (mirrors
+ *     instrumentation.ts) — the DSN alone would be green while no server errors ship.
+ *   - UptimeRobot: account-wide, green by default, decoupled from the
+ *     Production-only UPTIMEROBOT_API_KEY (so the dev/staging admin no longer
+ *     falsely reads "not configured"); only UPTIMEROBOT_ENABLED='false' disables.
+ *   - Public status page: not a configurable integration -> no pill.
+ */
+import { getMonitoringIntegrations } from '@/app/admin/monitoring/integration-status';
+
+const row = (env: Record<string, string | undefined>, name: string) =>
+  getMonitoringIntegrations(env).find((i) => i.name === name)!;
+
+describe('getMonitoringIntegrations (SEC-96 honest badges)', () => {
+  describe('Sentry (errors)', () => {
+    it('is configured only when the DSN AND IS_SENTRY_ENABLED=true', () => {
+      expect(
+        row({ NEXT_PUBLIC_SENTRY_DSN: 'https://x@sentry.io/1', IS_SENTRY_ENABLED: 'true' }, 'Sentry (errors)')
+          .configured,
+      ).toBe(true);
+    });
+
+    it('is NOT configured when the DSN is set but the enable flag is off/missing', () => {
+      expect(row({ NEXT_PUBLIC_SENTRY_DSN: 'https://x@sentry.io/1' }, 'Sentry (errors)').configured).toBe(false);
+      expect(
+        row({ NEXT_PUBLIC_SENTRY_DSN: 'https://x@sentry.io/1', IS_SENTRY_ENABLED: 'false' }, 'Sentry (errors)')
+          .configured,
+      ).toBe(false);
+    });
+
+    it('is NOT configured when the flag is on but there is no DSN', () => {
+      expect(row({ IS_SENTRY_ENABLED: 'true' }, 'Sentry (errors)').configured).toBe(false);
+    });
+  });
+
+  describe('UptimeRobot (uptime)', () => {
+    it('is configured by default (account-wide) with no env at all', () => {
+      expect(row({}, 'UptimeRobot (uptime)').configured).toBe(true);
+    });
+
+    it('is configured WITHOUT the Production-only key present (dev/staging parity — the SEC-96 bug)', () => {
+      // No UPTIMEROBOT_API_KEY, as on the dev/staging deployments.
+      expect(row({ IS_SENTRY_ENABLED: 'true' }, 'UptimeRobot (uptime)').configured).toBe(true);
+    });
+
+    it('is turned off only by an explicit UPTIMEROBOT_ENABLED=false', () => {
+      expect(row({ UPTIMEROBOT_ENABLED: 'false' }, 'UptimeRobot (uptime)').configured).toBe(false);
+      expect(row({ UPTIMEROBOT_ENABLED: 'true' }, 'UptimeRobot (uptime)').configured).toBe(true);
+    });
+  });
+
+  describe('Public status page', () => {
+    it('is a link-only row (no configured pill)', () => {
+      expect(row({}, 'Public status page').configured).toBeUndefined();
+    });
+  });
+
+  it('returns the three integrations in a stable order', () => {
+    expect(getMonitoringIntegrations({}).map((i) => i.name)).toEqual([
+      'Sentry (errors)',
+      'UptimeRobot (uptime)',
+      'Public status page',
+    ]);
+  });
+});


### PR DESCRIPTION
Makes the admin `/admin/monitoring` **External monitoring** badges reflect real config instead of raw env-var presence (**SEC-96**). Prompted by the dev admin showing UptimeRobot **"not configured"** even though dev *is* monitored.

### Changes
New pure, unit-tested helper `getMonitoringIntegrations()` (`src/app/admin/monitoring/integration-status.ts`); the page maps over it.

- **Sentry:** green only when `NEXT_PUBLIC_SENTRY_DSN` **AND** `IS_SENTRY_ENABLED === 'true'` (matches `instrumentation.ts`). Previously green on DSN alone — which would read "configured" while zero server errors actually ship. *(Verified `IS_SENTRY_ENABLED=true` in prod, so this stays green on prod.)*
- **UptimeRobot:** now an **account-wide** fact, decoupled from the Production-only `UPTIMEROBOT_API_KEY`. UptimeRobot monitors the whole platform from one account (monitor list committed in `scripts/uptimerobot/lib.js`), so the dev/staging admin no longer falsely reads "not configured". Configured by default; turn off only with `UPTIMEROBOT_ENABLED='false'`. **No env change needed** — dev/prod both read "configured" on next deploy, without spreading the secret to more envs.
- **Public status page:** now a **link-only** row (no fake green pill) — it's our own route, not a configurable integration; its own live `/status` probes are the real signal.

### Tests
`tests/unit/monitoring-status.test.ts` (8 tests): Sentry needs both flags; UptimeRobot configured without the key present (the dev-parity bug) and off only via the explicit flag; status page has no pill. `npx jest` → 8/8; `tsc --noEmit` clean; eslint clean; no existing test touched.

### Notes / scope
- **Not in this PR (SEC-96 residual):** the **user-facing** `/status` page still hardcodes the Website check `ok: true` (finding #3). That's a user-facing behaviour change (and needs a probe decision), so it's left for a founder-aware follow-up.
- **Docs / system map:** N/A — internal ops page; no user-facing/schema/env/route change. New env var `UPTIMEROBOT_ENABLED` is **optional** (default-on) and documented in code.
- **MCP coverage:** N/A — internal `/admin/monitoring` route (KAN-222 exemption).
- Branches off current `develop` (post-SEC-94), so the `npm audit` gate is green (unlike #564).

Refs SEC-96.

🤖 Generated with [Claude Code](https://claude.com/claude-code)