### PR TITLE
refactor(KAN-424): move computeAccessTransition out of the admin route tree into src/lib/access-model/

### DIFF
--- a/src/app/admin/users/actions.ts
+++ b/src/app/admin/users/actions.ts
@@ -22,10 +22,10 @@ import { revalidatePath } from 'next/cache';
 import { createClient } from '@/lib/supabase-server';
 import { getCurrentAdmin, getAdminServiceClient, logModerationAction, logModerationActionsBatch } from '@/lib/admin';
 import { sendBetaApprovedEmail } from '@/lib/beta-access/email';
+import { computeAccessTransition } from '@/lib/access-model';
 import {
   BULK_MAX,
   EMAIL_CAP,
-  computeAccessTransition,
   isBulkAction,
   type BulkAction,
   type UserFilter,

--- a/src/app/admin/users/users-actions-shared.ts
+++ b/src/app/admin/users/users-actions-shared.ts
@@ -2,17 +2,18 @@
  * KAN-309 (epic) / KAN-311: pure helpers + constants for the user-management
  * console's bulk actions.
  *
- * This file is NOT 'use server' — it holds the runtime constants, types and the
- * pure transition function so the action module (`actions.ts`) can stay
- * async-only (BUGS-12: a 'use server' file may only export async functions).
+ * This file is NOT 'use server' — it holds the runtime constants and types so
+ * the action module (`actions.ts`) can stay async-only (BUGS-12: a 'use server'
+ * file may only export async functions).
  *
- * The transition matrix is the single source of truth for how each admin action
- * maps onto the two-axis access model (access_stage + early_access) AND the
- * legacy enforced gate (is_beta_eligible / beta_access_status). Keeping it pure
- * makes it directly unit-testable without a DB.
+ * KAN-424 (F2): the transition matrix itself (`computeAccessTransition`,
+ * `AccessTransition`) moved OUT of this admin route tree to `@/lib/access-model`
+ * — it is access policy, not an admin-console detail, and living here made it
+ * the codebase's only lib -> app import edge. What remains is genuinely admin's:
+ * the console's menu, its caps, and its filter shape.
  */
 
-import type { ModerationAction } from '@/lib/admin';
+import type { AccessAction } from '@/lib/access-model';
 
 /** Hard ceiling on a single bulk action (server-enforced). */
 export const BULK_MAX = 500;
@@ -21,7 +22,7 @@ export const BULK_MAX = 500;
 export const EMAIL_CAP = 100;
 
 export interface BulkActionConfig {
-  value: string;
+  value: AccessAction;
   label: string;
   requiresReason: boolean;
   danger: boolean;
@@ -43,95 +44,6 @@ const BULK_ACTION_VALUES = new Set<string>(BULK_ACTIONS.map((a) => a.value));
 
 export function isBulkAction(value: string): value is BulkAction {
   return BULK_ACTION_VALUES.has(value);
-}
-
-export interface AccessTransition {
-  /** The partial `profiles` update to apply. */
-  update: Record<string, unknown>;
-  /** The moderation_logs action string to audit. */
-  moderationAction: ModerationAction;
-  /** Whether a "you're in" approval email is appropriate for this transition. */
-  sendApprovalEmail: boolean;
-}
-
-/**
- * Map a bulk action onto the concrete column changes + audit action.
- *
- * KAN-326: the clean axes (user_status, access_tier) are the SOLE source of
- * truth. The legacy state columns (access_stage, early_access, is_beta_eligible,
- * beta_access_status) were dropped in Phase C — this function no longer writes
- * them. `beta_approved_at` / `beta_requested_at` are kept as audit timestamps.
- * `now` and `reason` are passed in to keep this function pure (no Date.now / no I/O).
- */
-export function computeAccessTransition(
-  action: BulkAction,
-  opts: { now: string; reason?: string | null },
-): AccessTransition {
-  switch (action) {
-    case 'enable_beta':
-      return {
-        update: {
-          user_status: 'live',
-          access_tier: 'beta',
-          beta_approved_at: opts.now,
-        },
-        moderationAction: 'enable_beta',
-        sendApprovalEmail: true,
-      };
-    case 'disable_beta':
-      return {
-        update: {
-          user_status: 'waitlist',
-          access_tier: 'beta',
-          beta_approved_at: null,
-        },
-        moderationAction: 'disable_beta',
-        sendApprovalEmail: false,
-      };
-    case 'promote_live_with_beta':
-      return {
-        update: {
-          user_status: 'live',
-          access_tier: 'prod',
-        },
-        moderationAction: 'promote_live',
-        sendApprovalEmail: true,
-      };
-    case 'promote_live_no_beta':
-      return {
-        // KAN-326 Phase C: with the legacy early_access flag dropped, "with" vs
-        // "without beta features" no longer differs at the column level — both
-        // set access_tier='prod'. Experimental-feature access for a prod-tier
-        // user is now an explicit feature_entitlements grant (KAN-328), not a
-        // profile column. The two actions still differ in the approval email.
-        update: {
-          user_status: 'live',
-          access_tier: 'prod',
-        },
-        moderationAction: 'promote_live',
-        sendApprovalEmail: false,
-      };
-    case 'suspend':
-      return {
-        update: {
-          is_suspended: true,
-          suspended_at: opts.now,
-          suspension_reason: opts.reason ?? null,
-        },
-        moderationAction: 'suspend',
-        sendApprovalEmail: false,
-      };
-    case 'unsuspend':
-      return {
-        update: {
-          is_suspended: false,
-          suspended_at: null,
-          suspension_reason: null,
-        },
-        moderationAction: 'unsuspend',
-        sendApprovalEmail: false,
-      };
-  }
 }
 
 /** Parsed shape of the filter posted by "select all matching filter". */

--- a/src/app/waitlist/actions.ts
+++ b/src/app/waitlist/actions.ts
@@ -4,7 +4,7 @@ import { redirect } from 'next/navigation';
 import { createServiceRoleClient } from '@/lib/supabase-service';
 import { createClient } from '@/lib/supabase-server';
 import { env } from '@/lib/env';
-import { computeAccessTransition } from '@/app/admin/users/users-actions-shared';
+import { computeAccessTransition } from '@/lib/access-model';
 import { getAccountStanding, shouldRefuseIssuance } from '@/lib/account-status';
 
 /**

--- a/src/lib/access-model/access-transitions.ts
+++ b/src/lib/access-model/access-transitions.ts
@@ -1,0 +1,129 @@
+/**
+ * KAN-424 (F2, epic KAN-414 / KAN-415): the access-transition matrix.
+ *
+ * This is the single source of truth for how a user moves between access
+ * states. It used to live in `src/app/admin/users/users-actions-shared.ts` —
+ * inside the admin UI route tree — which made it the codebase's only
+ * `src/lib/**` -> `src/app/**` import edge: `src/lib/beta-access/flow.ts` and
+ * `src/app/waitlist/actions.ts` both reached into the admin console for it.
+ * It is a pure policy function, not an admin-console detail, so it lives here.
+ *
+ * Moved verbatim in KAN-424 — the function body is unchanged, by design (see
+ * that ticket's Security Review: this is motion, not an edit). The admin-only
+ * symbols (BULK_ACTIONS, BULK_MAX, EMAIL_CAP, UserFilter) deliberately stayed
+ * behind in the console, because they genuinely are admin's.
+ *
+ * Pure by construction: `now` and `reason` are passed in, so there is no
+ * Date.now() and no I/O, and it is directly unit-testable without a DB.
+ */
+
+import type { ModerationAction } from '@/lib/admin';
+
+/** The two axes of the access model (KAN-326). */
+export type UserStatus = 'not_applied' | 'waitlist' | 'live';
+export type AccessTier = 'beta' | 'prod';
+
+/**
+ * The vocabulary of access transitions.
+ *
+ * The admin console's `BULK_ACTIONS` is one presentation of this list (it adds
+ * labels and danger flags, which are UI concerns); typing `BulkActionConfig.value`
+ * as `AccessAction` keeps the two in lockstep at compile time without dragging
+ * the console's menu ordering into this module.
+ */
+export type AccessAction =
+  | 'enable_beta'
+  | 'disable_beta'
+  | 'promote_live_with_beta'
+  | 'promote_live_no_beta'
+  | 'suspend'
+  | 'unsuspend';
+
+export interface AccessTransition {
+  /** The partial `profiles` update to apply. */
+  update: Record<string, unknown>;
+  /** The moderation_logs action string to audit. */
+  moderationAction: ModerationAction;
+  /** Whether a "you're in" approval email is appropriate for this transition. */
+  sendApprovalEmail: boolean;
+}
+
+/**
+ * Map an access action onto the concrete column changes + audit action.
+ *
+ * KAN-326: the clean axes (user_status, access_tier) are the SOLE source of
+ * truth. The legacy state columns (access_stage, early_access, is_beta_eligible,
+ * beta_access_status) were dropped in Phase C — this function no longer writes
+ * them. `beta_approved_at` / `beta_requested_at` are kept as audit timestamps.
+ * `now` and `reason` are passed in to keep this function pure (no Date.now / no I/O).
+ */
+export function computeAccessTransition(
+  action: AccessAction,
+  opts: { now: string; reason?: string | null },
+): AccessTransition {
+  switch (action) {
+    case 'enable_beta':
+      return {
+        update: {
+          user_status: 'live',
+          access_tier: 'beta',
+          beta_approved_at: opts.now,
+        },
+        moderationAction: 'enable_beta',
+        sendApprovalEmail: true,
+      };
+    case 'disable_beta':
+      return {
+        update: {
+          user_status: 'waitlist',
+          access_tier: 'beta',
+          beta_approved_at: null,
+        },
+        moderationAction: 'disable_beta',
+        sendApprovalEmail: false,
+      };
+    case 'promote_live_with_beta':
+      return {
+        update: {
+          user_status: 'live',
+          access_tier: 'prod',
+        },
+        moderationAction: 'promote_live',
+        sendApprovalEmail: true,
+      };
+    case 'promote_live_no_beta':
+      return {
+        // KAN-326 Phase C: with the legacy early_access flag dropped, "with" vs
+        // "without beta features" no longer differs at the column level — both
+        // set access_tier='prod'. Experimental-feature access for a prod-tier
+        // user is now an explicit feature_entitlements grant (KAN-328), not a
+        // profile column. The two actions still differ in the approval email.
+        update: {
+          user_status: 'live',
+          access_tier: 'prod',
+        },
+        moderationAction: 'promote_live',
+        sendApprovalEmail: false,
+      };
+    case 'suspend':
+      return {
+        update: {
+          is_suspended: true,
+          suspended_at: opts.now,
+          suspension_reason: opts.reason ?? null,
+        },
+        moderationAction: 'suspend',
+        sendApprovalEmail: false,
+      };
+    case 'unsuspend':
+      return {
+        update: {
+          is_suspended: false,
+          suspended_at: null,
+          suspension_reason: null,
+        },
+        moderationAction: 'unsuspend',
+        sendApprovalEmail: false,
+      };
+  }
+}

--- a/src/lib/access-model/index.ts
+++ b/src/lib/access-model/index.ts
@@ -1,0 +1,14 @@
+/**
+ * KAN-424 (F2): `access-model` — the neutral home for access-state policy.
+ *
+ * Seed of the future `access` module (KAN-415). Import from `@/lib/access-model`
+ * rather than reaching into the file directly.
+ */
+
+export {
+  computeAccessTransition,
+  type AccessAction,
+  type AccessTier,
+  type AccessTransition,
+  type UserStatus,
+} from './access-transitions';

--- a/src/lib/beta-access/flow.ts
+++ b/src/lib/beta-access/flow.ts
@@ -15,13 +15,14 @@
 import { createServiceRoleClient } from '@/lib/supabase-service';
 import { env } from '@/lib/env';
 import { sendBetaQueueNotice } from './email';
-import { computeAccessTransition } from '@/app/admin/users/users-actions-shared';
+import { computeAccessTransition, type AccessTier, type UserStatus } from '@/lib/access-model';
 
 const BETA_HOST = 'https://beta.checklyra.com';
 const PROD_HOST = 'https://checklyra.com';
 
-export type UserStatus = 'not_applied' | 'waitlist' | 'live';
-export type AccessTier = 'beta' | 'prod';
+// KAN-424 (F2): the access-model axes now live in @/lib/access-model; re-exported
+// here so this module's long-standing public surface is unchanged.
+export type { UserStatus, AccessTier };
 
 /**
  * Pure: where to redirect after sign-in (KAN-326 — route by access tier).

--- a/tests/unit/access-model-transitions.test.ts
+++ b/tests/unit/access-model-transitions.test.ts
@@ -3,8 +3,8 @@
  * test it directly — every action's exact column changes, the audited action
  * string, and whether an approval email is appropriate.
  */
+import { computeAccessTransition } from '@/lib/access-model';
 import {
-  computeAccessTransition,
   isBulkAction,
   BULK_ACTIONS,
 } from '@/app/admin/users/users-actions-shared';


### PR DESCRIPTION
## Summary

KAN-424 (F2) **Defect 1 only** — eliminates the codebase's **only `src/lib/**` → `src/app/**` import edge**, plus one of the two remaining app→app cross-segment edges.

`computeAccessTransition` is the single source of truth for how a user moves between access states, but it lived in `src/app/admin/users/users-actions-shared.ts` — inside the admin UI route tree. `src/lib/beta-access/flow.ts` and `src/app/waitlist/actions.ts` both reached into the admin console for it, which is what made `admin` / `access` / `beta-access` / `auth` one inseparable knot. It now lives in the neutral `src/lib/access-model/` module, the seed of the future `access` module (KAN-415).

**This is motion, not an edit.** The function body is byte-identical before and after — verified by diffing the extracted `switch (action)` block against `origin/develop` (66 lines, no differences). The only signature change is the parameter type, `BulkAction` → `AccessAction`: the action *vocabulary* moves to `access-model`, while the admin console's *presentation* of it (`BULK_ACTIONS` with its labels, danger flags and menu order) stays behind, with `BulkActionConfig.value` typed as `AccessAction` so the two cannot drift.

Also moved: the `UserStatus` / `AccessTier` axes, previously declared in `beta-access/flow.ts`, which re-exports them so its public surface is unchanged. Deliberately left in the console per the ticket: `BULK_ACTIONS`, `BULK_MAX`, `EMAIL_CAP`, `UserFilter`.

### Scope: 1 of KAN-424's 3 defects — the other two are Luisa's

Re-derived against current `develop` rather than trusting the survey list, as the ticket asks. State after this PR:

| Acceptance criterion | Before | After |
|---|---|---|
| `src/lib/**` → `src/app/**` edges | 1 | **0** ✅ |
| app→app cross-segment edges | 2 (`waitlist`→`admin`, `[slug]`→`dashboard`) | 1 (`[slug]`→`dashboard`) |
| `madge --circular` | 1 cycle | 1 cycle (unchanged) |

The two remaining defects are **not** in this PR, because both are confined to Luisa-owned UI paths and `scripts/check-ui-copy-ownership.sh` correctly requires her `UI-Change-Approved` trailer for them:

- **Defect 2** — the `WizardContact` cycle: `src/app/dashboard/convene/organise/page.tsx` ↔ `organise-wizard.tsx`, with the fix landing in `organise-fields.ts` (a named protected copy module).
- **Defect 3 remainder** — `src/app/[slug]/page.tsx` importing `@/app/dashboard/profile/section-visibility` + `manual-of-me-fields`.

KAN-424 therefore stays **In Progress**. Note this also means KAN-425 (F3) can currently land `no-module-to-app` as green, but `no-circular` and `no-cross-segment-app` will still have one violation each until Luisa initiates the UI-path legs.

## Jira Ticket

KAN-424

## Checklist

- [x] Unit tests added/updated for new/changed functionality — *no new behaviour, so no new tests, per the ticket ("this must be pure motion"). `tests/unit/access-model-transitions.test.ts` got an import-path update only; no assertion touched.*
- [x] All existing tests pass (`npm run test:unit`) — 2564 passed / 217 suites; **test count unchanged**
- [x] Lint passes (`npm run lint`) — 0 errors (24 pre-existing warnings)
- [x] Type check passes (`npm run type-check`) — clean
- [x] Build succeeds (`npm run build`) — clean
- [x] Coverage has not decreased — no code removed from test scope; same assertions over the same function
- [x] No eslint-disable or ts-ignore without KAN-XX reference — none added
- [x] ARCHITECTURE.md updated if architectural changes were made — **N/A**: no new service, table, env var, route, job or security boundary. The new `src/lib/access-model/` is an internal file location; the module map itself is the deliverable of KAN-415, which will document it.
- [x] Ops routine / Control-Room registry updated — **N/A**: no scheduled-routine behaviour, cadence or ownership change.
- [x] Docs / system map updated — **N/A** for the same reason; this is pure code motion with no design decision to record. The rationale is in KAN-424 and `LYRA_MODULARISATION_PLAN_2026-07-26.md` §6.

## Security review

`computeAccessTransition` is security-load-bearing — it decides how a user moves between `user_status` and `access_tier` states, so a subtle change during the move would alter who gets access to what. The ticket's constraint was that the body be byte-identical; reviewers can verify this directly:

```
git show origin/develop:src/app/admin/users/users-actions-shared.ts \
  | awk '/^  switch \(action\) \{$/,/^\}$/' > /tmp/a.txt
awk '/^  switch \(action\) \{$/,/^\}$/' src/lib/access-model/access-transitions.ts > /tmp/b.txt
diff /tmp/a.txt /tmp/b.txt   # no output
```

No RLS, auth, or input-validation change; no new threat surface. Moving a pure policy function out from behind the admin UI's file layout is itself a small improvement — an unrelated admin-page refactor can no longer disturb it.

## MCP coverage

**N/A** — internal refactor, no user-facing data, no new API route or server action.

## UI / copy ownership

No Luisa-owned UI or copy path is touched. `scripts/check-ui-copy-ownership.sh` passes with *"no founder-owned UI/copy paths changed"*; no approval trailer was needed or used. Changed files: `src/lib/access-model/**` (new), `src/app/admin/users/{actions,users-actions-shared}.ts` (admin console — explicit non-protected carve-out), `src/app/waitlist/actions.ts`, `src/lib/beta-access/flow.ts`, `tests/unit/access-model-transitions.test.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015DLzfdpufF4bQB48sbpgYE

---
_Generated by [Claude Code](https://claude.ai/code/session_015DLzfdpufF4bQB48sbpgYE)_