### PR TITLE
fix(BUGS-79): target-branch develop for github-actions Dependabot ecosystem

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,9 +1,13 @@
 version: 2
 updates:
-  # npm deps target develop so they flow through the standard
-  # develop → staging → main pipeline. Workflow-file bumps below
-  # (github-actions ecosystem) still target main since workflow
-  # changes only take effect once on main (CLAUDE.md gotcha #1).
+  # Every ecosystem below targets develop so its PRs flow through the
+  # standard develop → staging → beta → main pipeline (SEC-98: main is
+  # reached ONLY via that chain, never a PR — main-chain-guard.yml blocks
+  # any PR based on main outright). CLAUDE.md gotcha #1 ("workflow changes
+  # only take effect once on main") is still true, but it argues for WHEN a
+  # workflow bump takes effect, not for WHERE its PR is based — a bump
+  # entering at develop still reaches main via the normal promote chain,
+  # just one promote cycle later. See BUGS-79.
   - package-ecosystem: "npm"
     directory: "/"
     target-branch: "develop"
@@ -42,6 +46,7 @@ updates:
 
   - package-ecosystem: "github-actions"
     directory: "/"
+    target-branch: "develop"
     schedule:
       interval: "weekly"
       day: "monday"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -453,7 +453,7 @@ This is policy, not a suggestion. Tracked under KAN-167.
 
 These have caused real bugs. Read before making related changes:
 
- 1. **Promotion workflow chicken-and-egg**: Workflow file changes must be on `main` before they take effect on subsequent promotion runs. If you change a workflow file on develop, it won't take effect until it reaches main — may need a manual merge.
+ 1. **Promotion workflow chicken-and-egg**: Workflow file changes must be on `main` before they take effect on subsequent promotion runs. If you change a workflow file on develop, it won't take effect until it reaches main — may need a manual merge. **This is not license to base a workflow-change PR on `main`** (BUGS-79): it argues for *when* the change takes effect, not *where* its PR is based. Every PR — workflow files included — still enters at `develop` and reaches `main` only via the normal promote chain (SEC-98); it just takes effect on `main` one promote cycle later than a hypothetical direct PR would. `.github/dependabot.yml` sets `target-branch: "develop"` on every ecosystem, including `github-actions`, for exactly this reason.
 
  2. **Vercel branch scoping**: The `develop` branch deploys as a Preview environment. Variables must be scoped via CLI (`vercel env add [VAR] preview develop`) — the dashboard UI cannot scope to a specific branch.
 

--- a/controls/registry.json
+++ b/controls/registry.json
@@ -577,6 +577,22 @@
       "self_test": "python3 scripts/check-bash-portability.py --self-test",
       "escape_hatch": "# bash-portability-ok:",
       "added": "2026-07-27"
+    },
+    {
+      "id": "CTL-032",
+      "name": "Dependabot target-branch",
+      "defect_class": "release-pipeline-config-drift",
+      "summary": "Fails the build if any .github/dependabot.yml ecosystem block omits target-branch: develop. The github-actions ecosystem had no target-branch and fell back to the repo default (main), so every weekly Actions bump opened a PR that main-chain-guard.yml (SEC-98) correctly blocks as a chain-bypass attempt — a permanently-red required check on a benign PR, which trains reviewers to stop reading it.",
+      "implementation": "tests/unit/dependabot-target-branch.test.js",
+      "kind": "test",
+      "wired_in": [
+        ".github/workflows/pr-checks.yml"
+      ],
+      "prevents": [
+        "BUGS-79"
+      ],
+      "escape_hatch": "None. Every ecosystem must target develop so its PRs flow through the develop -> staging -> beta -> main chain like any other change.",
+      "added": "2026-07-28"
     }
   ]
 }

--- a/tests/unit/dependabot-target-branch.test.js
+++ b/tests/unit/dependabot-target-branch.test.js
@@ -1,0 +1,22 @@
+const fs = require('fs');
+const path = require('path');
+const yaml = require('js-yaml');
+
+// BUGS-79: the github-actions ecosystem block had no target-branch, so it
+// fell back to the repo default (main) — putting every weekly bump in direct
+// conflict with SEC-98 (main-chain-guard.yml blocks any PR targeting main).
+// This test is the control: it fails the build if a future ecosystem block
+// omits target-branch, so the config cannot silently drift back.
+describe('.github/dependabot.yml', () => {
+  const configPath = path.join(__dirname, '..', '..', '.github', 'dependabot.yml');
+  const config = yaml.load(fs.readFileSync(configPath, 'utf8'));
+
+  test('every ecosystem targets develop (SEC-98: main is reached only via the promote chain)', () => {
+    expect(Array.isArray(config.updates)).toBe(true);
+    expect(config.updates.length).toBeGreaterThan(0);
+
+    for (const update of config.updates) {
+      expect(update['target-branch']).toBe('develop');
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- `.github/dependabot.yml`'s `github-actions` ecosystem block had no `target-branch`, so it fell back to the repo default (`main`) — every weekly Actions bump opened a PR that `main-chain-guard.yml` (SEC-98) correctly blocks as a chain-bypass attempt (live evidence: PR #600, red on Main Chain Guard, green everywhere else).
- Sets `target-branch: "develop"` on the `github-actions` block, matching the existing `npm` block, so Actions bumps flow through `develop → staging → beta → main` like every other change.
- Adds `tests/unit/dependabot-target-branch.test.js` asserting every ecosystem in `dependabot.yml` declares `target-branch: develop`, registered as **CTL-032** in `controls/registry.json`.
- Reconciles CLAUDE.md gotcha #1 with SEC-98: a workflow-file PR still enters at `develop`; only its *effect* on `main` is delayed to the next promote, not its base branch.
- PR #600 (the currently-stuck main-based Actions bump) should be closed once this merges — Dependabot will reopen the grouped bump against `develop` on its next weekly run.

## Jira Ticket

BUGS-79

## Checklist

- [x] Unit tests added/updated for new/changed functionality
- [x] All existing tests pass (`npm run test:unit` — 2575/2575, 219 suites)
- [x] Lint passes (`npm run lint` — 0 errors, pre-existing warnings only)
- [x] Type check passes (`npm run type-check`)
- [ ] Build succeeds (`npm run build`) — not run locally (config/test-only change, no app code touched); CI will run it
- [x] Coverage has not decreased (net +1 test)
- [x] No eslint-disable or ts-ignore without KAN-XX reference
- [x] Dependency-rule gate reviewed — no app code touched, no new violation possible
- [ ] ARCHITECTURE.md updated if architectural changes were made — N/A, CI config only, no architecture change
- [ ] Ops routine / Control-Room registry updated — N/A, not a scheduled-routine change
- [x] Docs / system map updated — CLAUDE.md gotcha #1 reconciled with SEC-98; N/A for Confluence system-map pages (pure CI-config fix, no service/table/env-var/route change)

---
Run as part of the weekly health + regression routine (SEC-22). Found during residual-bug triage against open BUGS tickets.


---
_Generated by [Claude Code](https://claude.ai/code/session_01HDyoAYZUiQyzHWCcWjrXxz)_