### PR TITLE
fix(BUGS-73): Manual-of-Me autosave loses edit on fast blur + soak commissioning

### DIFF
--- a/.github/workflows/soak-journey.yml
+++ b/.github/workflows/soak-journey.yml
@@ -56,8 +56,8 @@ jobs:
       # that back e2e-authed.yml. supabase-admin.ts allows only the dev/staging
       # refs and hard-refuses prod. Provision these as GitHub Secrets pointing at
       # the STAGING project (uobmlkzrjkptwhttzmmi), NEVER prod.
-      E2E_SUPABASE_URL: ${{ secrets.E2E_SUPABASE_URL_STAGING }}
-      E2E_SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.E2E_SUPABASE_SERVICE_ROLE_KEY_STAGING }}
+      E2E_SUPABASE_URL: ${{ secrets.STAGING_SUPABASE_URL }}
+      E2E_SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.STAGING_SUPABASE_SERVICE_ROLE_KEY }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6
 

--- a/src/app/dashboard/profile/sections/use-auto-save.tsx
+++ b/src/app/dashboard/profile/sections/use-auto-save.tsx
@@ -30,7 +30,7 @@
  * matching what users expect from auto-save.
  */
 
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react';
 import { runSave } from './auto-save-core';
 
 export type AutoSaveStatus = 'idle' | 'saving' | 'saved' | 'error';
@@ -57,13 +57,21 @@ export function useAutoSave<T>(
 ): UseAutoSaveReturn {
   // Hold `save` and the newest `value` in refs so flush() can force-save the
   // current value with the current save fn, and so re-creating `save` on every
-  // parent render doesn't re-trigger the debounce effect. Both are synced in a
-  // commit effect — react-hooks/refs disallows writing refs during render, and
-  // an effect commits before any user click can call flush(), so the refs are
-  // always current at flush time.
+  // parent render doesn't re-trigger the debounce effect.
+  //
+  // BUGS-70 residual (found by the KAN-413 staging soak, C3.5): these refs MUST
+  // be synced in a *layout* effect, not a passive one. A passive useEffect runs
+  // after paint, so on a fast type-then-blur — Playwright fill()+blur(), or a
+  // real user who blurs immediately after a keystroke — onBlur→flush() fired
+  // BEFORE the passive effect had synced latestValueRef, and flush saved the
+  // STALE value (the pre-edit text), so the edit never landed in
+  // profile_manual_of_me even though the status showed "Saved". useLayoutEffect
+  // commits synchronously after the render, before the browser dispatches the
+  // subsequent blur event, so the ref is current at flush time. (Writing the ref
+  // in render would be simpler but the react-hooks/refs lint disallows it.)
   const saveRef = useRef(save);
   const latestValueRef = useRef(value);
-  useEffect(() => {
+  useLayoutEffect(() => {
     saveRef.current = save;
     latestValueRef.current = value;
   });

--- a/tests/e2e/soak/journey.soak.spec.ts
+++ b/tests/e2e/soak/journey.soak.spec.ts
@@ -1,6 +1,6 @@
 import { test, expect } from '@playwright/test';
 import path from 'node:path';
-import { mkdirSync } from 'node:fs';
+import { mkdirSync, writeFileSync } from 'node:fs';
 import { adminClient } from '../support/supabase-admin';
 import { mintSession } from '../support/mint-session';
 import {
@@ -44,6 +44,11 @@ test.beforeAll(async () => {
   const dirty = await assertInitialBaseline(soak);
   expect(dirty, `soak reset left rows behind at start: ${dirty.join('; ')}`).toEqual([]);
   mkdirSync(AUTH_DIR, { recursive: true });
+  // The file-level test.use({ storageState: SOAK_STATE }) makes Playwright apply
+  // that storageState to EVERY context created in this file — including
+  // mintSession's own browser.newContext — so SOAK_STATE must exist before we
+  // mint. Seed an empty state; mintSession overwrites it with the real session.
+  writeFileSync(SOAK_STATE, JSON.stringify({ cookies: [], origins: [] }));
   await mintSession(baseURL, SOAK_EMAIL, SOAK_STATE);
 });
 


### PR DESCRIPTION
## BUGS-73 — the KAN-413 staging soak's first real finding
On its first full journey run (against `e2e-stage`), the soak caught that editing a Manual-of-Me box → "Saved" → the edit **doesn't appear on the published profile**, and a DB check confirmed **no `profile_manual_of_me` row** was written — on a deployed staging build that **already has the BUGS-70 fix**. (The CF-blocked authed E2E couldn't catch this; the soak's grey-cloud path can.)

**Root cause:** `useAutoSave.flush()` force-saves `latestValueRef.current`, but that ref was synced in a **passive `useEffect`** (runs after paint). On a fast type-then-blur — Playwright `fill()`+`blur()`, **or a real user who blurs right after typing** — `onBlur→flush()` fires before the ref syncs, so it saves the **stale value**. Status shows "Saved" (the save ran, with the old value) so it looks fine while nothing persists.

**Fix:** sync the refs in `useLayoutEffect` (synchronous, before the next event). One-line effect swap; debounce/last-write-wins semantics unchanged. Only affects `useAutoSave` (BasicInfo/Bio/ManualOfMe).

**Tests:** existing `auto-save-flush.test.ts` (19) pass unchanged; the soak C3.5 / authed KAN-271 E2E is the end-to-end acceptance (verified after deploy).

## Soak commissioning fixes (KAN-413)
- `journey.soak.spec.ts`: seed an empty storageState before minting (the file-level `test.use({storageState})` made Playwright load `soak.json` for mintSession's own context before it existed).
- `soak-journey.yml`: use the existing `STAGING_SUPABASE_URL`/`STAGING_SUPABASE_SERVICE_ROLE_KEY` secrets (the invented `E2E_*_STAGING` names didn't exist).

With this deployed, the soak's C3 goes 5/5 → the routine is 6/6. Verifying via the authed KAN-271 test on `e2e-dev` after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)