### PR TITLE
fix(BUGS-72): promote wait-for-deploy budget + honest timeout diagnosis

### DIFF
--- a/.github/workflows/promote-staging-to-beta.yml
+++ b/.github/workflows/promote-staging-to-beta.yml
@@ -147,9 +147,16 @@ jobs:
         run: |
           set -euo pipefail
           echo "Waiting for deploy-beta.yml run with headSha=$EXPECTED_SHA..."
-          TIMEOUT=420
+          # BUGS-72: 420s only passed here by a near-miss (~5.5 min deploy) while the
+          # identical staging budget false-failed. 900s gives real headroom (prod uses
+          # 600s against a ~330s deploy). Never shorten a deploy step to fit this budget.
+          TIMEOUT=900
           ELAPSED=0
           INTERVAL=20
+          # BUGS-72: remember whether we ever saw a run for our SHA, so the
+          # timeout message can tell "never triggered" apart from "too slow".
+          SEEN_RUN_ID=""
+          LAST_STATUS=""
           while [ $ELAPSED -lt $TIMEOUT ]; do
             sleep $INTERVAL
             ELAPSED=$((ELAPSED + INTERVAL))
@@ -180,6 +187,9 @@ jobs:
               continue
             fi
 
+            SEEN_RUN_ID="$RUN_ID"
+            LAST_STATUS="$STATUS"
+
             if [ "$STATUS" = "completed" ]; then
               if [ "$CONCLUSION" = "success" ]; then
                 echo "::notice::deploy-beta run $RUN_ID succeeded for SHA ${EXPECTED_SHA:0:8}"
@@ -193,9 +203,16 @@ jobs:
             echo "  deploy-beta run $RUN_ID is $STATUS for SHA ${EXPECTED_SHA:0:8} ($ELAPSED/${TIMEOUT}s)"
           done
 
-          echo "::error::deploy-beta.yml never produced a run for SHA ${EXPECTED_SHA:0:8} after ${TIMEOUT}s"
-          echo "::error::This usually means the merge push did not trigger downstream workflows."
-          echo "::error::Check that LYRA_RELEASE_PAT is set and the merge job uses it (not GITHUB_TOKEN)."
+          # BUGS-72: two very different failures used to share one message that always
+          # pointed at LYRA_RELEASE_PAT. Report the one that actually happened.
+          if [ -n "$SEEN_RUN_ID" ]; then
+            echo "::error::deploy-beta run $SEEN_RUN_ID for SHA ${EXPECTED_SHA:0:8} was still '$LAST_STATUS' after ${TIMEOUT}s — this promote exceeded its wait budget, it is NOT a trigger failure."
+            echo "::error::The deploy itself may still finish successfully. Check run $SEEN_RUN_ID; once it is green, re-run this job: gh run rerun ${{ github.run_id }} --failed"
+          else
+            echo "::error::deploy-beta.yml never produced a run for SHA ${EXPECTED_SHA:0:8} after ${TIMEOUT}s"
+            echo "::error::No matching run ever appeared, which means the merge push did not trigger downstream workflows."
+            echo "::error::Check that LYRA_RELEASE_PAT is set and the merge job uses it (not GITHUB_TOKEN)."
+          fi
           exit 1
 
   post-deploy-health:

--- a/.github/workflows/promote-to-production.yml
+++ b/.github/workflows/promote-to-production.yml
@@ -261,9 +261,16 @@ jobs:
         run: |
           set -euo pipefail
           echo "Waiting for deploy-production.yml run with headSha=$EXPECTED_SHA..."
+          # BUGS-72: 600s is adequate today (prod deploy runs ~330s) so the budget is
+          # unchanged here; only the timeout diagnosis below is fixed. If a prod promote
+          # ever times out with a run already in flight, raise this — never shorten a deploy.
           TIMEOUT=600
           ELAPSED=0
           INTERVAL=20
+          # BUGS-72: remember whether we ever saw a run for our SHA, so the
+          # timeout message can tell "never triggered" apart from "too slow".
+          SEEN_RUN_ID=""
+          LAST_STATUS=""
           while [ $ELAPSED -lt $TIMEOUT ]; do
             sleep $INTERVAL
             ELAPSED=$((ELAPSED + INTERVAL))
@@ -294,6 +301,9 @@ jobs:
               continue
             fi
 
+            SEEN_RUN_ID="$RUN_ID"
+            LAST_STATUS="$STATUS"
+
             if [ "$STATUS" = "completed" ]; then
               if [ "$CONCLUSION" = "success" ]; then
                 echo "::notice::deploy-production run $RUN_ID succeeded for SHA ${EXPECTED_SHA:0:8}"
@@ -307,9 +317,16 @@ jobs:
             echo "  deploy-production run $RUN_ID is $STATUS for SHA ${EXPECTED_SHA:0:8} ($ELAPSED/${TIMEOUT}s)"
           done
 
-          echo "::error::deploy-production.yml never produced a run for SHA ${EXPECTED_SHA:0:8} after ${TIMEOUT}s"
-          echo "::error::This usually means the merge push did not trigger downstream workflows."
-          echo "::error::Check that LYRA_RELEASE_PAT is set and the merge job uses it (not GITHUB_TOKEN)."
+          # BUGS-72: two very different failures used to share one message that always
+          # pointed at LYRA_RELEASE_PAT. Report the one that actually happened.
+          if [ -n "$SEEN_RUN_ID" ]; then
+            echo "::error::deploy-production run $SEEN_RUN_ID for SHA ${EXPECTED_SHA:0:8} was still '$LAST_STATUS' after ${TIMEOUT}s — this promote exceeded its wait budget, it is NOT a trigger failure."
+            echo "::error::The deploy itself may still finish successfully. Check run $SEEN_RUN_ID; once it is green, re-run this job: gh run rerun ${{ github.run_id }} --failed"
+          else
+            echo "::error::deploy-production.yml never produced a run for SHA ${EXPECTED_SHA:0:8} after ${TIMEOUT}s"
+            echo "::error::No matching run ever appeared, which means the merge push did not trigger downstream workflows."
+            echo "::error::Check that LYRA_RELEASE_PAT is set and the merge job uses it (not GITHUB_TOKEN)."
+          fi
           exit 1
 
   smoke-tests:

--- a/.github/workflows/promote-to-staging.yml
+++ b/.github/workflows/promote-to-staging.yml
@@ -266,9 +266,17 @@ jobs:
         run: |
           set -euo pipefail
           echo "Waiting for deploy-staging.yml run with headSha=$EXPECTED_SHA..."
-          TIMEOUT=420
+          # BUGS-72: 420s was shorter than a normal staging deploy, so a promote
+          # whose deploy succeeded still reported failure and needed a manual
+          # `gh run rerun --failed`. 900s gives real headroom (prod uses 600s
+          # against a ~330s deploy). Never shorten a deploy step to fit this budget.
+          TIMEOUT=900
           ELAPSED=0
           INTERVAL=20
+          # BUGS-72: remember whether we ever saw a run for our SHA, so the
+          # timeout message can tell "never triggered" apart from "too slow".
+          SEEN_RUN_ID=""
+          LAST_STATUS=""
           while [ $ELAPSED -lt $TIMEOUT ]; do
             sleep $INTERVAL
             ELAPSED=$((ELAPSED + INTERVAL))
@@ -299,6 +307,9 @@ jobs:
               continue
             fi
 
+            SEEN_RUN_ID="$RUN_ID"
+            LAST_STATUS="$STATUS"
+
             if [ "$STATUS" = "completed" ]; then
               if [ "$CONCLUSION" = "success" ]; then
                 echo "::notice::deploy-staging run $RUN_ID succeeded for SHA ${EXPECTED_SHA:0:8}"
@@ -312,9 +323,16 @@ jobs:
             echo "  deploy-staging run $RUN_ID is $STATUS for SHA ${EXPECTED_SHA:0:8} ($ELAPSED/${TIMEOUT}s)"
           done
 
-          echo "::error::deploy-staging.yml never produced a run for SHA ${EXPECTED_SHA:0:8} after ${TIMEOUT}s"
-          echo "::error::This usually means the merge push did not trigger downstream workflows."
-          echo "::error::Check that LYRA_RELEASE_PAT is set and the merge job uses it (not GITHUB_TOKEN)."
+          # BUGS-72: two very different failures used to share one message that always
+          # pointed at LYRA_RELEASE_PAT. Report the one that actually happened.
+          if [ -n "$SEEN_RUN_ID" ]; then
+            echo "::error::deploy-staging run $SEEN_RUN_ID for SHA ${EXPECTED_SHA:0:8} was still '$LAST_STATUS' after ${TIMEOUT}s — this promote exceeded its wait budget, it is NOT a trigger failure."
+            echo "::error::The deploy itself may still finish successfully. Check run $SEEN_RUN_ID; once it is green, re-run this job: gh run rerun ${{ github.run_id }} --failed"
+          else
+            echo "::error::deploy-staging.yml never produced a run for SHA ${EXPECTED_SHA:0:8} after ${TIMEOUT}s"
+            echo "::error::No matching run ever appeared, which means the merge push did not trigger downstream workflows."
+            echo "::error::Check that LYRA_RELEASE_PAT is set and the merge job uses it (not GITHUB_TOKEN)."
+          fi
           exit 1
 
   post-deploy-health:

--- a/tests/unit/promote-wait-budget-bugs72.test.ts
+++ b/tests/unit/promote-wait-budget-bugs72.test.ts
@@ -1,0 +1,112 @@
+/**
+ * BUGS-72 meta-test: the promote workflows' "wait for deploy" step must give a
+ * real deploy enough headroom, and must diagnose a timeout honestly.
+ *
+ * History:
+ *   * 2026-07-25 (SEC-23/SEC-98 promote chain): `promote-to-staging.yml` reported
+ *     FAILURE even though its merge job succeeded and `deploy-staging.yml`
+ *     completed successfully. The wait step's TIMEOUT was 420s while the staging
+ *     deploy took longer; the step found the matching run ("is in_progress for
+ *     SHA … (420/420s)") and then exited 1 with the message
+ *     "deploy-staging.yml never produced a run for SHA … after 420s".
+ *   * That message names the wrong cause: "never produced a run" is the
+ *     GITHUB_TOKEN downstream-trigger-suppression case (BUGS-4 / Gotcha #16,
+ *     remediated by LYRA_RELEASE_PAT). Conflating it with "the run exists but is
+ *     still going" sent the operator to the wrong remediation, and the promote
+ *     only needed `gh run rerun <id> --failed`.
+ *
+ * This is a FALSE NEGATIVE — a red that isn't real — which the Workflow &
+ * Backup Integrity Policy treats as just as corrosive as a false green: it
+ * teaches operators to distrust and re-run red promotes.
+ *
+ * These assertions guard both halves of the fix. They deliberately read the
+ * workflow source rather than parsing YAML, because the budget and the messages
+ * live inside a shell `run:` block.
+ */
+
+import { readFileSync, existsSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+type PromoteWorkflow = {
+  /** Workflow filename under .github/workflows */
+  file: string;
+  /** The deploy workflow it waits on */
+  deploy: string;
+  /** Minimum acceptable wait budget in seconds */
+  minBudget: number;
+};
+
+const WORKFLOWS: PromoteWorkflow[] = [
+  // BUGS-72 raised these two from 420s. The staging one demonstrably false-failed;
+  // beta shared the identical budget and only passed on a ~5.5min near-miss.
+  { file: 'promote-to-staging.yml', deploy: 'deploy-staging', minBudget: 900 },
+  { file: 'promote-staging-to-beta.yml', deploy: 'deploy-beta', minBudget: 900 },
+  // Production was already 600s against a ~330s deploy, so its budget is
+  // unchanged; it gets the same honest timeout diagnosis.
+  { file: 'promote-to-production.yml', deploy: 'deploy-production', minBudget: 600 },
+];
+
+describe('BUGS-72 — promote wait-for-deploy budget and timeout diagnosis', () => {
+  const sources = new Map<string, string>();
+
+  beforeAll(() => {
+    for (const { file } of WORKFLOWS) {
+      const path = resolve(__dirname, '../../.github/workflows', file);
+      if (!existsSync(path)) {
+        throw new Error(`Workflow file not found at ${path}`);
+      }
+      sources.set(file, readFileSync(path, 'utf-8'));
+    }
+  });
+
+  describe.each(WORKFLOWS)('$file', ({ file, deploy, minBudget }) => {
+    const budgetOf = (source: string): number => {
+      const match = source.match(/^\s*TIMEOUT=(\d+)\s*$/m);
+      if (!match) {
+        throw new Error(`No TIMEOUT= assignment found in ${file}`);
+      }
+      return Number(match[1]);
+    };
+
+    test(`wait budget is at least ${minBudget}s`, () => {
+      expect(budgetOf(sources.get(file)!)).toBeGreaterThanOrEqual(minBudget);
+    });
+
+    test('wait budget is never the 420s value that false-failed', () => {
+      expect(budgetOf(sources.get(file)!)).not.toBe(420);
+    });
+
+    test('records the run id it saw, so a timeout can name the real cause', () => {
+      const source = sources.get(file)!;
+      // Initialised before the loop (the block runs under `set -u`) and
+      // assigned once a run matching our SHA is found.
+      expect(source).toMatch(/^\s*SEEN_RUN_ID=""\s*$/m);
+      expect(source).toMatch(/^\s*SEEN_RUN_ID="\$RUN_ID"\s*$/m);
+      expect(source).toMatch(/^\s*LAST_STATUS=""\s*$/m);
+      expect(source).toMatch(/^\s*LAST_STATUS="\$STATUS"\s*$/m);
+    });
+
+    test('timeout message distinguishes never-triggered from exceeded-budget', () => {
+      const source = sources.get(file)!;
+      // The branch that fires when a run WAS seen must not blame the PAT, and
+      // must point at the re-run remedy.
+      expect(source).toContain('exceeded its wait budget, it is NOT a trigger failure');
+      expect(source).toContain('--failed');
+      // The branch that fires when no run ever appeared keeps the PAT guidance,
+      // which is the correct remediation for that case only.
+      expect(source).toContain(`${deploy}.yml never produced a run`);
+      expect(source).toContain('LYRA_RELEASE_PAT');
+      // Both messages must be reachable — i.e. guarded by the SEEN_RUN_ID test.
+      expect(source).toMatch(/if \[ -n "\$SEEN_RUN_ID" \]; then/);
+    });
+
+    test('still fails the job on timeout (no silent-skip)', () => {
+      // Workflow & Backup Integrity Policy: a wait that gives up must exit
+      // non-zero. Better diagnostics must never soften the failure.
+      const source = sources.get(file)!;
+      const afterLoop = source.slice(source.indexOf('SEEN_RUN_ID="$RUN_ID"'));
+      expect(afterLoop).toContain('exit 1');
+      expect(afterLoop).not.toContain('continue-on-error: true');
+    });
+  });
+});


### PR DESCRIPTION
Closes BUGS-72.

## What was wrong

On 2026-07-25 the SEC-23/SEC-98 supervised promote chain showed `promote-to-staging.yml` as **failed** — while its merge job succeeded *and* `deploy-staging.yml` completed **success**. Two separate defects produced that false red:

1. **The budget was too short.** `TIMEOUT=420` (7 min) is less than a normal staging deploy. The wait step correctly *found* the run for our SHA (`is in_progress for SHA … (420/420s)`) and then ran out of budget. `promote-staging-to-beta.yml` carried the identical 420s and only passed on a ~5.5 min near-miss.
2. **The timeout message named the wrong cause.** Both workflows printed `deploy-*.yml never produced a run for SHA … after 420s` and pointed at `LYRA_RELEASE_PAT`. That is the remediation for *GITHUB_TOKEN downstream-trigger suppression* (BUGS-4 / Gotcha #16) — a completely different failure. Here the run plainly existed; the promote just needed `gh run rerun <id> --failed`.

A false red costs as much trust as a false green: it trains operators to blind-rerun red promotes, which is exactly what the Workflow & Backup Integrity Policy exists to prevent.

## What changed

| File | Change |
|---|---|
| `promote-to-staging.yml` | `TIMEOUT` 420 → **900**; branched timeout diagnosis |
| `promote-staging-to-beta.yml` | `TIMEOUT` 420 → **900**; branched timeout diagnosis |
| `promote-to-production.yml` | `TIMEOUT` **unchanged at 600** (adequate — prod deploy ~330s); branched timeout diagnosis only |
| `tests/unit/promote-wait-budget-bugs72.test.ts` | **new** — 15 assertions |

The wait loop now records `SEEN_RUN_ID`/`LAST_STATUS` when a run matching our SHA appears, so the timeout can tell the two cases apart:

- **run seen** → *"…was still 'in_progress' after 900s — this promote exceeded its wait budget, it is NOT a trigger failure… re-run this job: `gh run rerun <id> --failed`"*
- **no run ever seen** → the original message, with the `LYRA_RELEASE_PAT` guidance that is correct for *that* case.

Both branches still `exit 1`. No silent-skip, no `continue-on-error`, and **no deploy step was shortened to fit a budget**.

## Tests

`tests/unit/promote-wait-budget-bugs72.test.ts` asserts, per workflow: the budget floor, that 420 never returns, the `SEEN_RUN_ID`/`LAST_STATUS` plumbing (initialised before the loop — the block runs under `set -u`), both message branches, and the non-zero exit.

Verified as a real regression guard, not a tautology: reverting `promote-to-staging.yml` to its pre-fix content fails **5/5** of its assertions; restoring the fix returns 15/15 green.

Local `npm run test:unit`: **2472 passed**. The 7 pre-existing local failures (`Cannot find module 'jose'` ×8 suites, and `check-fix-only-promote.test.js` exiting 127 on a missing GNU binary) reproduce identically on an untouched `develop` checkout and are local-environment only — CI's own *Lint & Unit Tests* is green on `develop`.

## Note on effect

Per Gotcha #1, workflow changes only take effect once they reach `main`, so this fix arms itself as it rides `develop → staging → beta → main`. The staging and beta promotes of *this* change still run under the old 420s budget and may need one last `gh run rerun --failed`.

## Docs / system map updated

N/A — CI-only change. No service, table, env var, route, scheduled job, or security boundary altered. `docs/RELEASE_POLICY.md` and `docs/RUNBOOK.md` never documented the numeric budget, so there is no doc drift; the corrected error message is self-documenting at the point of failure.