### PR TITLE
fix(profile): stop the editor NULLing good_to_know + boundaries (BUGS-74)

### DIFF
--- a/src/app/dashboard/profile/legacy/page.tsx
+++ b/src/app/dashboard/profile/legacy/page.tsx
@@ -1,7 +1,7 @@
 import { createClient } from '@/lib/supabase-server';
 import { redirect } from 'next/navigation';
 import { ProfileWizard } from '../wizard';
-import type { ManualOfMe } from '../manual-of-me-fields';
+import { MANUAL_OF_ME_FIELDS, type ManualOfMe } from '../manual-of-me-fields';
 
 export const metadata = {
   title: 'Edit your profile (legacy) — Lyra',
@@ -58,7 +58,9 @@ export default async function LegacyProfilePage() {
 
   const { data: manualOfMeRow } = await supabase
     .from('profile_manual_of_me')
-    .select('communication_style, working_preferences, energises_me, drains_me')
+    // BUGS-74 — same defect as the single-page editor: derive from the shared
+    // allowlist so a hand-listed subset can never silently NULL the rest.
+    .select(MANUAL_OF_ME_FIELDS.join(', '))
     .eq('profile_id', profile.id)
     .maybeSingle();
 

--- a/src/app/dashboard/profile/manual-of-me-actions.ts
+++ b/src/app/dashboard/profile/manual-of-me-actions.ts
@@ -34,9 +34,17 @@ import {
  *
  * Null / empty-string values are written as null in the DB so the public-view
  * "skip if empty" logic works correctly.
+ *
+ * BUGS-74 — "explicitly cleared" and "not provided" are NOT the same thing:
+ *   - `null` or `''`  → the member cleared the box → write NULL.
+ *   - `undefined`     → the caller did not supply this field → omit it from
+ *                       the upsert payload entirely, leaving the stored value
+ *                       untouched.
+ * Previously `undefined` was coerced to NULL, so any caller holding a
+ * partially-loaded row destroyed the columns it had never read.
  */
 export async function updateManualOfMe(
-  data: Record<string, string | null>
+  data: Record<string, string | null | undefined>
 ): Promise<ActionResult> {
   const supabase = await createClient();
   const { data: { user } } = await supabase.auth.getUser();
@@ -54,7 +62,12 @@ export async function updateManualOfMe(
       rejected.push(key);
       continue;
     }
-    if (val === null || val === undefined) {
+    // BUGS-74 — not-supplied ≠ cleared. Omit undefined so the upsert never
+    // overwrites a column the caller never loaded.
+    if (val === undefined) {
+      continue;
+    }
+    if (val === null) {
       sanitised[key] = null;
       continue;
     }

--- a/src/app/dashboard/profile/page.tsx
+++ b/src/app/dashboard/profile/page.tsx
@@ -1,7 +1,7 @@
 import { createClient } from '@/lib/supabase-server';
 import { redirect } from 'next/navigation';
 import { EditProfileForm } from './edit-profile-form';
-import type { ManualOfMe } from './manual-of-me-fields';
+import { MANUAL_OF_ME_FIELDS, type ManualOfMe } from './manual-of-me-fields';
 import { isConveneEnabledForCurrentUser } from '@/lib/convene/flags-user';
 
 export const metadata = {
@@ -57,7 +57,11 @@ export default async function ProfilePage() {
 
   const { data: manualOfMeRow } = await supabase
     .from('profile_manual_of_me')
-    .select('communication_style, working_preferences, energises_me, drains_me')
+    // BUGS-74 — derive the column list from the shared allowlist. Hard-coding a
+    // subset here silently deleted good_to_know + boundaries: the section
+    // autosaves the WHOLE draft, so any column the loader failed to fetch was
+    // seeded as '' and written back as NULL. Never hand-list these again.
+    .select(MANUAL_OF_ME_FIELDS.join(', '))
     .eq('profile_id', profile.id)
     .maybeSingle();
 

--- a/tests/unit/bugs74-manual-of-me-field-drift.test.ts
+++ b/tests/unit/bugs74-manual-of-me-field-drift.test.ts
@@ -1,0 +1,182 @@
+/**
+ * BUGS-74 — the profile editor silently deleted "Good to know about me" and
+ * "My boundaries" whenever any Manual-of-Me field was edited.
+ *
+ * Root cause: `src/app/dashboard/profile/page.tsx` hand-listed FOUR of the six
+ * allowlisted `profile_manual_of_me` columns. `good_to_know` + `boundaries`
+ * (added later under KAN-263) were never fetched, so the section seeded them as
+ * '' and the autosave — which posts the WHOLE draft — wrote NULL over both.
+ * The member saw no error; the text stayed on their public profile (which reads
+ * all six) until the next page load, by which point the DB value was gone.
+ *
+ * Two independent guards, because either alone would have stopped this:
+ *
+ *   1. LOADER-vs-ALLOWLIST DRIFT — every query against profile_manual_of_me
+ *      must cover every entry in MANUAL_OF_ME_FIELDS. Deriving the select from
+ *      the shared constant satisfies this permanently; a hand-listed subset
+ *      fails here. This is the test that would have caught the original bug,
+ *      and it will catch the next field added to the allowlist.
+ *
+ *   2. PARTIAL-SAFE WRITES — "not supplied" (undefined) must never be written
+ *      as NULL. Only an explicit null / '' clears a field. This kills the whole
+ *      bug class rather than this one instance: even a future caller holding a
+ *      partially-loaded row can no longer destroy the columns it never read.
+ */
+
+// --- Mocks --------------------------------------------------------------
+
+const mockRevalidatePath = jest.fn();
+jest.mock('next/cache', () => ({
+  revalidatePath: (...args: unknown[]) => mockRevalidatePath(...args),
+}));
+
+const mockUpsert = jest.fn();
+const mockGetUser = jest.fn();
+const mockProfileSelectSingle = jest.fn();
+
+jest.mock('@/lib/supabase-server', () => ({
+  createClient: jest.fn().mockImplementation(async () => ({
+    auth: { getUser: mockGetUser },
+    from: jest.fn().mockImplementation((table: string) => {
+      if (table === 'profiles') {
+        return { select: () => ({ eq: () => ({ single: mockProfileSelectSingle }) }) };
+      }
+      if (table === 'profile_manual_of_me') {
+        return {
+          upsert: (data: unknown, opts: unknown) => Promise.resolve(mockUpsert(data, opts)),
+        };
+      }
+      if (table === 'content_moderation_flags') {
+        return { insert: () => Promise.resolve({ error: null }) };
+      }
+      throw new Error(`Unexpected table in test: ${table}`);
+    }),
+  })),
+}));
+
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { updateManualOfMe } from '@/app/dashboard/profile/manual-of-me-actions';
+import { MANUAL_OF_ME_FIELDS } from '@/app/dashboard/profile/manual-of-me-fields';
+
+beforeEach(() => {
+  mockRevalidatePath.mockClear();
+  mockGetUser.mockReset();
+  mockProfileSelectSingle.mockReset();
+  mockUpsert.mockReset();
+  mockGetUser.mockResolvedValue({ data: { user: { id: 'user-1' } } });
+  mockProfileSelectSingle.mockResolvedValue({ data: { id: 'profile-1' }, error: null });
+  mockUpsert.mockReturnValue({ error: null });
+});
+
+// --- 1. Loader-vs-allowlist drift guard ---------------------------------
+
+/** Extract the `.select(...)` argument of the profile_manual_of_me query. */
+function manualOfMeSelectExpr(relPath: string): string {
+  const src = readFileSync(resolve(__dirname, '../..', relPath), 'utf-8');
+  const block = src.match(/\.from\(\s*['"]profile_manual_of_me['"]\s*\)([\s\S]{0,800}?)\.eq\(/);
+  if (!block) {
+    throw new Error(
+      `${relPath}: no profile_manual_of_me query found. If the query moved, ` +
+        `move this guard with it — do not delete it (BUGS-74).`,
+    );
+  }
+  const sel = block[1].match(/\.select\(([^\n]*)\)/);
+  if (!sel) throw new Error(`${relPath}: profile_manual_of_me query has no .select(...)`);
+  return sel[1];
+}
+
+describe('BUGS-74: every profile_manual_of_me loader covers the full allowlist', () => {
+  // All three routes that read the table for display. The public profile was
+  // always correct and is included as the reference case — if it ever drifts,
+  // members' saved text stops rendering publicly.
+  const LOADERS = [
+    'src/app/dashboard/profile/page.tsx', // the editor — where BUGS-74 lived
+    'src/app/dashboard/profile/legacy/page.tsx', // the wizard rollback path — same defect
+    'src/app/[slug]/page.tsx', // the public profile — the correct reference
+  ];
+
+  test.each(LOADERS)('%s selects every MANUAL_OF_ME_FIELDS column', (relPath) => {
+    const expr = manualOfMeSelectExpr(relPath);
+
+    // Deriving the list from the shared constant is drift-proof by construction
+    // and is the preferred form. A hand-written literal list is still allowed,
+    // but then it must name every allowlisted column.
+    const derivesFromAllowlist = /MANUAL_OF_ME_FIELDS/.test(expr);
+    const missing = derivesFromAllowlist
+      ? []
+      : MANUAL_OF_ME_FIELDS.filter((f) => !expr.includes(f));
+
+    // A non-empty list here IS the bug: any column the loader fails to fetch is
+    // seeded as '' by the section and written back as NULL on the next edit.
+    expect(missing).toEqual([]);
+  });
+
+  test('the allowlist still contains the two columns the editor used to drop', () => {
+    // Pins the specific regression: if these are ever removed from the
+    // allowlist the guard above would pass vacuously.
+    expect(MANUAL_OF_ME_FIELDS).toContain('good_to_know');
+    expect(MANUAL_OF_ME_FIELDS).toContain('boundaries');
+    expect(MANUAL_OF_ME_FIELDS).toHaveLength(6);
+  });
+});
+
+// --- 2. Partial-safe writes: cleared vs not-supplied ---------------------
+
+describe('BUGS-74: updateManualOfMe never NULLs a field it was not given', () => {
+  test('a single-field update does not touch the other five', async () => {
+    const result = await updateManualOfMe({ communication_style: 'Direct and brief' });
+
+    expect(result).toEqual({ success: true });
+    const [payload] = mockUpsert.mock.calls[0];
+    expect(payload).toEqual({ profile_id: 'profile-1', communication_style: 'Direct and brief' });
+    // The exact destroy path: these keys must be ABSENT, not null.
+    expect(payload).not.toHaveProperty('good_to_know');
+    expect(payload).not.toHaveProperty('boundaries');
+  });
+
+  test('explicitly-undefined keys are omitted from the payload (the partially-loaded-row case)', async () => {
+    // This is precisely what the editor sent before the fix: a draft built from
+    // a row that never contained the two columns.
+    const result = await updateManualOfMe({
+      communication_style: 'Direct and brief',
+      good_to_know: undefined,
+      boundaries: undefined,
+    });
+
+    expect(result).toEqual({ success: true });
+    const [payload] = mockUpsert.mock.calls[0];
+    expect(payload).not.toHaveProperty('good_to_know');
+    expect(payload).not.toHaveProperty('boundaries');
+  });
+
+  test('an all-undefined update writes nothing at all', async () => {
+    const result = await updateManualOfMe({ good_to_know: undefined, boundaries: undefined });
+
+    expect(result).toEqual({ success: true });
+    expect(mockUpsert).not.toHaveBeenCalled();
+  });
+
+  // --- the other half of the distinction: clearing must still clear ---
+
+  test('an explicit null still clears the field', async () => {
+    await updateManualOfMe({ good_to_know: null });
+
+    const [payload] = mockUpsert.mock.calls[0];
+    expect(payload).toEqual({ profile_id: 'profile-1', good_to_know: null });
+  });
+
+  test('an emptied textarea (empty string) still clears the field', async () => {
+    await updateManualOfMe({ boundaries: '' });
+
+    const [payload] = mockUpsert.mock.calls[0];
+    expect(payload).toEqual({ profile_id: 'profile-1', boundaries: null });
+  });
+
+  test('a whitespace-only textarea still clears the field', async () => {
+    await updateManualOfMe({ boundaries: '   ' });
+
+    const [payload] = mockUpsert.mock.calls[0];
+    expect(payload).toEqual({ profile_id: 'profile-1', boundaries: null });
+  });
+});


### PR DESCRIPTION
## Summary

**Data-loss fix. The defect is live on `develop`, `staging`, `beta` and `main`.**

The single-page profile editor selected only **four** of the six allowlisted `profile_manual_of_me` columns. `good_to_know` and `boundaries` (added later under KAN-263) were never fetched, so `ManualOfMeSection` seeded them as `''` and the autosave — which posts the **whole** draft — wrote `NULL` over both on the first edit to *any* of the six fields.

The member saw no error, and the text still rendered on their **public** profile (which reads all six correctly), so the loss stayed invisible until the next editor load — by which point the value was already gone from the database.

Two independent fixes, either of which alone would have prevented it:

**(a) Derive the loader's `select` from the shared allowlist** so it can never drift again:

```
.select(MANUAL_OF_ME_FIELDS.join(', '))
```

Applied to **both** `src/app/dashboard/profile/page.tsx` (where the bug was reported) **and** `src/app/dashboard/profile/legacy/page.tsx`, which carried the byte-identical defect and is still the live rollback path. `src/app/[slug]/page.tsx` was already correct and is kept as the reference case in the guard.

**(b) Make `updateManualOfMe` genuinely partial-safe**, as its doc comment has always claimed. "Not supplied" (`undefined`) is now omitted from the upsert payload rather than coerced to `NULL`; only an explicit `null` or `''` clears a field. This removes the whole bug class rather than this one instance — a future caller holding a partially-loaded row can no longer destroy columns it never read.

Optional part (c) from the ticket (client-side `undefined` handling in the section) was **deliberately not taken**, to keep the diff limited to the correction.

### UI ownership

Two of the four files are under `src/app/**/*.tsx`, which is Luisa-owned. This change **adds no design, layout, colour, typography or user-facing copy, and alters none** — it is a data-fetch correction that *restores* two saved-text boxes which currently render blank. That is the rendering-error carve-out in House rule 9, so the commit carries the `UI-Bugfix-Only: BUGS-74` trailer. `scripts/check-ui-copy-ownership.sh` passes and names both touched paths. Worth a spot-check on exactly those two lines.

### Verification

The new drift guard was confirmed to **fail on the pre-fix loader** with exactly `["good_to_know", "boundaries"]`, and to pass after — it is a real regression test, not a vacuous one.

- Full unit suite: **2550 passed / 215 suites** (floor 2118)
- The two existing Manual-of-Me suites (`manual-of-me-actions`, `bugs70-manual-of-me-persist`) pass **unmodified** — no assertion was changed, weakened or skipped

### Not covered by this PR

- The **E2E** leg from the ticket's test plan (seed all six → edit one → reload → assert all six survive) is not included here; it belongs in the founder-gated authed journey suite.
- Acceptance also asks for a **read-only check across all three environments** confirming realised loss is zero. Not run: the autopilot does not touch production data. Luisa's call.

## Jira Ticket

BUGS-74

## Checklist

- [x] Unit tests added/updated for new/changed functionality — new `tests/unit/bugs74-manual-of-me-field-drift.test.ts` (10 tests: loader-vs-allowlist drift guard across all three loaders + cleared-vs-not-supplied behaviour)
- [x] All existing tests pass (`npm run test:unit`) — 2550 passed / 215 suites
- [x] Lint passes (`npm run lint`) — 0 errors (24 pre-existing warnings, unchanged)
- [x] Type check passes (`npm run type-check`) — 0 errors
- [x] Build succeeds (`npm run build`)
- [x] Coverage has not decreased — net new tests only, no test removed
- [x] No eslint-disable or ts-ignore without KAN-XX reference — none added
- [ ] ARCHITECTURE.md updated if architectural changes were made — **N/A**, no schema, route, env var or service change
- [ ] Ops routine / Control-Room registry updated — **N/A**, no scheduled-routine behaviour, cadence or ownership changed
- [ ] Docs / system map updated — **N/A**: no architectural or data-model change (the column set is unchanged; only which columns the loader reads). The ticket suggests capturing the general lesson — *any page that loads a subset of an allowlisted field set and saves the whole form back will silently delete the difference* — as a `CLAUDE.md` gotcha; deliberately left out of this PR to keep the fix diff minimal, and flagged here so it is a conscious decision rather than an omission.

MCP coverage: N/A — the MCP server already reads and writes all six columns correctly (`lyra-mcp-server/src/index.ts:214`). This closes an existing web-vs-MCP divergence rather than creating one.

https://claude.ai/code/session_01MQsMAwMEvMU3sDKxa4PhRA

---
_Generated by [Claude Code](https://claude.ai/code/session_01MQsMAwMEvMU3sDKxa4PhRA)_