### PR TITLE
test(KAN-348): make the authed-journey convene assertion environment-aware

### DIFF
--- a/.github/workflows/e2e-authed.yml
+++ b/.github/workflows/e2e-authed.yml
@@ -35,6 +35,15 @@ on:
         description: 'DNS-only dev/staging URL to run against (bypasses CF bot-mgmt)'
         required: false
         default: 'https://e2e-dev.checklyra.com'
+      convene_enabled:
+        # KAN-308: Convene is OFF on dev/staging by owner decision. With it off
+        # the journey asserts the widget is ABSENT; set this to 'true' once
+        # Convene is enabled on the target env and the suite goes back to
+        # asserting the widget RENDERS for an entitled identity. Neither mode
+        # skips the check — see tests/e2e/authed/journey.authed.spec.ts.
+        description: 'Assert the Convene widget renders (true once Convene is enabled on the target env)'
+        required: false
+        default: 'false'
 
 permissions:
   contents: read
@@ -57,6 +66,9 @@ jobs:
       CI: 'true'
       E2E_AUTHED: '1'
       BASE_URL: ${{ github.event.inputs.base_url || 'https://e2e-dev.checklyra.com' }}
+      # KAN-308 — Convene enablement on the environment under test. Default
+      # 'false' matches dev/staging today; the journey asserts widget-absent.
+      E2E_CONVENE_ENABLED: ${{ github.event.inputs.convene_enabled || 'false' }}
       # Harness creds — DISTINCT from the app's own SUPABASE_* so they never leak
       # into an app runtime. Scope these GitHub Secrets to DEV/STAGING, NEVER prod.
       E2E_SUPABASE_URL: ${{ secrets.E2E_SUPABASE_URL }}

--- a/tests/e2e/authed/journey.authed.spec.ts
+++ b/tests/e2e/authed/journey.authed.spec.ts
@@ -31,6 +31,24 @@ function manifest(): Manifest {
   return _manifest;
 }
 
+/**
+ * KAN-348 / KAN-308 — is Convene enabled on the environment under test?
+ *
+ * Convene is deliberately OFF on the dev/staging targets this suite runs
+ * against (Luisa, 2026-07-26: leave Convene off for now and release the gate).
+ * With the feature off the widget cannot render, so asserting `toBeVisible()`
+ * unconditionally fails for an ENVIRONMENT reason, not a product defect.
+ *
+ * This is NOT a loosened assertion — both branches assert real behaviour:
+ *   Convene OFF → the convene widget must be ABSENT (nothing leaks past the flag)
+ *   Convene ON  → the convene widget must be VISIBLE for an entitled identity
+ *
+ * Flip `E2E_CONVENE_ENABLED=true` (workflow input `convene_enabled`) the moment
+ * Convene is enabled on the target env; the original entitlement assertion then
+ * comes back automatically with no further code change.
+ */
+const CONVENE_ENABLED = process.env.E2E_CONVENE_ENABLED === 'true';
+
 /** Shared BUGS-63 hard-load smoke reused for every authed identity. */
 async function assertDashboardHardLoad(page: import('@playwright/test').Page): Promise<void> {
   // Hard navigation + cache-bust — soft navs can mask a broken Suspense reveal.
@@ -80,11 +98,19 @@ test.describe('KAN-348 journey — published_activate (no convene)', () => {
 test.describe('KAN-348 journey — published_grow (convene-entitled)', () => {
   test.use({ storageState: statePath('published_grow') });
 
-  test('published_grow: share + convene visible', async ({ page }) => {
+  test('published_grow: share visible; convene follows env enablement', async ({ page }) => {
     await assertDashboardHardLoad(page);
     await expect(page.locator('[data-onboarding-state="published_grow"]')).toBeVisible();
     await expect(page.locator('[data-widget="share"]')).toBeVisible();
-    await expect(page.locator('[data-widget="convene"]')).toBeVisible();
+    if (CONVENE_ENABLED) {
+      // Convene on + entitled identity → the widget must render.
+      await expect(page.locator('[data-widget="convene"]')).toBeVisible();
+    } else {
+      // Convene off → the widget must NOT leak past the flag, even for an
+      // entitled identity. This is the assertion that has real value while the
+      // KAN-308 hold stands.
+      await expect(page.locator('[data-widget="convene"]')).toHaveCount(0);
+    }
   });
 });
 


### PR DESCRIPTION
## Summary

Releases the authed-journey E2E promote gate, which has been red since 2026-07-25 on a single assertion.

The `published_grow` leg asserted `[data-widget="convene"]` was visible unconditionally. Convene is deliberately **off** on the dev/staging targets this suite runs against (KAN-308 hold), so the widget cannot render and the leg failed for an **environment** reason, not a product defect. That one assertion has been blocking the KAN-349/404 promote wave (Control Room queue #11).

Owner decision, 2026-07-26: leave Convene off for now and release the gate.

**The assertion is scoped to the environment, not weakened or skipped.** Both branches assert real behaviour:

| Convene | Assertion |
|---|---|
| OFF (default, dev/staging today) | the widget must be **absent** — nothing leaks past the flag, even for an entitled identity |
| ON | the widget must be **visible** for an entitled identity (the original assertion) |

Driven by `E2E_CONVENE_ENABLED`, wired to a new `convene_enabled` `workflow_dispatch` input on `e2e-authed.yml` (default `'false'`). Setting it to `'true'` restores the original entitlement assertion with **no further code change** the day Convene is enabled on the target env.

No `test.skip` / `.only` / `.todo` introduced; test count unchanged at 7 listed, 7 run.

### Verification

- Authed journey on this branch: [run 30214783501](https://github.com/luisa-sys/lyra/actions/runs/30214783501) — **success**, 7/7 passed (was 6 passed / 1 failed on develop across runs 26, 27).
- `npm run test:unit` — 2525 passed, 213 suites (floor 2118).
- `npm run type-check` — 0 errors. `npx eslint` on the changed spec — clean.
- `npx playwright test --project=authed-journey --list` — all 7 tests still listed, none skipped.

## Jira Ticket

KAN-348 (related: KAN-308 Convene enablement hold, KAN-349 promote wave)

## Checklist

- [x] Unit tests added/updated for new/changed functionality — this PR *is* the test change; both env branches assert behaviour
- [x] All existing tests pass (`npm run test:unit`) — 2525 passed
- [x] Lint passes (`npm run lint`)
- [x] Type check passes (`npm run type-check`)
- [ ] Build succeeds (`npm run build`) — **not run**: no `src/` change, diff is one spec file + one workflow file
- [x] Coverage has not decreased — same 7 authed tests, same assertion count per run
- [x] No eslint-disable or ts-ignore without KAN-XX reference — none added
- [x] ARCHITECTURE.md updated if architectural changes were made — N/A, no architectural change
- [x] Ops routine / Control-Room registry updated — N/A, no scheduled-routine behaviour, cadence or ownership change
- [x] Docs / system map updated — N/A: the one new variable (`E2E_CONVENE_ENABLED`) is CI-only, never read by the app, and is documented inline at both its definition and its use site

---
_Generated by [Claude Code](https://claude.ai/code/session_01PgHrWX4kWkP6yuemoTh2cE)_