### PR TITLE
KAN-422: R7 dead-export disposition register — research artefact

### DIFF
--- a/docs/modularisation/KAN-422-dead-exports.md
+++ b/docs/modularisation/KAN-422-dead-exports.md
@@ -1,0 +1,230 @@
+# KAN-422 (R7) — Dead-but-tested exports: disposition register
+
+**Status:** research artefact · read-only · no code changed
+**Date:** 2026-07-28
+**Epic:** KAN-414 · **Plan:** `LYRA_MODULARISATION_PLAN_2026-07-26.md` §6 Workstream A, discovery D-11
+**Derivation script:** `docs/modularisation/kan422-dead-exports.py`
+**Machine-readable output:** `docs/modularisation/data/kan422-dead-exports.json`
+
+Reproduce with:
+
+```bash
+python3 docs/modularisation/kan422-dead-exports.py
+```
+
+---
+
+## 1. Headline
+
+> **The premise needs correcting in two places, and the spike found two live defects
+> that have nothing to do with modularisation.**
+
+| Measure | Figure |
+|---|---|
+| `src/**` files scanned (`.ts`/`.tsx`, non-test) | **274** |
+| Exported symbols enumerated | **829** |
+| — of which Next.js/tooling framework contracts (not imports; excluded) | **147** |
+| **Zero-importer exports** | **219** |
+| — **OVER-EXPORTED** (live code, over-wide `export`) | **160** (1,463 LOC) |
+| — **DEAD-TESTED** (no reference anywhere; has tests) | **36** (588 LOC) |
+| — **DEAD-ISOLATED** (no reference anywhere; no tests) | **23** (542 LOC) |
+| **Genuinely dead LOC** | **1,130** |
+
+**Correction 1 — the raw count is nearly 3× too pessimistic.** The ticket's framing
+("exports with zero production consumers") is satisfied by 219 symbols, but **160 of
+them are not dead code**. They are symbols used *inside their own file*, exported only
+so a unit test can reach them. Deleting them would break live behaviour. Their defect
+is the `export` keyword, not the code, and the fix is to narrow the export at
+extraction time — a completely different disposition from deletion, with no Test
+Integrity Policy exposure. Any run that reported "219 dead exports" would have been
+wrong by 1,463 LOC.
+
+The discriminator is now measured, not assumed: `internalUses` counts references to the
+symbol elsewhere in its own file (`kan422-dead-exports.py::internal_uses`).
+
+**Correction 2 — the two files the ticket names for deletion must NOT be deleted.**
+`src/lib/recommender/inputs.ts` and `src/lib/recommender/events.ts` are the scaffolding
+for **KAN-198** (Rec-Engine 01 — recommender input audit) and **KAN-202** (Rec-Engine 05
+— feedback/learning loop). Both tickets are **In Progress today**. They are unconsumed
+because their consumers are not built yet, which is exactly the KEEP AS CONTRACT case.
+The ticket asked for this check explicitly; the answer is *keep*.
+
+The ~650 LOC estimate in the ticket is close to the real DEAD-TESTED figure (**588 LOC /
+36 symbols**) — but it is a different 588 LOC from the one the ticket assumed.
+
+**Two live defects found.** Both are cases where the "dead" export turned out to be the
+*correct* implementation that a live surface bypasses. Raised as SEC tickets, not
+cleanup items (§4).
+
+---
+
+## 2. Method
+
+1. **Export enumeration** — line-oriented scan of every export form used in this repo
+   (`export const|function|class|type|interface|enum`, `export {…}`, `export * as`,
+   `export default`, destructured `export const {…}`), comments stripped first.
+2. **Import graph** — every file under `src/`, `tests/`, `scripts/`, `.github/`,
+   `supabase/`, `controls/` plus root configs (523 files). Resolves the single tsconfig
+   alias `@/* → ./src/*`, relative specifiers, and directory `index.*`. Counts static
+   `import`, `import type`, re-export `export … from`, side-effect `import '…'`, dynamic
+   `import()`/`require()`, and `jest.mock()`/`requireActual()` specifiers. Namespace
+   imports (`import * as ns`) mark the whole target as consumed — deliberately
+   conservative, so a namespace importer can never produce a false "dead".
+3. **Framework contracts excluded** — Next.js consumes `page`/`layout`/`route`/
+   `middleware`/`sitemap`/… exports by convention with no import statement anywhere.
+   147 such symbols are reported separately rather than counted as dead.
+4. **Internal-use discriminator** — for each zero-importer symbol, count references in
+   its own file outside the declaration line. `>0` ⇒ OVER-EXPORTED, not dead.
+5. **Cross-repo string reachability** — literal grep for each candidate name across
+   `.github/`, `scripts/`, `supabase/`, `controls/`, `docs/` **and both sibling repos**
+   (`lyra-mcp-server`, `lyra-admin-mcp-server`, both present on disk and confirmed
+   readable), so a string-keyed or RPC-name reference is visible before anything is
+   proposed for deletion. Recorded in `stringReachability` in the JSON.
+
+### Known limits (stated so the number is honest)
+
+- A regex scan, not a TypeScript program graph. It cannot see a symbol reached through
+  a re-exported barrel under an alias rename, or through `eval`/computed member access.
+  Mitigated by (2)'s conservative namespace handling and (5)'s string sweep, but a
+  DELETE decision on any individual symbol still needs the human read that §3 records.
+- `loc` is a brace-balance span, adequate for sizing, not a compiler measurement.
+- The 147 framework-contract exclusions are matched by filename + symbol name. A
+  conventional symbol name in a non-conventional file is *not* excluded (correctly), but
+  a genuinely dead `default` export in a `page.tsx` would be (conservatively) kept.
+
+---
+
+## 3. Disposition register
+
+### 3a. DELETE — genuinely dead, no in-flight ticket, no live consumer
+
+| # | File | Symbols | LOC | Tests to delete with it | Evidence |
+|---|---|---|---|---|---|
+| D1 | `src/app/_marketing/sections.tsx` | `Hero`, `ProfilePreview`, `HowItWorks`, `Sections`, `UseCases`, `WhatLyraIsNot`, `AboutLyra`, `ParentTeacherCallout`, `WishKnowFindFirstHand`, `CTA` | **376** | *none* | Only `AboutTrio` is imported (`src/app/(legal)/about/page.tsx:4`). The homepage inlines its own markup. Every other name's remaining repo hits are comments or unrelated identifiers. **Keep the file, keep `AboutTrio`.** |
+| D2 | `src/app/dashboard/share-profile.tsx` | `default` | **81** | *none* | KAN-154-B "Share your invite" client card. No importer; the only repo reference is a comment in `src/lib/invite-text.ts:7`. |
+| D3 | `src/lib/convene/google/calendar.ts` | `getFreeBusy` | **29** | *none* | Superseded by `src/lib/convene/calendar/google.ts::googleCalendarAdapter.getFreeBusy`, which is the one `adapterFor('google')` returns and `organise/actions.ts:188` calls. |
+| D4 | `src/lib/convene/google/oauth.ts` | `exchangeCodeForTokens` | 23 | `tests/unit/convene/google-oauth.test.ts` (**partial — see note**) | The Google callback route reimplemented this inline as `exchangeCodeForTokensVerbose` (`src/app/api/convene/oauth/google/callback/route.ts:61`). Sibling exports `buildAuthorizeUrl` + `refreshAccessToken` in the same file **are live** — so this test file covers live code and **cannot be deleted**, only the `exchangeCodeForTokens` describe-block. |
+| D5 | `src/lib/convene/invites/repository.ts` | `markInviteSent`, `markInviteFailed` | 21 | `tests/unit/…/invites-actions.test.ts`, `rsvp-submit-validation.test.ts` (**partial**) | No caller in any of the three repos; the dispatcher writes the same columns inline. Both test files also cover live code. |
+| D6 | `src/lib/oauth/config.ts` | `wwwAuthenticateHeader` | 6 | `tests/unit/…/metadata.test.ts` (**partial**) | No route emits a `WWW-Authenticate` header via this helper. |
+| D7 | *small dead constants & types* — `ContactMethodKind`, `RateLimitGate`, `PROD_SITE_URL`, `INVITE_COOKIE`, `INVITE_COOKIE_MAX_AGE`, `SupportedDeliveryCountry`, `RecommendationEventRow`, `sections/index.ts` re-exports (`useAutoSave`, `SectionSaveBar`) | 9 symbols | 14 | *none* | Type/constant declarations with no importer and no internal use. Zero runtime risk. |
+
+**DELETE subtotal: ~550 LOC across 7 groups.** Note that **only D1, D2, D3 and D7 are
+clean deletions with no test impact at all** (486 LOC). D4–D6 require editing shared test
+files rather than deleting them, which is a *narrower* ask than the ticket anticipated.
+
+### 3b. KEEP AS CONTRACT — intentionally unconsumed
+
+| Symbols | Reason | Reference |
+|---|---|---|
+| `_internal` × 5 (`convene/invites/dispatch.ts`, `email.ts`, `twilio.ts`, `recommend/convene/score-attendee.ts`, `score-venue.ts`), `__resetCfAccessJwksCacheForTests`, `_clearFxCacheForTests`, `MERCHANT_RULES_INTERNAL` | Deliberate, named test seams. Their naming convention already declares the intent. | — |
+| `src/lib/recommender/inputs.ts` (4 symbols, 55 LOC) | **KAN-198 In Progress** — recommender input coercion; consumers not built yet. | KAN-198 |
+| `src/lib/recommender/events.ts` (3 symbols, 36 LOC) | **KAN-202 In Progress** — feedback/learning loop; `recommendation_events` consumers not built yet. | KAN-202 |
+| `filterCandidatesByEligibility` (60 LOC) + `src/lib/affiliate/eligibility.ts` (3 symbols, 35 LOC) + `affiliate/types.ts` `parseSubId`/`isCountryCode` | The V2 pipeline comment says the eligibility filter is "built into the candidate sourcing buyer-country filter". **That is true today and only today**: Tier 1 (curated catalogue) does check `is_active` + `buyer_countries`, and Tiers 2–3 are stubbed (`candidate-sourcing.ts:152` — `TODO(KAN-184)`). The filter's own docblock explains it exists precisely to cover Tier 2/3. **It becomes load-bearing the moment KAN-184 lands `SOVRN_API_KEY`.** | KAN-190; **blocks KAN-184** |
+| `microsoftCalendarAdapter` (102 LOC) | Phase-7 scaffolding. `calendar/index.ts` registers `google` only, and the connections UI states "More providers coming in Phase 7 (Microsoft, Apple, CalDAV)" — so no user can connect Outlook. Not a live gap. | — |
+| `verifyAccessToken` (36 LOC) | Its docblock: *"AS-side self-check verifier (the load-bearing verification is the MCP resource server's)"*. Intentionally unconsumed by design. | KAN-88 |
+| `approveBetaUser` (44 LOC) | `beta-queue/page.tsx` docblock: *"The single-row `approveBetaUser` action is retained — it remains a valid one-off approve path and is covered by its unit test"*. | KAN-277 → KAN-311 |
+| `updateSectionVisibility` (42 LOC) | Documented as retained after the June-2026 editor redesign; `tests/unit/phase3-ui-integration.test.ts:233` **asserts the editor does not reference it**. Deleting it would contradict a live test. | KAN-221 |
+| `getAnomalyWindow`, `getMetricsForWindow` (30 LOC) | Docblock: *"the same metrics surface is useful in the admin dashboard (eventual KAN-63-D operator observability work)"*. | KAN-63-D |
+| `canTransition`, `isFieldEditable`, `isEvergreenFallback`, `disconnectConnection`¹ | Gathering state-machine predicates and evergreen fallback — small, cheap, semantically part of their module's declared contract. | — |
+
+¹ `disconnectConnection` is listed here for completeness but is **actually a WIRE UP** — see §4.1.
+
+### 3c. OVER-EXPORTED — 160 symbols, 1,463 LOC
+
+Live code reached from inside its own file, exported solely for test access. **Not
+dead; do not delete.** Full list in the JSON (`bucket == "OVER-EXPORTED"`). Largest
+concentrations: `src/lib/content-moderation.ts` (8), `dashboard/settings/discoverability-helpers.ts` (6),
+`dashboard/profile/visibility.ts` (5), `lib/oauth/jwt.ts` (5), `lib/oauth/refresh.ts` (5).
+
+**Recommended disposition — none, for now.** Narrowing these is a per-module decision to
+be taken *during* each extraction (KAN-415), because the alternative to an over-wide
+export is usually restructuring the test, which is sign-off territory. What matters for
+this epic is the negative result: **they must not be written into `modules.json`
+`publicApi`.** KAN-416's manifest should mark a module's public API from the
+`CONSUMED` bucket only.
+
+---
+
+## 4. Security findings — raised separately
+
+Both were found because a "dead" export turned out to be the *correct* implementation
+that a live surface bypasses. Neither is a modularisation issue; both are live defects.
+
+### 4.1 `disconnectConnection` is dead because the UI bypasses it — the vaulted refresh token is never revoked
+
+`src/lib/convene/oauth-connections.ts:152` soft-deletes the connection **and** calls
+`vaultRevokeRefreshToken(conn.refresh_token_secret_id)`. Nothing calls it.
+
+The Disconnect button (`src/app/dashboard/convene/connections/connections-client.tsx:50`)
+instead performs a **client-side PostgREST update** setting `deleted_at` + `status='revoked'`
+— and stops there. `vaultRevokeRefreshToken` has exactly two call sites in the entire
+codebase (`oauth-connections.ts:117` re-connect, `:162` inside the dead function); there
+is no DB trigger on `oauth_connections` and no retention sweep that touches it.
+
+The user is told, in the confirm dialog: *"Lyra will forget your tokens and any draft
+gatherings using this calendar will need a new connection"*, and on the page: *"You can
+disconnect at any time; we'll forget your tokens immediately."* **The Google Calendar
+refresh token remains live in the Supabase vault indefinitely.**
+
+Severity: **High** — a stated consent withdrawal is not honoured; a long-lived
+calendar-scope OAuth token is retained after the user asked for it to be deleted, on a
+service holding minors' data.
+
+### 4.2 `search_by_contact_hash` is a privileged, RLS-bypassing RPC with no product consumer
+
+`searchByPhone` (`discoverability-actions.ts:150`) is the **only** caller of the
+SECURITY DEFINER RPC `search_by_contact_hash` — and `searchByPhone` itself has no caller.
+The settings UI imports `setDiscoverability` and `getDiscoverability` only; there is no
+search box, no API route, and no MCP tool in either sibling repo (verified by
+`org:luisa-sys` code search). Its sibling `searchByPostcode` was already removed under
+KAN-339, leaving the file's own docblock stale.
+
+So: users are invited to toggle "Allow discovery by phone number" — which hashes and
+stores their phone number — for a lookup feature that **has no entry point**. Meanwhile
+the RPC stays `EXECUTE`-granted to `authenticated`, bypasses RLS, and is directly
+callable via PostgREST. It has already cost three findings (**BUGS-45** anon-callable,
+**SEC-80** returned suspended profiles, and it is one of the four named R2 root-cause
+entries in `supabase/migration-privileges-baseline.json`).
+
+Severity: **Medium** — unreachable-from-product privileged surface, plus personal data
+(phone hash) collected for a purpose that cannot currently be delivered.
+
+---
+
+## 5. Batched sign-off request (Test Integrity Policy)
+
+Per CLAUDE.md, deleting a test file requires explicit founder sign-off. **Nothing has
+been deleted.** The single batched decision, when the deletions execute inside KAN-415:
+
+**(a) Test files that may be deleted whole — none.** Every DELETE candidate with tests
+shares its test file with live code.
+
+**(b) Test files needing a partial edit** (remove only the block covering the deleted
+symbol; every other block in the file covers live code and stays):
+
+| Test file | Block to remove | Covers dead symbol |
+|---|---|---|
+| `tests/unit/convene/google-oauth.test.ts` | `exchangeCodeForTokens` describe | D4 |
+| `tests/unit/…/invites-actions.test.ts`, `…/rsvp-submit-validation.test.ts` | `markInviteSent` / `markInviteFailed` assertions | D5 |
+| `tests/unit/…/metadata.test.ts` | `wwwAuthenticateHeader` assertions | D6 |
+
+**(c) Test-floor impact.** D1, D2, D3 and D7 (486 LOC, the bulk of the deletion) carry
+**zero tests** — the floor of 2118 does not move for them. Only (b) reduces the count,
+by the number of assertions removed. The exact delta must be measured on the branch that
+executes the deletion and reconciled with the F5 floors, not estimated here.
+
+---
+
+## 6. Feeds into
+
+- **KAN-416 (R1 manifest)** — `modules.json` `publicApi` must be drawn from the
+  `CONSUMED` bucket only. Writing the 219 zero-importer symbols into module public APIs
+  would freeze 1,463 LOC of test-only surface plus 1,130 LOC of dead code into
+  permanent contracts. This is the D-11 risk the epic exists to avoid, now quantified.
+- **KAN-415 (extraction)** — §3a is the execution list; §3c is a per-module judgement
+  call at extraction time.
+- **KAN-421 (profiles ADR)** — no interaction; `profiles` access is column-level, not
+  export-level.
+- **KAN-184** — must wire `filterCandidatesByEligibility` into the V2 pipeline before
+  Sovrn Tier 2 goes live, or ineligible/deactivated merchants reach users.
+- **KAN-353** — `lib/recommend/convene/` `_internal` seams confirmed as KEEP.

--- a/docs/modularisation/data/kan422-dead-exports.json
+++ b/docs/modularisation/data/kan422-dead-exports.json
@@ -1,0 +1,4968 @@
+{
+ "$comment": "KAN-422 R7 \u2014 zero-consumer export enumeration. Reproduce with `python3 docs/modularisation/kan422-dead-exports.py`.",
+ "generatedFrom": "674f0a7f47c73d5673f2550f589b7f3fc4d086e0",
+ "totals": {
+  "srcFilesScanned": 274,
+  "exportedSymbols": 829,
+  "frameworkContractSymbols": 147,
+  "zeroConsumerSymbols": 219,
+  "zeroConsumerButTested": 125,
+  "bucket_OVER_EXPORTED": 160,
+  "bucket_DEAD_TESTED": 36,
+  "bucket_DEAD_ISOLATED": 23,
+  "deadLOC": 1130,
+  "overExportedLOC": 1463,
+  "filesWithAnyZeroConsumerExport": 90,
+  "filesEntirelyZeroConsumer": 9
+ },
+ "zeroConsumerByFile": {
+  "src/app/_marketing/sections.tsx": [
+   "AboutLyra",
+   "CTA",
+   "Hero",
+   "HowItWorks",
+   "ParentTeacherCallout",
+   "ProfilePreview",
+   "Sections",
+   "UseCases",
+   "WhatLyraIsNot",
+   "WishKnowFindFirstHand"
+  ],
+  "src/app/admin/beta-queue/actions.ts": [
+   "approveBetaUser"
+  ],
+  "src/app/admin/monitoring/integration-status.ts": [
+   "MonitoringIntegration"
+  ],
+  "src/app/admin/users/status-badges.ts": [
+   "Badge"
+  ],
+  "src/app/consent-state.ts": [
+   "CONSENT_STORAGE_KEY",
+   "ConsentValue"
+  ],
+  "src/app/dashboard/convene/contacts/contacts-helpers.ts": [
+   "ContactMethodKind",
+   "ContactMethodView"
+  ],
+  "src/app/dashboard/convene/gatherings/[id]/invite-actions.tsx": [
+   "InviteeView",
+   "ProposedSlot"
+  ],
+  "src/app/dashboard/profile/actions.ts": [
+   "ItemActionResult",
+   "updateSectionVisibility"
+  ],
+  "src/app/dashboard/profile/affiliation-fields.ts": [
+   "ALLOWED_AFFILIATION_TYPES",
+   "isAffiliationType"
+  ],
+  "src/app/dashboard/profile/city-actions.ts": [
+   "ResolveCityResult"
+  ],
+  "src/app/dashboard/profile/manual-of-me-fields.ts": [
+   "ManualOfMeField"
+  ],
+  "src/app/dashboard/profile/profile-fields.ts": [
+   "ALLOWED_PROFILE_FIELDS",
+   "AllowedProfileField"
+  ],
+  "src/app/dashboard/profile/section-visibility.ts": [
+   "CONTROLLABLE_SECTION_KEYS",
+   "ControllableSectionKey",
+   "ITEM_CATEGORY_TO_SECTION",
+   "getEffectiveItemVisibility"
+  ],
+  "src/app/dashboard/profile/sections/auto-save-core.ts": [
+   "AutoSaveResult",
+   "AutoSaveStatus"
+  ],
+  "src/app/dashboard/profile/sections/index.ts": [
+   "SectionSaveBar",
+   "useAutoSave"
+  ],
+  "src/app/dashboard/profile/visibility.ts": [
+   "DEFAULT_VISIBILITY",
+   "VISIBILITY_LEVELS",
+   "filterItemsByVisibility",
+   "isAllowedVisibility",
+   "isItemVisibleToViewer"
+  ],
+  "src/app/dashboard/settings/discoverability-actions.ts": [
+   "searchByPhone"
+  ],
+  "src/app/dashboard/settings/discoverability-helpers.ts": [
+   "ContactKind",
+   "RateLimitGate",
+   "getContactSearchHmacKey",
+   "getSearchPepper",
+   "hashContact",
+   "normalisePhone"
+  ],
+  "src/app/dashboard/share-profile.tsx": [
+   "default"
+  ],
+  "src/components/AffiliateBadge.tsx": [
+   "AffiliateBadgeProps"
+  ],
+  "src/lib/account-status.ts": [
+   "AccountStanding"
+  ],
+  "src/lib/admin.ts": [
+   "AdminUser",
+   "LogModerationActionInput",
+   "LogModerationActionsBatchInput"
+  ],
+  "src/lib/affiliate/country-codes.ts": [
+   "SupportedDeliveryCountry"
+  ],
+  "src/lib/affiliate/eligibility.ts": [
+   "AffiliateNetwork",
+   "MerchantEligibilityRow",
+   "isAffiliateNetwork",
+   "isMerchantEligibleInCountry"
+  ],
+  "src/lib/affiliate/fx.ts": [
+   "_clearFxCacheForTests"
+  ],
+  "src/lib/affiliate/link-service.ts": [
+   "AffiliateLinkRequest",
+   "AffiliateLinkResult"
+  ],
+  "src/lib/affiliate/merchant-detector.ts": [
+   "MERCHANT_RULES_INTERNAL"
+  ],
+  "src/lib/affiliate/reporting.ts": [
+   "ReconciliationUpdate",
+   "parseClickIdFromSubId"
+  ],
+  "src/lib/affiliate/smoke.ts": [
+   "FetchLike",
+   "MerchantSmokeProbe",
+   "ProbeResult",
+   "SMOKE_PROBES",
+   "SmokeMatrixEntry",
+   "SmokeRunSummary"
+  ],
+  "src/lib/affiliate/types.ts": [
+   "isCountryCode",
+   "parseSubId"
+  ],
+  "src/lib/age/didit.ts": [
+   "CHALLENGE_AGE",
+   "CreateSessionResult",
+   "NormalisedDecision"
+  ],
+  "src/lib/age/provider-gate.ts": [
+   "AgeStatus"
+  ],
+  "src/lib/beta-access/email.ts": [
+   "BetaEmailResult"
+  ],
+  "src/lib/beta-access/invite-link.ts": [
+   "INVITE_COOKIE",
+   "INVITE_COOKIE_MAX_AGE",
+   "buildBetaInviteLink"
+  ],
+  "src/lib/cf-access.ts": [
+   "__resetCfAccessJwksCacheForTests"
+  ],
+  "src/lib/compliance/disclosures.ts": [
+   "DisclosureFlags",
+   "disclosuresFromSwitches"
+  ],
+  "src/lib/content-moderation.ts": [
+   "ModerationResult",
+   "ModerationSeverity",
+   "PIIResult",
+   "ProfanityResult",
+   "SpamResult",
+   "containsPII",
+   "containsProfanity",
+   "detectSpam"
+  ],
+  "src/lib/convene/busy-time-consent.ts": [
+   "BusyTimeConsentError"
+  ],
+  "src/lib/convene/calendar/microsoft.ts": [
+   "microsoftCalendarAdapter"
+  ],
+  "src/lib/convene/gatherings/state-machine.ts": [
+   "InvalidTransitionError",
+   "canTransition",
+   "isFieldEditable"
+  ],
+  "src/lib/convene/google/calendar.ts": [
+   "BusyBlock",
+   "getFreeBusy"
+  ],
+  "src/lib/convene/google/oauth.ts": [
+   "GOOGLE_SCOPES",
+   "GoogleTokenResponse",
+   "exchangeCodeForTokens"
+  ],
+  "src/lib/convene/invites/dispatch.ts": [
+   "DispatchSummary",
+   "_internal",
+   "buildSendInputs",
+   "buildSmsBody"
+  ],
+  "src/lib/convene/invites/email.ts": [
+   "_internal"
+  ],
+  "src/lib/convene/invites/repository.ts": [
+   "InviteeLookup",
+   "PersistInviteInput",
+   "markInviteFailed",
+   "markInviteSent"
+  ],
+  "src/lib/convene/invites/sms-templates.ts": [
+   "SmsTemplateInput"
+  ],
+  "src/lib/convene/invites/templates.ts": [
+   "InviteTemplateInput"
+  ],
+  "src/lib/convene/invites/twilio.ts": [
+   "_internal"
+  ],
+  "src/lib/convene/microsoft/oauth.ts": [
+   "MICROSOFT_SCOPES"
+  ],
+  "src/lib/convene/oauth-connections.ts": [
+   "OAuthConnection",
+   "disconnectConnection",
+   "getConnection"
+  ],
+  "src/lib/convene/post-event.ts": [
+   "PostEventSummary"
+  ],
+  "src/lib/cookie-domain.ts": [
+   "PARENT_COOKIE_DOMAIN",
+   "PROD_SITE_URL",
+   "parentCookieDomain"
+  ],
+  "src/lib/dashboard/dismissal.ts": [
+   "WidgetDismissal"
+  ],
+  "src/lib/dashboard/profile-completion.ts": [
+   "COMPLETION_COMPONENTS",
+   "ProfileCompletionInput"
+  ],
+  "src/lib/dashboard/resolve-widgets.ts": [
+   "EMPTY_TO_DRAFTED_THRESHOLD",
+   "ResolvedWidget",
+   "WidgetResolverInput"
+  ],
+  "src/lib/deploy-env.ts": [
+   "DEPLOY_ENVS"
+  ],
+  "src/lib/features/entitlements-service.ts": [
+   "isFeatureEnabledByProfile",
+   "isPaidLinksComplianceReady"
+  ],
+  "src/lib/features/global-features.ts": [
+   "GlobalFeatureConfig"
+  ],
+  "src/lib/features/registry.ts": [
+   "FEATURE_KEYS",
+   "FeatureConfig",
+   "FeatureTier"
+  ],
+  "src/lib/file-magic-bytes.ts": [
+   "UploadPreflightOptions",
+   "matchesSignature",
+   "validateFileMagicBytes"
+  ],
+  "src/lib/geo/places-city.ts": [
+   "CityLookupResult",
+   "extractCity"
+  ],
+  "src/lib/metrics.ts": [
+   "getAnomalyWindow",
+   "getMetricsForWindow"
+  ],
+  "src/lib/moderation-audit.ts": [
+   "ModerationSource"
+  ],
+  "src/lib/oauth/access-tokens.ts": [
+   "AccessTokenRecord",
+   "IssueAccessJtiInput"
+  ],
+  "src/lib/oauth/authorize.ts": [
+   "AuthorizeError",
+   "AuthorizeRequest",
+   "ValidatedAuthorizeRequest"
+  ],
+  "src/lib/oauth/client-trust.ts": [
+   "ClientTrust"
+  ],
+  "src/lib/oauth/clients.ts": [
+   "RegisterClientInput",
+   "RegisteredClient",
+   "generateClientId",
+   "generateClientSecret"
+  ],
+  "src/lib/oauth/codes.ts": [
+   "CodeRecord",
+   "IssueCodeInput",
+   "generateAuthCode"
+  ],
+  "src/lib/oauth/config.ts": [
+   "wwwAuthenticateHeader"
+  ],
+  "src/lib/oauth/consents.ts": [
+   "ConsentRecord"
+  ],
+  "src/lib/oauth/jwt.ts": [
+   "AccessTokenClaims",
+   "IssueAccessTokenInput",
+   "IssuedAccessToken",
+   "VerifyOptions",
+   "verifyAccessToken"
+  ],
+  "src/lib/oauth/refresh.ts": [
+   "IssueRefreshInput",
+   "RefreshTokenRecord",
+   "generateRefreshToken",
+   "hashRefreshToken",
+   "issueAccessTokenJti"
+  ],
+  "src/lib/profile-rate-limit.ts": [
+   "ProfileRateLimitOutcome"
+  ],
+  "src/lib/rate-limit-shared.ts": [
+   "SharedRateLimitResult"
+  ],
+  "src/lib/recommend/categories.ts": [
+   "GiftCategory"
+  ],
+  "src/lib/recommend/convene/score-attendee.ts": [
+   "_internal",
+   "scoreAttendee"
+  ],
+  "src/lib/recommend/convene/score-venue.ts": [
+   "_internal"
+  ],
+  "src/lib/recommend/index.ts": [
+   "ProfileInsights",
+   "RecommendationOptions"
+  ],
+  "src/lib/recommender/events.ts": [
+   "RECOMMENDATION_EVENT_TYPES",
+   "RecommendationEventRow",
+   "RecommendationEventSource",
+   "RecommendationEventType",
+   "isRecommendationEventSource",
+   "isRecommendationEventType",
+   "sanitiseEventMetadata"
+  ],
+  "src/lib/recommender/inputs.ts": [
+   "AGE_RANGE_BUCKETS",
+   "ALLERGIES",
+   "AgeRangeBucket",
+   "Allergy",
+   "DIETARY_RESTRICTIONS",
+   "DietaryRestriction",
+   "OCCASIONS",
+   "Occasion",
+   "RELATIONSHIPS",
+   "RecipientAttributes",
+   "Relationship",
+   "coerceRecipientAttributes",
+   "isAgeRangeBucket",
+   "isAllergy",
+   "isDietaryRestriction",
+   "isOccasion",
+   "isRelationship"
+  ],
+  "src/lib/recommender/v2/candidate-sourcing.ts": [
+   "sourceCandidatesForConcept"
+  ],
+  "src/lib/recommender/v2/eligibility-filter.ts": [
+   "EligibilityFilterInput",
+   "EligibilityFilterResult",
+   "canShipTo",
+   "filterCandidatesByEligibility"
+  ],
+  "src/lib/recommender/v2/evergreen.ts": [
+   "isEvergreenFallback"
+  ],
+  "src/lib/recommender/v2/rank.ts": [
+   "DEFAULT_WEIGHTS",
+   "RankerWeights"
+  ],
+  "src/lib/retention/affiliate-clicks.ts": [
+   "DEFAULT_AFFILIATE_CLICKS_RETENTION_MONTHS",
+   "affiliateClicksCutoff",
+   "affiliateClicksRetentionMonths"
+  ],
+  "src/lib/retention/gatherings.ts": [
+   "DEFAULT_GATHERINGS_RETENTION_MONTHS",
+   "gatheringsCutoff",
+   "gatheringsRetentionMonths"
+  ],
+  "src/lib/retention/sweep.ts": [
+   "RetentionJobSummary",
+   "RetentionSweepSummary"
+  ],
+  "src/lib/sanitise.ts": [
+   "stripHtml"
+  ],
+  "src/lib/turnstile.ts": [
+   "TurnstileResult",
+   "isTurnstileEnabled"
+  ],
+  "src/middleware.ts": [
+   "middleware"
+  ]
+ },
+ "zeroConsumerSymbols": [
+  {
+   "file": "src/app/_marketing/sections.tsx",
+   "dir": "src/app/_marketing",
+   "symbol": "AboutLyra",
+   "line": 288,
+   "loc": 36,
+   "internalUses": 0,
+   "bucket": "DEAD-ISOLATED",
+   "frameworkContract": false,
+   "consumersOutsideDir": [],
+   "consumersSameDir": [],
+   "toolingConsumers": [],
+   "testConsumers": [],
+   "zeroConsumer": true,
+   "testedOnly": false
+  },
+  {
+   "file": "src/app/_marketing/sections.tsx",
+   "dir": "src/app/_marketing",
+   "symbol": "CTA",
+   "line": 413,
+   "loc": 20,
+   "internalUses": 0,
+   "bucket": "DEAD-ISOLATED",
+   "frameworkContract": false,
+   "consumersOutsideDir": [],
+   "consumersSameDir": [],
+   "toolingConsumers": [],
+   "testConsumers": [],
+   "zeroConsumer": true,
+   "testedOnly": false
+  },
+  {
+   "file": "src/app/_marketing/sections.tsx",
+   "dir": "src/app/_marketing",
+   "symbol": "Hero",
+   "line": 45,
+   "loc": 32,
+   "internalUses": 0,
+   "bucket": "DEAD-ISOLATED",
+   "frameworkContract": false,
+   "consumersOutsideDir": [],
+   "consumersSameDir": [],
+   "toolingConsumers": [],
+   "testConsumers": [],
+   "zeroConsumer": true,
+   "testedOnly": false
+  },
+  {
+   "file": "src/app/_marketing/sections.tsx",
+   "dir": "src/app/_marketing",
+   "symbol": "HowItWorks",
+   "line": 120,
+   "loc": 49,
+   "internalUses": 0,
+   "bucket": "DEAD-ISOLATED",
+   "frameworkContract": false,
+   "consumersOutsideDir": [],
+   "consumersSameDir": [],
+   "toolingConsumers": [],
+   "testConsumers": [],
+   "zeroConsumer": true,
+   "testedOnly": false
+  },
+  {
+   "file": "src/app/_marketing/sections.tsx",
+   "dir": "src/app/_marketing",
+   "symbol": "ParentTeacherCallout",
+   "line": 326,
+   "loc": 47,
+   "internalUses": 0,
+   "bucket": "DEAD-ISOLATED",
+   "frameworkContract": false,
+   "consumersOutsideDir": [],
+   "consumersSameDir": [],
+   "toolingConsumers": [],
+   "testConsumers": [],
+   "zeroConsumer": true,
+   "testedOnly": false
+  },
+  {
+   "file": "src/app/_marketing/sections.tsx",
+   "dir": "src/app/_marketing",
+   "symbol": "ProfilePreview",
+   "line": 78,
+   "loc": 41,
+   "internalUses": 0,
+   "bucket": "DEAD-ISOLATED",
+   "frameworkContract": false,
+   "consumersOutsideDir": [],
+   "consumersSameDir": [],
+   "toolingConsumers": [],
+   "testConsumers": [],
+   "zeroConsumer": true,
+   "testedOnly": false
+  },
+  {
+   "file": "src/app/_marketing/sections.tsx",
+   "dir": "src/app/_marketing",
+   "symbol": "Sections",
+   "line": 170,
+   "loc": 32,
+   "internalUses": 0,
+   "bucket": "DEAD-ISOLATED",
+   "frameworkContract": false,
+   "consumersOutsideDir": [],
+   "consumersSameDir": [],
+   "toolingConsumers": [],
+   "testConsumers": [],
+   "zeroConsumer": true,
+   "testedOnly": false
+  },
+  {
+   "file": "src/app/_marketing/sections.tsx",
+   "dir": "src/app/_marketing",
+   "symbol": "UseCases",
+   "line": 203,
+   "loc": 41,
+   "internalUses": 0,
+   "bucket": "DEAD-ISOLATED",
+   "frameworkContract": false,
+   "consumersOutsideDir": [],
+   "consumersSameDir": [],
+   "toolingConsumers": [],
+   "testConsumers": [],
+   "zeroConsumer": true,
+   "testedOnly": false
+  },
+  {
+   "file": "src/app/_marketing/sections.tsx",
+   "dir": "src/app/_marketing",
+   "symbol": "WhatLyraIsNot",
+   "line": 245,
+   "loc": 41,
+   "internalUses": 0,
+   "bucket": "DEAD-ISOLATED",
+   "frameworkContract": false,
+   "consumersOutsideDir": [],
+   "consumersSameDir": [],
+   "toolingConsumers": [],
+   "testConsumers": [],
+   "zeroConsumer": true,
+   "testedOnly": false
+  },
+  {
+   "file": "src/app/_marketing/sections.tsx",
+   "dir": "src/app/_marketing",
+   "symbol": "WishKnowFindFirstHand",
+   "line": 375,
+   "loc": 37,
+   "internalUses": 0,
+   "bucket": "DEAD-ISOLATED",
+   "frameworkContract": false,
+   "consumersOutsideDir": [],
+   "consumersSameDir": [],
+   "toolingConsumers": [],
+   "testConsumers": [],
+   "zeroConsumer": true,
+   "testedOnly": false
+  },
+  {
+   "file": "src/app/admin/beta-queue/actions.ts",
+   "dir": "src/app/admin/beta-queue",
+   "symbol": "approveBetaUser",
+   "line": 8,
+   "loc": 44,
+   "internalUses": 0,
+   "bucket": "DEAD-TESTED",
+   "frameworkContract": false,
+   "consumersOutsideDir": [],
+   "consumersSameDir": [],
+   "toolingConsumers": [],
+   "testConsumers": [
+    "tests/unit/beta-queue-approve.test.ts"
+   ],
+   "zeroConsumer": true,
+   "testedOnly": true
+  },
+  {
+   "file": "src/app/admin/monitoring/integration-status.ts",
+   "dir": "src/app/admin/monitoring",
+   "symbol": "MonitoringIntegration",
+   "line": 2,
+   "loc": 6,
+   "internalUses": 1,
+   "bucket": "OVER-EXPORTED",
+   "frameworkContract": false,
+   "consumersOutsideDir": [],
+   "consumersSameDir": [],
+   "toolingConsumers": [],
+   "testConsumers": [],
+   "zeroConsumer": true,
+   "testedOnly": false
+  },
+  {
+   "file": "src/app/admin/users/status-badges.ts",
+   "dir": "src/app/admin/users",
+   "symbol": "Badge",
+   "line": 3,
+   "loc": 1,
+   "internalUses": 3,
+   "bucket": "OVER-EXPORTED",
+   "frameworkContract": false,
+   "consumersOutsideDir": [],
+   "consumersSameDir": [],
+   "toolingConsumers": [],
+   "testConsumers": [],
+   "zeroConsumer": true,
+   "testedOnly": false
+  },
+  {
+   "file": "src/app/consent-state.ts",
+   "dir": "src/app",
+   "symbol": "CONSENT_STORAGE_KEY",
+   "line": 11,
+   "loc": 1,
+   "internalUses": 1,
+   "bucket": "OVER-EXPORTED",
+   "frameworkContract": false,
+   "consumersOutsideDir": [],
+   "consumersSameDir": [],
+   "toolingConsumers": [],
+   "testConsumers": [
+    "tests/unit/consented-analytics.test.ts"
+   ],
+   "zeroConsumer": true,
+   "testedOnly": true
+  },
+  {
+   "file": "src/app/consent-state.ts",
+   "dir": "src/app",
+   "symbol": "ConsentValue",
+   "line": 14,
+   "loc": 1,
+   "internalUses": 4,
+   "bucket": "OVER-EXPORTED",
+   "frameworkContract": false,
+   "consumersOutsideDir": [],
+   "consumersSameDir": [],
+   "toolingConsumers": [],
+   "testConsumers": [
+    "tests/unit/consented-analytics.test.ts"
+   ],
+   "zeroConsumer": true,
+   "testedOnly": true
+  },
+  {
+   "file": "src/app/dashboard/convene/contacts/contacts-helpers.ts",
+   "dir": "src/app/dashboard/convene/contacts",
+   "symbol": "ContactMethodKind",
+   "line": 3,
+   "loc": 1,
+   "internalUses": 0,
+   "bucket": "DEAD-ISOLATED",
+   "frameworkContract": false,
+   "consumersOutsideDir": [],
+   "consumersSameDir": [],
+   "toolingConsumers": [],
+   "testConsumers": [],
+   "zeroConsumer": true,
+   "testedOnly": false
+  },
+  {
+   "file": "src/app/dashboard/convene/contacts/contacts-helpers.ts",
+   "dir": "src/app/dashboard/convene/contacts",
+   "symbol": "ContactMethodView",
+   "line": 5,
+   "loc": 6,
+   "internalUses": 1,
+   "bucket": "OVER-EXPORTED",
+   "frameworkContract": false,
+   "consumersOutsideDir": [],
+   "consumersSameDir": [],
+   "toolingConsumers": [],
+   "testConsumers": [],
+   "zeroConsumer": true,
+   "testedOnly": false
+  },
+  {
+   "file": "src/app/dashboard/convene/gatherings/[id]/invite-actions.tsx",
+   "dir": "src/app/dashboard/convene/gatherings/[id]",
+   "symbol": "InviteeView",
+   "line": 75,
+   "loc": 7,
+   "internalUses": 1,
+   "bucket": "OVER-EXPORTED",
+   "frameworkContract": false,
+   "consumersOutsideDir": [],
+   "consumersSameDir": [],
+   "toolingConsumers": [],
+   "testConsumers": [],
+   "zeroConsumer": true,
+   "testedOnly": false
+  },
+  {
+   "file": "src/app/dashboard/convene/gatherings/[id]/invite-actions.tsx",
+   "dir": "src/app/dashboard/convene/gatherings/[id]",
+   "symbol": "ProposedSlot",
+   "line": 20,
+   "loc": 5,
+   "internalUses": 1,
+   "bucket": "OVER-EXPORTED",
+   "frameworkContract": false,
+   "consumersOutsideDir": [],
+   "consumersSameDir": [],
+   "toolingConsumers": [],
+   "testConsumers": [],
+   "zeroConsumer": true,
+   "testedOnly": false
+  },
+  {
+   "file": "src/app/dashboard/profile/actions.ts",
+   "dir": "src/app/dashboard/profile",
+   "symbol": "ItemActionResult",
+   "line": 238,
+   "loc": 2,
+   "internalUses": 1,
+   "bucket": "OVER-EXPORTED",
+   "frameworkContract": false,
+   "consumersOutsideDir": [],
+   "consumersSameDir": [],
+   "toolingConsumers": [],
+   "testConsumers": [],
+   "zeroConsumer": true,
+   "testedOnly": false
+  },
+  {
+   "file": "src/app/dashboard/profile/actions.ts",
+   "dir": "src/app/dashboard/profile",
+   "symbol": "updateSectionVisibility",
+   "line": 525,
+   "loc": 42,
+   "internalUses": 0,
+   "bucket": "DEAD-TESTED",
+   "frameworkContract": false,
+   "consumersOutsideDir": [],
+   "consumersSameDir": [],
+   "toolingConsumers": [],
+   "testConsumers": [
+    "tests/unit/section-visibility.test.ts"
+   ],
+   "zeroConsumer": true,
+   "testedOnly": true
+  },
+  {
+   "file": "src/app/dashboard/profile/affiliation-fields.ts",
+   "dir": "src/app/dashboard/profile",
+   "symbol": "ALLOWED_AFFILIATION_TYPES",
+   "line": 3,
+   "loc": 1,
+   "internalUses": 2,
+   "bucket": "OVER-EXPORTED",
+   "frameworkContract": false,
+   "consumersOutsideDir": [],
+   "consumersSameDir": [],
+   "toolingConsumers": [],
+   "testConsumers": [
+    "tests/unit/affiliations-and-autosave.test.ts"
+   ],
+   "zeroConsumer": true,
+   "testedOnly": true
+  },
+  {
+   "file": "src/app/dashboard/profile/affiliation-fields.ts",
+   "dir": "src/app/dashboard/profile",
+   "symbol": "isAffiliationType",
+   "line": 7,
+   "loc": 3,
+   "internalUses": 1,
+   "bucket": "OVER-EXPORTED",
+   "frameworkContract": false,
+   "consumersOutsideDir": [],
+   "consumersSameDir": [],
+   "toolingConsumers": [],
+   "testConsumers": [
+    "tests/unit/affiliations-and-autosave.test.ts"
+   ],
+   "zeroConsumer": true,
+   "testedOnly": true
+  },
+  {
+   "file": "src/app/dashboard/profile/city-actions.ts",
+   "dir": "src/app/dashboard/profile",
+   "symbol": "ResolveCityResult",
+   "line": 7,
+   "loc": 2,
+   "internalUses": 1,
+   "bucket": "OVER-EXPORTED",
+   "frameworkContract": false,
+   "consumersOutsideDir": [],
+   "consumersSameDir": [],
+   "toolingConsumers": [],
+   "testConsumers": [],
+   "zeroConsumer": true,
+   "testedOnly": false
+  },
+  {
+   "file": "src/app/dashboard/profile/manual-of-me-fields.ts",
+   "dir": "src/app/dashboard/profile",
+   "symbol": "ManualOfMeField",
+   "line": 13,
+   "loc": 1,
+   "internalUses": 2,
+   "bucket": "OVER-EXPORTED",
+   "frameworkContract": false,
+   "consumersOutsideDir": [],
+   "consumersSameDir": [],
+   "toolingConsumers": [],
+   "testConsumers": [],
+   "zeroConsumer": true,
+   "testedOnly": false
+  },
+  {
+   "file": "src/app/dashboard/profile/profile-fields.ts",
+   "dir": "src/app/dashboard/profile",
+   "symbol": "ALLOWED_PROFILE_FIELDS",
+   "line": 2,
+   "loc": 16,
+   "internalUses": 2,
+   "bucket": "OVER-EXPORTED",
+   "frameworkContract": false,
+   "consumersOutsideDir": [],
+   "consumersSameDir": [],
+   "toolingConsumers": [],
+   "testConsumers": [
+    "tests/unit/partial-write-safety.test.ts",
+    "tests/unit/profile-actions.test.ts"
+   ],
+   "zeroConsumer": true,
+   "testedOnly": true
+  },
+  {
+   "file": "src/app/dashboard/profile/profile-fields.ts",
+   "dir": "src/app/dashboard/profile",
+   "symbol": "AllowedProfileField",
+   "line": 19,
+   "loc": 1,
+   "internalUses": 1,
+   "bucket": "OVER-EXPORTED",
+   "frameworkContract": false,
+   "consumersOutsideDir": [],
+   "consumersSameDir": [],
+   "toolingConsumers": [],
+   "testConsumers": [],
+   "zeroConsumer": true,
+   "testedOnly": false
+  },
+  {
+   "file": "src/app/dashboard/profile/section-visibility.ts",
+   "dir": "src/app/dashboard/profile",
+   "symbol": "CONTROLLABLE_SECTION_KEYS",
+   "line": 7,
+   "loc": 8,
+   "internalUses": 2,
+   "bucket": "OVER-EXPORTED",
+   "frameworkContract": false,
+   "consumersOutsideDir": [],
+   "consumersSameDir": [],
+   "toolingConsumers": [],
+   "testConsumers": [
+    "tests/unit/section-visibility.test.ts"
+   ],
+   "zeroConsumer": true,
+   "testedOnly": true
+  },
+  {
+   "file": "src/app/dashboard/profile/section-visibility.ts",
+   "dir": "src/app/dashboard/profile",
+   "symbol": "ControllableSectionKey",
+   "line": 16,
+   "loc": 1,
+   "internalUses": 3,
+   "bucket": "OVER-EXPORTED",
+   "frameworkContract": false,
+   "consumersOutsideDir": [],
+   "consumersSameDir": [],
+   "toolingConsumers": [],
+   "testConsumers": [],
+   "zeroConsumer": true,
+   "testedOnly": false
+  },
+  {
+   "file": "src/app/dashboard/profile/section-visibility.ts",
+   "dir": "src/app/dashboard/profile",
+   "symbol": "ITEM_CATEGORY_TO_SECTION",
+   "line": 23,
+   "loc": 17,
+   "internalUses": 1,
+   "bucket": "OVER-EXPORTED",
+   "frameworkContract": false,
+   "consumersOutsideDir": [],
+   "consumersSameDir": [],
+   "toolingConsumers": [],
+   "testConsumers": [
+    "tests/unit/section-visibility.test.ts"
+   ],
+   "zeroConsumer": true,
+   "testedOnly": true
+  },
+  {
+   "file": "src/app/dashboard/profile/section-visibility.ts",
+   "dir": "src/app/dashboard/profile",
+   "symbol": "getEffectiveItemVisibility",
+   "line": 63,
+   "loc": 14,
+   "internalUses": 1,
+   "bucket": "OVER-EXPORTED",
+   "frameworkContract": false,
+   "consumersOutsideDir": [],
+   "consumersSameDir": [],
+   "toolingConsumers": [],
+   "testConsumers": [
+    "tests/unit/section-visibility.test.ts"
+   ],
+   "zeroConsumer": true,
+   "testedOnly": true
+  },
+  {
+   "file": "src/app/dashboard/profile/sections/auto-save-core.ts",
+   "dir": "src/app/dashboard/profile/sections",
+   "symbol": "AutoSaveResult",
+   "line": 5,
+   "loc": 2,
+   "internalUses": 1,
+   "bucket": "OVER-EXPORTED",
+   "frameworkContract": false,
+   "consumersOutsideDir": [],
+   "consumersSameDir": [],
+   "toolingConsumers": [],
+   "testConsumers": [],
+   "zeroConsumer": true,
+   "testedOnly": false
+  },
+  {
+   "file": "src/app/dashboard/profile/sections/auto-save-core.ts",
+   "dir": "src/app/dashboard/profile/sections",
+   "symbol": "AutoSaveStatus",
+   "line": 3,
+   "loc": 1,
+   "internalUses": 1,
+   "bucket": "OVER-EXPORTED",
+   "frameworkContract": false,
+   "consumersOutsideDir": [],
+   "consumersSameDir": [],
+   "toolingConsumers": [],
+   "testConsumers": [],
+   "zeroConsumer": true,
+   "testedOnly": false
+  },
+  {
+   "file": "src/app/dashboard/profile/sections/index.ts",
+   "dir": "src/app/dashboard/profile/sections",
+   "symbol": "SectionSaveBar",
+   "line": 9,
+   "loc": 1,
+   "internalUses": 0,
+   "bucket": "DEAD-ISOLATED",
+   "frameworkContract": false,
+   "consumersOutsideDir": [],
+   "consumersSameDir": [],
+   "toolingConsumers": [],
+   "testConsumers": [],
+   "zeroConsumer": true,
+   "testedOnly": false
+  },
+  {
+   "file": "src/app/dashboard/profile/sections/index.ts",
+   "dir": "src/app/dashboard/profile/sections",
+   "symbol": "useAutoSave",
+   "line": 7,
+   "loc": 1,
+   "internalUses": 0,
+   "bucket": "DEAD-ISOLATED",
+   "frameworkContract": false,
+   "consumersOutsideDir": [],
+   "consumersSameDir": [],
+   "toolingConsumers": [],
+   "testConsumers": [],
+   "zeroConsumer": true,
+   "testedOnly": false
+  },
+  {
+   "file": "src/app/dashboard/profile/visibility.ts",
+   "dir": "src/app/dashboard/profile",
+   "symbol": "DEFAULT_VISIBILITY",
+   "line": 7,
+   "loc": 1,
+   "internalUses": 1,
+   "bucket": "OVER-EXPORTED",
+   "frameworkContract": false,
+   "consumersOutsideDir": [],
+   "consumersSameDir": [],
+   "toolingConsumers": [],
+   "testConsumers": [
+    "tests/unit/visibility.test.ts"
+   ],
+   "zeroConsumer": true,
+   "testedOnly": true
+  },
+  {
+   "file": "src/app/dashboard/profile/visibility.ts",
+   "dir": "src/app/dashboard/profile",
+   "symbol": "VISIBILITY_LEVELS",
+   "line": 3,
+   "loc": 1,
+   "internalUses": 2,
+   "bucket": "OVER-EXPORTED",
+   "frameworkContract": false,
+   "consumersOutsideDir": [],
+   "consumersSameDir": [],
+   "toolingConsumers": [],
+   "testConsumers": [
+    "tests/unit/visibility.test.ts"
+   ],
+   "zeroConsumer": true,
+   "testedOnly": true
+  },
+  {
+   "file": "src/app/dashboard/profile/visibility.ts",
+   "dir": "src/app/dashboard/profile",
+   "symbol": "filterItemsByVisibility",
+   "line": 36,
+   "loc": 6,
+   "internalUses": 0,
+   "bucket": "DEAD-TESTED",
+   "frameworkContract": false,
+   "consumersOutsideDir": [],
+   "consumersSameDir": [],
+   "toolingConsumers": [],
+   "testConsumers": [
+    "tests/unit/visibility.test.ts"
+   ],
+   "zeroConsumer": true,
+   "testedOnly": true
+  },
+  {
+   "file": "src/app/dashboard/profile/visibility.ts",
+   "dir": "src/app/dashboard/profile",
+   "symbol": "isAllowedVisibility",
+   "line": 10,
+   "loc": 6,
+   "internalUses": 1,
+   "bucket": "OVER-EXPORTED",
+   "frameworkContract": false,
+   "consumersOutsideDir": [],
+   "consumersSameDir": [],
+   "toolingConsumers": [],
+   "testConsumers": [
+    "tests/unit/visibility.test.ts"
+   ],
+   "zeroConsumer": true,
+   "testedOnly": true
+  },
+  {
+   "file": "src/app/dashboard/profile/visibility.ts",
+   "dir": "src/app/dashboard/profile",
+   "symbol": "isItemVisibleToViewer",
+   "line": 23,
+   "loc": 11,
+   "internalUses": 1,
+   "bucket": "OVER-EXPORTED",
+   "frameworkContract": false,
+   "consumersOutsideDir": [],
+   "consumersSameDir": [],
+   "toolingConsumers": [],
+   "testConsumers": [
+    "tests/unit/visibility.test.ts"
+   ],
+   "zeroConsumer": true,
+   "testedOnly": true
+  },
+  {
+   "file": "src/app/dashboard/settings/discoverability-actions.ts",
+   "dir": "src/app/dashboard/settings",
+   "symbol": "searchByPhone",
+   "line": 150,
+   "loc": 16,
+   "internalUses": 0,
+   "bucket": "DEAD-TESTED",
+   "frameworkContract": false,
+   "consumersOutsideDir": [],
+   "consumersSameDir": [],
+   "toolingConsumers": [],
+   "testConsumers": [
+    "tests/unit/discoverability-actions.test.ts"
+   ],
+   "zeroConsumer": true,
+   "testedOnly": true
+  },
+  {
+   "file": "src/app/dashboard/settings/discoverability-helpers.ts",
+   "dir": "src/app/dashboard/settings",
+   "symbol": "ContactKind",
+   "line": 5,
+   "loc": 1,
+   "internalUses": 1,
+   "bucket": "OVER-EXPORTED",
+   "frameworkContract": false,
+   "consumersOutsideDir": [],
+   "consumersSameDir": [],
+   "toolingConsumers": [],
+   "testConsumers": [],
+   "zeroConsumer": true,
+   "testedOnly": false
+  },
+  {
+   "file": "src/app/dashboard/settings/discoverability-helpers.ts",
+   "dir": "src/app/dashboard/settings",
+   "symbol": "RateLimitGate",
+   "line": 80,
+   "loc": 5,
+   "internalUses": 0,
+   "bucket": "DEAD-ISOLATED",
+   "frameworkContract": false,
+   "consumersOutsideDir": [],
+   "consumersSameDir": [],
+   "toolingConsumers": [],
+   "testConsumers": [],
+   "zeroConsumer": true,
+   "testedOnly": false
+  },
+  {
+   "file": "src/app/dashboard/settings/discoverability-helpers.ts",
+   "dir": "src/app/dashboard/settings",
+   "symbol": "getContactSearchHmacKey",
+   "line": 25,
+   "loc": 6,
+   "internalUses": 1,
+   "bucket": "OVER-EXPORTED",
+   "frameworkContract": false,
+   "consumersOutsideDir": [],
+   "consumersSameDir": [],
+   "toolingConsumers": [],
+   "testConsumers": [
+    "tests/unit/convene/sec18-hmac-hash.test.ts"
+   ],
+   "zeroConsumer": true,
+   "testedOnly": true
+  },
+  {
+   "file": "src/app/dashboard/settings/discoverability-helpers.ts",
+   "dir": "src/app/dashboard/settings",
+   "symbol": "getSearchPepper",
+   "line": 14,
+   "loc": 9,
+   "internalUses": 1,
+   "bucket": "OVER-EXPORTED",
+   "frameworkContract": false,
+   "consumersOutsideDir": [],
+   "consumersSameDir": [],
+   "toolingConsumers": [],
+   "testConsumers": [
+    "tests/unit/discoverability-helpers.test.ts"
+   ],
+   "zeroConsumer": true,
+   "testedOnly": true
+  },
+  {
+   "file": "src/app/dashboard/settings/discoverability-helpers.ts",
+   "dir": "src/app/dashboard/settings",
+   "symbol": "hashContact",
+   "line": 59,
+   "loc": 10,
+   "internalUses": 2,
+   "bucket": "OVER-EXPORTED",
+   "frameworkContract": false,
+   "consumersOutsideDir": [],
+   "consumersSameDir": [],
+   "toolingConsumers": [],
+   "testConsumers": [
+    "tests/unit/convene/sec18-hmac-hash.test.ts",
+    "tests/unit/discoverability-helpers.test.ts"
+   ],
+   "zeroConsumer": true,
+   "testedOnly": true
+  },
+  {
+   "file": "src/app/dashboard/settings/discoverability-helpers.ts",
+   "dir": "src/app/dashboard/settings",
+   "symbol": "normalisePhone",
+   "line": 33,
+   "loc": 24,
+   "internalUses": 1,
+   "bucket": "OVER-EXPORTED",
+   "frameworkContract": false,
+   "consumersOutsideDir": [],
+   "consumersSameDir": [],
+   "toolingConsumers": [],
+   "testConsumers": [
+    "tests/unit/discoverability-helpers.test.ts"
+   ],
+   "zeroConsumer": true,
+   "testedOnly": true
+  },
+  {
+   "file": "src/app/dashboard/share-profile.tsx",
+   "dir": "src/app/dashboard",
+   "symbol": "default",
+   "line": 7,
+   "loc": 81,
+   "internalUses": 0,
+   "bucket": "DEAD-ISOLATED",
+   "frameworkContract": false,
+   "consumersOutsideDir": [],
+   "consumersSameDir": [],
+   "toolingConsumers": [],
+   "testConsumers": [],
+   "zeroConsumer": true,
+   "testedOnly": false
+  },
+  {
+   "file": "src/components/AffiliateBadge.tsx",
+   "dir": "src/components",
+   "symbol": "AffiliateBadgeProps",
+   "line": 5,
+   "loc": 8,
+   "internalUses": 1,
+   "bucket": "OVER-EXPORTED",
+   "frameworkContract": false,
+   "consumersOutsideDir": [],
+   "consumersSameDir": [],
+   "toolingConsumers": [],
+   "testConsumers": [],
+   "zeroConsumer": true,
+   "testedOnly": false
+  },
+  {
+   "file": "src/lib/account-status.ts",
+   "dir": "src/lib",
+   "symbol": "AccountStanding",
+   "line": 5,
+   "loc": 1,
+   "internalUses": 2,
+   "bucket": "OVER-EXPORTED",
+   "frameworkContract": false,
+   "consumersOutsideDir": [],
+   "consumersSameDir": [],
+   "toolingConsumers": [],
+   "testConsumers": [],
+   "zeroConsumer": true,
+   "testedOnly": false
+  },
+  {
+   "file": "src/lib/admin.ts",
+   "dir": "src/lib",
+   "symbol": "AdminUser",
+   "line": 34,
+   "loc": 6,
+   "internalUses": 3,
+   "bucket": "OVER-EXPORTED",
+   "frameworkContract": false,
+   "consumersOutsideDir": [],
+   "consumersSameDir": [],
+   "toolingConsumers": [],
+   "testConsumers": [
+    "tests/unit/account-deletion.test.ts",
+    "tests/unit/beta-queue-approve.test.ts",
+    "tests/unit/sec57-issuance-suspension.test.ts",
+    "tests/unit/sec82-reports-item-ownership.test.ts",
+    "tests/unit/set-feature-entitlement.test.ts",
+    "tests/unit/set-global-feature.test.ts",
+    "tests/unit/users-bulk-actions.test.ts"
+   ],
+   "zeroConsumer": true,
+   "testedOnly": true
+  },
+  {
+   "file": "src/lib/admin.ts",
+   "dir": "src/lib",
+   "symbol": "LogModerationActionInput",
+   "line": 68,
+   "loc": 8,
+   "internalUses": 1,
+   "bucket": "OVER-EXPORTED",
+   "frameworkContract": false,
+   "consumersOutsideDir": [],
+   "consumersSameDir": [],
+   "toolingConsumers": [],
+   "testConsumers": [
+    "tests/unit/account-deletion.test.ts",
+    "tests/unit/beta-queue-approve.test.ts",
+    "tests/unit/sec57-issuance-suspension.test.ts",
+    "tests/unit/sec82-reports-item-ownership.test.ts",
+    "tests/unit/set-feature-entitlement.test.ts",
+    "tests/unit/set-global-feature.test.ts",
+    "tests/unit/users-bulk-actions.test.ts"
+   ],
+   "zeroConsumer": true,
+   "testedOnly": true
+  },
+  {
+   "file": "src/lib/admin.ts",
+   "dir": "src/lib",
+   "symbol": "LogModerationActionsBatchInput",
+   "line": 99,
+   "loc": 7,
+   "internalUses": 1,
+   "bucket": "OVER-EXPORTED",
+   "frameworkContract": false,
+   "consumersOutsideDir": [],
+   "consumersSameDir": [],
+   "toolingConsumers": [],
+   "testConsumers": [
+    "tests/unit/account-deletion.test.ts",
+    "tests/unit/beta-queue-approve.test.ts",
+    "tests/unit/sec57-issuance-suspension.test.ts",
+    "tests/unit/sec82-reports-item-ownership.test.ts",
+    "tests/unit/set-feature-entitlement.test.ts",
+    "tests/unit/set-global-feature.test.ts",
+    "tests/unit/users-bulk-actions.test.ts"
+   ],
+   "zeroConsumer": true,
+   "testedOnly": true
+  },
+  {
+   "file": "src/lib/affiliate/country-codes.ts",
+   "dir": "src/lib/affiliate",
+   "symbol": "SupportedDeliveryCountry",
+   "line": 16,
+   "loc": 2,
+   "internalUses": 0,
+   "bucket": "DEAD-TESTED",
+   "frameworkContract": false,
+   "consumersOutsideDir": [],
+   "consumersSameDir": [],
+   "toolingConsumers": [],
+   "testConsumers": [
+    "tests/unit/delivery-country.test.ts"
+   ],
+   "zeroConsumer": true,
+   "testedOnly": true
+  },
+  {
+   "file": "src/lib/affiliate/eligibility.ts",
+   "dir": "src/lib/affiliate",
+   "symbol": "AffiliateNetwork",
+   "line": 5,
+   "loc": 7,
+   "internalUses": 3,
+   "bucket": "OVER-EXPORTED",
+   "frameworkContract": false,
+   "consumersOutsideDir": [],
+   "consumersSameDir": [],
+   "toolingConsumers": [],
+   "testConsumers": [],
+   "zeroConsumer": true,
+   "testedOnly": false
+  },
+  {
+   "file": "src/lib/affiliate/eligibility.ts",
+   "dir": "src/lib/affiliate",
+   "symbol": "MerchantEligibilityRow",
+   "line": 13,
+   "loc": 12,
+   "internalUses": 0,
+   "bucket": "DEAD-TESTED",
+   "frameworkContract": false,
+   "consumersOutsideDir": [],
+   "consumersSameDir": [],
+   "toolingConsumers": [],
+   "testConsumers": [
+    "tests/unit/affiliate-eligibility.test.ts"
+   ],
+   "zeroConsumer": true,
+   "testedOnly": true
+  },
+  {
+   "file": "src/lib/affiliate/eligibility.ts",
+   "dir": "src/lib/affiliate",
+   "symbol": "isAffiliateNetwork",
+   "line": 79,
+   "loc": 3,
+   "internalUses": 0,
+   "bucket": "DEAD-TESTED",
+   "frameworkContract": false,
+   "consumersOutsideDir": [],
+   "consumersSameDir": [],
+   "toolingConsumers": [],
+   "testConsumers": [
+    "tests/unit/affiliate-eligibility.test.ts"
+   ],
+   "zeroConsumer": true,
+   "testedOnly": true
+  },
+  {
+   "file": "src/lib/affiliate/eligibility.ts",
+   "dir": "src/lib/affiliate",
+   "symbol": "isMerchantEligibleInCountry",
+   "line": 27,
+   "loc": 20,
+   "internalUses": 0,
+   "bucket": "DEAD-TESTED",
+   "frameworkContract": false,
+   "consumersOutsideDir": [],
+   "consumersSameDir": [],
+   "toolingConsumers": [],
+   "testConsumers": [
+    "tests/unit/affiliate-eligibility.test.ts"
+   ],
+   "zeroConsumer": true,
+   "testedOnly": true
+  },
+  {
+   "file": "src/lib/affiliate/fx.ts",
+   "dir": "src/lib/affiliate",
+   "symbol": "_clearFxCacheForTests",
+   "line": 67,
+   "loc": 3,
+   "internalUses": 0,
+   "bucket": "DEAD-ISOLATED",
+   "frameworkContract": false,
+   "consumersOutsideDir": [],
+   "consumersSameDir": [],
+   "toolingConsumers": [],
+   "testConsumers": [],
+   "zeroConsumer": true,
+   "testedOnly": false
+  },
+  {
+   "file": "src/lib/affiliate/link-service.ts",
+   "dir": "src/lib/affiliate",
+   "symbol": "AffiliateLinkRequest",
+   "line": 12,
+   "loc": 20,
+   "internalUses": 1,
+   "bucket": "OVER-EXPORTED",
+   "frameworkContract": false,
+   "consumersOutsideDir": [],
+   "consumersSameDir": [],
+   "toolingConsumers": [],
+   "testConsumers": [],
+   "zeroConsumer": true,
+   "testedOnly": false
+  },
+  {
+   "file": "src/lib/affiliate/link-service.ts",
+   "dir": "src/lib/affiliate",
+   "symbol": "AffiliateLinkResult",
+   "line": 33,
+   "loc": 12,
+   "internalUses": 2,
+   "bucket": "OVER-EXPORTED",
+   "frameworkContract": false,
+   "consumersOutsideDir": [],
+   "consumersSameDir": [],
+   "toolingConsumers": [],
+   "testConsumers": [],
+   "zeroConsumer": true,
+   "testedOnly": false
+  },
+  {
+   "file": "src/lib/affiliate/merchant-detector.ts",
+   "dir": "src/lib/affiliate",
+   "symbol": "MERCHANT_RULES_INTERNAL",
+   "line": 91,
+   "loc": 1,
+   "internalUses": 0,
+   "bucket": "DEAD-TESTED",
+   "frameworkContract": false,
+   "consumersOutsideDir": [],
+   "consumersSameDir": [],
+   "toolingConsumers": [],
+   "testConsumers": [
+    "tests/unit/affiliate-link-service.test.ts"
+   ],
+   "zeroConsumer": true,
+   "testedOnly": true
+  },
+  {
+   "file": "src/lib/affiliate/reporting.ts",
+   "dir": "src/lib/affiliate",
+   "symbol": "ReconciliationUpdate",
+   "line": 109,
+   "loc": 7,
+   "internalUses": 2,
+   "bucket": "OVER-EXPORTED",
+   "frameworkContract": false,
+   "consumersOutsideDir": [],
+   "consumersSameDir": [],
+   "toolingConsumers": [],
+   "testConsumers": [],
+   "zeroConsumer": true,
+   "testedOnly": false
+  },
+  {
+   "file": "src/lib/affiliate/reporting.ts",
+   "dir": "src/lib/affiliate",
+   "symbol": "parseClickIdFromSubId",
+   "line": 139,
+   "loc": 8,
+   "internalUses": 1,
+   "bucket": "OVER-EXPORTED",
+   "frameworkContract": false,
+   "consumersOutsideDir": [],
+   "consumersSameDir": [],
+   "toolingConsumers": [],
+   "testConsumers": [
+    "tests/unit/affiliate-reporting.test.ts"
+   ],
+   "zeroConsumer": true,
+   "testedOnly": true
+  },
+  {
+   "file": "src/lib/affiliate/smoke.ts",
+   "dir": "src/lib/affiliate",
+   "symbol": "FetchLike",
+   "line": 203,
+   "loc": 1,
+   "internalUses": 2,
+   "bucket": "OVER-EXPORTED",
+   "frameworkContract": false,
+   "consumersOutsideDir": [],
+   "consumersSameDir": [],
+   "toolingConsumers": [],
+   "testConsumers": [
+    "tests/unit/affiliate-smoke.test.ts"
+   ],
+   "zeroConsumer": true,
+   "testedOnly": true
+  },
+  {
+   "file": "src/lib/affiliate/smoke.ts",
+   "dir": "src/lib/affiliate",
+   "symbol": "MerchantSmokeProbe",
+   "line": 7,
+   "loc": 9,
+   "internalUses": 1,
+   "bucket": "OVER-EXPORTED",
+   "frameworkContract": false,
+   "consumersOutsideDir": [],
+   "consumersSameDir": [],
+   "toolingConsumers": [],
+   "testConsumers": [],
+   "zeroConsumer": true,
+   "testedOnly": false
+  },
+  {
+   "file": "src/lib/affiliate/smoke.ts",
+   "dir": "src/lib/affiliate",
+   "symbol": "ProbeResult",
+   "line": 210,
+   "loc": 2,
+   "internalUses": 1,
+   "bucket": "OVER-EXPORTED",
+   "frameworkContract": false,
+   "consumersOutsideDir": [],
+   "consumersSameDir": [],
+   "toolingConsumers": [],
+   "testConsumers": [],
+   "zeroConsumer": true,
+   "testedOnly": false
+  },
+  {
+   "file": "src/lib/affiliate/smoke.ts",
+   "dir": "src/lib/affiliate",
+   "symbol": "SMOKE_PROBES",
+   "line": 17,
+   "loc": 114,
+   "internalUses": 1,
+   "bucket": "OVER-EXPORTED",
+   "frameworkContract": false,
+   "consumersOutsideDir": [],
+   "consumersSameDir": [],
+   "toolingConsumers": [],
+   "testConsumers": [
+    "tests/unit/affiliate-smoke.test.ts"
+   ],
+   "zeroConsumer": true,
+   "testedOnly": true
+  },
+  {
+   "file": "src/lib/affiliate/smoke.ts",
+   "dir": "src/lib/affiliate",
+   "symbol": "SmokeMatrixEntry",
+   "line": 133,
+   "loc": 6,
+   "internalUses": 2,
+   "bucket": "OVER-EXPORTED",
+   "frameworkContract": false,
+   "consumersOutsideDir": [],
+   "consumersSameDir": [],
+   "toolingConsumers": [],
+   "testConsumers": [],
+   "zeroConsumer": true,
+   "testedOnly": false
+  },
+  {
+   "file": "src/lib/affiliate/smoke.ts",
+   "dir": "src/lib/affiliate",
+   "symbol": "SmokeRunSummary",
+   "line": 312,
+   "loc": 20,
+   "internalUses": 1,
+   "bucket": "OVER-EXPORTED",
+   "frameworkContract": false,
+   "consumersOutsideDir": [],
+   "consumersSameDir": [],
+   "toolingConsumers": [],
+   "testConsumers": [],
+   "zeroConsumer": true,
+   "testedOnly": false
+  },
+  {
+   "file": "src/lib/affiliate/types.ts",
+   "dir": "src/lib/affiliate",
+   "symbol": "isCountryCode",
+   "line": 58,
+   "loc": 3,
+   "internalUses": 0,
+   "bucket": "DEAD-TESTED",
+   "frameworkContract": false,
+   "consumersOutsideDir": [],
+   "consumersSameDir": [],
+   "toolingConsumers": [],
+   "testConsumers": [
+    "tests/unit/affiliate-clicks.test.ts"
+   ],
+   "zeroConsumer": true,
+   "testedOnly": true
+  },
+  {
+   "file": "src/lib/affiliate/types.ts",
+   "dir": "src/lib/affiliate",
+   "symbol": "parseSubId",
+   "line": 36,
+   "loc": 20,
+   "internalUses": 0,
+   "bucket": "DEAD-TESTED",
+   "frameworkContract": false,
+   "consumersOutsideDir": [],
+   "consumersSameDir": [],
+   "toolingConsumers": [],
+   "testConsumers": [
+    "tests/unit/affiliate-clicks.test.ts"
+   ],
+   "zeroConsumer": true,
+   "testedOnly": true
+  },
+  {
+   "file": "src/lib/age/didit.ts",
+   "dir": "src/lib/age",
+   "symbol": "CHALLENGE_AGE",
+   "line": 5,
+   "loc": 1,
+   "internalUses": 1,
+   "bucket": "OVER-EXPORTED",
+   "frameworkContract": false,
+   "consumersOutsideDir": [],
+   "consumersSameDir": [],
+   "toolingConsumers": [],
+   "testConsumers": [
+    "tests/unit/didit-age.test.ts"
+   ],
+   "zeroConsumer": true,
+   "testedOnly": true
+  },
+  {
+   "file": "src/lib/age/didit.ts",
+   "dir": "src/lib/age",
+   "symbol": "CreateSessionResult",
+   "line": 13,
+   "loc": 2,
+   "internalUses": 1,
+   "bucket": "OVER-EXPORTED",
+   "frameworkContract": false,
+   "consumersOutsideDir": [],
+   "consumersSameDir": [],
+   "toolingConsumers": [],
+   "testConsumers": [],
+   "zeroConsumer": true,
+   "testedOnly": false
+  },
+  {
+   "file": "src/lib/age/didit.ts",
+   "dir": "src/lib/age",
+   "symbol": "NormalisedDecision",
+   "line": 68,
+   "loc": 6,
+   "internalUses": 2,
+   "bucket": "OVER-EXPORTED",
+   "frameworkContract": false,
+   "consumersOutsideDir": [],
+   "consumersSameDir": [],
+   "toolingConsumers": [],
+   "testConsumers": [],
+   "zeroConsumer": true,
+   "testedOnly": false
+  },
+  {
+   "file": "src/lib/age/provider-gate.ts",
+   "dir": "src/lib/age",
+   "symbol": "AgeStatus",
+   "line": 4,
+   "loc": 1,
+   "internalUses": 1,
+   "bucket": "OVER-EXPORTED",
+   "frameworkContract": false,
+   "consumersOutsideDir": [],
+   "consumersSameDir": [],
+   "toolingConsumers": [],
+   "testConsumers": [],
+   "zeroConsumer": true,
+   "testedOnly": false
+  },
+  {
+   "file": "src/lib/beta-access/email.ts",
+   "dir": "src/lib/beta-access",
+   "symbol": "BetaEmailResult",
+   "line": 2,
+   "loc": 2,
+   "internalUses": 3,
+   "bucket": "OVER-EXPORTED",
+   "frameworkContract": false,
+   "consumersOutsideDir": [],
+   "consumersSameDir": [],
+   "toolingConsumers": [],
+   "testConsumers": [
+    "tests/unit/beta-access-resolve.test.ts",
+    "tests/unit/beta-queue-approve.test.ts",
+    "tests/unit/set-feature-entitlement.test.ts",
+    "tests/unit/users-bulk-actions.test.ts"
+   ],
+   "zeroConsumer": true,
+   "testedOnly": true
+  },
+  {
+   "file": "src/lib/beta-access/invite-link.ts",
+   "dir": "src/lib/beta-access",
+   "symbol": "INVITE_COOKIE",
+   "line": 5,
+   "loc": 1,
+   "internalUses": 0,
+   "bucket": "DEAD-ISOLATED",
+   "frameworkContract": false,
+   "consumersOutsideDir": [],
+   "consumersSameDir": [],
+   "toolingConsumers": [],
+   "testConsumers": [],
+   "zeroConsumer": true,
+   "testedOnly": false
+  },
+  {
+   "file": "src/lib/beta-access/invite-link.ts",
+   "dir": "src/lib/beta-access",
+   "symbol": "INVITE_COOKIE_MAX_AGE",
+   "line": 5,
+   "loc": 1,
+   "internalUses": 0,
+   "bucket": "DEAD-ISOLATED",
+   "frameworkContract": false,
+   "consumersOutsideDir": [],
+   "consumersSameDir": [],
+   "toolingConsumers": [],
+   "testConsumers": [],
+   "zeroConsumer": true,
+   "testedOnly": false
+  },
+  {
+   "file": "src/lib/beta-access/invite-link.ts",
+   "dir": "src/lib/beta-access",
+   "symbol": "buildBetaInviteLink",
+   "line": 8,
+   "loc": 3,
+   "internalUses": 1,
+   "bucket": "OVER-EXPORTED",
+   "frameworkContract": false,
+   "consumersOutsideDir": [],
+   "consumersSameDir": [],
+   "toolingConsumers": [],
+   "testConsumers": [
+    "tests/unit/invite-link.test.ts"
+   ],
+   "zeroConsumer": true,
+   "testedOnly": true
+  },
+  {
+   "file": "src/lib/cf-access.ts",
+   "dir": "src/lib",
+   "symbol": "__resetCfAccessJwksCacheForTests",
+   "line": 52,
+   "loc": 4,
+   "internalUses": 0,
+   "bucket": "DEAD-TESTED",
+   "frameworkContract": false,
+   "consumersOutsideDir": [],
+   "consumersSameDir": [],
+   "toolingConsumers": [],
+   "testConsumers": [
+    "tests/unit/admin/cf-access.test.ts"
+   ],
+   "zeroConsumer": true,
+   "testedOnly": true
+  },
+  {
+   "file": "src/lib/compliance/disclosures.ts",
+   "dir": "src/lib/compliance",
+   "symbol": "DisclosureFlags",
+   "line": 6,
+   "loc": 4,
+   "internalUses": 2,
+   "bucket": "OVER-EXPORTED",
+   "frameworkContract": false,
+   "consumersOutsideDir": [],
+   "consumersSameDir": [],
+   "toolingConsumers": [],
+   "testConsumers": [],
+   "zeroConsumer": true,
+   "testedOnly": false
+  },
+  {
+   "file": "src/lib/compliance/disclosures.ts",
+   "dir": "src/lib/compliance",
+   "symbol": "disclosuresFromSwitches",
+   "line": 12,
+   "loc": 7,
+   "internalUses": 1,
+   "bucket": "OVER-EXPORTED",
+   "frameworkContract": false,
+   "consumersOutsideDir": [],
+   "consumersSameDir": [],
+   "toolingConsumers": [],
+   "testConsumers": [
+    "tests/unit/compliance/disclosures.test.ts"
+   ],
+   "zeroConsumer": true,
+   "testedOnly": true
+  },
+  {
+   "file": "src/lib/content-moderation.ts",
+   "dir": "src/lib",
+   "symbol": "ModerationResult",
+   "line": 293,
+   "loc": 8,
+   "internalUses": 1,
+   "bucket": "OVER-EXPORTED",
+   "frameworkContract": false,
+   "consumersOutsideDir": [],
+   "consumersSameDir": [],
+   "toolingConsumers": [],
+   "testConsumers": [],
+   "zeroConsumer": true,
+   "testedOnly": false
+  },
+  {
+   "file": "src/lib/content-moderation.ts",
+   "dir": "src/lib",
+   "symbol": "ModerationSeverity",
+   "line": 291,
+   "loc": 1,
+   "internalUses": 2,
+   "bucket": "OVER-EXPORTED",
+   "frameworkContract": false,
+   "consumersOutsideDir": [],
+   "consumersSameDir": [],
+   "toolingConsumers": [],
+   "testConsumers": [],
+   "zeroConsumer": true,
+   "testedOnly": false
+  },
+  {
+   "file": "src/lib/content-moderation.ts",
+   "dir": "src/lib",
+   "symbol": "PIIResult",
+   "line": 242,
+   "loc": 4,
+   "internalUses": 1,
+   "bucket": "OVER-EXPORTED",
+   "frameworkContract": false,
+   "consumersOutsideDir": [],
+   "consumersSameDir": [],
+   "toolingConsumers": [],
+   "testConsumers": [],
+   "zeroConsumer": true,
+   "testedOnly": false
+  },
+  {
+   "file": "src/lib/content-moderation.ts",
+   "dir": "src/lib",
+   "symbol": "ProfanityResult",
+   "line": 106,
+   "loc": 4,
+   "internalUses": 1,
+   "bucket": "OVER-EXPORTED",
+   "frameworkContract": false,
+   "consumersOutsideDir": [],
+   "consumersSameDir": [],
+   "toolingConsumers": [],
+   "testConsumers": [],
+   "zeroConsumer": true,
+   "testedOnly": false
+  },
+  {
+   "file": "src/lib/content-moderation.ts",
+   "dir": "src/lib",
+   "symbol": "SpamResult",
+   "line": 150,
+   "loc": 4,
+   "internalUses": 1,
+   "bucket": "OVER-EXPORTED",
+   "frameworkContract": false,
+   "consumersOutsideDir": [],
+   "consumersSameDir": [],
+   "toolingConsumers": [],
+   "testConsumers": [],
+   "zeroConsumer": true,
+   "testedOnly": false
+  },
+  {
+   "file": "src/lib/content-moderation.ts",
+   "dir": "src/lib",
+   "symbol": "containsPII",
+   "line": 248,
+   "loc": 37,
+   "internalUses": 1,
+   "bucket": "OVER-EXPORTED",
+   "frameworkContract": false,
+   "consumersOutsideDir": [],
+   "consumersSameDir": [],
+   "toolingConsumers": [],
+   "testConsumers": [
+    "tests/unit/content-moderation.test.ts"
+   ],
+   "zeroConsumer": true,
+   "testedOnly": true
+  },
+  {
+   "file": "src/lib/content-moderation.ts",
+   "dir": "src/lib",
+   "symbol": "containsProfanity",
+   "line": 112,
+   "loc": 34,
+   "internalUses": 1,
+   "bucket": "OVER-EXPORTED",
+   "frameworkContract": false,
+   "consumersOutsideDir": [],
+   "consumersSameDir": [],
+   "toolingConsumers": [],
+   "testConsumers": [
+    "tests/unit/content-moderation.test.ts"
+   ],
+   "zeroConsumer": true,
+   "testedOnly": true
+  },
+  {
+   "file": "src/lib/content-moderation.ts",
+   "dir": "src/lib",
+   "symbol": "detectSpam",
+   "line": 160,
+   "loc": 7,
+   "internalUses": 1,
+   "bucket": "OVER-EXPORTED",
+   "frameworkContract": false,
+   "consumersOutsideDir": [],
+   "consumersSameDir": [],
+   "toolingConsumers": [],
+   "testConsumers": [
+    "tests/unit/content-moderation.test.ts"
+   ],
+   "zeroConsumer": true,
+   "testedOnly": true
+  },
+  {
+   "file": "src/lib/convene/busy-time-consent.ts",
+   "dir": "src/lib/convene",
+   "symbol": "BusyTimeConsentError",
+   "line": 6,
+   "loc": 6,
+   "internalUses": 4,
+   "bucket": "OVER-EXPORTED",
+   "frameworkContract": false,
+   "consumersOutsideDir": [],
+   "consumersSameDir": [],
+   "toolingConsumers": [],
+   "testConsumers": [
+    "tests/unit/convene/busy-time-consent.test.ts"
+   ],
+   "zeroConsumer": true,
+   "testedOnly": true
+  },
+  {
+   "file": "src/lib/convene/calendar/microsoft.ts",
+   "dir": "src/lib/convene/calendar",
+   "symbol": "microsoftCalendarAdapter",
+   "line": 48,
+   "loc": 102,
+   "internalUses": 0,
+   "bucket": "DEAD-TESTED",
+   "frameworkContract": false,
+   "consumersOutsideDir": [],
+   "consumersSameDir": [],
+   "toolingConsumers": [],
+   "testConsumers": [
+    "tests/unit/convene/busy-time-consent.test.ts"
+   ],
+   "zeroConsumer": true,
+   "testedOnly": true
+  },
+  {
+   "file": "src/lib/convene/gatherings/state-machine.ts",
+   "dir": "src/lib/convene/gatherings",
+   "symbol": "InvalidTransitionError",
+   "line": 41,
+   "loc": 11,
+   "internalUses": 2,
+   "bucket": "OVER-EXPORTED",
+   "frameworkContract": false,
+   "consumersOutsideDir": [],
+   "consumersSameDir": [],
+   "toolingConsumers": [],
+   "testConsumers": [
+    "tests/unit/convene/gathering-state-machine.test.ts"
+   ],
+   "zeroConsumer": true,
+   "testedOnly": true
+  },
+  {
+   "file": "src/lib/convene/gatherings/state-machine.ts",
+   "dir": "src/lib/convene/gatherings",
+   "symbol": "canTransition",
+   "line": 64,
+   "loc": 6,
+   "internalUses": 0,
+   "bucket": "DEAD-TESTED",
+   "frameworkContract": false,
+   "consumersOutsideDir": [],
+   "consumersSameDir": [],
+   "toolingConsumers": [],
+   "testConsumers": [
+    "tests/unit/convene/gathering-state-machine.test.ts"
+   ],
+   "zeroConsumer": true,
+   "testedOnly": true
+  },
+  {
+   "file": "src/lib/convene/gatherings/state-machine.ts",
+   "dir": "src/lib/convene/gatherings",
+   "symbol": "isFieldEditable",
+   "line": 77,
+   "loc": 3,
+   "internalUses": 0,
+   "bucket": "DEAD-TESTED",
+   "frameworkContract": false,
+   "consumersOutsideDir": [],
+   "consumersSameDir": [],
+   "toolingConsumers": [],
+   "testConsumers": [
+    "tests/unit/convene/gathering-state-machine.test.ts"
+   ],
+   "zeroConsumer": true,
+   "testedOnly": true
+  },
+  {
+   "file": "src/lib/convene/google/calendar.ts",
+   "dir": "src/lib/convene/google",
+   "symbol": "BusyBlock",
+   "line": 3,
+   "loc": 4,
+   "internalUses": 2,
+   "bucket": "OVER-EXPORTED",
+   "frameworkContract": false,
+   "consumersOutsideDir": [],
+   "consumersSameDir": [],
+   "toolingConsumers": [],
+   "testConsumers": [],
+   "zeroConsumer": true,
+   "testedOnly": false
+  },
+  {
+   "file": "src/lib/convene/google/calendar.ts",
+   "dir": "src/lib/convene/google",
+   "symbol": "getFreeBusy",
+   "line": 8,
+   "loc": 29,
+   "internalUses": 0,
+   "bucket": "DEAD-ISOLATED",
+   "frameworkContract": false,
+   "consumersOutsideDir": [],
+   "consumersSameDir": [],
+   "toolingConsumers": [],
+   "testConsumers": [],
+   "zeroConsumer": true,
+   "testedOnly": false
+  },
+  {
+   "file": "src/lib/convene/google/oauth.ts",
+   "dir": "src/lib/convene/google",
+   "symbol": "GOOGLE_SCOPES",
+   "line": 5,
+   "loc": 5,
+   "internalUses": 1,
+   "bucket": "OVER-EXPORTED",
+   "frameworkContract": false,
+   "consumersOutsideDir": [],
+   "consumersSameDir": [],
+   "toolingConsumers": [],
+   "testConsumers": [
+    "tests/unit/convene/google-oauth.test.ts"
+   ],
+   "zeroConsumer": true,
+   "testedOnly": true
+  },
+  {
+   "file": "src/lib/convene/google/oauth.ts",
+   "dir": "src/lib/convene/google",
+   "symbol": "GoogleTokenResponse",
+   "line": 11,
+   "loc": 7,
+   "internalUses": 4,
+   "bucket": "OVER-EXPORTED",
+   "frameworkContract": false,
+   "consumersOutsideDir": [],
+   "consumersSameDir": [],
+   "toolingConsumers": [],
+   "testConsumers": [],
+   "zeroConsumer": true,
+   "testedOnly": false
+  },
+  {
+   "file": "src/lib/convene/google/oauth.ts",
+   "dir": "src/lib/convene/google",
+   "symbol": "exchangeCodeForTokens",
+   "line": 33,
+   "loc": 23,
+   "internalUses": 0,
+   "bucket": "DEAD-TESTED",
+   "frameworkContract": false,
+   "consumersOutsideDir": [],
+   "consumersSameDir": [],
+   "toolingConsumers": [],
+   "testConsumers": [
+    "tests/unit/convene/google-oauth.test.ts"
+   ],
+   "zeroConsumer": true,
+   "testedOnly": true
+  },
+  {
+   "file": "src/lib/convene/invites/dispatch.ts",
+   "dir": "src/lib/convene/invites",
+   "symbol": "DispatchSummary",
+   "line": 33,
+   "loc": 8,
+   "internalUses": 3,
+   "bucket": "OVER-EXPORTED",
+   "frameworkContract": false,
+   "consumersOutsideDir": [],
+   "consumersSameDir": [],
+   "toolingConsumers": [],
+   "testConsumers": [
+    "tests/unit/convene/dispatch.test.ts",
+    "tests/unit/convene/invites-actions.test.ts"
+   ],
+   "zeroConsumer": true,
+   "testedOnly": true
+  },
+  {
+   "file": "src/lib/convene/invites/dispatch.ts",
+   "dir": "src/lib/convene/invites",
+   "symbol": "_internal",
+   "line": 484,
+   "loc": 1,
+   "internalUses": 0,
+   "bucket": "DEAD-TESTED",
+   "frameworkContract": false,
+   "consumersOutsideDir": [],
+   "consumersSameDir": [],
+   "toolingConsumers": [],
+   "testConsumers": [
+    "tests/unit/convene/dispatch-atomic-claim.test.ts",
+    "tests/unit/convene/dispatch.test.ts",
+    "tests/unit/convene/invites-actions.test.ts"
+   ],
+   "zeroConsumer": true,
+   "testedOnly": true
+  },
+  {
+   "file": "src/lib/convene/invites/dispatch.ts",
+   "dir": "src/lib/convene/invites",
+   "symbol": "buildSendInputs",
+   "line": 178,
+   "loc": 36,
+   "internalUses": 2,
+   "bucket": "OVER-EXPORTED",
+   "frameworkContract": false,
+   "consumersOutsideDir": [],
+   "consumersSameDir": [],
+   "toolingConsumers": [],
+   "testConsumers": [
+    "tests/unit/convene/dispatch.test.ts",
+    "tests/unit/convene/invites-actions.test.ts"
+   ],
+   "zeroConsumer": true,
+   "testedOnly": true
+  },
+  {
+   "file": "src/lib/convene/invites/dispatch.ts",
+   "dir": "src/lib/convene/invites",
+   "symbol": "buildSmsBody",
+   "line": 216,
+   "loc": 9,
+   "internalUses": 1,
+   "bucket": "OVER-EXPORTED",
+   "frameworkContract": false,
+   "consumersOutsideDir": [],
+   "consumersSameDir": [],
+   "toolingConsumers": [],
+   "testConsumers": [
+    "tests/unit/convene/dispatch.test.ts",
+    "tests/unit/convene/invites-actions.test.ts"
+   ],
+   "zeroConsumer": true,
+   "testedOnly": true
+  },
+  {
+   "file": "src/lib/convene/invites/email.ts",
+   "dir": "src/lib/convene/invites",
+   "symbol": "_internal",
+   "line": 75,
+   "loc": 1,
+   "internalUses": 0,
+   "bucket": "DEAD-TESTED",
+   "frameworkContract": false,
+   "consumersOutsideDir": [],
+   "consumersSameDir": [],
+   "toolingConsumers": [],
+   "testConsumers": [
+    "tests/unit/convene/invites.test.ts"
+   ],
+   "zeroConsumer": true,
+   "testedOnly": true
+  },
+  {
+   "file": "src/lib/convene/invites/repository.ts",
+   "dir": "src/lib/convene/invites",
+   "symbol": "InviteeLookup",
+   "line": 82,
+   "loc": 13,
+   "internalUses": 1,
+   "bucket": "OVER-EXPORTED",
+   "frameworkContract": false,
+   "consumersOutsideDir": [],
+   "consumersSameDir": [],
+   "toolingConsumers": [],
+   "testConsumers": [
+    "tests/unit/convene/invites-actions.test.ts",
+    "tests/unit/convene/rsvp-submit-validation.test.ts"
+   ],
+   "zeroConsumer": true,
+   "testedOnly": true
+  },
+  {
+   "file": "src/lib/convene/invites/repository.ts",
+   "dir": "src/lib/convene/invites",
+   "symbol": "PersistInviteInput",
+   "line": 15,
+   "loc": 6,
+   "internalUses": 1,
+   "bucket": "OVER-EXPORTED",
+   "frameworkContract": false,
+   "consumersOutsideDir": [],
+   "consumersSameDir": [],
+   "toolingConsumers": [],
+   "testConsumers": [
+    "tests/unit/convene/invites-actions.test.ts",
+    "tests/unit/convene/rsvp-submit-validation.test.ts"
+   ],
+   "zeroConsumer": true,
+   "testedOnly": true
+  },
+  {
+   "file": "src/lib/convene/invites/repository.ts",
+   "dir": "src/lib/convene/invites",
+   "symbol": "markInviteFailed",
+   "line": 52,
+   "loc": 10,
+   "internalUses": 0,
+   "bucket": "DEAD-TESTED",
+   "frameworkContract": false,
+   "consumersOutsideDir": [],
+   "consumersSameDir": [],
+   "toolingConsumers": [],
+   "testConsumers": [
+    "tests/unit/convene/invites-actions.test.ts",
+    "tests/unit/convene/rsvp-submit-validation.test.ts"
+   ],
+   "zeroConsumer": true,
+   "testedOnly": true
+  },
+  {
+   "file": "src/lib/convene/invites/repository.ts",
+   "dir": "src/lib/convene/invites",
+   "symbol": "markInviteSent",
+   "line": 40,
+   "loc": 11,
+   "internalUses": 0,
+   "bucket": "DEAD-TESTED",
+   "frameworkContract": false,
+   "consumersOutsideDir": [],
+   "consumersSameDir": [],
+   "toolingConsumers": [],
+   "testConsumers": [
+    "tests/unit/convene/invites-actions.test.ts",
+    "tests/unit/convene/rsvp-submit-validation.test.ts"
+   ],
+   "zeroConsumer": true,
+   "testedOnly": true
+  },
+  {
+   "file": "src/lib/convene/invites/sms-templates.ts",
+   "dir": "src/lib/convene/invites",
+   "symbol": "SmsTemplateInput",
+   "line": 3,
+   "loc": 7,
+   "internalUses": 1,
+   "bucket": "OVER-EXPORTED",
+   "frameworkContract": false,
+   "consumersOutsideDir": [],
+   "consumersSameDir": [],
+   "toolingConsumers": [],
+   "testConsumers": [],
+   "zeroConsumer": true,
+   "testedOnly": false
+  },
+  {
+   "file": "src/lib/convene/invites/templates.ts",
+   "dir": "src/lib/convene/invites",
+   "symbol": "InviteTemplateInput",
+   "line": 5,
+   "loc": 13,
+   "internalUses": 3,
+   "bucket": "OVER-EXPORTED",
+   "frameworkContract": false,
+   "consumersOutsideDir": [],
+   "consumersSameDir": [],
+   "toolingConsumers": [],
+   "testConsumers": [],
+   "zeroConsumer": true,
+   "testedOnly": false
+  },
+  {
+   "file": "src/lib/convene/invites/twilio.ts",
+   "dir": "src/lib/convene/invites",
+   "symbol": "_internal",
+   "line": 91,
+   "loc": 1,
+   "internalUses": 0,
+   "bucket": "DEAD-TESTED",
+   "frameworkContract": false,
+   "consumersOutsideDir": [],
+   "consumersSameDir": [],
+   "toolingConsumers": [],
+   "testConsumers": [
+    "tests/unit/convene/twilio-send.test.ts"
+   ],
+   "zeroConsumer": true,
+   "testedOnly": true
+  },
+  {
+   "file": "src/lib/convene/microsoft/oauth.ts",
+   "dir": "src/lib/convene/microsoft",
+   "symbol": "MICROSOFT_SCOPES",
+   "line": 5,
+   "loc": 5,
+   "internalUses": 2,
+   "bucket": "OVER-EXPORTED",
+   "frameworkContract": false,
+   "consumersOutsideDir": [],
+   "consumersSameDir": [],
+   "toolingConsumers": [],
+   "testConsumers": [],
+   "zeroConsumer": true,
+   "testedOnly": false
+  },
+  {
+   "file": "src/lib/convene/oauth-connections.ts",
+   "dir": "src/lib/convene",
+   "symbol": "OAuthConnection",
+   "line": 16,
+   "loc": 12,
+   "internalUses": 7,
+   "bucket": "OVER-EXPORTED",
+   "frameworkContract": false,
+   "consumersOutsideDir": [],
+   "consumersSameDir": [],
+   "toolingConsumers": [],
+   "testConsumers": [
+    "tests/unit/convene/busy-time-consent.test.ts",
+    "tests/unit/convene/calendar-google-adapter.test.ts",
+    "tests/unit/convene/invites-actions.test.ts",
+    "tests/unit/convene/organise-actions.test.ts"
+   ],
+   "zeroConsumer": true,
+   "testedOnly": true
+  },
+  {
+   "file": "src/lib/convene/oauth-connections.ts",
+   "dir": "src/lib/convene",
+   "symbol": "disconnectConnection",
+   "line": 138,
+   "loc": 15,
+   "internalUses": 0,
+   "bucket": "DEAD-TESTED",
+   "frameworkContract": false,
+   "consumersOutsideDir": [],
+   "consumersSameDir": [],
+   "toolingConsumers": [],
+   "testConsumers": [
+    "tests/unit/convene/busy-time-consent.test.ts",
+    "tests/unit/convene/calendar-google-adapter.test.ts",
+    "tests/unit/convene/invites-actions.test.ts",
+    "tests/unit/convene/organise-actions.test.ts"
+   ],
+   "zeroConsumer": true,
+   "testedOnly": true
+  },
+  {
+   "file": "src/lib/convene/oauth-connections.ts",
+   "dir": "src/lib/convene",
+   "symbol": "getConnection",
+   "line": 29,
+   "loc": 14,
+   "internalUses": 3,
+   "bucket": "OVER-EXPORTED",
+   "frameworkContract": false,
+   "consumersOutsideDir": [],
+   "consumersSameDir": [],
+   "toolingConsumers": [],
+   "testConsumers": [
+    "tests/unit/convene/busy-time-consent.test.ts",
+    "tests/unit/convene/calendar-google-adapter.test.ts",
+    "tests/unit/convene/invites-actions.test.ts",
+    "tests/unit/convene/organise-actions.test.ts"
+   ],
+   "zeroConsumer": true,
+   "testedOnly": true
+  },
+  {
+   "file": "src/lib/convene/post-event.ts",
+   "dir": "src/lib/convene",
+   "symbol": "PostEventSummary",
+   "line": 6,
+   "loc": 7,
+   "internalUses": 2,
+   "bucket": "OVER-EXPORTED",
+   "frameworkContract": false,
+   "consumersOutsideDir": [],
+   "consumersSameDir": [],
+   "toolingConsumers": [],
+   "testConsumers": [],
+   "zeroConsumer": true,
+   "testedOnly": false
+  },
+  {
+   "file": "src/lib/cookie-domain.ts",
+   "dir": "src/lib",
+   "symbol": "PARENT_COOKIE_DOMAIN",
+   "line": 3,
+   "loc": 1,
+   "internalUses": 2,
+   "bucket": "OVER-EXPORTED",
+   "frameworkContract": false,
+   "consumersOutsideDir": [],
+   "consumersSameDir": [],
+   "toolingConsumers": [],
+   "testConsumers": [
+    "tests/unit/cookie-domain.test.ts"
+   ],
+   "zeroConsumer": true,
+   "testedOnly": true
+  },
+  {
+   "file": "src/lib/cookie-domain.ts",
+   "dir": "src/lib",
+   "symbol": "PROD_SITE_URL",
+   "line": 2,
+   "loc": 1,
+   "internalUses": 0,
+   "bucket": "DEAD-ISOLATED",
+   "frameworkContract": false,
+   "consumersOutsideDir": [],
+   "consumersSameDir": [],
+   "toolingConsumers": [],
+   "testConsumers": [],
+   "zeroConsumer": true,
+   "testedOnly": false
+  },
+  {
+   "file": "src/lib/cookie-domain.ts",
+   "dir": "src/lib",
+   "symbol": "parentCookieDomain",
+   "line": 11,
+   "loc": 13,
+   "internalUses": 1,
+   "bucket": "OVER-EXPORTED",
+   "frameworkContract": false,
+   "consumersOutsideDir": [],
+   "consumersSameDir": [],
+   "toolingConsumers": [],
+   "testConsumers": [
+    "tests/unit/cookie-domain.test.ts"
+   ],
+   "zeroConsumer": true,
+   "testedOnly": true
+  },
+  {
+   "file": "src/lib/dashboard/dismissal.ts",
+   "dir": "src/lib/dashboard",
+   "symbol": "WidgetDismissal",
+   "line": 4,
+   "loc": 4,
+   "internalUses": 1,
+   "bucket": "OVER-EXPORTED",
+   "frameworkContract": false,
+   "consumersOutsideDir": [],
+   "consumersSameDir": [],
+   "toolingConsumers": [],
+   "testConsumers": [],
+   "zeroConsumer": true,
+   "testedOnly": false
+  },
+  {
+   "file": "src/lib/dashboard/profile-completion.ts",
+   "dir": "src/lib/dashboard",
+   "symbol": "COMPLETION_COMPONENTS",
+   "line": 18,
+   "loc": 12,
+   "internalUses": 1,
+   "bucket": "OVER-EXPORTED",
+   "frameworkContract": false,
+   "consumersOutsideDir": [],
+   "consumersSameDir": [],
+   "toolingConsumers": [],
+   "testConsumers": [
+    "tests/unit/profile-completion.test.ts"
+   ],
+   "zeroConsumer": true,
+   "testedOnly": true
+  },
+  {
+   "file": "src/lib/dashboard/profile-completion.ts",
+   "dir": "src/lib/dashboard",
+   "symbol": "ProfileCompletionInput",
+   "line": 2,
+   "loc": 12,
+   "internalUses": 2,
+   "bucket": "OVER-EXPORTED",
+   "frameworkContract": false,
+   "consumersOutsideDir": [],
+   "consumersSameDir": [],
+   "toolingConsumers": [],
+   "testConsumers": [
+    "tests/unit/profile-completion.test.ts"
+   ],
+   "zeroConsumer": true,
+   "testedOnly": true
+  },
+  {
+   "file": "src/lib/dashboard/resolve-widgets.ts",
+   "dir": "src/lib/dashboard",
+   "symbol": "EMPTY_TO_DRAFTED_THRESHOLD",
+   "line": 16,
+   "loc": 1,
+   "internalUses": 1,
+   "bucket": "OVER-EXPORTED",
+   "frameworkContract": false,
+   "consumersOutsideDir": [],
+   "consumersSameDir": [],
+   "toolingConsumers": [],
+   "testConsumers": [
+    "tests/unit/dashboard-resolve-widgets.test.ts"
+   ],
+   "zeroConsumer": true,
+   "testedOnly": true
+  },
+  {
+   "file": "src/lib/dashboard/resolve-widgets.ts",
+   "dir": "src/lib/dashboard",
+   "symbol": "ResolvedWidget",
+   "line": 39,
+   "loc": 4,
+   "internalUses": 1,
+   "bucket": "OVER-EXPORTED",
+   "frameworkContract": false,
+   "consumersOutsideDir": [],
+   "consumersSameDir": [],
+   "toolingConsumers": [],
+   "testConsumers": [],
+   "zeroConsumer": true,
+   "testedOnly": false
+  },
+  {
+   "file": "src/lib/dashboard/resolve-widgets.ts",
+   "dir": "src/lib/dashboard",
+   "symbol": "WidgetResolverInput",
+   "line": 24,
+   "loc": 14,
+   "internalUses": 2,
+   "bucket": "OVER-EXPORTED",
+   "frameworkContract": false,
+   "consumersOutsideDir": [],
+   "consumersSameDir": [],
+   "toolingConsumers": [],
+   "testConsumers": [
+    "tests/unit/dashboard-resolve-widgets.test.ts"
+   ],
+   "zeroConsumer": true,
+   "testedOnly": true
+  },
+  {
+   "file": "src/lib/deploy-env.ts",
+   "dir": "src/lib",
+   "symbol": "DEPLOY_ENVS",
+   "line": 5,
+   "loc": 1,
+   "internalUses": 1,
+   "bucket": "OVER-EXPORTED",
+   "frameworkContract": false,
+   "consumersOutsideDir": [],
+   "consumersSameDir": [],
+   "toolingConsumers": [],
+   "testConsumers": [
+    "tests/unit/deploy-env.test.ts",
+    "tests/unit/set-global-feature.test.ts"
+   ],
+   "zeroConsumer": true,
+   "testedOnly": true
+  },
+  {
+   "file": "src/lib/features/entitlements-service.ts",
+   "dir": "src/lib/features",
+   "symbol": "isFeatureEnabledByProfile",
+   "line": 24,
+   "loc": 6,
+   "internalUses": 2,
+   "bucket": "OVER-EXPORTED",
+   "frameworkContract": false,
+   "consumersOutsideDir": [],
+   "consumersSameDir": [],
+   "toolingConsumers": [],
+   "testConsumers": [],
+   "zeroConsumer": true,
+   "testedOnly": false
+  },
+  {
+   "file": "src/lib/features/entitlements-service.ts",
+   "dir": "src/lib/features",
+   "symbol": "isPaidLinksComplianceReady",
+   "line": 48,
+   "loc": 3,
+   "internalUses": 1,
+   "bucket": "OVER-EXPORTED",
+   "frameworkContract": false,
+   "consumersOutsideDir": [],
+   "consumersSameDir": [],
+   "toolingConsumers": [],
+   "testConsumers": [],
+   "zeroConsumer": true,
+   "testedOnly": false
+  },
+  {
+   "file": "src/lib/features/global-features.ts",
+   "dir": "src/lib/features",
+   "symbol": "GlobalFeatureConfig",
+   "line": 15,
+   "loc": 13,
+   "internalUses": 1,
+   "bucket": "OVER-EXPORTED",
+   "frameworkContract": false,
+   "consumersOutsideDir": [],
+   "consumersSameDir": [],
+   "toolingConsumers": [],
+   "testConsumers": [],
+   "zeroConsumer": true,
+   "testedOnly": false
+  },
+  {
+   "file": "src/lib/features/registry.ts",
+   "dir": "src/lib/features",
+   "symbol": "FEATURE_KEYS",
+   "line": 3,
+   "loc": 8,
+   "internalUses": 5,
+   "bucket": "OVER-EXPORTED",
+   "frameworkContract": false,
+   "consumersOutsideDir": [],
+   "consumersSameDir": [],
+   "toolingConsumers": [],
+   "testConsumers": [
+    "tests/unit/admin-status-badges.test.ts",
+    "tests/unit/feature-entitlements.test.ts"
+   ],
+   "zeroConsumer": true,
+   "testedOnly": true
+  },
+  {
+   "file": "src/lib/features/registry.ts",
+   "dir": "src/lib/features",
+   "symbol": "FeatureConfig",
+   "line": 17,
+   "loc": 11,
+   "internalUses": 1,
+   "bucket": "OVER-EXPORTED",
+   "frameworkContract": false,
+   "consumersOutsideDir": [],
+   "consumersSameDir": [],
+   "toolingConsumers": [],
+   "testConsumers": [],
+   "zeroConsumer": true,
+   "testedOnly": false
+  },
+  {
+   "file": "src/lib/features/registry.ts",
+   "dir": "src/lib/features",
+   "symbol": "FeatureTier",
+   "line": 15,
+   "loc": 1,
+   "internalUses": 1,
+   "bucket": "OVER-EXPORTED",
+   "frameworkContract": false,
+   "consumersOutsideDir": [],
+   "consumersSameDir": [],
+   "toolingConsumers": [],
+   "testConsumers": [],
+   "zeroConsumer": true,
+   "testedOnly": false
+  },
+  {
+   "file": "src/lib/file-magic-bytes.ts",
+   "dir": "src/lib",
+   "symbol": "UploadPreflightOptions",
+   "line": 99,
+   "loc": 9,
+   "internalUses": 1,
+   "bucket": "OVER-EXPORTED",
+   "frameworkContract": false,
+   "consumersOutsideDir": [],
+   "consumersSameDir": [],
+   "toolingConsumers": [],
+   "testConsumers": [],
+   "zeroConsumer": true,
+   "testedOnly": false
+  },
+  {
+   "file": "src/lib/file-magic-bytes.ts",
+   "dir": "src/lib",
+   "symbol": "matchesSignature",
+   "line": 43,
+   "loc": 27,
+   "internalUses": 1,
+   "bucket": "OVER-EXPORTED",
+   "frameworkContract": false,
+   "consumersOutsideDir": [],
+   "consumersSameDir": [],
+   "toolingConsumers": [],
+   "testConsumers": [
+    "tests/unit/file-magic-bytes.test.ts"
+   ],
+   "zeroConsumer": true,
+   "testedOnly": true
+  },
+  {
+   "file": "src/lib/file-magic-bytes.ts",
+   "dir": "src/lib",
+   "symbol": "validateFileMagicBytes",
+   "line": 72,
+   "loc": 25,
+   "internalUses": 1,
+   "bucket": "OVER-EXPORTED",
+   "frameworkContract": false,
+   "consumersOutsideDir": [],
+   "consumersSameDir": [],
+   "toolingConsumers": [],
+   "testConsumers": [
+    "tests/unit/file-magic-bytes.test.ts"
+   ],
+   "zeroConsumer": true,
+   "testedOnly": true
+  },
+  {
+   "file": "src/lib/geo/places-city.ts",
+   "dir": "src/lib/geo",
+   "symbol": "CityLookupResult",
+   "line": 5,
+   "loc": 5,
+   "internalUses": 2,
+   "bucket": "OVER-EXPORTED",
+   "frameworkContract": false,
+   "consumersOutsideDir": [],
+   "consumersSameDir": [],
+   "toolingConsumers": [],
+   "testConsumers": [],
+   "zeroConsumer": true,
+   "testedOnly": false
+  },
+  {
+   "file": "src/lib/geo/places-city.ts",
+   "dir": "src/lib/geo",
+   "symbol": "extractCity",
+   "line": 17,
+   "loc": 8,
+   "internalUses": 1,
+   "bucket": "OVER-EXPORTED",
+   "frameworkContract": false,
+   "consumersOutsideDir": [],
+   "consumersSameDir": [],
+   "toolingConsumers": [],
+   "testConsumers": [
+    "tests/unit/places-city.test.ts"
+   ],
+   "zeroConsumer": true,
+   "testedOnly": true
+  },
+  {
+   "file": "src/lib/metrics.ts",
+   "dir": "src/lib",
+   "symbol": "getAnomalyWindow",
+   "line": 24,
+   "loc": 13,
+   "internalUses": 0,
+   "bucket": "DEAD-ISOLATED",
+   "frameworkContract": false,
+   "consumersOutsideDir": [],
+   "consumersSameDir": [],
+   "toolingConsumers": [],
+   "testConsumers": [],
+   "zeroConsumer": true,
+   "testedOnly": false
+  },
+  {
+   "file": "src/lib/metrics.ts",
+   "dir": "src/lib",
+   "symbol": "getMetricsForWindow",
+   "line": 39,
+   "loc": 17,
+   "internalUses": 0,
+   "bucket": "DEAD-ISOLATED",
+   "frameworkContract": false,
+   "consumersOutsideDir": [],
+   "consumersSameDir": [],
+   "toolingConsumers": [],
+   "testConsumers": [],
+   "zeroConsumer": true,
+   "testedOnly": false
+  },
+  {
+   "file": "src/lib/moderation-audit.ts",
+   "dir": "src/lib",
+   "symbol": "ModerationSource",
+   "line": 7,
+   "loc": 1,
+   "internalUses": 2,
+   "bucket": "OVER-EXPORTED",
+   "frameworkContract": false,
+   "consumersOutsideDir": [],
+   "consumersSameDir": [],
+   "toolingConsumers": [],
+   "testConsumers": [
+    "tests/unit/convene/organise-actions.test.ts"
+   ],
+   "zeroConsumer": true,
+   "testedOnly": true
+  },
+  {
+   "file": "src/lib/oauth/access-tokens.ts",
+   "dir": "src/lib/oauth",
+   "symbol": "AccessTokenRecord",
+   "line": 30,
+   "loc": 8,
+   "internalUses": 2,
+   "bucket": "OVER-EXPORTED",
+   "frameworkContract": false,
+   "consumersOutsideDir": [],
+   "consumersSameDir": [],
+   "toolingConsumers": [],
+   "testConsumers": [
+    "tests/unit/oauth/revoke-route.test.ts",
+    "tests/unit/oauth/token-route.test.ts"
+   ],
+   "zeroConsumer": true,
+   "testedOnly": true
+  },
+  {
+   "file": "src/lib/oauth/access-tokens.ts",
+   "dir": "src/lib/oauth",
+   "symbol": "IssueAccessJtiInput",
+   "line": 10,
+   "loc": 7,
+   "internalUses": 1,
+   "bucket": "OVER-EXPORTED",
+   "frameworkContract": false,
+   "consumersOutsideDir": [],
+   "consumersSameDir": [],
+   "toolingConsumers": [],
+   "testConsumers": [
+    "tests/unit/oauth/revoke-route.test.ts",
+    "tests/unit/oauth/token-route.test.ts"
+   ],
+   "zeroConsumer": true,
+   "testedOnly": true
+  },
+  {
+   "file": "src/lib/oauth/authorize.ts",
+   "dir": "src/lib/oauth",
+   "symbol": "AuthorizeError",
+   "line": 15,
+   "loc": 7,
+   "internalUses": 1,
+   "bucket": "OVER-EXPORTED",
+   "frameworkContract": false,
+   "consumersOutsideDir": [],
+   "consumersSameDir": [],
+   "toolingConsumers": [],
+   "testConsumers": [
+    "tests/unit/sec57-issuance-suspension.test.ts"
+   ],
+   "zeroConsumer": true,
+   "testedOnly": true
+  },
+  {
+   "file": "src/lib/oauth/authorize.ts",
+   "dir": "src/lib/oauth",
+   "symbol": "AuthorizeRequest",
+   "line": 5,
+   "loc": 9,
+   "internalUses": 1,
+   "bucket": "OVER-EXPORTED",
+   "frameworkContract": false,
+   "consumersOutsideDir": [],
+   "consumersSameDir": [],
+   "toolingConsumers": [],
+   "testConsumers": [
+    "tests/unit/sec57-issuance-suspension.test.ts"
+   ],
+   "zeroConsumer": true,
+   "testedOnly": true
+  },
+  {
+   "file": "src/lib/oauth/authorize.ts",
+   "dir": "src/lib/oauth",
+   "symbol": "ValidatedAuthorizeRequest",
+   "line": 31,
+   "loc": 8,
+   "internalUses": 1,
+   "bucket": "OVER-EXPORTED",
+   "frameworkContract": false,
+   "consumersOutsideDir": [],
+   "consumersSameDir": [],
+   "toolingConsumers": [],
+   "testConsumers": [
+    "tests/unit/sec57-issuance-suspension.test.ts"
+   ],
+   "zeroConsumer": true,
+   "testedOnly": true
+  },
+  {
+   "file": "src/lib/oauth/client-trust.ts",
+   "dir": "src/lib/oauth",
+   "symbol": "ClientTrust",
+   "line": 3,
+   "loc": 5,
+   "internalUses": 1,
+   "bucket": "OVER-EXPORTED",
+   "frameworkContract": false,
+   "consumersOutsideDir": [],
+   "consumersSameDir": [],
+   "toolingConsumers": [],
+   "testConsumers": [],
+   "zeroConsumer": true,
+   "testedOnly": false
+  },
+  {
+   "file": "src/lib/oauth/clients.ts",
+   "dir": "src/lib/oauth",
+   "symbol": "RegisterClientInput",
+   "line": 11,
+   "loc": 8,
+   "internalUses": 2,
+   "bucket": "OVER-EXPORTED",
+   "frameworkContract": false,
+   "consumersOutsideDir": [],
+   "consumersSameDir": [],
+   "toolingConsumers": [],
+   "testConsumers": [
+    "tests/unit/oauth/authorize.test.ts",
+    "tests/unit/oauth/token-route.test.ts",
+    "tests/unit/sec57-issuance-suspension.test.ts"
+   ],
+   "zeroConsumer": true,
+   "testedOnly": true
+  },
+  {
+   "file": "src/lib/oauth/clients.ts",
+   "dir": "src/lib/oauth",
+   "symbol": "RegisteredClient",
+   "line": 20,
+   "loc": 12,
+   "internalUses": 1,
+   "bucket": "OVER-EXPORTED",
+   "frameworkContract": false,
+   "consumersOutsideDir": [],
+   "consumersSameDir": [],
+   "toolingConsumers": [],
+   "testConsumers": [
+    "tests/unit/oauth/authorize.test.ts",
+    "tests/unit/oauth/token-route.test.ts",
+    "tests/unit/sec57-issuance-suspension.test.ts"
+   ],
+   "zeroConsumer": true,
+   "testedOnly": true
+  },
+  {
+   "file": "src/lib/oauth/clients.ts",
+   "dir": "src/lib/oauth",
+   "symbol": "generateClientId",
+   "line": 33,
+   "loc": 5,
+   "internalUses": 1,
+   "bucket": "OVER-EXPORTED",
+   "frameworkContract": false,
+   "consumersOutsideDir": [],
+   "consumersSameDir": [],
+   "toolingConsumers": [],
+   "testConsumers": [
+    "tests/unit/oauth/authorize.test.ts",
+    "tests/unit/oauth/clients.test.ts",
+    "tests/unit/oauth/token-route.test.ts",
+    "tests/unit/sec57-issuance-suspension.test.ts"
+   ],
+   "zeroConsumer": true,
+   "testedOnly": true
+  },
+  {
+   "file": "src/lib/oauth/clients.ts",
+   "dir": "src/lib/oauth",
+   "symbol": "generateClientSecret",
+   "line": 39,
+   "loc": 4,
+   "internalUses": 1,
+   "bucket": "OVER-EXPORTED",
+   "frameworkContract": false,
+   "consumersOutsideDir": [],
+   "consumersSameDir": [],
+   "toolingConsumers": [],
+   "testConsumers": [
+    "tests/unit/oauth/authorize.test.ts",
+    "tests/unit/oauth/clients.test.ts",
+    "tests/unit/oauth/token-route.test.ts",
+    "tests/unit/sec57-issuance-suspension.test.ts"
+   ],
+   "zeroConsumer": true,
+   "testedOnly": true
+  },
+  {
+   "file": "src/lib/oauth/codes.ts",
+   "dir": "src/lib/oauth",
+   "symbol": "CodeRecord",
+   "line": 44,
+   "loc": 11,
+   "internalUses": 2,
+   "bucket": "OVER-EXPORTED",
+   "frameworkContract": false,
+   "consumersOutsideDir": [],
+   "consumersSameDir": [],
+   "toolingConsumers": [],
+   "testConsumers": [
+    "tests/unit/oauth/token-route.test.ts",
+    "tests/unit/sec57-issuance-suspension.test.ts"
+   ],
+   "zeroConsumer": true,
+   "testedOnly": true
+  },
+  {
+   "file": "src/lib/oauth/codes.ts",
+   "dir": "src/lib/oauth",
+   "symbol": "IssueCodeInput",
+   "line": 16,
+   "loc": 8,
+   "internalUses": 1,
+   "bucket": "OVER-EXPORTED",
+   "frameworkContract": false,
+   "consumersOutsideDir": [],
+   "consumersSameDir": [],
+   "toolingConsumers": [],
+   "testConsumers": [
+    "tests/unit/oauth/token-route.test.ts",
+    "tests/unit/sec57-issuance-suspension.test.ts"
+   ],
+   "zeroConsumer": true,
+   "testedOnly": true
+  },
+  {
+   "file": "src/lib/oauth/codes.ts",
+   "dir": "src/lib/oauth",
+   "symbol": "generateAuthCode",
+   "line": 12,
+   "loc": 3,
+   "internalUses": 1,
+   "bucket": "OVER-EXPORTED",
+   "frameworkContract": false,
+   "consumersOutsideDir": [],
+   "consumersSameDir": [],
+   "toolingConsumers": [],
+   "testConsumers": [
+    "tests/unit/oauth/token-route.test.ts",
+    "tests/unit/sec57-issuance-suspension.test.ts"
+   ],
+   "zeroConsumer": true,
+   "testedOnly": true
+  },
+  {
+   "file": "src/lib/oauth/config.ts",
+   "dir": "src/lib/oauth",
+   "symbol": "wwwAuthenticateHeader",
+   "line": 35,
+   "loc": 6,
+   "internalUses": 0,
+   "bucket": "DEAD-TESTED",
+   "frameworkContract": false,
+   "consumersOutsideDir": [],
+   "consumersSameDir": [],
+   "toolingConsumers": [],
+   "testConsumers": [
+    "tests/unit/oauth/metadata.test.ts"
+   ],
+   "zeroConsumer": true,
+   "testedOnly": true
+  },
+  {
+   "file": "src/lib/oauth/consents.ts",
+   "dir": "src/lib/oauth",
+   "symbol": "ConsentRecord",
+   "line": 10,
+   "loc": 7,
+   "internalUses": 2,
+   "bucket": "OVER-EXPORTED",
+   "frameworkContract": false,
+   "consumersOutsideDir": [],
+   "consumersSameDir": [],
+   "toolingConsumers": [],
+   "testConsumers": [
+    "tests/unit/sec57-issuance-suspension.test.ts"
+   ],
+   "zeroConsumer": true,
+   "testedOnly": true
+  },
+  {
+   "file": "src/lib/oauth/jwt.ts",
+   "dir": "src/lib/oauth",
+   "symbol": "AccessTokenClaims",
+   "line": 37,
+   "loc": 10,
+   "internalUses": 3,
+   "bucket": "OVER-EXPORTED",
+   "frameworkContract": false,
+   "consumersOutsideDir": [],
+   "consumersSameDir": [],
+   "toolingConsumers": [],
+   "testConsumers": [],
+   "zeroConsumer": true,
+   "testedOnly": false
+  },
+  {
+   "file": "src/lib/oauth/jwt.ts",
+   "dir": "src/lib/oauth",
+   "symbol": "IssueAccessTokenInput",
+   "line": 48,
+   "loc": 5,
+   "internalUses": 1,
+   "bucket": "OVER-EXPORTED",
+   "frameworkContract": false,
+   "consumersOutsideDir": [],
+   "consumersSameDir": [],
+   "toolingConsumers": [],
+   "testConsumers": [],
+   "zeroConsumer": true,
+   "testedOnly": false
+  },
+  {
+   "file": "src/lib/oauth/jwt.ts",
+   "dir": "src/lib/oauth",
+   "symbol": "IssuedAccessToken",
+   "line": 54,
+   "loc": 6,
+   "internalUses": 1,
+   "bucket": "OVER-EXPORTED",
+   "frameworkContract": false,
+   "consumersOutsideDir": [],
+   "consumersSameDir": [],
+   "toolingConsumers": [],
+   "testConsumers": [],
+   "zeroConsumer": true,
+   "testedOnly": false
+  },
+  {
+   "file": "src/lib/oauth/jwt.ts",
+   "dir": "src/lib/oauth",
+   "symbol": "VerifyOptions",
+   "line": 102,
+   "loc": 4,
+   "internalUses": 1,
+   "bucket": "OVER-EXPORTED",
+   "frameworkContract": false,
+   "consumersOutsideDir": [],
+   "consumersSameDir": [],
+   "toolingConsumers": [],
+   "testConsumers": [],
+   "zeroConsumer": true,
+   "testedOnly": false
+  },
+  {
+   "file": "src/lib/oauth/jwt.ts",
+   "dir": "src/lib/oauth",
+   "symbol": "verifyAccessToken",
+   "line": 108,
+   "loc": 36,
+   "internalUses": 0,
+   "bucket": "DEAD-TESTED",
+   "frameworkContract": false,
+   "consumersOutsideDir": [],
+   "consumersSameDir": [],
+   "toolingConsumers": [],
+   "testConsumers": [
+    "tests/unit/oauth/jwt-pkce.test.ts"
+   ],
+   "zeroConsumer": true,
+   "testedOnly": true
+  },
+  {
+   "file": "src/lib/oauth/refresh.ts",
+   "dir": "src/lib/oauth",
+   "symbol": "IssueRefreshInput",
+   "line": 21,
+   "loc": 7,
+   "internalUses": 1,
+   "bucket": "OVER-EXPORTED",
+   "frameworkContract": false,
+   "consumersOutsideDir": [],
+   "consumersSameDir": [],
+   "toolingConsumers": [],
+   "testConsumers": [
+    "tests/unit/oauth/revoke-route.test.ts",
+    "tests/unit/oauth/token-route.test.ts"
+   ],
+   "zeroConsumer": true,
+   "testedOnly": true
+  },
+  {
+   "file": "src/lib/oauth/refresh.ts",
+   "dir": "src/lib/oauth",
+   "symbol": "RefreshTokenRecord",
+   "line": 48,
+   "loc": 9,
+   "internalUses": 4,
+   "bucket": "OVER-EXPORTED",
+   "frameworkContract": false,
+   "consumersOutsideDir": [],
+   "consumersSameDir": [],
+   "toolingConsumers": [],
+   "testConsumers": [
+    "tests/unit/oauth/revoke-route.test.ts",
+    "tests/unit/oauth/token-route.test.ts"
+   ],
+   "zeroConsumer": true,
+   "testedOnly": true
+  },
+  {
+   "file": "src/lib/oauth/refresh.ts",
+   "dir": "src/lib/oauth",
+   "symbol": "generateRefreshToken",
+   "line": 13,
+   "loc": 3,
+   "internalUses": 1,
+   "bucket": "OVER-EXPORTED",
+   "frameworkContract": false,
+   "consumersOutsideDir": [],
+   "consumersSameDir": [],
+   "toolingConsumers": [],
+   "testConsumers": [
+    "tests/unit/oauth/revoke-route.test.ts",
+    "tests/unit/oauth/token-route.test.ts"
+   ],
+   "zeroConsumer": true,
+   "testedOnly": true
+  },
+  {
+   "file": "src/lib/oauth/refresh.ts",
+   "dir": "src/lib/oauth",
+   "symbol": "hashRefreshToken",
+   "line": 17,
+   "loc": 3,
+   "internalUses": 3,
+   "bucket": "OVER-EXPORTED",
+   "frameworkContract": false,
+   "consumersOutsideDir": [],
+   "consumersSameDir": [],
+   "toolingConsumers": [],
+   "testConsumers": [
+    "tests/unit/oauth/revoke-route.test.ts",
+    "tests/unit/oauth/token-route.test.ts"
+   ],
+   "zeroConsumer": true,
+   "testedOnly": true
+  },
+  {
+   "file": "src/lib/oauth/refresh.ts",
+   "dir": "src/lib/oauth",
+   "symbol": "issueAccessTokenJti",
+   "line": 113,
+   "loc": 1,
+   "internalUses": 1,
+   "bucket": "OVER-EXPORTED",
+   "frameworkContract": false,
+   "consumersOutsideDir": [],
+   "consumersSameDir": [],
+   "toolingConsumers": [],
+   "testConsumers": [
+    "tests/unit/oauth/revoke-route.test.ts",
+    "tests/unit/oauth/token-route.test.ts"
+   ],
+   "zeroConsumer": true,
+   "testedOnly": true
+  },
+  {
+   "file": "src/lib/profile-rate-limit.ts",
+   "dir": "src/lib",
+   "symbol": "ProfileRateLimitOutcome",
+   "line": 7,
+   "loc": 2,
+   "internalUses": 1,
+   "bucket": "OVER-EXPORTED",
+   "frameworkContract": false,
+   "consumersOutsideDir": [],
+   "consumersSameDir": [],
+   "toolingConsumers": [],
+   "testConsumers": [
+    "tests/unit/kan417-poc-media-uploads-gate.test.ts"
+   ],
+   "zeroConsumer": true,
+   "testedOnly": true
+  },
+  {
+   "file": "src/lib/rate-limit-shared.ts",
+   "dir": "src/lib",
+   "symbol": "SharedRateLimitResult",
+   "line": 6,
+   "loc": 8,
+   "internalUses": 1,
+   "bucket": "OVER-EXPORTED",
+   "frameworkContract": false,
+   "consumersOutsideDir": [],
+   "consumersSameDir": [],
+   "toolingConsumers": [],
+   "testConsumers": [],
+   "zeroConsumer": true,
+   "testedOnly": false
+  },
+  {
+   "file": "src/lib/recommend/categories.ts",
+   "dir": "src/lib/recommend",
+   "symbol": "GiftCategory",
+   "line": 15,
+   "loc": 4,
+   "internalUses": 1,
+   "bucket": "OVER-EXPORTED",
+   "frameworkContract": false,
+   "consumersOutsideDir": [],
+   "consumersSameDir": [],
+   "toolingConsumers": [],
+   "testConsumers": [],
+   "zeroConsumer": true,
+   "testedOnly": false
+  },
+  {
+   "file": "src/lib/recommend/convene/score-attendee.ts",
+   "dir": "src/lib/recommend/convene",
+   "symbol": "_internal",
+   "line": 166,
+   "loc": 1,
+   "internalUses": 0,
+   "bucket": "DEAD-TESTED",
+   "frameworkContract": false,
+   "consumersOutsideDir": [],
+   "consumersSameDir": [],
+   "toolingConsumers": [],
+   "testConsumers": [
+    "tests/unit/convene/score-attendee.test.ts"
+   ],
+   "zeroConsumer": true,
+   "testedOnly": true
+  },
+  {
+   "file": "src/lib/recommend/convene/score-attendee.ts",
+   "dir": "src/lib/recommend/convene",
+   "symbol": "scoreAttendee",
+   "line": 124,
+   "loc": 41,
+   "internalUses": 0,
+   "bucket": "DEAD-TESTED",
+   "frameworkContract": false,
+   "consumersOutsideDir": [],
+   "consumersSameDir": [],
+   "toolingConsumers": [],
+   "testConsumers": [
+    "tests/unit/convene/score-attendee.test.ts"
+   ],
+   "zeroConsumer": true,
+   "testedOnly": true
+  },
+  {
+   "file": "src/lib/recommend/convene/score-venue.ts",
+   "dir": "src/lib/recommend/convene",
+   "symbol": "_internal",
+   "line": 266,
+   "loc": 1,
+   "internalUses": 0,
+   "bucket": "DEAD-TESTED",
+   "frameworkContract": false,
+   "consumersOutsideDir": [],
+   "consumersSameDir": [],
+   "toolingConsumers": [],
+   "testConsumers": [
+    "tests/unit/convene/score-venue.test.ts"
+   ],
+   "zeroConsumer": true,
+   "testedOnly": true
+  },
+  {
+   "file": "src/lib/recommend/index.ts",
+   "dir": "src/lib/recommend",
+   "symbol": "ProfileInsights",
+   "line": 72,
+   "loc": 12,
+   "internalUses": 1,
+   "bucket": "OVER-EXPORTED",
+   "frameworkContract": false,
+   "consumersOutsideDir": [],
+   "consumersSameDir": [],
+   "toolingConsumers": [],
+   "testConsumers": [],
+   "zeroConsumer": true,
+   "testedOnly": false
+  },
+  {
+   "file": "src/lib/recommend/index.ts",
+   "dir": "src/lib/recommend",
+   "symbol": "RecommendationOptions",
+   "line": 7,
+   "loc": 6,
+   "internalUses": 1,
+   "bucket": "OVER-EXPORTED",
+   "frameworkContract": false,
+   "consumersOutsideDir": [],
+   "consumersSameDir": [],
+   "toolingConsumers": [],
+   "testConsumers": [],
+   "zeroConsumer": true,
+   "testedOnly": false
+  },
+  {
+   "file": "src/lib/recommender/events.ts",
+   "dir": "src/lib/recommender",
+   "symbol": "RECOMMENDATION_EVENT_TYPES",
+   "line": 3,
+   "loc": 8,
+   "internalUses": 2,
+   "bucket": "OVER-EXPORTED",
+   "frameworkContract": false,
+   "consumersOutsideDir": [],
+   "consumersSameDir": [],
+   "toolingConsumers": [],
+   "testConsumers": [
+    "tests/unit/recommendation-events.test.ts"
+   ],
+   "zeroConsumer": true,
+   "testedOnly": true
+  },
+  {
+   "file": "src/lib/recommender/events.ts",
+   "dir": "src/lib/recommender",
+   "symbol": "RecommendationEventRow",
+   "line": 33,
+   "loc": 12,
+   "internalUses": 0,
+   "bucket": "DEAD-ISOLATED",
+   "frameworkContract": false,
+   "consumersOutsideDir": [],
+   "consumersSameDir": [],
+   "toolingConsumers": [],
+   "testConsumers": [],
+   "zeroConsumer": true,
+   "testedOnly": false
+  },
+  {
+   "file": "src/lib/recommender/events.ts",
+   "dir": "src/lib/recommender",
+   "symbol": "RecommendationEventSource",
+   "line": 23,
+   "loc": 1,
+   "internalUses": 2,
+   "bucket": "OVER-EXPORTED",
+   "frameworkContract": false,
+   "consumersOutsideDir": [],
+   "consumersSameDir": [],
+   "toolingConsumers": [],
+   "testConsumers": [],
+   "zeroConsumer": true,
+   "testedOnly": false
+  },
+  {
+   "file": "src/lib/recommender/events.ts",
+   "dir": "src/lib/recommender",
+   "symbol": "RecommendationEventType",
+   "line": 12,
+   "loc": 2,
+   "internalUses": 2,
+   "bucket": "OVER-EXPORTED",
+   "frameworkContract": false,
+   "consumersOutsideDir": [],
+   "consumersSameDir": [],
+   "toolingConsumers": [],
+   "testConsumers": [],
+   "zeroConsumer": true,
+   "testedOnly": false
+  },
+  {
+   "file": "src/lib/recommender/events.ts",
+   "dir": "src/lib/recommender",
+   "symbol": "isRecommendationEventSource",
+   "line": 27,
+   "loc": 5,
+   "internalUses": 0,
+   "bucket": "DEAD-TESTED",
+   "frameworkContract": false,
+   "consumersOutsideDir": [],
+   "consumersSameDir": [],
+   "toolingConsumers": [],
+   "testConsumers": [
+    "tests/unit/recommendation-events.test.ts"
+   ],
+   "zeroConsumer": true,
+   "testedOnly": true
+  },
+  {
+   "file": "src/lib/recommender/events.ts",
+   "dir": "src/lib/recommender",
+   "symbol": "isRecommendationEventType",
+   "line": 17,
+   "loc": 5,
+   "internalUses": 0,
+   "bucket": "DEAD-TESTED",
+   "frameworkContract": false,
+   "consumersOutsideDir": [],
+   "consumersSameDir": [],
+   "toolingConsumers": [],
+   "testConsumers": [
+    "tests/unit/recommendation-events.test.ts"
+   ],
+   "zeroConsumer": true,
+   "testedOnly": true
+  },
+  {
+   "file": "src/lib/recommender/events.ts",
+   "dir": "src/lib/recommender",
+   "symbol": "sanitiseEventMetadata",
+   "line": 47,
+   "loc": 26,
+   "internalUses": 0,
+   "bucket": "DEAD-TESTED",
+   "frameworkContract": false,
+   "consumersOutsideDir": [],
+   "consumersSameDir": [],
+   "toolingConsumers": [],
+   "testConsumers": [
+    "tests/unit/recommendation-events.test.ts"
+   ],
+   "zeroConsumer": true,
+   "testedOnly": true
+  },
+  {
+   "file": "src/lib/recommender/inputs.ts",
+   "dir": "src/lib/recommender",
+   "symbol": "AGE_RANGE_BUCKETS",
+   "line": 5,
+   "loc": 9,
+   "internalUses": 2,
+   "bucket": "OVER-EXPORTED",
+   "frameworkContract": false,
+   "consumersOutsideDir": [],
+   "consumersSameDir": [],
+   "toolingConsumers": [],
+   "testConsumers": [
+    "tests/unit/recommender-inputs.test.ts"
+   ],
+   "zeroConsumer": true,
+   "testedOnly": true
+  },
+  {
+   "file": "src/lib/recommender/inputs.ts",
+   "dir": "src/lib/recommender",
+   "symbol": "ALLERGIES",
+   "line": 51,
+   "loc": 13,
+   "internalUses": 2,
+   "bucket": "OVER-EXPORTED",
+   "frameworkContract": false,
+   "consumersOutsideDir": [],
+   "consumersSameDir": [],
+   "toolingConsumers": [],
+   "testConsumers": [
+    "tests/unit/recommender-inputs.test.ts"
+   ],
+   "zeroConsumer": true,
+   "testedOnly": true
+  },
+  {
+   "file": "src/lib/recommender/inputs.ts",
+   "dir": "src/lib/recommender",
+   "symbol": "AgeRangeBucket",
+   "line": 15,
+   "loc": 1,
+   "internalUses": 1,
+   "bucket": "OVER-EXPORTED",
+   "frameworkContract": false,
+   "consumersOutsideDir": [],
+   "consumersSameDir": [],
+   "toolingConsumers": [],
+   "testConsumers": [],
+   "zeroConsumer": true,
+   "testedOnly": false
+  },
+  {
+   "file": "src/lib/recommender/inputs.ts",
+   "dir": "src/lib/recommender",
+   "symbol": "Allergy",
+   "line": 65,
+   "loc": 1,
+   "internalUses": 2,
+   "bucket": "OVER-EXPORTED",
+   "frameworkContract": false,
+   "consumersOutsideDir": [],
+   "consumersSameDir": [],
+   "toolingConsumers": [],
+   "testConsumers": [],
+   "zeroConsumer": true,
+   "testedOnly": false
+  },
+  {
+   "file": "src/lib/recommender/inputs.ts",
+   "dir": "src/lib/recommender",
+   "symbol": "DIETARY_RESTRICTIONS",
+   "line": 26,
+   "loc": 13,
+   "internalUses": 2,
+   "bucket": "OVER-EXPORTED",
+   "frameworkContract": false,
+   "consumersOutsideDir": [],
+   "consumersSameDir": [],
+   "toolingConsumers": [],
+   "testConsumers": [
+    "tests/unit/recommender-inputs.test.ts"
+   ],
+   "zeroConsumer": true,
+   "testedOnly": true
+  },
+  {
+   "file": "src/lib/recommender/inputs.ts",
+   "dir": "src/lib/recommender",
+   "symbol": "DietaryRestriction",
+   "line": 40,
+   "loc": 1,
+   "internalUses": 2,
+   "bucket": "OVER-EXPORTED",
+   "frameworkContract": false,
+   "consumersOutsideDir": [],
+   "consumersSameDir": [],
+   "toolingConsumers": [],
+   "testConsumers": [],
+   "zeroConsumer": true,
+   "testedOnly": false
+  },
+  {
+   "file": "src/lib/recommender/inputs.ts",
+   "dir": "src/lib/recommender",
+   "symbol": "OCCASIONS",
+   "line": 139,
+   "loc": 8,
+   "internalUses": 2,
+   "bucket": "OVER-EXPORTED",
+   "frameworkContract": false,
+   "consumersOutsideDir": [],
+   "consumersSameDir": [],
+   "toolingConsumers": [],
+   "testConsumers": [
+    "tests/unit/recommender-inputs.test.ts"
+   ],
+   "zeroConsumer": true,
+   "testedOnly": true
+  },
+  {
+   "file": "src/lib/recommender/inputs.ts",
+   "dir": "src/lib/recommender",
+   "symbol": "Occasion",
+   "line": 148,
+   "loc": 1,
+   "internalUses": 1,
+   "bucket": "OVER-EXPORTED",
+   "frameworkContract": false,
+   "consumersOutsideDir": [],
+   "consumersSameDir": [],
+   "toolingConsumers": [],
+   "testConsumers": [],
+   "zeroConsumer": true,
+   "testedOnly": false
+  },
+  {
+   "file": "src/lib/recommender/inputs.ts",
+   "dir": "src/lib/recommender",
+   "symbol": "RELATIONSHIPS",
+   "line": 156,
+   "loc": 9,
+   "internalUses": 2,
+   "bucket": "OVER-EXPORTED",
+   "frameworkContract": false,
+   "consumersOutsideDir": [],
+   "consumersSameDir": [],
+   "toolingConsumers": [],
+   "testConsumers": [
+    "tests/unit/recommender-inputs.test.ts"
+   ],
+   "zeroConsumer": true,
+   "testedOnly": true
+  },
+  {
+   "file": "src/lib/recommender/inputs.ts",
+   "dir": "src/lib/recommender",
+   "symbol": "RecipientAttributes",
+   "line": 76,
+   "loc": 11,
+   "internalUses": 3,
+   "bucket": "OVER-EXPORTED",
+   "frameworkContract": false,
+   "consumersOutsideDir": [],
+   "consumersSameDir": [],
+   "toolingConsumers": [],
+   "testConsumers": [],
+   "zeroConsumer": true,
+   "testedOnly": false
+  },
+  {
+   "file": "src/lib/recommender/inputs.ts",
+   "dir": "src/lib/recommender",
+   "symbol": "Relationship",
+   "line": 166,
+   "loc": 1,
+   "internalUses": 1,
+   "bucket": "OVER-EXPORTED",
+   "frameworkContract": false,
+   "consumersOutsideDir": [],
+   "consumersSameDir": [],
+   "toolingConsumers": [],
+   "testConsumers": [],
+   "zeroConsumer": true,
+   "testedOnly": false
+  },
+  {
+   "file": "src/lib/recommender/inputs.ts",
+   "dir": "src/lib/recommender",
+   "symbol": "coerceRecipientAttributes",
+   "line": 89,
+   "loc": 46,
+   "internalUses": 0,
+   "bucket": "DEAD-TESTED",
+   "frameworkContract": false,
+   "consumersOutsideDir": [],
+   "consumersSameDir": [],
+   "toolingConsumers": [],
+   "testConsumers": [
+    "tests/unit/recommender-inputs.test.ts"
+   ],
+   "zeroConsumer": true,
+   "testedOnly": true
+  },
+  {
+   "file": "src/lib/recommender/inputs.ts",
+   "dir": "src/lib/recommender",
+   "symbol": "isAgeRangeBucket",
+   "line": 19,
+   "loc": 3,
+   "internalUses": 0,
+   "bucket": "DEAD-TESTED",
+   "frameworkContract": false,
+   "consumersOutsideDir": [],
+   "consumersSameDir": [],
+   "toolingConsumers": [],
+   "testConsumers": [
+    "tests/unit/recommender-inputs.test.ts"
+   ],
+   "zeroConsumer": true,
+   "testedOnly": true
+  },
+  {
+   "file": "src/lib/recommender/inputs.ts",
+   "dir": "src/lib/recommender",
+   "symbol": "isAllergy",
+   "line": 69,
+   "loc": 3,
+   "internalUses": 1,
+   "bucket": "OVER-EXPORTED",
+   "frameworkContract": false,
+   "consumersOutsideDir": [],
+   "consumersSameDir": [],
+   "toolingConsumers": [],
+   "testConsumers": [
+    "tests/unit/recommender-inputs.test.ts"
+   ],
+   "zeroConsumer": true,
+   "testedOnly": true
+  },
+  {
+   "file": "src/lib/recommender/inputs.ts",
+   "dir": "src/lib/recommender",
+   "symbol": "isDietaryRestriction",
+   "line": 44,
+   "loc": 3,
+   "internalUses": 1,
+   "bucket": "OVER-EXPORTED",
+   "frameworkContract": false,
+   "consumersOutsideDir": [],
+   "consumersSameDir": [],
+   "toolingConsumers": [],
+   "testConsumers": [
+    "tests/unit/recommender-inputs.test.ts"
+   ],
+   "zeroConsumer": true,
+   "testedOnly": true
+  },
+  {
+   "file": "src/lib/recommender/inputs.ts",
+   "dir": "src/lib/recommender",
+   "symbol": "isOccasion",
+   "line": 152,
+   "loc": 3,
+   "internalUses": 0,
+   "bucket": "DEAD-TESTED",
+   "frameworkContract": false,
+   "consumersOutsideDir": [],
+   "consumersSameDir": [],
+   "toolingConsumers": [],
+   "testConsumers": [
+    "tests/unit/recommender-inputs.test.ts"
+   ],
+   "zeroConsumer": true,
+   "testedOnly": true
+  },
+  {
+   "file": "src/lib/recommender/inputs.ts",
+   "dir": "src/lib/recommender",
+   "symbol": "isRelationship",
+   "line": 170,
+   "loc": 3,
+   "internalUses": 0,
+   "bucket": "DEAD-TESTED",
+   "frameworkContract": false,
+   "consumersOutsideDir": [],
+   "consumersSameDir": [],
+   "toolingConsumers": [],
+   "testConsumers": [
+    "tests/unit/recommender-inputs.test.ts"
+   ],
+   "zeroConsumer": true,
+   "testedOnly": true
+  },
+  {
+   "file": "src/lib/recommender/v2/candidate-sourcing.ts",
+   "dir": "src/lib/recommender/v2",
+   "symbol": "sourceCandidatesForConcept",
+   "line": 40,
+   "loc": 14,
+   "internalUses": 1,
+   "bucket": "OVER-EXPORTED",
+   "frameworkContract": false,
+   "consumersOutsideDir": [],
+   "consumersSameDir": [],
+   "toolingConsumers": [],
+   "testConsumers": [],
+   "zeroConsumer": true,
+   "testedOnly": false
+  },
+  {
+   "file": "src/lib/recommender/v2/eligibility-filter.ts",
+   "dir": "src/lib/recommender/v2",
+   "symbol": "EligibilityFilterInput",
+   "line": 7,
+   "loc": 7,
+   "internalUses": 1,
+   "bucket": "OVER-EXPORTED",
+   "frameworkContract": false,
+   "consumersOutsideDir": [],
+   "consumersSameDir": [],
+   "toolingConsumers": [],
+   "testConsumers": [],
+   "zeroConsumer": true,
+   "testedOnly": false
+  },
+  {
+   "file": "src/lib/recommender/v2/eligibility-filter.ts",
+   "dir": "src/lib/recommender/v2",
+   "symbol": "EligibilityFilterResult",
+   "line": 15,
+   "loc": 9,
+   "internalUses": 1,
+   "bucket": "OVER-EXPORTED",
+   "frameworkContract": false,
+   "consumersOutsideDir": [],
+   "consumersSameDir": [],
+   "toolingConsumers": [],
+   "testConsumers": [],
+   "zeroConsumer": true,
+   "testedOnly": false
+  },
+  {
+   "file": "src/lib/recommender/v2/eligibility-filter.ts",
+   "dir": "src/lib/recommender/v2",
+   "symbol": "canShipTo",
+   "line": 107,
+   "loc": 5,
+   "internalUses": 1,
+   "bucket": "OVER-EXPORTED",
+   "frameworkContract": false,
+   "consumersOutsideDir": [],
+   "consumersSameDir": [],
+   "toolingConsumers": [],
+   "testConsumers": [
+    "tests/unit/eligibility-filter.test.ts"
+   ],
+   "zeroConsumer": true,
+   "testedOnly": true
+  },
+  {
+   "file": "src/lib/recommender/v2/eligibility-filter.ts",
+   "dir": "src/lib/recommender/v2",
+   "symbol": "filterCandidatesByEligibility",
+   "line": 26,
+   "loc": 60,
+   "internalUses": 0,
+   "bucket": "DEAD-TESTED",
+   "frameworkContract": false,
+   "consumersOutsideDir": [],
+   "consumersSameDir": [],
+   "toolingConsumers": [],
+   "testConsumers": [
+    "tests/unit/eligibility-filter.test.ts"
+   ],
+   "zeroConsumer": true,
+   "testedOnly": true
+  },
+  {
+   "file": "src/lib/recommender/v2/evergreen.ts",
+   "dir": "src/lib/recommender/v2",
+   "symbol": "isEvergreenFallback",
+   "line": 54,
+   "loc": 6,
+   "internalUses": 0,
+   "bucket": "DEAD-TESTED",
+   "frameworkContract": false,
+   "consumersOutsideDir": [],
+   "consumersSameDir": [],
+   "toolingConsumers": [],
+   "testConsumers": [
+    "tests/unit/recommender-v2-evergreen.test.ts"
+   ],
+   "zeroConsumer": true,
+   "testedOnly": true
+  },
+  {
+   "file": "src/lib/recommender/v2/rank.ts",
+   "dir": "src/lib/recommender/v2",
+   "symbol": "DEFAULT_WEIGHTS",
+   "line": 14,
+   "loc": 8,
+   "internalUses": 1,
+   "bucket": "OVER-EXPORTED",
+   "frameworkContract": false,
+   "consumersOutsideDir": [],
+   "consumersSameDir": [],
+   "toolingConsumers": [],
+   "testConsumers": [],
+   "zeroConsumer": true,
+   "testedOnly": false
+  },
+  {
+   "file": "src/lib/recommender/v2/rank.ts",
+   "dir": "src/lib/recommender/v2",
+   "symbol": "RankerWeights",
+   "line": 5,
+   "loc": 8,
+   "internalUses": 3,
+   "bucket": "OVER-EXPORTED",
+   "frameworkContract": false,
+   "consumersOutsideDir": [],
+   "consumersSameDir": [],
+   "toolingConsumers": [],
+   "testConsumers": [],
+   "zeroConsumer": true,
+   "testedOnly": false
+  },
+  {
+   "file": "src/lib/retention/affiliate-clicks.ts",
+   "dir": "src/lib/retention",
+   "symbol": "DEFAULT_AFFILIATE_CLICKS_RETENTION_MONTHS",
+   "line": 8,
+   "loc": 1,
+   "internalUses": 2,
+   "bucket": "OVER-EXPORTED",
+   "frameworkContract": false,
+   "consumersOutsideDir": [],
+   "consumersSameDir": [],
+   "toolingConsumers": [],
+   "testConsumers": [
+    "tests/unit/retention/affiliate-clicks-retention.test.ts"
+   ],
+   "zeroConsumer": true,
+   "testedOnly": true
+  },
+  {
+   "file": "src/lib/retention/affiliate-clicks.ts",
+   "dir": "src/lib/retention",
+   "symbol": "affiliateClicksCutoff",
+   "line": 31,
+   "loc": 5,
+   "internalUses": 1,
+   "bucket": "OVER-EXPORTED",
+   "frameworkContract": false,
+   "consumersOutsideDir": [],
+   "consumersSameDir": [],
+   "toolingConsumers": [],
+   "testConsumers": [
+    "tests/unit/retention/affiliate-clicks-retention.test.ts"
+   ],
+   "zeroConsumer": true,
+   "testedOnly": true
+  },
+  {
+   "file": "src/lib/retention/affiliate-clicks.ts",
+   "dir": "src/lib/retention",
+   "symbol": "affiliateClicksRetentionMonths",
+   "line": 22,
+   "loc": 7,
+   "internalUses": 1,
+   "bucket": "OVER-EXPORTED",
+   "frameworkContract": false,
+   "consumersOutsideDir": [],
+   "consumersSameDir": [],
+   "toolingConsumers": [],
+   "testConsumers": [
+    "tests/unit/retention/affiliate-clicks-retention.test.ts"
+   ],
+   "zeroConsumer": true,
+   "testedOnly": true
+  },
+  {
+   "file": "src/lib/retention/gatherings.ts",
+   "dir": "src/lib/retention",
+   "symbol": "DEFAULT_GATHERINGS_RETENTION_MONTHS",
+   "line": 8,
+   "loc": 1,
+   "internalUses": 2,
+   "bucket": "OVER-EXPORTED",
+   "frameworkContract": false,
+   "consumersOutsideDir": [],
+   "consumersSameDir": [],
+   "toolingConsumers": [],
+   "testConsumers": [
+    "tests/unit/retention/gatherings-retention.test.ts"
+   ],
+   "zeroConsumer": true,
+   "testedOnly": true
+  },
+  {
+   "file": "src/lib/retention/gatherings.ts",
+   "dir": "src/lib/retention",
+   "symbol": "gatheringsCutoff",
+   "line": 31,
+   "loc": 5,
+   "internalUses": 1,
+   "bucket": "OVER-EXPORTED",
+   "frameworkContract": false,
+   "consumersOutsideDir": [],
+   "consumersSameDir": [],
+   "toolingConsumers": [],
+   "testConsumers": [
+    "tests/unit/retention/gatherings-retention.test.ts"
+   ],
+   "zeroConsumer": true,
+   "testedOnly": true
+  },
+  {
+   "file": "src/lib/retention/gatherings.ts",
+   "dir": "src/lib/retention",
+   "symbol": "gatheringsRetentionMonths",
+   "line": 22,
+   "loc": 7,
+   "internalUses": 1,
+   "bucket": "OVER-EXPORTED",
+   "frameworkContract": false,
+   "consumersOutsideDir": [],
+   "consumersSameDir": [],
+   "toolingConsumers": [],
+   "testConsumers": [
+    "tests/unit/retention/gatherings-retention.test.ts"
+   ],
+   "zeroConsumer": true,
+   "testedOnly": true
+  },
+  {
+   "file": "src/lib/retention/sweep.ts",
+   "dir": "src/lib/retention",
+   "symbol": "RetentionJobSummary",
+   "line": 12,
+   "loc": 3,
+   "internalUses": 1,
+   "bucket": "OVER-EXPORTED",
+   "frameworkContract": false,
+   "consumersOutsideDir": [],
+   "consumersSameDir": [],
+   "toolingConsumers": [],
+   "testConsumers": [],
+   "zeroConsumer": true,
+   "testedOnly": false
+  },
+  {
+   "file": "src/lib/retention/sweep.ts",
+   "dir": "src/lib/retention",
+   "symbol": "RetentionSweepSummary",
+   "line": 16,
+   "loc": 4,
+   "internalUses": 2,
+   "bucket": "OVER-EXPORTED",
+   "frameworkContract": false,
+   "consumersOutsideDir": [],
+   "consumersSameDir": [],
+   "toolingConsumers": [],
+   "testConsumers": [],
+   "zeroConsumer": true,
+   "testedOnly": false
+  },
+  {
+   "file": "src/lib/sanitise.ts",
+   "dir": "src/lib",
+   "symbol": "stripHtml",
+   "line": 4,
+   "loc": 9,
+   "internalUses": 1,
+   "bucket": "OVER-EXPORTED",
+   "frameworkContract": false,
+   "consumersOutsideDir": [],
+   "consumersSameDir": [],
+   "toolingConsumers": [],
+   "testConsumers": [
+    "tests/unit/sanitise.test.ts"
+   ],
+   "zeroConsumer": true,
+   "testedOnly": true
+  },
+  {
+   "file": "src/lib/turnstile.ts",
+   "dir": "src/lib",
+   "symbol": "TurnstileResult",
+   "line": 16,
+   "loc": 2,
+   "internalUses": 1,
+   "bucket": "OVER-EXPORTED",
+   "frameworkContract": false,
+   "consumersOutsideDir": [],
+   "consumersSameDir": [],
+   "toolingConsumers": [],
+   "testConsumers": [
+    "tests/unit/redesign-fidelity.test.js"
+   ],
+   "zeroConsumer": true,
+   "testedOnly": true
+  },
+  {
+   "file": "src/lib/turnstile.ts",
+   "dir": "src/lib",
+   "symbol": "isTurnstileEnabled",
+   "line": 4,
+   "loc": 6,
+   "internalUses": 1,
+   "bucket": "OVER-EXPORTED",
+   "frameworkContract": false,
+   "consumersOutsideDir": [],
+   "consumersSameDir": [],
+   "toolingConsumers": [],
+   "testConsumers": [
+    "tests/unit/redesign-fidelity.test.js"
+   ],
+   "zeroConsumer": true,
+   "testedOnly": true
+  },
+  {
+   "file": "src/middleware.ts",
+   "dir": "src",
+   "symbol": "middleware",
+   "line": 37,
+   "loc": 227,
+   "internalUses": 1,
+   "bucket": "OVER-EXPORTED",
+   "frameworkContract": false,
+   "consumersOutsideDir": [],
+   "consumersSameDir": [],
+   "toolingConsumers": [],
+   "testConsumers": [
+    "tests/unit/admin-host-routing.test.ts",
+    "tests/unit/middleware-suspension.test.ts"
+   ],
+   "zeroConsumer": true,
+   "testedOnly": true
+  }
+ ],
+ "stringReachability": {
+  "AGE_RANGE_BUCKETS": [
+   "/home/user/lyra/docs/RECOMMENDER_INPUTS.md",
+   "/home/user/lyra/docs/modularisation/data/kan422-dead-exports.json"
+  ],
+  "ALLERGIES": [
+   "/home/user/lyra/docs/modularisation/data/kan422-dead-exports.json"
+  ],
+  "ALLOWED_AFFILIATION_TYPES": [
+   "/home/user/lyra/docs/modularisation/data/kan422-dead-exports.json"
+  ],
+  "ALLOWED_PROFILE_FIELDS": [
+   "/home/user/lyra/scripts/check-server-action-exports.sh",
+   "/home/user/lyra/scripts/check-partial-write-safety.py",
+   "/home/user/lyra/supabase/migrations/20260620120100_beta_access_lockdown.sql",
+   "/home/user/lyra/supabase/migrations/20260630020000_kan339_scrub_postcode.sql",
+   "/home/user/lyra/supabase/migrations/20260720100000_age_self_declaration.sql",
+   "/home/user/lyra/docs/modularisation/LYRA_MODULARISATION_PLAN_2026-07-26.md",
+   "/home/user/lyra/docs/modularisation/data/kan422-dead-exports.json",
+   "/home/user/lyra/docs/ARCHITECTURE.md"
+  ],
+  "AboutLyra": [
+   "/home/user/lyra/docs/modularisation/data/kan422-dead-exports.json"
+  ],
+  "AccessTokenClaims": [
+   "/home/user/lyra/docs/modularisation/data/kan422-dead-exports.json"
+  ],
+  "AccessTokenRecord": [
+   "/home/user/lyra/docs/modularisation/data/kan422-dead-exports.json"
+  ],
+  "AccountStanding": [
+   "/home/user/lyra/docs/modularisation/LYRA_MODULARISATION_PLAN_2026-07-26.md",
+   "/home/user/lyra/docs/modularisation/data/kan422-dead-exports.json"
+  ],
+  "AdminUser": [
+   "/home/user/lyra/docs/modularisation/data/kan422-dead-exports.json"
+  ],
+  "AffiliateBadgeProps": [
+   "/home/user/lyra/docs/modularisation/data/kan422-dead-exports.json"
+  ],
+  "AffiliateLinkRequest": [
+   "/home/user/lyra/docs/AFFILIATE_LINK_SERVICE_DESIGN.md",
+   "/home/user/lyra/docs/modularisation/data/kan422-dead-exports.json"
+  ],
+  "AffiliateLinkResult": [
+   "/home/user/lyra/docs/AFFILIATE_LINK_SERVICE_DESIGN.md",
+   "/home/user/lyra/docs/modularisation/data/kan422-dead-exports.json"
+  ],
+  "AffiliateNetwork": [
+   "/home/user/lyra/docs/modularisation/data/kan422-dead-exports.json"
+  ],
+  "AgeRangeBucket": [
+   "/home/user/lyra/docs/RECOMMENDER_INPUTS.md",
+   "/home/user/lyra/docs/modularisation/data/kan422-dead-exports.json"
+  ],
+  "AgeStatus": [
+   "/home/user/lyra/docs/modularisation/data/kan422-dead-exports.json"
+  ],
+  "Allergy": [
+   "/home/user/lyra/docs/RECOMMENDER_INPUTS.md",
+   "/home/user/lyra/docs/modularisation/data/kan422-dead-exports.json"
+  ],
+  "AllowedProfileField": [
+   "/home/user/lyra/scripts/check-partial-write-safety.py",
+   "/home/user/lyra/docs/modularisation/data/kan422-dead-exports.json"
+  ],
+  "AuthorizeError": [
+   "/home/user/lyra/docs/modularisation/data/kan422-dead-exports.json"
+  ],
+  "AuthorizeRequest": [
+   "/home/user/lyra/docs/modularisation/data/kan422-dead-exports.json"
+  ],
+  "AutoSaveResult": [
+   "/home/user/lyra/docs/modularisation/data/kan422-dead-exports.json"
+  ],
+  "AutoSaveStatus": [
+   "/home/user/lyra/docs/modularisation/data/kan422-dead-exports.json"
+  ],
+  "Badge": [
+   "/home/user/lyra/docs/modularisation/kan416-derive.py",
+   "/home/user/lyra/docs/modularisation/LYRA_MODULARISATION_PLAN_2026-07-26.md",
+   "/home/user/lyra/docs/modularisation/data/kan422-dead-exports.json"
+  ],
+  "BetaEmailResult": [
+   "/home/user/lyra/docs/modularisation/data/kan422-dead-exports.json"
+  ],
+  "BusyBlock": [
+   "/home/user/lyra/docs/CONVENE.md",
+   "/home/user/lyra/docs/modularisation/data/kan422-dead-exports.json"
+  ],
+  "BusyTimeConsentError": [
+   "/home/user/lyra/docs/modularisation/data/kan422-dead-exports.json"
+  ],
+  "CHALLENGE_AGE": [
+   "/home/user/lyra/docs/modularisation/data/kan422-dead-exports.json"
+  ],
+  "COMPLETION_COMPONENTS": [
+   "/home/user/lyra/docs/modularisation/data/kan422-dead-exports.json"
+  ],
+  "CONSENT_STORAGE_KEY": [
+   "/home/user/lyra/docs/modularisation/data/kan422-dead-exports.json"
+  ],
+  "CONTROLLABLE_SECTION_KEYS": [
+   "/home/user/lyra/docs/modularisation/data/kan422-dead-exports.json"
+  ],
+  "CityLookupResult": [
+   "/home/user/lyra/docs/modularisation/data/kan422-dead-exports.json"
+  ],
+  "ClientTrust": [
+   "/home/user/lyra/docs/modularisation/data/kan422-dead-exports.json"
+  ],
+  "CodeRecord": [
+   "/home/user/lyra/docs/modularisation/data/kan422-dead-exports.json"
+  ],
+  "ConsentRecord": [
+   "/home/user/lyra/docs/modularisation/data/kan422-dead-exports.json"
+  ],
+  "ConsentValue": [
+   "/home/user/lyra/docs/modularisation/data/kan422-dead-exports.json"
+  ],
+  "ContactKind": [
+   "/home/user/lyra/docs/modularisation/data/kan422-dead-exports.json"
+  ],
+  "ContactMethodKind": [
+   "/home/user/lyra/docs/modularisation/data/kan422-dead-exports.json"
+  ],
+  "ContactMethodView": [
+   "/home/user/lyra/docs/modularisation/data/kan422-dead-exports.json"
+  ],
+  "ControllableSectionKey": [
+   "/home/user/lyra/docs/modularisation/data/kan422-dead-exports.json"
+  ],
+  "CreateSessionResult": [
+   "/home/user/lyra/docs/modularisation/data/kan422-dead-exports.json"
+  ],
+  "DEFAULT_AFFILIATE_CLICKS_RETENTION_MONTHS": [
+   "/home/user/lyra/docs/modularisation/data/kan422-dead-exports.json"
+  ],
+  "DEFAULT_GATHERINGS_RETENTION_MONTHS": [
+   "/home/user/lyra/docs/modularisation/data/kan422-dead-exports.json"
+  ],
+  "DEFAULT_VISIBILITY": [
+   "/home/user/lyra/docs/modularisation/data/kan422-dead-exports.json"
+  ],
+  "DEFAULT_WEIGHTS": [
+   "/home/user/lyra/docs/modularisation/data/kan422-dead-exports.json"
+  ],
+  "DEPLOY_ENVS": [
+   "/home/user/lyra/docs/modularisation/data/kan422-dead-exports.json"
+  ],
+  "DIETARY_RESTRICTIONS": [
+   "/home/user/lyra/docs/modularisation/data/kan422-dead-exports.json"
+  ],
+  "DietaryRestriction": [
+   "/home/user/lyra/docs/RECOMMENDER_INPUTS.md",
+   "/home/user/lyra/docs/modularisation/data/kan422-dead-exports.json"
+  ],
+  "DisclosureFlags": [
+   "/home/user/lyra/docs/modularisation/data/kan422-dead-exports.json"
+  ],
+  "DispatchSummary": [
+   "/home/user/lyra/docs/modularisation/data/kan422-dead-exports.json"
+  ],
+  "EMPTY_TO_DRAFTED_THRESHOLD": [
+   "/home/user/lyra/docs/modularisation/data/kan422-dead-exports.json"
+  ],
+  "EligibilityFilterInput": [
+   "/home/user/lyra/docs/modularisation/data/kan422-dead-exports.json"
+  ],
+  "EligibilityFilterResult": [
+   "/home/user/lyra/docs/modularisation/data/kan422-dead-exports.json"
+  ],
+  "FEATURE_KEYS": [
+   "/home/user/lyra/docs/modularisation/data/kan422-dead-exports.json",
+   "/home/user/lyra-mcp-server/src/feature-registry.ts",
+   "/home/user/lyra-admin-mcp-server/src/admin-tools.ts"
+  ],
+  "FeatureConfig": [
+   "/home/user/lyra/docs/modularisation/data/kan422-dead-exports.json"
+  ],
+  "FeatureTier": [
+   "/home/user/lyra/docs/modularisation/data/kan422-dead-exports.json",
+   "/home/user/lyra-mcp-server/src/feature-registry.ts"
+  ],
+  "FetchLike": [
+   "/home/user/lyra/docs/modularisation/data/kan422-dead-exports.json"
+  ],
+  "GOOGLE_SCOPES": [
+   "/home/user/lyra/docs/modularisation/data/kan422-dead-exports.json"
+  ],
+  "GiftCategory": [
+   "/home/user/lyra/docs/modularisation/data/kan422-dead-exports.json"
+  ],
+  "GlobalFeatureConfig": [
+   "/home/user/lyra/docs/modularisation/data/kan422-dead-exports.json"
+  ],
+  "GoogleTokenResponse": [
+   "/home/user/lyra/docs/modularisation/data/kan422-dead-exports.json"
+  ],
+  "HowItWorks": [
+   "/home/user/lyra/docs/modularisation/data/kan422-dead-exports.json"
+  ],
+  "INVITE_COOKIE": [
+   "/home/user/lyra/docs/modularisation/data/kan422-dead-exports.json"
+  ],
+  "INVITE_COOKIE_MAX_AGE": [
+   "/home/user/lyra/docs/modularisation/data/kan422-dead-exports.json"
+  ],
+  "ITEM_CATEGORY_TO_SECTION": [
+   "/home/user/lyra/docs/modularisation/data/kan422-dead-exports.json"
+  ],
+  "InvalidTransitionError": [
+   "/home/user/lyra/docs/modularisation/data/kan422-dead-exports.json"
+  ],
+  "InviteTemplateInput": [
+   "/home/user/lyra/docs/modularisation/data/kan422-dead-exports.json"
+  ],
+  "InviteeLookup": [
+   "/home/user/lyra/docs/modularisation/data/kan422-dead-exports.json"
+  ],
+  "InviteeView": [
+   "/home/user/lyra/docs/modularisation/data/kan422-dead-exports.json"
+  ],
+  "IssueAccessJtiInput": [
+   "/home/user/lyra/docs/modularisation/data/kan422-dead-exports.json"
+  ],
+  "IssueAccessTokenInput": [
+   "/home/user/lyra/docs/modularisation/data/kan422-dead-exports.json"
+  ],
+  "IssueCodeInput": [
+   "/home/user/lyra/docs/modularisation/data/kan422-dead-exports.json"
+  ],
+  "IssueRefreshInput": [
+   "/home/user/lyra/docs/modularisation/data/kan422-dead-exports.json"
+  ],
+  "IssuedAccessToken": [
+   "/home/user/lyra/docs/modularisation/data/kan422-dead-exports.json"
+  ],
+  "ItemActionResult": [
+   "/home/user/lyra/docs/modularisation/data/kan422-dead-exports.json"
+  ],
+  "LogModerationActionInput": [
+   "/home/user/lyra/docs/modularisation/data/kan422-dead-exports.json"
+  ],
+  "LogModerationActionsBatchInput": [
+   "/home/user/lyra/docs/modularisation/data/kan422-dead-exports.json"
+  ],
+  "MERCHANT_RULES_INTERNAL": [
+   "/home/user/lyra/docs/modularisation/data/kan422-dead-exports.json"
+  ],
+  "MICROSOFT_SCOPES": [
+   "/home/user/lyra/docs/modularisation/data/kan422-dead-exports.json"
+  ],
+  "ManualOfMeField": [
+   "/home/user/lyra/scripts/check-partial-write-safety.py",
+   "/home/user/lyra/docs/modularisation/data/kan422-dead-exports.json"
+  ],
+  "MerchantEligibilityRow": [
+   "/home/user/lyra/docs/modularisation/data/kan422-dead-exports.json"
+  ],
+  "MerchantSmokeProbe": [
+   "/home/user/lyra/docs/modularisation/data/kan422-dead-exports.json"
+  ],
+  "ModerationResult": [
+   "/home/user/lyra/docs/modularisation/data/kan422-dead-exports.json",
+   "/home/user/lyra-mcp-server/src/content-moderation.ts",
+   "/home/user/lyra-mcp-server/tests/moderation-policy.test.cjs"
+  ],
+  "ModerationSeverity": [
+   "/home/user/lyra/docs/modularisation/data/kan422-dead-exports.json",
+   "/home/user/lyra-mcp-server/src/content-moderation.ts"
+  ],
+  "ModerationSource": [
+   "/home/user/lyra/docs/modularisation/data/kan422-dead-exports.json"
+  ],
+  "MonitoringIntegration": [
+   "/home/user/lyra/docs/modularisation/data/kan422-dead-exports.json"
+  ],
+  "NormalisedDecision": [
+   "/home/user/lyra/docs/modularisation/data/kan422-dead-exports.json"
+  ],
+  "OAuthConnection": [
+   "/home/user/lyra/docs/modularisation/data/kan422-dead-exports.json"
+  ],
+  "OCCASIONS": [
+   "/home/user/lyra/docs/modularisation/data/kan422-dead-exports.json"
+  ],
+  "Occasion": [
+   "/home/user/lyra/docs/DEV_E2E_REGRESSION.md",
+   "/home/user/lyra/docs/modularisation/data/kan422-dead-exports.json",
+   "/home/user/lyra/docs/proposals/kan-178-occasion-gift-inspiration.md"
+  ],
+  "PARENT_COOKIE_DOMAIN": [
+   "/home/user/lyra/docs/modularisation/data/kan422-dead-exports.json"
+  ],
+  "PIIResult": [
+   "/home/user/lyra/docs/modularisation/data/kan422-dead-exports.json",
+   "/home/user/lyra-mcp-server/src/content-moderation.ts"
+  ],
+  "PROD_SITE_URL": [
+   "/home/user/lyra/docs/modularisation/data/kan422-dead-exports.json"
+  ],
+  "ParentTeacherCallout": [
+   "/home/user/lyra/docs/modularisation/data/kan422-dead-exports.json"
+  ],
+  "PersistInviteInput": [
+   "/home/user/lyra/docs/modularisation/data/kan422-dead-exports.json"
+  ],
+  "PostEventSummary": [
+   "/home/user/lyra/docs/modularisation/data/kan422-dead-exports.json"
+  ],
+  "ProbeResult": [
+   "/home/user/lyra/docs/modularisation/data/kan422-dead-exports.json"
+  ],
+  "ProfanityResult": [
+   "/home/user/lyra/docs/modularisation/data/kan422-dead-exports.json",
+   "/home/user/lyra-mcp-server/src/content-moderation.ts"
+  ],
+  "ProfileCompletionInput": [
+   "/home/user/lyra/docs/modularisation/data/kan422-dead-exports.json"
+  ],
+  "ProfileInsights": [
+   "/home/user/lyra/docs/modularisation/data/kan422-dead-exports.json"
+  ],
+  "ProfilePreview": [
+   "/home/user/lyra/docs/modularisation/data/kan422-dead-exports.json"
+  ],
+  "ProfileRateLimitOutcome": [
+   "/home/user/lyra/docs/modularisation/data/kan422-dead-exports.json"
+  ],
+  "ProposedSlot": [
+   "/home/user/lyra/docs/modularisation/data/kan422-dead-exports.json"
+  ],
+  "RECOMMENDATION_EVENT_TYPES": [
+   "/home/user/lyra/docs/modularisation/data/kan422-dead-exports.json"
+  ],
+  "RELATIONSHIPS": [
+   "/home/user/lyra/docs/modularisation/data/kan422-dead-exports.json"
+  ],
+  "RankerWeights": [
+   "/home/user/lyra/docs/modularisation/data/kan422-dead-exports.json"
+  ],
+  "RateLimitGate": [
+   "/home/user/lyra/docs/modularisation/data/kan422-dead-exports.json"
+  ],
+  "RecipientAttributes": [
+   "/home/user/lyra/docs/RECOMMENDER_INPUTS.md",
+   "/home/user/lyra/docs/modularisation/data/kan422-dead-exports.json"
+  ],
+  "RecommendationEventRow": [
+   "/home/user/lyra/docs/modularisation/data/kan422-dead-exports.json"
+  ],
+  "RecommendationEventSource": [
+   "/home/user/lyra/docs/modularisation/data/kan422-dead-exports.json"
+  ],
+  "RecommendationEventType": [
+   "/home/user/lyra/docs/modularisation/data/kan422-dead-exports.json"
+  ],
+  "RecommendationOptions": [
+   "/home/user/lyra/docs/modularisation/data/kan422-dead-exports.json"
+  ],
+  "ReconciliationUpdate": [
+   "/home/user/lyra/scripts/reconcile-affiliate-clicks.ts",
+   "/home/user/lyra/docs/modularisation/data/kan422-dead-exports.json"
+  ],
+  "RefreshTokenRecord": [
+   "/home/user/lyra/docs/modularisation/data/kan422-dead-exports.json"
+  ],
+  "RegisterClientInput": [
+   "/home/user/lyra/docs/modularisation/data/kan422-dead-exports.json"
+  ],
+  "RegisteredClient": [
+   "/home/user/lyra/docs/modularisation/data/kan422-dead-exports.json"
+  ],
+  "Relationship": [
+   "/home/user/lyra/docs/RECOMMENDER_INPUTS.md",
+   "/home/user/lyra/docs/modularisation/LYRA_MODULARISATION_PLAN_2026-07-26.md",
+   "/home/user/lyra/docs/modularisation/data/kan422-dead-exports.json",
+   "/home/user/lyra-mcp-server/src/convene-recommend-tools.ts",
+   "/home/user/lyra-mcp-server/src/write-tools.ts",
+   "/home/user/lyra-mcp-server/src/convene-recommend-scoring.ts"
+  ],
+  "ResolveCityResult": [
+   "/home/user/lyra/docs/modularisation/data/kan422-dead-exports.json"
+  ],
+  "ResolvedWidget": [
+   "/home/user/lyra/docs/modularisation/data/kan422-dead-exports.json"
+  ],
+  "RetentionJobSummary": [
+   "/home/user/lyra/docs/modularisation/data/kan422-dead-exports.json"
+  ],
+  "RetentionSweepSummary": [
+   "/home/user/lyra/docs/modularisation/data/kan422-dead-exports.json"
+  ],
+  "SMOKE_PROBES": [
+   "/home/user/lyra/docs/AFFILIATE_MONETIZATION.md",
+   "/home/user/lyra/docs/modularisation/data/kan422-dead-exports.json"
+  ],
+  "SectionSaveBar": [
+   "/home/user/lyra/docs/modularisation/data/kan422-dead-exports.json"
+  ],
+  "Sections": [
+   "/home/user/lyra/.github/workflows/weekly-report.yml",
+   "/home/user/lyra/docs/OPS_ROUTINES_CONTROL_ROOM.md",
+   "/home/user/lyra/docs/JIRA_TICKET_STANDARD.md",
+   "/home/user/lyra/docs/STAGING_SOAK_TEST_PLAN.md",
+   "/home/user/lyra/docs/CYBER_LOCKDOWN.md",
+   "/home/user/lyra/docs/lyra-project-reference.jsx",
+   "/home/user/lyra/docs/modularisation/data/kan422-dead-exports.json",
+   "/home/user/lyra/docs/KAN-131-FEATURE-GAP-AUDIT.md"
+  ],
+  "SharedRateLimitResult": [
+   "/home/user/lyra/docs/modularisation/data/kan422-dead-exports.json"
+  ],
+  "SmokeMatrixEntry": [
+   "/home/user/lyra/docs/modularisation/data/kan422-dead-exports.json"
+  ],
+  "SmokeRunSummary": [
+   "/home/user/lyra/docs/modularisation/data/kan422-dead-exports.json"
+  ],
+  "SmsTemplateInput": [
+   "/home/user/lyra/docs/modularisation/data/kan422-dead-exports.json"
+  ],
+  "SpamResult": [
+   "/home/user/lyra/docs/modularisation/data/kan422-dead-exports.json",
+   "/home/user/lyra-mcp-server/src/content-moderation.ts"
+  ],
+  "SupportedDeliveryCountry": [
+   "/home/user/lyra/docs/modularisation/data/kan422-dead-exports.json"
+  ],
+  "TurnstileResult": [
+   "/home/user/lyra/docs/modularisation/data/kan422-dead-exports.json"
+  ],
+  "UploadPreflightOptions": [
+   "/home/user/lyra/docs/modularisation/data/kan422-dead-exports.json"
+  ],
+  "UseCases": [
+   "/home/user/lyra/docs/modularisation/data/kan422-dead-exports.json"
+  ],
+  "VISIBILITY_LEVELS": [
+   "/home/user/lyra/docs/modularisation/data/kan422-dead-exports.json"
+  ],
+  "ValidatedAuthorizeRequest": [
+   "/home/user/lyra/docs/modularisation/data/kan422-dead-exports.json"
+  ],
+  "VerifyOptions": [
+   "/home/user/lyra/docs/modularisation/data/kan422-dead-exports.json"
+  ],
+  "WhatLyraIsNot": [
+   "/home/user/lyra/docs/modularisation/data/kan422-dead-exports.json"
+  ],
+  "WidgetDismissal": [
+   "/home/user/lyra/docs/modularisation/data/kan422-dead-exports.json"
+  ],
+  "WidgetResolverInput": [
+   "/home/user/lyra/docs/modularisation/data/kan422-dead-exports.json"
+  ],
+  "WishKnowFindFirstHand": [
+   "/home/user/lyra/docs/modularisation/data/kan422-dead-exports.json"
+  ],
+  "__resetCfAccessJwksCacheForTests": [
+   "/home/user/lyra/docs/modularisation/data/kan422-dead-exports.json"
+  ],
+  "_clearFxCacheForTests": [
+   "/home/user/lyra/docs/modularisation/data/kan422-dead-exports.json"
+  ],
+  "_internal": [
+   "/home/user/lyra/docs/CYBER_LOCKDOWN.md",
+   "/home/user/lyra/docs/modularisation/data/kan422-dead-exports.json",
+   "/home/user/lyra-mcp-server/src/convene-recommend-venue-scoring.ts",
+   "/home/user/lyra-mcp-server/src/convene-places-adapter.ts",
+   "/home/user/lyra-mcp-server/src/convene-recommend-scoring.ts"
+  ],
+  "affiliateClicksCutoff": [
+   "/home/user/lyra/docs/modularisation/data/kan422-dead-exports.json"
+  ],
+  "affiliateClicksRetentionMonths": [
+   "/home/user/lyra/docs/modularisation/data/kan422-dead-exports.json"
+  ],
+  "approveBetaUser": [
+   "/home/user/lyra/docs/modularisation/data/kan422-dead-exports.json"
+  ],
+  "buildBetaInviteLink": [
+   "/home/user/lyra/docs/modularisation/data/kan422-dead-exports.json"
+  ],
+  "buildSendInputs": [
+   "/home/user/lyra/docs/modularisation/data/kan422-dead-exports.json"
+  ],
+  "buildSmsBody": [
+   "/home/user/lyra/docs/modularisation/data/kan422-dead-exports.json"
+  ],
+  "canShipTo": [
+   "/home/user/lyra/docs/modularisation/data/kan422-dead-exports.json"
+  ],
+  "canTransition": [
+   "/home/user/lyra/docs/modularisation/data/kan422-dead-exports.json"
+  ],
+  "coerceRecipientAttributes": [
+   "/home/user/lyra/docs/RECOMMENDER_INPUTS.md",
+   "/home/user/lyra/docs/modularisation/data/kan422-dead-exports.json"
+  ],
+  "containsPII": [
+   "/home/user/lyra/docs/modularisation/data/kan422-dead-exports.json",
+   "/home/user/lyra-mcp-server/src/content-moderation.ts"
+  ],
+  "containsProfanity": [
+   "/home/user/lyra/docs/modularisation/data/kan422-dead-exports.json",
+   "/home/user/lyra-mcp-server/src/content-moderation.ts"
+  ],
+  "default": [
+   "/home/user/lyra/.github/workflows/promote-staging-to-beta.yml",
+   "/home/user/lyra/.github/workflows/auto-fix-known-failures.yml",
+   "/home/user/lyra/.github/workflows/deploy-beta.yml",
+   "/home/user/lyra/.github/workflows/auto-promote-to-staging.yml",
+   "/home/user/lyra/.github/workflows/promote-to-production.yml",
+   "/home/user/lyra/.github/workflows/db-invariants.yml",
+   "/home/user/lyra/.github/workflows/cleanup-phantom-check-suites.yml",
+   "/home/user/lyra/.github/workflows/beta-gate-smoke.yml",
+   "/home/user/lyra/.github/workflows/mutation-testing.yml",
+   "/home/user/lyra/.github/workflows/e2e-authed.yml",
+   "/home/user/lyra/.github/workflows/backup-platform.yml",
+   "/home/user/lyra/.github/workflows/secret-rotation-reminder.yml"
+  ],
+  "detectSpam": [
+   "/home/user/lyra/docs/modularisation/data/kan422-dead-exports.json",
+   "/home/user/lyra-mcp-server/src/content-moderation.ts"
+  ],
+  "disclosuresFromSwitches": [
+   "/home/user/lyra/docs/modularisation/data/kan422-dead-exports.json"
+  ],
+  "disconnectConnection": [
+   "/home/user/lyra/docs/modularisation/data/kan422-dead-exports.json"
+  ],
+  "exchangeCodeForTokens": [
+   "/home/user/lyra/docs/CONVENE.md",
+   "/home/user/lyra/docs/modularisation/data/kan422-dead-exports.json"
+  ],
+  "extractCity": [
+   "/home/user/lyra/docs/modularisation/data/kan422-dead-exports.json"
+  ],
+  "filterCandidatesByEligibility": [
+   "/home/user/lyra/docs/modularisation/data/kan422-dead-exports.json"
+  ],
+  "filterItemsByVisibility": [
+   "/home/user/lyra/docs/modularisation/data/kan422-dead-exports.json"
+  ],
+  "gatheringsCutoff": [
+   "/home/user/lyra/docs/modularisation/data/kan422-dead-exports.json"
+  ],
+  "gatheringsRetentionMonths": [
+   "/home/user/lyra/docs/modularisation/data/kan422-dead-exports.json"
+  ],
+  "generateAuthCode": [
+   "/home/user/lyra/docs/modularisation/data/kan422-dead-exports.json"
+  ],
+  "generateClientId": [
+   "/home/user/lyra/docs/modularisation/data/kan422-dead-exports.json"
+  ],
+  "generateClientSecret": [
+   "/home/user/lyra/docs/modularisation/data/kan422-dead-exports.json"
+  ],
+  "generateRefreshToken": [
+   "/home/user/lyra/docs/modularisation/data/kan422-dead-exports.json"
+  ],
+  "getAnomalyWindow": [
+   "/home/user/lyra/docs/modularisation/data/kan422-dead-exports.json"
+  ],
+  "getConnection": [
+   "/home/user/lyra/docs/modularisation/data/kan422-dead-exports.json"
+  ],
+  "getContactSearchHmacKey": [
+   "/home/user/lyra/docs/modularisation/data/kan422-dead-exports.json"
+  ],
+  "getEffectiveItemVisibility": [
+   "/home/user/lyra/docs/modularisation/data/kan422-dead-exports.json"
+  ],
+  "getFreeBusy": [
+   "/home/user/lyra/docs/CONVENE.md",
+   "/home/user/lyra/docs/modularisation/data/kan422-dead-exports.json"
+  ],
+  "getMetricsForWindow": [
+   "/home/user/lyra/docs/modularisation/data/kan422-dead-exports.json"
+  ],
+  "getSearchPepper": [
+   "/home/user/lyra/docs/modularisation/data/kan422-dead-exports.json"
+  ],
+  "hashContact": [
+   "/home/user/lyra/docs/modularisation/data/kan422-dead-exports.json"
+  ],
+  "hashRefreshToken": [
+   "/home/user/lyra/docs/modularisation/data/kan422-dead-exports.json"
+  ],
+  "isAffiliateNetwork": [
+   "/home/user/lyra/docs/modularisation/data/kan422-dead-exports.json"
+  ],
+  "isAffiliationType": [
+   "/home/user/lyra/docs/modularisation/data/kan422-dead-exports.json"
+  ],
+  "isAgeRangeBucket": [
+   "/home/user/lyra/docs/RECOMMENDER_INPUTS.md",
+   "/home/user/lyra/docs/modularisation/data/kan422-dead-exports.json"
+  ],
+  "isAllergy": [
+   "/home/user/lyra/docs/RECOMMENDER_INPUTS.md",
+   "/home/user/lyra/docs/modularisation/data/kan422-dead-exports.json"
+  ],
+  "isAllowedVisibility": [
+   "/home/user/lyra/docs/modularisation/data/kan422-dead-exports.json"
+  ],
+  "isCountryCode": [
+   "/home/user/lyra/docs/modularisation/data/kan422-dead-exports.json"
+  ],
+  "isDietaryRestriction": [
+   "/home/user/lyra/docs/RECOMMENDER_INPUTS.md",
+   "/home/user/lyra/docs/modularisation/data/kan422-dead-exports.json"
+  ],
+  "isEvergreenFallback": [
+   "/home/user/lyra/docs/modularisation/data/kan422-dead-exports.json"
+  ],
+  "isFeatureEnabledByProfile": [
+   "/home/user/lyra/docs/modularisation/data/kan422-dead-exports.json"
+  ],
+  "isFieldEditable": [
+   "/home/user/lyra/docs/modularisation/data/kan422-dead-exports.json"
+  ],
+  "isItemVisibleToViewer": [
+   "/home/user/lyra/docs/modularisation/data/kan422-dead-exports.json"
+  ],
+  "isMerchantEligibleInCountry": [
+   "/home/user/lyra/docs/modularisation/data/kan422-dead-exports.json"
+  ],
+  "isOccasion": [
+   "/home/user/lyra/docs/modularisation/data/kan422-dead-exports.json"
+  ],
+  "isPaidLinksComplianceReady": [
+   "/home/user/lyra/docs/modularisation/data/kan422-dead-exports.json"
+  ],
+  "isRecommendationEventSource": [
+   "/home/user/lyra/docs/modularisation/data/kan422-dead-exports.json"
+  ],
+  "isRecommendationEventType": [
+   "/home/user/lyra/docs/modularisation/data/kan422-dead-exports.json"
+  ],
+  "isRelationship": [
+   "/home/user/lyra/docs/modularisation/data/kan422-dead-exports.json"
+  ],
+  "isTurnstileEnabled": [
+   "/home/user/lyra/docs/modularisation/data/kan422-dead-exports.json"
+  ],
+  "issueAccessTokenJti": [
+   "/home/user/lyra/docs/modularisation/data/kan422-dead-exports.json"
+  ],
+  "markInviteFailed": [
+   "/home/user/lyra/docs/modularisation/data/kan422-dead-exports.json"
+  ],
+  "markInviteSent": [
+   "/home/user/lyra/docs/modularisation/data/kan422-dead-exports.json"
+  ],
+  "matchesSignature": [
+   "/home/user/lyra/docs/modularisation/data/kan422-dead-exports.json"
+  ],
+  "microsoftCalendarAdapter": [
+   "/home/user/lyra/docs/modularisation/data/kan422-dead-exports.json"
+  ],
+  "middleware": [
+   "/home/user/lyra/.github/workflows/deploy-beta.yml",
+   "/home/user/lyra/.github/workflows/beta-gate-smoke.yml",
+   "/home/user/lyra/.github/workflows/pr-checks.yml",
+   "/home/user/lyra/.github/signup-surface.paths",
+   "/home/user/lyra/scripts/daily-security-check.sh",
+   "/home/user/lyra/scripts/check-ui-copy-ownership.sh",
+   "/home/user/lyra/supabase/migrations/20260504220000_add_beta_eligible_flag.sql",
+   "/home/user/lyra/supabase/migrations/20260622120000_two_axis_access_model.sql",
+   "/home/user/lyra/docs/WEEKLY_HEALTH_REGRESSION_ROUTINE.md",
+   "/home/user/lyra/docs/HANDOVER_BETA_2026-05-11.md",
+   "/home/user/lyra/docs/DAILY_SECURITY_CHECK.md",
+   "/home/user/lyra/docs/JIRA_TICKET_STANDARD.md"
+  ],
+  "normalisePhone": [
+   "/home/user/lyra/docs/modularisation/data/kan422-dead-exports.json"
+  ],
+  "parentCookieDomain": [
+   "/home/user/lyra/docs/modularisation/data/kan422-dead-exports.json"
+  ],
+  "parseClickIdFromSubId": [
+   "/home/user/lyra/docs/modularisation/data/kan422-dead-exports.json"
+  ],
+  "parseSubId": [
+   "/home/user/lyra/docs/modularisation/data/kan422-dead-exports.json"
+  ],
+  "sanitiseEventMetadata": [
+   "/home/user/lyra/docs/modularisation/data/kan422-dead-exports.json"
+  ],
+  "scoreAttendee": [
+   "/home/user/lyra/supabase/migrations/20260516230400_convene_relationship_signals.sql",
+   "/home/user/lyra/docs/modularisation/data/kan422-dead-exports.json",
+   "/home/user/lyra/docs/proposals/kan-203-lyra-convene.md",
+   "/home/user/lyra-mcp-server/src/convene-recommend-tools.ts",
+   "/home/user/lyra-mcp-server/src/convene-recommend-scoring.ts",
+   "/home/user/lyra-mcp-server/tests/convene-recommend-tools.test.cjs"
+  ],
+  "searchByPhone": [
+   "/home/user/lyra/docs/modularisation/data/kan422-dead-exports.json"
+  ],
+  "sourceCandidatesForConcept": [
+   "/home/user/lyra/docs/modularisation/data/kan422-dead-exports.json"
+  ],
+  "stripHtml": [
+   "/home/user/lyra/docs/modularisation/data/kan422-dead-exports.json",
+   "/home/user/lyra/docs/ARCHITECTURE.md",
+   "/home/user/lyra-mcp-server/src/sanitise.ts",
+   "/home/user/lyra-mcp-server/tests/sec59-striphtml-convergence.test.cjs"
+  ],
+  "updateSectionVisibility": [
+   "/home/user/lyra/docs/modularisation/data/kan422-dead-exports.json"
+  ],
+  "useAutoSave": [
+   "/home/user/lyra/docs/modularisation/data/kan422-dead-exports.json"
+  ],
+  "validateFileMagicBytes": [
+   "/home/user/lyra/docs/modularisation/data/kan422-dead-exports.json"
+  ],
+  "verifyAccessToken": [
+   "/home/user/lyra/docs/modularisation/data/kan422-dead-exports.json"
+  ],
+  "wwwAuthenticateHeader": [
+   "/home/user/lyra/docs/modularisation/data/kan422-dead-exports.json"
+  ]
+ }
+}

--- a/docs/modularisation/kan422-dead-exports.py
+++ b/docs/modularisation/kan422-dead-exports.py
@@ -1,0 +1,411 @@
+#!/usr/bin/env python3
+"""KAN-422 (R7) — enumerate exported symbols in src/** with zero consumers.
+
+Read-only. Produces docs/modularisation/data/kan422-dead-exports.json.
+
+Definition used (from the ticket):
+  A symbol is a ZERO-CONSUMER EXPORT when no file *outside its own directory*
+  and outside its own co-located tests imports it by name.
+
+Method
+------
+1. Enumerate exported symbols per file in src/** (.ts/.tsx) with a line-oriented
+   scan of the export forms actually used in this repo.
+2. Build the import graph over the whole repo (src, tests, scripts, .github,
+   root configs), resolving the single tsconfig alias `@/* -> ./src/*`, relative
+   specifiers, and bare specifiers (ignored). Both static `import`, re-export
+   `export ... from`, dynamic `import()` and `require()` are counted.
+3. For each symbol, partition its importers into
+      same-dir / other-src-dir / test / script-or-ci
+   and flag those with an empty `other-src-dir` set.
+4. Subtract framework-contract exports: Next.js consumes some exports by
+   convention with no import statement anywhere (page/layout/route handlers,
+   metadata, middleware, instrumentation, generateStaticParams, ...). Those are
+   NOT dead; they are reported separately so the number stays honest.
+5. Grep for the symbol name as a *string* anywhere in the repo (and the two
+   sibling repos, if present) so dynamic/string-keyed reachability is visible
+   before anything is proposed for deletion.
+
+Run:  python3 docs/modularisation/kan422-dead-exports.py
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import subprocess
+import sys
+from collections import defaultdict
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[2]
+SRC = REPO / "src"
+OUT = REPO / "docs" / "modularisation" / "data" / "kan422-dead-exports.json"
+
+CODE_EXT = {".ts", ".tsx", ".js", ".jsx", ".mjs", ".cjs"}
+
+# Directories scanned for *consumers* (the import graph), repo-relative.
+CONSUMER_ROOTS = ["src", "tests", "scripts", ".github", "supabase", "controls"]
+# Root-level config files that can import from src.
+ROOT_GLOBS = ["*.ts", "*.js", "*.mjs", "*.cjs", "*.config.ts", "*.config.js"]
+
+SKIP_DIR_PARTS = {"node_modules", ".git", ".next", "dist", "coverage", "out"}
+
+# ---------------------------------------------------------------------------
+# Next.js / tooling framework contracts: exported by convention, never imported.
+# ---------------------------------------------------------------------------
+NEXT_FILE_CONVENTIONS = {
+    "page", "layout", "template", "loading", "error", "global-error",
+    "not-found", "route", "default", "sitemap", "robots", "manifest",
+    "opengraph-image", "twitter-image", "icon", "apple-icon",
+    "middleware", "instrumentation", "instrumentation-client",
+}
+NEXT_CONVENTION_SYMBOLS = {
+    "default", "metadata", "generateMetadata", "generateStaticParams",
+    "generateViewport", "viewport", "dynamic", "dynamicParams", "revalidate",
+    "fetchCache", "runtime", "preferredRegion", "maxDuration", "alt", "size",
+    "contentType", "config", "onRequestError", "register",
+    "GET", "POST", "PUT", "PATCH", "DELETE", "HEAD", "OPTIONS",
+}
+
+TEST_RE = re.compile(r"(^|/)(tests?|__tests__)/|\.(test|spec)\.[cm]?[jt]sx?$")
+
+
+def is_test(rel: str) -> bool:
+    return bool(TEST_RE.search(rel))
+
+
+def walk(root: Path):
+    for dirpath, dirnames, filenames in os.walk(root):
+        dirnames[:] = [d for d in dirnames if d not in SKIP_DIR_PARTS]
+        for fn in filenames:
+            p = Path(dirpath) / fn
+            if p.suffix in CODE_EXT:
+                yield p
+
+
+# ---------------------------------------------------------------------------
+# 1. Exported symbols
+# ---------------------------------------------------------------------------
+DECL_RE = re.compile(
+    r"^\s*export\s+(?:declare\s+)?"
+    r"(?:(?:async\s+)?function\*?|const|let|var|class|abstract\s+class|"
+    r"type|interface|enum|const\s+enum)\s+"
+    r"([A-Za-z_$][\w$]*)"
+)
+DEFAULT_RE = re.compile(r"^\s*export\s+default\b")
+# export { a, b as c }   /   export { a } from './x'   /   export * from './x'
+BRACE_RE = re.compile(r"^\s*export\s*\{([^}]*)\}\s*(from\s*['\"]([^'\"]+)['\"])?")
+STAR_FROM_RE = re.compile(r"^\s*export\s*\*\s*(?:as\s+([\w$]+)\s*)?from\s*['\"]([^'\"]+)['\"]")
+# export const { a, b } = ...
+DESTRUCT_RE = re.compile(r"^\s*export\s+(?:const|let|var)\s*\{([^}]*)\}")
+
+
+def strip_comments(text: str) -> str:
+    text = re.sub(r"/\*.*?\*/", "", text, flags=re.S)
+    return re.sub(r"^\s*//.*$", "", text, flags=re.M)
+
+
+def internal_uses(text_nocomments: str, sym: str, decl_line: int) -> int:
+    """How many times the symbol is referenced in its own file, other than at
+    its declaration. Distinguishes DEAD code from live code with a too-wide
+    `export` — the two need opposite dispositions."""
+    if sym == "default":
+        return 0
+    rx = re.compile(r"\b" + re.escape(sym) + r"\b")
+    n = 0
+    for i, line in enumerate(text_nocomments.splitlines(), 1):
+        if i == decl_line:
+            continue
+        n += len(rx.findall(line))
+    return n
+
+
+def decl_loc(text_nocomments: str, decl_line: int) -> int:
+    """Lines spanned by a declaration, by brace/paren balance from its first line."""
+    lines = text_nocomments.splitlines()
+    if decl_line > len(lines):
+        return 1
+    depth, started, span = 0, False, 0
+    for line in lines[decl_line - 1:]:
+        span += 1
+        for ch in line:
+            if ch in "{([":
+                depth += 1
+                started = True
+            elif ch in "})]":
+                depth -= 1
+        if started and depth <= 0:
+            break
+        if not started and line.rstrip().endswith(";"):
+            break
+        if span > 400:
+            break
+    return span
+
+
+def exports_of(path: Path) -> dict[str, int]:
+    """symbol -> 1-based line number of its export."""
+    raw = path.read_text(encoding="utf-8", errors="replace")
+    text = strip_comments(raw)
+    found: dict[str, int] = {}
+    for i, line in enumerate(text.splitlines(), 1):
+        m = DECL_RE.match(line)
+        if m:
+            found.setdefault(m.group(1), i)
+            continue
+        m = DESTRUCT_RE.match(line)
+        if m:
+            for part in m.group(1).split(","):
+                name = part.split(":")[-1].strip().lstrip(".")
+                if re.fullmatch(r"[A-Za-z_$][\w$]*", name):
+                    found.setdefault(name, i)
+            continue
+        m = BRACE_RE.match(line)
+        if m:
+            for part in m.group(1).split(","):
+                part = part.strip()
+                if not part:
+                    continue
+                name = part.split(" as ")[-1].strip()
+                if re.fullmatch(r"[A-Za-z_$][\w$]*", name):
+                    found.setdefault(name, i)
+            continue
+        m = STAR_FROM_RE.match(line)
+        if m and m.group(1):
+            found.setdefault(m.group(1), i)
+            continue
+        if DEFAULT_RE.match(line):
+            found.setdefault("default", i)
+    return found
+
+
+# ---------------------------------------------------------------------------
+# 2. Import graph
+# ---------------------------------------------------------------------------
+IMPORT_FROM_RE = re.compile(
+    r"import\s+(?:type\s+)?([\s\S]*?)\s+from\s*['\"]([^'\"]+)['\"]"
+)
+SIDE_EFFECT_RE = re.compile(r"import\s*['\"]([^'\"]+)['\"]")
+EXPORT_FROM_RE = re.compile(r"export\s+(?:type\s+)?(?:\*|\{[\s\S]*?\})\s*from\s*['\"]([^'\"]+)['\"]")
+DYNAMIC_RE = re.compile(r"(?:import|require)\s*\(\s*['\"]([^'\"]+)['\"]\s*\)")
+JEST_MOCK_RE = re.compile(r"jest\.(?:mock|unstable_mockModule|requireActual|doMock)\s*\(\s*['\"]([^'\"]+)['\"]")
+
+
+def parse_clause(clause: str) -> set[str]:
+    """`{a, b as c}, Default, * as ns` -> the set of *source* names imported."""
+    names: set[str] = set()
+    brace = re.search(r"\{([\s\S]*)\}", clause)
+    if brace:
+        for part in brace.group(1).split(","):
+            part = part.strip().removeprefix("type ").strip()
+            if not part:
+                continue
+            src_name = part.split(" as ")[0].strip()
+            if re.fullmatch(r"[A-Za-z_$][\w$]*", src_name):
+                names.add(src_name)
+        clause = clause[: brace.start()] + clause[brace.end():]
+    if re.search(r"\*\s*as\s+[\w$]+", clause):
+        names.add("*")
+    head = clause.split("{")[0].split(",")[0].strip()
+    if re.fullmatch(r"[A-Za-z_$][\w$]*", head):
+        names.add("default")
+    return names
+
+
+def resolve(spec: str, importer: Path) -> Path | None:
+    """Resolve a specifier to a repo file, or None for bare/unresolvable."""
+    if spec.startswith("@/"):
+        base = SRC / spec[2:]
+    elif spec.startswith("."):
+        base = (importer.parent / spec).resolve()
+    elif spec.startswith("/"):
+        return None
+    else:
+        return None
+    cands = [base]
+    for ext in (".ts", ".tsx", ".js", ".jsx", ".mjs", ".cjs"):
+        cands.append(base.with_suffix(base.suffix + ext) if base.suffix else Path(str(base) + ext))
+        cands.append(Path(str(base) + ext))
+        cands.append(base / ("index" + ext))
+    for c in cands:
+        if c.is_file():
+            return c.resolve()
+    return None
+
+
+def consumer_files() -> list[Path]:
+    files: list[Path] = []
+    for root in CONSUMER_ROOTS:
+        p = REPO / root
+        if p.is_dir():
+            files.extend(walk(p))
+    for pat in ROOT_GLOBS:
+        files.extend(x for x in REPO.glob(pat) if x.is_file())
+    # .github workflows are YAML — scanned separately for string references.
+    return sorted(set(files))
+
+
+def build_graph(files: list[Path]):
+    """(target_abs, symbol) -> set of importer rel paths.  '*' = namespace import."""
+    edges: dict[tuple[str, str], set[str]] = defaultdict(set)
+    for f in files:
+        try:
+            text = strip_comments(f.read_text(encoding="utf-8", errors="replace"))
+        except Exception:
+            continue
+        rel = str(f.relative_to(REPO))
+        for clause, spec in IMPORT_FROM_RE.findall(text):
+            t = resolve(spec, f)
+            if not t:
+                continue
+            for name in parse_clause(clause):
+                edges[(str(t.relative_to(REPO)), name)].add(rel)
+        for spec in EXPORT_FROM_RE.findall(text):
+            t = resolve(spec, f)
+            if t:
+                edges[(str(t.relative_to(REPO)), "*")].add(rel)
+        for rx in (SIDE_EFFECT_RE, DYNAMIC_RE, JEST_MOCK_RE):
+            for spec in rx.findall(text):
+                t = resolve(spec, f)
+                if t:
+                    edges[(str(t.relative_to(REPO)), "*")].add(rel)
+    return edges
+
+
+# ---------------------------------------------------------------------------
+# 5. string reachability
+# ---------------------------------------------------------------------------
+def string_hits(symbols: list[str], extra_repos: list[Path]) -> dict[str, list[str]]:
+    """Literal occurrences of each symbol name outside its own module tree."""
+    hits: dict[str, list[str]] = {}
+    roots = [REPO / d for d in (".github", "scripts", "supabase", "controls", "docs")]
+    roots += [r for r in extra_repos if r.is_dir()]
+    roots = [r for r in roots if r.is_dir()]
+    if not roots:
+        return hits
+    for sym in symbols:
+        try:
+            res = subprocess.run(
+                ["grep", "-rIl", "--exclude-dir=node_modules", "--exclude-dir=.git",
+                 "--exclude-dir=.next", "-F", sym, *[str(r) for r in roots]],
+                capture_output=True, text=True, timeout=90,
+            )
+        except Exception:
+            continue
+        files = [ln for ln in res.stdout.splitlines() if ln.strip()]
+        if files:
+            hits[sym] = files[:12]
+    return hits
+
+
+def main() -> int:
+    src_files = sorted(walk(SRC))
+    graph = build_graph(consumer_files())
+
+    # namespace / side-effect importers, per target file
+    ns_importers: dict[str, set[str]] = defaultdict(set)
+    for (tgt, name), imps in graph.items():
+        if name == "*":
+            ns_importers[tgt] |= imps
+
+    records = []
+    for f in src_files:
+        rel = str(f.relative_to(REPO))
+        if is_test(rel):
+            continue
+        stem = f.stem
+        conventional_file = stem in NEXT_FILE_CONVENTIONS
+        d = str(f.parent.relative_to(REPO))
+        body = strip_comments(f.read_text(encoding="utf-8", errors="replace"))
+        for sym, line in exports_of(f).items():
+            imps = set(graph.get((rel, sym), set())) | ns_importers.get(rel, set())
+            imps.discard(rel)
+            same_dir, other_src, tests, tooling = [], [], [], []
+            for i in sorted(imps):
+                if is_test(i):
+                    tests.append(i)
+                elif i.startswith("src/"):
+                    (same_dir if str(Path(i).parent) == d else other_src).append(i)
+                else:
+                    tooling.append(i)
+            framework = conventional_file and sym in NEXT_CONVENTION_SYMBOLS
+            zero = (not framework) and not other_src and not same_dir and not tooling
+            uses = internal_uses(body, sym, line) if zero else 0
+            # Disposition bucket — the distinction the raw zero-importer count hides:
+            #   OVER-EXPORTED = live code reached from inside its own file; the
+            #                   defect is the `export` keyword, not the code.
+            #   DEAD-*        = no reference anywhere; the code itself is dead.
+            if not zero:
+                bucket = "CONSUMED"
+            elif uses > 0:
+                bucket = "OVER-EXPORTED"
+            elif tests:
+                bucket = "DEAD-TESTED"
+            else:
+                bucket = "DEAD-ISOLATED"
+            records.append({
+                "file": rel,
+                "dir": d,
+                "symbol": sym,
+                "line": line,
+                "loc": decl_loc(body, line) if zero else 0,
+                "internalUses": uses,
+                "bucket": bucket,
+                "frameworkContract": framework,
+                "consumersOutsideDir": other_src,
+                "consumersSameDir": same_dir,
+                "toolingConsumers": tooling,
+                "testConsumers": tests,
+                "zeroConsumer": zero,
+                "testedOnly": zero and bool(tests),
+            })
+
+    dead = [r for r in records if r["zeroConsumer"]]
+    tested_dead = [r for r in records if r["testedOnly"]]
+    truly_dead = [r for r in records if r["bucket"].startswith("DEAD")]
+
+    extra = [REPO.parent / "lyra-mcp-server", REPO.parent / "lyra-admin-mcp-server"]
+    syms = sorted({r["symbol"] for r in dead if len(r["symbol"]) > 4})
+    hits = string_hits(syms, extra)
+
+    by_file: dict[str, list[str]] = defaultdict(list)
+    for r in dead:
+        by_file[r["file"]].append(r["symbol"])
+
+    out = {
+        "$comment": "KAN-422 R7 — zero-consumer export enumeration. Reproduce with "
+                    "`python3 docs/modularisation/kan422-dead-exports.py`.",
+        "generatedFrom": subprocess.run(["git", "rev-parse", "HEAD"], cwd=REPO,
+                                        capture_output=True, text=True).stdout.strip(),
+        "totals": {
+            "srcFilesScanned": len(src_files),
+            "exportedSymbols": len(records),
+            "frameworkContractSymbols": sum(1 for r in records if r["frameworkContract"]),
+            "zeroConsumerSymbols": len(dead),
+            "zeroConsumerButTested": len(tested_dead),
+            "bucket_OVER_EXPORTED": sum(1 for r in dead if r["bucket"] == "OVER-EXPORTED"),
+            "bucket_DEAD_TESTED": sum(1 for r in dead if r["bucket"] == "DEAD-TESTED"),
+            "bucket_DEAD_ISOLATED": sum(1 for r in dead if r["bucket"] == "DEAD-ISOLATED"),
+            "deadLOC": sum(r["loc"] for r in truly_dead),
+            "overExportedLOC": sum(r["loc"] for r in dead if r["bucket"] == "OVER-EXPORTED"),
+            "filesWithAnyZeroConsumerExport": len(by_file),
+            "filesEntirelyZeroConsumer": sum(
+                1 for f, s in by_file.items()
+                if len(s) == len([r for r in records if r["file"] == f and not r["frameworkContract"]])
+            ),
+        },
+        "zeroConsumerByFile": {f: sorted(s) for f, s in sorted(by_file.items())},
+        "zeroConsumerSymbols": sorted(dead, key=lambda r: (r["file"], r["symbol"])),
+        "stringReachability": hits,
+    }
+    OUT.parent.mkdir(parents=True, exist_ok=True)
+    OUT.write_text(json.dumps(out, indent=1) + "\n")
+    print(json.dumps(out["totals"], indent=1))
+    print(f"\nwrote {OUT.relative_to(REPO)}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

R7 spike artefact for the modularisation epic (KAN-414). **Read-only** — no application code, no tests, no workflows changed. Adds three files under `docs/modularisation/`:

- `KAN-422-dead-exports.md` — the disposition register
- `kan422-dead-exports.py` — the derivation script (reproducible)
- `data/kan422-dead-exports.json` — machine-readable output

### Headline numbers

| Measure | Figure |
|---|---|
| `src/**` files scanned | 274 |
| Exported symbols | 829 |
| Next.js/tooling framework contracts (excluded) | 147 |
| **Zero-importer exports** | **219** |
| — OVER-EXPORTED (live code, over-wide `export`) | 160 (1,463 LOC) |
| — DEAD-TESTED | 36 (588 LOC) |
| — DEAD-ISOLATED | 23 (542 LOC) |
| **Genuinely dead LOC** | **1,130** |

### Two corrections to the epic's premise

**1. The raw zero-importer count is ~3× too pessimistic.** 160 of the 219 are *not dead code* — they are symbols used inside their own file and exported only so a unit test can reach them. Deleting them would break live behaviour. The defect is the `export` keyword, not the code, and the fix is narrowing at extraction time with no Test Integrity Policy exposure. The discriminator is measured (`internal_uses`), not assumed. A run reporting "219 dead exports" would have been wrong by 1,463 LOC.

**2. The two files the ticket names for deletion must NOT be deleted.** `src/lib/recommender/inputs.ts` and `events.ts` are scaffolding for **KAN-198** and **KAN-202** — both **In Progress today**. They are unconsumed because their consumers aren't built yet: the textbook KEEP AS CONTRACT case. The ticket asked for this check explicitly; the answer is *keep*.

The ~650 LOC estimate is close to the real DEAD-TESTED figure (588 LOC / 36 symbols) — but it is a different 588 LOC from the one assumed.

### Two live defects found — raised separately

In both cases the "dead" export turned out to be the **correct implementation that a live surface bypasses**:

- **SEC-109 (High)** — Convene "Disconnect" performs a client-side PostgREST update instead of calling `disconnectConnection`, so `vaultRevokeRefreshToken` is never invoked. The Google Calendar refresh token stays live in the Supabase vault indefinitely, while the UI tells the user twice that their tokens are forgotten immediately.
- **SEC-110 (Medium)** — `search_by_contact_hash` is a SECURITY DEFINER, RLS-bypassing RPC granted to `authenticated`, whose only caller (`searchByPhone`) has no caller of its own. No UI, no API route, no MCP tool in any of the three repos. It has already cost BUGS-45, SEC-80 and an R2 baseline entry; meanwhile users' phone hashes are collected for a lookup with no entry point.

### Feeds into

- **KAN-416** — `modules.json` `publicApi` must be drawn from the `CONSUMED` bucket only, or 1,463 LOC of test-only surface + 1,130 LOC of dead code gets frozen into permanent module contracts. That is the D-11 risk, now quantified.
- **KAN-184** — `filterCandidatesByEligibility` must be wired into the V2 pipeline before Sovrn Tier 2 goes live (Tiers 2/3 are stubbed today, which is the only reason the current arrangement is safe).
- **KAN-415** — §3a is the execution list.

### Test Integrity Policy

Nothing deleted, nothing weakened. §5 drafts the single batched sign-off request for when the deletions execute under KAN-415. Notable: **no test file can be deleted whole** — every DELETE candidate with tests shares its file with live code, so the ask is narrower than the ticket anticipated (partial edits to 4 files). The bulk of the deletion (486 LOC: D1, D2, D3, D7) carries **zero** tests, so the 2118 floor does not move for it.

## Jira Ticket

KAN-422 (also files SEC-109, SEC-110)

## Checklist

- [x] Unit tests added/updated for new/changed functionality — N/A, docs-only artefact; no source changed
- [x] All existing tests pass (`npm run test:unit`) — N/A, no code touched; nothing in this diff is executed by the suite
- [x] Lint passes (`npm run lint`) — N/A, no JS/TS added (the derivation script is Python, not in the lint path)
- [x] Type check passes (`npm run type-check`) — N/A, no TS added
- [x] Build succeeds (`npm run build`) — N/A, nothing under `src/`
- [x] Coverage has not decreased — N/A, no source changed
- [x] No eslint-disable or ts-ignore without KAN-XX reference — none added
- [x] Dependency-rule gate reviewed — N/A, no imports changed
- [x] ARCHITECTURE.md updated if architectural changes were made — N/A, research artefact; makes no architectural change. The two defects it found carry their own docs obligations on SEC-109 / SEC-110.
- [x] Ops routine / Control-Room registry updated — N/A, no routine behaviour, cadence or ownership changed
- [x] Docs / system map updated — this PR **is** the doc. Lands in `docs/modularisation/` alongside the KAN-416/417/419/420 artefacts. No system-map change: nothing about a service, table, env var, route, job or security boundary changed. The SEC tickets each name their own doc footprint.

---
_Generated by [Claude Code](https://claude.ai/code/session_018QYX2YoDEtJjJuHPDqdPuB)_