### PR TITLE
fix(KAN-413): soak C3 base-36 marker (fix false-positive) + enable daily schedule

### DIFF
--- a/.github/workflows/soak-journey.yml
+++ b/.github/workflows/soak-journey.yml
@@ -13,18 +13,18 @@ name: Soak Journey (staging C3)
 # DNS-only grey-cloud alias e2e-stage.checklyra.com (no Cloudflare challenge),
 # then resets it to initial account setup and asserts the reset is complete.
 #
-# TRIGGER: workflow_dispatch ONLY for now. The daily `schedule` (commented below)
-# is enabled once the STAGING E2E secrets are provisioned — otherwise a scheduled
-# run would fail every day on missing secrets and turn the Actions tab red.
-#
-#   on:
-#     schedule:
-#       - cron: '2 4 * * *'   # 04:02 UTC daily, before the 04:12 cloud routine
+# TRIGGER: daily `schedule` (04:02 UTC) + `workflow_dispatch`. The STAGING E2E
+# secrets are provisioned, so the scheduled run is live and C3 stays fresh for
+# the cloud routine to CITE. NOTE: GitHub only fires `schedule` from the DEFAULT
+# branch (main), so the daily run begins once this file reaches main via the
+# release chain; on develop/staging it remains dispatch-only until then.
 #
 # STAGING-ONLY: supabase-admin.ts hard-guards the prod ref, and the shell guard
 # below is defence-in-depth. NEVER point the E2E_SUPABASE_* secrets at prod.
 
 on:
+  schedule:
+    - cron: '2 4 * * *'   # 04:02 UTC daily — 10 min before the 04:12 cloud routine (KAN-413); fires from main only
   workflow_dispatch:
     inputs:
       base_url:

--- a/tests/e2e/soak/journey.soak.spec.ts
+++ b/tests/e2e/soak/journey.soak.spec.ts
@@ -122,7 +122,14 @@ test('C3.5 grow — gift + affiliation, and a Manual-of-Me edit round-trips', as
 
   // A real user-driven write through the app: edit a Manual-of-Me box and
   // confirm it appears on the published profile (reuses the KAN-271 pattern).
-  const marker = `Soak note ${Date.now()}`;
+  // The marker MUST be a base-36 token, NOT a raw Date.now(): a 13-digit
+  // timestamp matches the content-moderation PII rule `/\b\d{10,15}\b/`
+  // (content-moderation.ts:307 → `phone_plain`), so the save is *correctly*
+  // rejected before it can persist — a false-positive soak failure that masks
+  // the real round-trip assertion. Base-36 is a short alphanumeric token with
+  // no 10–15 digit run. Mirrors the authed KAN-271 fix (journey.authed.spec.ts,
+  // founder-signed-off 2026-07-25). Assertion unchanged.
+  const marker = `Soak note ref-${Date.now().toString(36)}`;
   await page.goto('/dashboard/profile', { waitUntil: 'load' });
   const goodToKnow = page.getByPlaceholder(/I'm a slow texter/);
   await expect(goodToKnow).toBeVisible();


### PR DESCRIPTION
## What & Why
Finalises the Staging Soak C3 journey after commissioning proved it working.

**Two changes, both from running the soak for real against staging:**

1. **`tests/e2e/soak/journey.soak.spec.ts` — base-36 marker (test-data fix).** The C3.5 Manual-of-Me round-trip used `Soak note ${Date.now()}` — a raw 13-digit timestamp. That matches the content-moderation PII rule `/\b\d{10,15}\b/` (`content-moderation.ts:307` → `phone_plain`), so the app **correctly rejects** the save and the marker never persists: a **false-positive** soak failure that masked the real round-trip assertion. Switched to a base-36 token (no 10–15 digit run), exactly mirroring the already-founder-signed-off authed KAN-271 fix (`journey.authed.spec.ts`). **Assertion unchanged** — this only changes how the unique marker is generated so the test exercises the intended path.

2. **`.github/workflows/soak-journey.yml` — enable the daily `schedule` (04:02 UTC).** C3 is now proven 5/5 green on staging and the `STAGING_SUPABASE_*` secrets are provisioned, so the scheduled run is safe. GitHub fires `schedule` only from the default branch, so the daily run begins once this reaches `main` via the chain; the cloud routine's C3 step CITES this workflow.

## Proof it works
Dispatched against the freshly-deployed staging build (`943d4bc`, carrying the BUGS-73 `useLayoutEffect` fix) via a temporary push-trigger branch:
```
✓ C3.1 baseline  ✓ C3.2 build  ✓ C3.3 drafted  ✓ C3.4 publish
✓ C3.5 grow — Manual-of-Me edit round-trips (13.0s)
5 passed (35.5s)
```
Full soak now 6/6: C1/C2/C4 (12/0/0) · C3 (5/5) · C5 (advisors 10=baseline, 0 null-token/queue/stale) · C6 (health ok).

## Tests Required
E2E only (the soak journey itself). No unit surface. Verified green on staging as above.

## Security Review
No auth/RLS/input-validation change. The PII filter is unchanged and still enforced — this fix stops the *test* from tripping it, it does not weaken it. Workflow secrets remain STAGING-scoped with a hard prod-ref guard.

## Architecture Impact
No new env vars/tables/routes. Enables an existing CI schedule. Docs: the routine + C1–C6 contract are already in `docs/STAGING_SOAK_ROUTINE.md`.

## Acceptance Criteria
- [x] C3.5 passes on staging (no PII false-positive)
- [x] Daily schedule enabled (fires once on main)
- [x] No temp push-trigger leaked into the workflow
- [x] MCP coverage: N/A (test + CI-schedule only, no user-facing data change)

UI-Bugfix-Only: KAN-413