### PR TITLE
fix(profile): close the BUGS-74 gap left on the legacy editor

### DIFF
--- a/src/app/dashboard/profile/legacy/page.tsx
+++ b/src/app/dashboard/profile/legacy/page.tsx
@@ -1,7 +1,7 @@
 import { createClient } from '@/lib/supabase-server';
 import { redirect } from 'next/navigation';
 import { ProfileWizard } from '../wizard';
-import type { ManualOfMe } from '../manual-of-me-fields';
+import { MANUAL_OF_ME_FIELDS, type ManualOfMe } from '../manual-of-me-fields';
 
 export const metadata = {
   title: 'Edit your profile (legacy) — Lyra',
@@ -58,7 +58,10 @@ export default async function LegacyProfilePage() {
 
   const { data: manualOfMeRow } = await supabase
     .from('profile_manual_of_me')
-    .select('communication_style, working_preferences, energises_me, drains_me')
+    // BUGS-74: the byte-identical defect the single-page editor had. This is
+    // still the live rollback path, so a rollback would resume the silent data
+    // loss. Derive from the allowlist so it can never drift again.
+    .select(MANUAL_OF_ME_FIELDS.join(', '))
     .eq('profile_id', profile.id)
     .maybeSingle();
 

--- a/tests/unit/bugs74-manual-of-me-field-coverage.test.ts
+++ b/tests/unit/bugs74-manual-of-me-field-coverage.test.ts
@@ -53,6 +53,11 @@ function assertCoversEveryField(selectArg: string, file: string): void {
 const LOADERS = [
   { label: 'profile editor', path: 'src/app/dashboard/profile/page.tsx' },
   { label: 'public profile', path: 'src/app/[slug]/page.tsx' },
+  // BUGS-74 follow-up: the legacy step-by-step editor carried the identical
+  // four-column select and was missed by the original fix. It is the live
+  // rollback path, so leaving it drifted meant a rollback would resume the
+  // data loss. Every loader belongs in this list, not just the default one.
+  { label: 'legacy profile editor', path: 'src/app/dashboard/profile/legacy/page.tsx' },
 ];
 
 describe('BUGS-74 — profile_manual_of_me loaders cover the full allowlist', () => {


### PR DESCRIPTION
## Summary

**Follow-up to PR #584, which fixed BUGS-74 incompletely.**

#584 landed on `develop` and fixed the single-page profile editor plus made `updateManualOfMe` partial-safe. It left `src/app/dashboard/profile/legacy/page.tsx` carrying the **byte-identical four-column select**:

```
.select('communication_style, working_preferences, energises_me, drains_me')
```

That page is still the **live rollback path** (`/dashboard/profile/legacy`, kept for one release). So a rollback to the legacy editor would have silently resumed deleting `good_to_know` + `boundaries` — the exact data loss BUGS-74 was raised to stop.

Two changes:

1. **`legacy/page.tsx` derives its select from `MANUAL_OF_ME_FIELDS`**, the same way `page.tsx` and `[slug]/page.tsx` already do after #584.
2. **The BUGS-74 coverage guard listed only two of the three loaders** — which is precisely why the legacy page slipped through #584. The legacy loader is added to `LOADERS` so the guard covers *every* loader, not just the default one.

### Verification the guard is non-vacuous

With the legacy fix reverted, `tests/unit/bugs74-manual-of-me-field-coverage.test.ts` fails with exactly:

```
src/app/dashboard/profile/legacy/page.tsx selects a literal column list
that is missing: good_to_know, boundaries
```

and passes with the fix applied. It is a real regression test.

### Test integrity

No assertion was changed, weakened or skipped. The only test edit is **adding an entry to the `LOADERS` list** — net-new coverage on an existing guard.

### Relationship to PR #585

PR #585 (open, draft) is a parallel session's independent fix for the same ticket. It conflicts with `develop` because #584 already landed the overlapping parts, and it is now largely redundant — **except** for the legacy-page fix, which this PR carries. Recommend closing #585 as superseded once this lands.

### Pre-existing failure noted, not touched

`tests/unit/version-drift.test.js` fails on **clean `develop`** as well as on this branch — `package.json` is `0.1.37` while tags have reached `v0.1.90`. That is the known **KAN-166** drift (gotcha #12), unrelated to this change. Per the Test Integrity Policy I have not modified it; flagging it for a decision.

## Jira Ticket

BUGS-74

## Checklist

- [x] Unit tests added/updated for new/changed functionality — legacy loader added to the BUGS-74 drift guard; 12/12 pass across both BUGS-74 suites
- [x] All existing tests pass (`npm run test:unit`) — **2551 passed / 215 suites**; the single failure is the pre-existing `version-drift` (KAN-166), identical on clean `develop`
- [x] Lint passes (`npm run lint`) — 0 errors (24 pre-existing warnings, unchanged)
- [x] Type check passes (`npm run type-check`) — 0 errors
- [x] Build succeeds (`npm run build`)
- [x] Coverage has not decreased — net-new coverage only, nothing removed
- [x] No eslint-disable or ts-ignore without KAN-XX reference — none added
- [ ] ARCHITECTURE.md updated if architectural changes were made — **N/A**: no schema, route, env var or service change; only which columns an existing loader reads
- [ ] Ops routine / Control-Room registry updated — **N/A**: no scheduled-routine behaviour, cadence or ownership changed
- [ ] Docs / system map updated — **N/A**: no architectural or data-model change. The column set is unchanged. The generalisable lesson (*a page that loads a subset of an allowlisted field set and saves the whole form back will silently delete the difference*) is worth a `CLAUDE.md` gotcha, but is deliberately left out of this fix diff — flagged so it is a conscious omission rather than an oversight.

### UI ownership

`legacy/page.tsx` is under `src/app/**/*.tsx` (Luisa-owned). This change **adds and alters no design, layout, colour, typography or user-facing copy** — it is a data-fetch correction that *restores* two saved-text boxes which currently render blank. That is the rendering-error carve-out in House rule 9, hence the `UI-Bugfix-Only: BUGS-74` commit trailer.

MCP coverage: N/A — the MCP server already reads and writes all six columns correctly. This closes a web-vs-MCP divergence rather than creating one.

---
_Generated by [Claude Code](https://claude.ai/code/session_01B2pZQL2UgSC6HPPt3JqBob)_