### PR TITLE
fix(BUGS-74): profile editor silently deletes good_to_know + boundaries (data loss)

### DIFF
--- a/src/app/dashboard/profile/manual-of-me-actions.ts
+++ b/src/app/dashboard/profile/manual-of-me-actions.ts
@@ -34,9 +34,17 @@ import {
  *
  * Null / empty-string values are written as null in the DB so the public-view
  * "skip if empty" logic works correctly.
+ *
+ * BUGS-74 — "not provided" and "explicitly cleared" are different things:
+ *   - `undefined`      → the field is OMITTED from the upsert, leaving whatever
+ *                        is already in the DB untouched. This is what makes the
+ *                        "accepts a partial" promise above actually true.
+ *   - `null` or `''`   → an explicit clear; written as NULL.
+ * Previously `undefined` was coerced to null and written, so any caller that
+ * sent an incomplete object silently destroyed the fields it omitted.
  */
 export async function updateManualOfMe(
-  data: Record<string, string | null>
+  data: Record<string, string | null | undefined>
 ): Promise<ActionResult> {
   const supabase = await createClient();
   const { data: { user } } = await supabase.auth.getUser();
@@ -54,7 +62,12 @@ export async function updateManualOfMe(
       rejected.push(key);
       continue;
     }
-    if (val === null || val === undefined) {
+    // BUGS-74: absent means "leave it alone", not "clear it". Omitting the key
+    // keeps it out of the upsert payload entirely.
+    if (val === undefined) {
+      continue;
+    }
+    if (val === null) {
       sanitised[key] = null;
       continue;
     }

--- a/src/app/dashboard/profile/page.tsx
+++ b/src/app/dashboard/profile/page.tsx
@@ -2,6 +2,7 @@ import { createClient } from '@/lib/supabase-server';
 import { redirect } from 'next/navigation';
 import { EditProfileForm } from './edit-profile-form';
 import type { ManualOfMe } from './manual-of-me-fields';
+import { MANUAL_OF_ME_FIELDS } from './manual-of-me-fields';
 import { isConveneEnabledForCurrentUser } from '@/lib/convene/flags-user';
 
 export const metadata = {
@@ -57,7 +58,12 @@ export default async function ProfilePage() {
 
   const { data: manualOfMeRow } = await supabase
     .from('profile_manual_of_me')
-    .select('communication_style, working_preferences, energises_me, drains_me')
+    // BUGS-74: this select MUST cover every field in MANUAL_OF_ME_FIELDS.
+    // It previously listed only the four v1 columns, so the two KAN-263 fields
+    // (good_to_know, boundaries) were never loaded — the editor rendered them
+    // empty and the section's whole-draft autosave then wrote NULL over saved
+    // member text. Derive it from the allowlist so it can never drift again.
+    .select(MANUAL_OF_ME_FIELDS.join(', '))
     .eq('profile_id', profile.id)
     .maybeSingle();
 

--- a/src/app/dashboard/profile/sections/manual-of-me-section.tsx
+++ b/src/app/dashboard/profile/sections/manual-of-me-section.tsx
@@ -8,9 +8,9 @@
  * any field. Status indicator at the top of the section.
  */
 
-import { useState } from 'react';
+import { useRef, useState } from 'react';
 import type { ManualOfMe } from '../manual-of-me-fields';
-import { MANUAL_OF_ME_MAX_LENGTHS } from '../manual-of-me-fields';
+import { MANUAL_OF_ME_FIELDS, MANUAL_OF_ME_MAX_LENGTHS } from '../manual-of-me-fields';
 import { updateManualOfMe } from '../manual-of-me-actions';
 import { useAutoSave } from './use-auto-save';
 import { SectionSaveBar } from './section-save-bar';
@@ -34,11 +34,30 @@ export function ManualOfMeSection({ manualOfMe }: { manualOfMe: ManualOfMe }) {
     drains_me: manualOfMe.drains_me || '',
   });
 
+  // BUGS-74 — belt-and-braces against a partially-loaded row.
+  //
+  // The real fix is in the loader (page.tsx now selects every field in
+  // MANUAL_OF_ME_FIELDS). This guard makes the section safe even if a caller
+  // ever hands it an incomplete row again: a field that arrived `undefined`
+  // was never loaded, so we cannot tell "the member cleared it" from "we never
+  // saw it" — and sending '' would null out saved text. Such a field is left
+  // OUT of the save payload until the member actually types in it, at which
+  // point it carries a real value and is safe to write.
+  const neverLoaded = useRef<Set<string>>(
+    new Set(MANUAL_OF_ME_FIELDS.filter((f) => manualOfMe[f] === undefined)),
+  );
+
   // `updateManualOfMe` takes Record<string, string | null>; ManualOfMeDraft's
   // typed keys narrow it to a literal-keyed object, so we widen explicitly.
-  const { status, flush } = useAutoSave(draft, async (v) =>
-    updateManualOfMe(v as unknown as Record<string, string | null>),
-  );
+  const { status, flush } = useAutoSave(draft, async (v) => {
+    const payload: Record<string, string | null> = {};
+    for (const [key, value] of Object.entries(v as unknown as Record<string, string>)) {
+      // Untouched + never loaded → omit, so the upsert leaves the DB value be.
+      if (neverLoaded.current.has(key) && value === '') continue;
+      payload[key] = value;
+    }
+    return updateManualOfMe(payload);
+  });
 
   const set = <K extends keyof ManualOfMeDraft>(key: K, value: ManualOfMeDraft[K]) =>
     setDraft((d) => ({ ...d, [key]: value }));

--- a/tests/unit/bugs74-manual-of-me-field-coverage.test.ts
+++ b/tests/unit/bugs74-manual-of-me-field-coverage.test.ts
@@ -1,0 +1,86 @@
+/**
+ * BUGS-74 regression guard — every page that LOADS profile_manual_of_me must
+ * load EVERY field in MANUAL_OF_ME_FIELDS.
+ *
+ * The bug: the single-page profile editor selected only the four v1 columns.
+ * The two KAN-263 fields (good_to_know, boundaries) were never fetched, so the
+ * editor seeded them as '' and its whole-draft autosave wrote NULL over saved
+ * member text on the first edit to ANY field. Silent, member-visible data loss
+ * — live on develop, staging, beta and production.
+ *
+ * The general lesson this guards: a page that loads a SUBSET of an allowlisted
+ * field set and saves the WHOLE form back will silently delete the difference.
+ * These tests fail the moment a loader drifts from the allowlist again, which
+ * is the only thing that would have caught the original defect.
+ */
+
+import { readFileSync, existsSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { MANUAL_OF_ME_FIELDS } from '@/app/dashboard/profile/manual-of-me-fields';
+
+/** Pull the `.select(...)` argument attached to the profile_manual_of_me query. */
+function manualOfMeSelectArg(source: string, file: string): string {
+  const from = source.indexOf("from('profile_manual_of_me')");
+  if (from === -1) {
+    throw new Error(`No profile_manual_of_me query found in ${file}`);
+  }
+  const after = source.slice(from);
+  const match = after.match(/\.select\(\s*([\s\S]*?)\s*\)/);
+  if (!match) {
+    throw new Error(`No .select() found after the profile_manual_of_me query in ${file}`);
+  }
+  return match[1];
+}
+
+/**
+ * A loader is safe if it either derives the column list from the shared
+ * allowlist (drift-proof by construction) or spells out every field literally.
+ */
+function assertCoversEveryField(selectArg: string, file: string): void {
+  const derived = selectArg.includes('MANUAL_OF_ME_FIELDS');
+  if (derived) return;
+
+  const missing = MANUAL_OF_ME_FIELDS.filter((f) => !selectArg.includes(f));
+  if (missing.length > 0) {
+    throw new Error(
+      `${file} selects a literal column list that is missing: ${missing.join(', ')}. ` +
+        'A field that is loaded-but-not-selected is silently NULLed by the section ' +
+        'autosave (BUGS-74). Add the field, or derive the select from MANUAL_OF_ME_FIELDS.',
+    );
+  }
+}
+
+const LOADERS = [
+  { label: 'profile editor', path: 'src/app/dashboard/profile/page.tsx' },
+  { label: 'public profile', path: 'src/app/[slug]/page.tsx' },
+];
+
+describe('BUGS-74 — profile_manual_of_me loaders cover the full allowlist', () => {
+  test.each(LOADERS)('$label ($path) loads every allowlisted field', ({ path }) => {
+    const abs = resolve(__dirname, '../..', path);
+    if (!existsSync(abs)) {
+      throw new Error(`Expected loader not found at ${abs}`);
+    }
+    const source = readFileSync(abs, 'utf-8');
+    const selectArg = manualOfMeSelectArg(source, path);
+    expect(() => assertCoversEveryField(selectArg, path)).not.toThrow();
+  });
+
+  test('the allowlist still has the two fields the editor used to drop', () => {
+    // If these are ever removed the tests above would vacuously pass.
+    expect(MANUAL_OF_ME_FIELDS).toContain('good_to_know');
+    expect(MANUAL_OF_ME_FIELDS).toContain('boundaries');
+    expect(MANUAL_OF_ME_FIELDS.length).toBe(6);
+  });
+
+  test('the guard itself catches a drifted literal select', () => {
+    // Proves these assertions are not vacuous: the pre-fix editor select
+    // (four columns) must be rejected.
+    expect(() =>
+      assertCoversEveryField(
+        "'communication_style, working_preferences, energises_me, drains_me'",
+        'fixture',
+      ),
+    ).toThrow();
+  });
+});

--- a/tests/unit/bugs74-manual-of-me-partial-save.test.ts
+++ b/tests/unit/bugs74-manual-of-me-partial-save.test.ts
@@ -1,0 +1,126 @@
+/**
+ * BUGS-74 — updateManualOfMe must be genuinely partial-safe.
+ *
+ * Its doc comment always claimed it "accepts a partial", but an `undefined`
+ * value was coerced to null and written, so a caller that sent an incomplete
+ * object silently destroyed the fields it omitted. That is exactly how the
+ * profile editor deleted members' `good_to_know` / `boundaries` text.
+ *
+ * These tests pin the distinction the fix introduces:
+ *   undefined  → NOT PROVIDED   → omitted from the upsert (DB value untouched)
+ *   null / ''  → EXPLICIT CLEAR → written as NULL
+ *
+ * The second half is just as important as the first: making the action
+ * partial-safe must not break a member's ability to actually empty a box.
+ */
+
+// --- Mocks (mirrors tests/unit/manual-of-me-actions.test.ts) -------------
+
+const mockRevalidatePath = jest.fn();
+jest.mock('next/cache', () => ({
+  revalidatePath: (...args: unknown[]) => mockRevalidatePath(...args),
+}));
+
+const mockUpsertCapture = jest.fn();
+const mockGetUser = jest.fn();
+const mockProfileSelectSingle = jest.fn();
+
+jest.mock('@/lib/supabase-server', () => ({
+  createClient: jest.fn().mockImplementation(async () => ({
+    auth: { getUser: mockGetUser },
+    from: jest.fn().mockImplementation((table: string) => {
+      if (table === 'profiles') {
+        return { select: () => ({ eq: () => ({ single: mockProfileSelectSingle }) }) };
+      }
+      if (table === 'profile_manual_of_me') {
+        return {
+          upsert: (data: unknown, opts: unknown) => {
+            mockUpsertCapture(data, opts);
+            return Promise.resolve({ error: null });
+          },
+        };
+      }
+      throw new Error(`Unexpected table in test: ${table}`);
+    }),
+  })),
+}));
+
+import { updateManualOfMe } from '@/app/dashboard/profile/manual-of-me-actions';
+
+beforeEach(() => {
+  mockUpsertCapture.mockClear();
+  mockRevalidatePath.mockClear();
+  mockGetUser.mockReset();
+  mockProfileSelectSingle.mockReset();
+  mockGetUser.mockResolvedValue({ data: { user: { id: 'user-1' } } });
+  mockProfileSelectSingle.mockResolvedValue({ data: { id: 'profile-1' }, error: null });
+});
+
+const payloadOf = () => mockUpsertCapture.mock.calls[0][0] as Record<string, unknown>;
+
+describe('BUGS-74 — "not provided" never destroys a stored value', () => {
+  test('a single-field update leaves the other five out of the upsert entirely', async () => {
+    const result = await updateManualOfMe({ communication_style: 'Async please' });
+
+    expect(result).toEqual({ success: true });
+    // The whole point: absent keys must not appear in the payload at all.
+    // A key present with value null would still NULL the column.
+    expect(payloadOf()).toEqual({
+      profile_id: 'profile-1',
+      communication_style: 'Async please',
+    });
+  });
+
+  test('explicitly-undefined keys are dropped, not written as null (the data-loss path)', async () => {
+    // This is the exact shape the editor used to send: the two fields it never
+    // loaded came through as undefined and were written as NULL.
+    await updateManualOfMe({
+      communication_style: 'Async please',
+      good_to_know: undefined,
+      boundaries: undefined,
+    });
+
+    const payload = payloadOf();
+    expect(payload).not.toHaveProperty('good_to_know');
+    expect(payload).not.toHaveProperty('boundaries');
+    expect(payload).toEqual({
+      profile_id: 'profile-1',
+      communication_style: 'Async please',
+    });
+  });
+
+  test('an all-undefined payload is a no-op success — no DB write at all', async () => {
+    const result = await updateManualOfMe({
+      good_to_know: undefined,
+      boundaries: undefined,
+    });
+
+    expect(result).toEqual({ success: true });
+    expect(mockUpsertCapture).not.toHaveBeenCalled();
+  });
+});
+
+describe('BUGS-74 — explicit clears still clear (the fix must not overshoot)', () => {
+  test('empty string still writes NULL', async () => {
+    await updateManualOfMe({ good_to_know: '' });
+    expect(payloadOf()).toEqual({ profile_id: 'profile-1', good_to_know: null });
+  });
+
+  test('explicit null still writes NULL', async () => {
+    await updateManualOfMe({ boundaries: null });
+    expect(payloadOf()).toEqual({ profile_id: 'profile-1', boundaries: null });
+  });
+
+  test('whitespace-only still writes NULL (sanitised to empty)', async () => {
+    await updateManualOfMe({ good_to_know: '   ' });
+    expect(payloadOf()).toEqual({ profile_id: 'profile-1', good_to_know: null });
+  });
+
+  test('clearing one field while omitting another clears only the one', async () => {
+    await updateManualOfMe({ good_to_know: '', boundaries: undefined });
+
+    const payload = payloadOf();
+    expect(payload).toEqual({ profile_id: 'profile-1', good_to_know: null });
+    expect(payload).not.toHaveProperty('boundaries');
+  });
+});


### PR DESCRIPTION
Closes BUGS-74. **Severity: silent member data loss, live on develop, staging, beta and production.**

## What was happening

`src/app/dashboard/profile/page.tsx` loaded only **four** of the six `profile_manual_of_me` columns. `good_to_know` and `boundaries` were never fetched, so:

1. the editor rendered them as **empty boxes** even for a member who had saved text;
2. `ManualOfMeSection` seeded the draft with `manualOfMe.good_to_know || ''` → `''`;
3. the section autosaves the **whole draft**, so editing *any one* of the six posted `''` for the two that were never loaded;
4. `manual-of-me-actions.ts` turns `''` into `null`;
5. the `.upsert()` writes all six columns → **the two are NULLed**.

No error surfaced. The values still rendered on the **public** profile (which correctly reads all six), so the loss stayed invisible until someone reopened the editor — by which point the text was gone from the database too. This is the most likely mechanical explanation for a member reporting that profile answers "disappeared".

Opening the editor was always safe — `useAutoSave` skips the first render. The write happened on the first edit to any field.

## Blast radius — measured, read-only, this commit

| Env | rows | `good_to_know` populated | `boundaries` populated |
|---|---|---|---|
| production | 25 | **25** | **10** |
| staging | 9 | 9 | 6 |
| dev | 26 | 25 | 9 |

Production still reads **25 / 10** — exactly the counts recorded when BUGS-74 was raised — so **no further loss has occurred since**. Every value is intact until its owner next edits a Manual-of-Me field, which is what this PR stops.

## The fix — three layers, smallest first

**(a) The loader, the actual bug.** `page.tsx` now derives the select from the shared allowlist rather than a hand-maintained literal, so it cannot drift again:

```ts
.select(MANUAL_OF_ME_FIELDS.join(', '))
```

Verified this keeps supabase-js type inference (`tsc --noEmit` clean apart from the repo's pre-existing local `jose` gap).

**(b) `updateManualOfMe` is now genuinely partial-safe.** Its docblock always claimed it "accepts a partial", but `undefined` was coerced to `null` and written. Now:

| input | meaning | result |
|---|---|---|
| `undefined` | not provided | **omitted from the upsert** — DB value untouched |
| `null` / `''` | explicit clear | written as `NULL` (unchanged) |

This removes the whole class of bug rather than this one instance.

**(c) The section hardens against a partially-loaded row.** A field arriving `undefined` was never loaded, so we cannot distinguish "the member cleared it" from "we never saw it" — it is left out of the save payload until the member actually types in it. Defensive only now that (a) is fixed.

## Tests — +11, no existing test touched

- **`bugs74-manual-of-me-field-coverage`** — the guard that would have caught this: asserts every `profile_manual_of_me` loader (editor **and** public profile) covers the full allowlist, and accepts either a derived or a complete literal select. Proven non-vacuous: restoring the pre-fix four-column select fails it with *"missing: good_to_know, boundaries"*.
- **`bugs74-manual-of-me-partial-save`** — pins `undefined`→omitted against `null`/`''`→`NULL`, including that clearing one field while omitting another clears **only** the one. The fix must not overshoot into "you can no longer empty a box".

**No existing assertion was modified** — nothing previously covered the `undefined` case, so the partial-safety change weakens nothing. The pre-existing Manual-of-Me suites (`manual-of-me-actions`, `bugs70-manual-of-me-persist`, `auto-save-flush`, `moderation-actions`, `profile-rate-limit-wiring`) all pass unchanged: 96/96.

Local `npm run test:unit`: **2483 passed** (baseline 2472). The 7 failures are the repo's pre-existing local-environment ones (missing `jose` module ×8 suites; a shell-script test exiting 127 on a missing GNU binary) and reproduce identically on an untouched `develop` checkout — CI's own *Lint & Unit Tests* is green on develop.

## Not included

The ticket also asks for an E2E round-trip. Its natural home, `tests/e2e/authed/journey.authed.spec.ts`, is being edited by another session right now (the Convene assertion work), so adding to it here would conflict. The two unit guards above cover the regression itself; flagged on the ticket as the remaining follow-up.

## Security review

No new attack surface. The widened `select` returns two extra columns of the requesting member's **own** row only — the query is already `.eq('profile_id', profile.id)` behind their session, and RLS still enforces ownership on the upsert. The writable allowlist is unchanged, so no new field becomes writable. Fix (b) strictly *reduces* risk by preventing an unintended destructive write.

## Docs / system map updated

N/A — no schema, migration, env var, route, scheduled job or security boundary changed. The MCP server already reads and writes all six columns correctly (`lyra-mcp-server/src/index.ts:214`), so this **closes** a web-vs-MCP divergence rather than creating one; no MCP-lockstep PR needed.