### PR TITLE
feat(KAN-413): point Staging Soak at the e2e-stage grey-cloud alias

### DIFF
--- a/docs/STAGING_SOAK_ROUTINE.md
+++ b/docs/STAGING_SOAK_ROUTINE.md
@@ -74,10 +74,11 @@ already exists.
   `vercelEnv` = `preview`. A mismatch is a **release-conformance** finding.
 - `/robots.txt`, `/sitemap.xml`, `/.well-known/security.txt` → 200 or 403.
 
-### C2 — Authenticated surface (with the Vercel/CF bypass header)
-- With `x-vercel-protection-bypass` (+ the CF-skip header when provisioned), the
-  key routes return **200** within the latency budget (C4): `/`, `/dashboard`,
-  `/dashboard/profile`, `/login`, `/signup`, `/join`, `/<published-slug>`.
+### C2 — Authenticated surface (via the grey-cloud alias)
+- Against `e2e-stage.checklyra.com` (`STAGE_SITE`/`BASE_URL`), the key routes
+  return **200** within the latency budget (C4): `/`, `/login`, `/signup`,
+  `/status`, `/api/health`. `/join` is a reachability check (it 307-redirects to
+  `/signup`). The C1 **gate** check stays on the real `stage.checklyra.com`.
 - No route in the set returns **5xx** across the repeated soak passes (C4).
 
 ### C3 — Persistent-user journey (read-write, staging DB is disposable)
@@ -146,12 +147,13 @@ service-role key + bypass headers in the routine env (below). The DB/error
 checks run through **connectors** (routed via Anthropic — no container tokens).
 
 ### Graceful degradation (no silent-skip)
-If the **CF bot-management** challenge blocks the routine's egress to
-`stage.checklyra.com` (the known CI-IP 403 — CLAUDE.md gotcha #7,
-`docs/E2E_AUTHED_CF_BYPASS.md`), the affected layer reports **UNVERIFIED**, never
-a green PASS and never a false FAIL, and the reply names the exact unblock (a CF
-WAF *skip* rule keyed to `E2E_CF_BYPASS_*`). The deterministic C1/C5/C6 layers
-still run. UNVERIFIED is a soft-FAIL for the heartbeat, not a pass.
+The content + journey layers target the grey-cloud `e2e-stage` alias, which has
+no Cloudflare in front of it, so they reach the origin directly. If a page is
+nonetheless challenged/redirected (e.g. `STAGE_SITE` misconfigured back to the
+CF-proxied host), the affected probe reports **UNVERIFIED** — never a green PASS
+and never a false FAIL — naming the unblock (point `STAGE_SITE`/`BASE_URL` at
+`e2e-stage.checklyra.com`). The C1-gate, C5 and C6 layers always run. UNVERIFIED
+is a soft-FAIL for the heartbeat, not a pass.
 
 ---
 
@@ -204,22 +206,26 @@ checkout failed — do NOT improvise probes.**
    NOT make it available here; each must be set in the claude.ai routine env,
    and proved with a supervised "Run now" (test-plan A4).
    - `RESEND_API_KEY` — FAIL-alert email (reuses `scripts/security-alert-email.sh`).
-   - `VERCEL_AUTOMATION_BYPASS` — reach protected staging routes (C2/C3).
    - `E2E_SUPABASE_URL` = `https://uobmlkzrjkptwhttzmmi.supabase.co`,
      `E2E_SUPABASE_SERVICE_ROLE_KEY` = the **staging** service-role key (the
      harness hard-guards against prod — `tests/e2e/support/supabase-admin.ts`).
      ⚠️ This is the **staging** key — a *different* value from the repo's
      `E2E_SUPABASE_*` GitHub secrets, which are **dev**-scoped (they back the
-     `e2e-dev` signup-gate run). Do not cross them.
-   - `E2E_CF_BYPASS_HEADER` + `E2E_CF_BYPASS_SECRET` — the CF WAF-skip header
-     pair (see `docs/E2E_AUTHED_CF_BYPASS.md`). **⚠️ C3 targets
-     `stage.checklyra.com`, which IS Cloudflare-proxied, and there is no
-     grey-cloud `e2e-stage` alias — so C3 stays UNVERIFIED every run until you
-     EITHER (a) set this pair + add a Cloudflare WAF *skip* rule on
-     `stage.checklyra.com` keyed to the header, OR (b) create a DNS-only
-     `e2e-stage.checklyra.com` alias of the staging deploy (like `e2e-dev`) and
-     point C3's `BASE_URL` at it.** UNVERIFIED here is the honest state, not a
-     skip — but it means the soak's core journey is un-commissioned until (a)/(b).
+     `e2e-dev` signup-gate run). Do not cross them. **Requires `*.supabase.co`
+     in the allowlist** (the harness hits Supabase directly).
+   - `STAGE_SITE` = `https://e2e-stage.checklyra.com` and
+     `BASE_URL` = `https://e2e-stage.checklyra.com` — point the **content** (C1
+     pages, C2/C4 latency) and the **browser journey** (C3) at the DNS-only
+     grey-cloud alias, which serves the same staging build with **no Cloudflare
+     challenge** (`docs/E2E_AUTHED_CF_BYPASS.md`). The C1 protection **gate** stays
+     on the real `stage.checklyra.com` via `GATE_SITE` (its default) — so we
+     still confirm the user-facing host is gated. Validated 2026-07-25: all of
+     C1/C2/C4 PASS against the alias.
+   - `VERCEL_AUTOMATION_BYPASS` — **optional.** The grey-cloud alias serves 200
+     without it, so it isn't required; harmless if present. **Do NOT set
+     `E2E_CF_BYPASS_*`** — a Cloudflare WAF *skip* rule cannot except free-plan
+     Bot Fight Mode (proven dead, `docs/E2E_AUTHED_CF_BYPASS.md`); the grey-cloud
+     alias is the working substitute.
    - Optional `ALERT_TO` / `ALERT_FROM` (default `luisa@santos-stephens.com` /
      `security@checklyra.com`, a Resend-verified sender).
 6. **Schedule:** **Daily ~04:12 UTC** (de-collided from the existing crons:
@@ -252,8 +258,8 @@ soft-FAIL, never a pass (Workflow & Backup Integrity Policy).
    The spec ensures + resets the soak user to initial account setup, drives
    build→publish→grow→(gather), and resets to initial in afterAll. A reset that
    leaves rows behind FAILS — file that as a soak-reset finding.
-   If Cloudflare blocks the browser (403 "Just a moment"), record C3 as
-   UNVERIFIED with the CF-skip unblock; do NOT mark it PASS or FAIL.
+   If a page is challenged/redirected (BASE_URL not pointed at the e2e-stage
+   alias), record C3 as UNVERIFIED naming that unblock; do NOT mark it PASS/FAIL.
 3. Via the Supabase connector on uobmlkzrjkptwhttzmmi (C5): get_advisors
    security+performance; invite-queue drain; NULL-token auth.users rows; stale
    one_time_tokens; migration parity (list vs supabase/migrations on staging).

--- a/scripts/staging-soak.sh
+++ b/scripts/staging-soak.sh
@@ -18,6 +18,12 @@
 set -uo pipefail
 
 SITE="${STAGE_SITE:-https://stage.checklyra.com}"
+# The C1 protection-gate probe hits the REAL user-facing host (Cloudflare-proxied),
+# which must stay gated (302/401/403). Content + latency (C1-content/C2/C4) instead
+# target STAGE_SITE, which the routine points at the DNS-only grey-cloud alias
+# e2e-stage.checklyra.com (serves the same staging build, 200s directly, no CF
+# challenge — see docs/E2E_AUTHED_CF_BYPASS.md). Defaults keep both on stage.
+GATE_SITE="${GATE_SITE:-https://stage.checklyra.com}"
 CURL_MAX_TIME="${CURL_MAX_TIME:-20}"
 PASSES="${SOAK_PASSES:-5}"            # C4: probe each latency route N times
 PAGE_BUDGET_MS="${PAGE_BUDGET_MS:-2500}"
@@ -105,8 +111,9 @@ latency_probe() {
 echo "# Lyra staging soak — $(date -u '+%Y-%m-%dT%H:%M:%SZ') — target $SITE"
 
 # ── C1 gate: root must be REACHABLE and GATED (never the full app anonymously) ─
-# This probe deliberately sends NO bypass header — it is testing the gate itself.
-root=$(curl -so /dev/null -w '%{http_code}' --max-time "$CURL_MAX_TIME" -A "$UA" "$SITE/" 2>/dev/null || echo "000")
+# Probes the REAL user-facing host (GATE_SITE, Cloudflare-proxied) with NO bypass
+# header — it is testing the protection gate itself, not content.
+root=$(curl -so /dev/null -w '%{http_code}' --max-time "$CURL_MAX_TIME" -A "$UA" "$GATE_SITE/" 2>/dev/null || echo "000")
 case "$root" in
   301|302|303|307|308|401|403) record PASS       "C1-gate" "staging root reachable + gated ($root)" ;;
   200)                          record FAIL       "C1-gate" "staging root served 200 ANONYMOUSLY — Vercel deployment protection appears DOWN (staging is engineering-only and must never serve the app unauthenticated)" ;;
@@ -115,45 +122,46 @@ case "$root" in
   *)                            record UNVERIFIED "C1-gate" "staging root unexpected code $root" ;;
 esac
 
-if [ -z "$BYPASS" ]; then
-  # Honest degradation: every content/latency check needs the bypass to reach
-  # protected staging pages. One UNVERIFIED line, not a wall of false FAILs.
-  record UNVERIFIED "C1-content" "public-page + /api/health conformance need VERCEL_AUTOMATION_BYPASS (staging is protection-gated) — not run"
-  record UNVERIFIED "C2-C4"      "authenticated-surface + latency need VERCEL_AUTOMATION_BYPASS — not run"
+# ── C1 content + C2/C4 latency (SITE = STAGE_SITE) ──────────────────────────
+# Always run these. On the grey-cloud alias (STAGE_SITE=e2e-stage) the pages
+# serve 200 directly; on the CF-proxied host without a bypass they 302/401/403
+# and each probe records UNVERIFIED (never a false FAIL, never a silent skip).
+# So the per-probe logic classifies reachability — no blanket bypass gate.
+expect_code "C1-status"  "$SITE/status"                   "status page"  200
+expect_code "C1-robots"  "$SITE/robots.txt"               "robots.txt"   200 403 401
+expect_code "C1-sitemap" "$SITE/sitemap.xml"              "sitemap.xml"  200 403 401
+expect_code "C1-sectxt"  "$SITE/.well-known/security.txt" "security.txt" 200 403 401
+# /join is the invite deep-link — it redirects to /signup (307/302), so it is a
+# reachability check, not a latency-measurable page.
+expect_code "C1-join"    "$SITE/join"                     "join (invite) reachable" 200 301 302 307 308
+
+# ── C1 release-conformance: /api/health JSON must match THIS env ──────────────
+# (the grey-cloud alias serves the SAME staging build, so siteUrl is still the
+# canonical https://stage.checklyra.com — the conformance check holds.)
+body=$(curl -s --max-time "$CURL_MAX_TIME" "${CURL_HDRS[@]}" "$SITE/api/health" 2>/dev/null)
+if [ -z "$body" ]; then
+  record UNVERIFIED "C1-health" "/api/health empty/unreachable"
+elif ! printf '%s' "$body" | jq -e . >/dev/null 2>&1; then
+  record UNVERIFIED "C1-health" "/api/health did not return JSON (gated/challenge — point STAGE_SITE at the e2e-stage alias or provide the bypass)"
 else
-  # ── C1 content (with bypass): the pages behind the gate ──────────────────
-  expect_code "C1-status"  "$SITE/status"                   "status page"  200
-  expect_code "C1-robots"  "$SITE/robots.txt"               "robots.txt"   200 403 401
-  expect_code "C1-sitemap" "$SITE/sitemap.xml"              "sitemap.xml"  200 403 401
-  expect_code "C1-sectxt"  "$SITE/.well-known/security.txt" "security.txt" 200 403 401
-
-  # ── C1 release-conformance: /api/health JSON must match THIS env ─────────
-  body=$(curl -s --max-time "$CURL_MAX_TIME" "${CURL_HDRS[@]}" "$SITE/api/health" 2>/dev/null)
-  if [ -z "$body" ]; then
-    record UNVERIFIED "C1-health" "/api/health empty/unreachable"
-  elif ! printf '%s' "$body" | jq -e . >/dev/null 2>&1; then
-    record UNVERIFIED "C1-health" "/api/health did not return JSON (protection challenge?)"
+  problems=""
+  [ "$(printf '%s' "$body" | jq -r '.ok')" = "true" ]                          || problems+="ok!=true; "
+  [ "$(printf '%s' "$body" | jq -r '.siteUrl // empty')" = "https://stage.checklyra.com" ] || problems+="siteUrl wrong; "
+  [ "$(printf '%s' "$body" | jq -r '.isBetaDeploy')" = "false" ]               || problems+="isBetaDeploy!=false; "
+  [ "$(printf '%s' "$body" | jq -r '.vercelEnv // empty')" = "preview" ]        || problems+="vercelEnv!=preview; "
+  if [ -n "$problems" ]; then
+    record FAIL "C1-health" "release-conformance mismatch: $problems(body: $(printf '%s' "$body" | head -c 160))"
   else
-    problems=""
-    [ "$(printf '%s' "$body" | jq -r '.ok')" = "true" ]                          || problems+="ok!=true; "
-    [ "$(printf '%s' "$body" | jq -r '.siteUrl // empty')" = "https://stage.checklyra.com" ] || problems+="siteUrl wrong; "
-    [ "$(printf '%s' "$body" | jq -r '.isBetaDeploy')" = "false" ]               || problems+="isBetaDeploy!=false; "
-    [ "$(printf '%s' "$body" | jq -r '.vercelEnv // empty')" = "preview" ]        || problems+="vercelEnv!=preview; "
-    if [ -n "$problems" ]; then
-      record FAIL "C1-health" "release-conformance mismatch: $problems(body: $(printf '%s' "$body" | head -c 160))"
-    else
-      record PASS "C1-health" "/api/health conformant (ok, siteUrl, isBetaDeploy=false, vercelEnv=preview)"
-    fi
+    record PASS "C1-health" "/api/health conformant (ok, siteUrl, isBetaDeploy=false, vercelEnv=preview)"
   fi
-
-  # ── C2/C4: sustained latency on the surface behind the gate ──────────────
-  latency_probe "C4-home"   "/"           "$PAGE_BUDGET_MS"   "home page"
-  latency_probe "C4-login"  "/login"      "$PAGE_BUDGET_MS"   "login page"
-  latency_probe "C4-signup" "/signup"     "$PAGE_BUDGET_MS"   "signup page"
-  latency_probe "C4-join"   "/join"       "$PAGE_BUDGET_MS"   "join (invite) page"
-  latency_probe "C4-status" "/status"     "$PAGE_BUDGET_MS"   "status page"
-  latency_probe "C4-health" "/api/health" "$HEALTH_BUDGET_MS" "health endpoint"
 fi
+
+# ── C2/C4: sustained latency on the content surface ──────────────────────────
+latency_probe "C4-home"   "/"           "$PAGE_BUDGET_MS"   "home page"
+latency_probe "C4-login"  "/login"      "$PAGE_BUDGET_MS"   "login page"
+latency_probe "C4-signup" "/signup"     "$PAGE_BUDGET_MS"   "signup page"
+latency_probe "C4-status" "/status"     "$PAGE_BUDGET_MS"   "status page"
+latency_probe "C4-health" "/api/health" "$HEALTH_BUDGET_MS" "health endpoint"
 
 echo ""
 echo "# Results: PASS=$PASS FAIL=$FAIL UNVERIFIED=$UNV"


### PR DESCRIPTION
Follow-up to #571 (KAN-413). The founder created the DNS-only grey-cloud alias **`e2e-stage.checklyra.com`** (mirrors `e2e-dev`), which is the working way to reach the staging origin — the WAF-skip approach is dead on the free Cloudflare plan (Bot Fight Mode can't be excepted; see `docs/E2E_AUTHED_CF_BYPASS.md`).

## Change
- **`staging-soak.sh`**: split `GATE_SITE` (C1 protection-gate check stays on the real, CF-proxied `stage.checklyra.com`) from `SITE`/`STAGE_SITE` (content + latency target the grey-cloud alias). Removed the blanket bypass-gate — always run the content/latency probes; per-probe UNVERIFIED already handles a gated/redirected page honestly. `/join` is now a reachability check (it 307-redirects), not a latency probe.
- **doc**: env-vars simplified — `E2E_SUPABASE_*` (staging) + `*.supabase.co` mandatory; `STAGE_SITE`/`BASE_URL`=e2e-stage; `VERCEL_AUTOMATION_BYPASS` optional; `E2E_CF_BYPASS_*` not needed.

## Validated live (2026-07-25)
Against `e2e-stage`: **12 PASS / 0 FAIL / 0 UNVERIFIED** — C1 gate on `stage.checklyra.com` (302 gated); C1/C2/C4 on the alias; `/api/health` conformant (`siteUrl=https://stage.checklyra.com`); p50 246–578 ms.

After merge I'll point the routine's `STAGE_SITE`/`BASE_URL` at the alias and run the full commissioning + fault-injection pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)