### PR TITLE
KAN-432: R10 modularisation plan re-validation + the 14 agreed edits (scope ruling A)

### DIFF
--- a/docs/modularisation/LYRA_MODULARISATION_PLAN_2026-07-26.md
+++ b/docs/modularisation/LYRA_MODULARISATION_PLAN_2026-07-26.md
@@ -5,6 +5,10 @@
 **Method:** 8 parallel read-only code surveys + 2 competing architecture proposals, synthesised. Every number below is re-derivable from the repos.
 **Relationship to existing work:** this is the successor programme to **KAN-350** Phase 3. It absorbs, re-scopes or depends on KAN-353, KAN-355, KAN-356, KAN-358 (see §7).
 
+> **⚠️ Baseline re-validated 2026-07-28 against `674f0a7`** — see [`PLAN-REVALIDATION-2026-07-28.md`](./PLAN-REVALIDATION-2026-07-28.md) (KAN-432). Unless a figure is explicitly marked *re-validated*, every number below is **as-surveyed 2026-07-26** and should be re-derived before it is relied on.
+>
+> **⚠️ SCOPE RULING — founder decision, 2026-07-28 (KAN-432 §5, option A): the extraction programme D1–D15 is DEFERRED.** The adopted scope is **Phase 0 in full + `@lyra/contracts` + the data boundary (C3) + the `profiles` ADR**. D1–D15 are not cancelled — they are re-decided after Phase 0, on evidence measured against a decoupled test estate and a typed schema, rather than on the 2026-07-26 survey. The reasoning is in §2.2 and §6. **No file moves into `src/modules/` under the current scope.**
+
 ---
 
 ## 1. What the survey actually found (and why it changes the plan)
@@ -13,17 +17,19 @@ The instinct behind this request — "the code is tangled, break it into modules
 
 ### 1.1 The code is already horizontally modular
 
-The static import graph of `src/` is 273 nodes and 525 edges. Of those:
+The static import graph of `src/` is 273 nodes and 525 edges (**re-validated 2026-07-28: 274 nodes / 527 edges**). Of those:
 
-| Measure | Value | Meaning |
-|---|---|---|
-| `lib` → `app` edges (wrong-direction) | **1** | `lib/beta-access/flow.ts` → `app/admin/users/users-actions-shared.ts` |
-| `app` segment → `app` segment edges | **5** | 14 of 19 route segments have **zero** fan-in |
-| Import cycles | **1** | type-only, inside `app/dashboard/convene/organise`, one line to fix |
-| Cross-group edges | 328 | of which **145 (44%) are deep imports** into another area's internals |
-| `index.ts` barrels in 272 files | **4** | mediating just **9 of 328** cross-group edges |
+| Measure | 2026-07-26 | Re-validated 2026-07-28 | Meaning |
+|---|---|---|---|
+| `lib` → `app` edges (wrong-direction) | **1** | **0** ✅ | Was `lib/beta-access/flow.ts` → `app/admin/users/users-actions-shared.ts`. **Fixed by KAN-424 / PR #596.** |
+| `app` segment → `app` segment edges | **5** | **3** ⚠️ | 14 → **16** of 19 route segments have **zero** fan-in. Partially fixed; see §7-P-6 and BUGS-80 |
+| Import cycles | **1** | **1** ❌ | type-only, inside `app/dashboard/convene/organise`, one line to fix — **still open**, see BUGS-80 |
+| Cross-group edges | 328 | **336** | of which **145 (44%)** → **142 (42.3%)** are deep imports into another area's internals |
+| `index.ts` barrels in 272 files | **4** | **5** | mediating just **9 of 328** → **10 of 336** cross-group edges |
 
-524 of 525 edges already point the right way. **There is no monolith to break apart.** A "decompose the tangle" refactor would spend its budget on a problem that does not exist.
+**Definition — "deep import":** an edge into a file *inside* another group's directory that does not go via that group's barrel, where a group is `src/<area>/<segment>`. Stated explicitly because two other plausible readings of the same phrase give 24 (7.1%) and 326 (97%); the figure above is not meaningful without this definition, and a headline whose definition has to be reverse-engineered is not "re-derivable from the repos".
+
+524 of 525 edges already pointed the right way; **re-validated, 527 of 527 do.** **There is no monolith to break apart.** A "decompose the tangle" refactor would spend its budget on a problem that does not exist.
 
 ### 1.2 The coupling that *does* exist is vertical — into an unnamed kernel and into the database
 
@@ -32,8 +38,10 @@ The static import graph of `src/` is 273 nodes and 525 edges. Of those:
 | Unnamed kernel | `lib/supabase-server.ts` fan-in 46 · `lib/supabase-service.ts` 39 · `lib/env.ts` 17 (140 transitive dependants) · `lib/admin.ts` 17 |
 | No repository layer | **280 `.from('table')` call sites over 33 tables**; 199 (71%) sit inside route/page/action files. Exactly one file in the codebase is named as a repository (`lib/convene/invites/repository.ts`) |
 | RLS bypassed everywhere | `createServiceRoleClient()` imported in **40 files** in `src/`; **both MCP servers use the service-role key for 100% of traffic** |
-| `profiles` is a god-table | touched by **15 module groups over 75 call sites**, carrying identity + access model + admin flags + suspension + age + discovery hashes + delivery country + recommender attributes + section-visibility JSON + dashboard widget state |
-| No typed schema | **No generated `Database` type in any of the three repos.** Every row is `any`, every column a string literal |
+| `profiles` is a god-table | touched by **15 module groups over 75 call sites** — **re-validated 2026-07-28: 17 groups over 77 call sites, i.e. WORSENING** — carrying identity + access model + admin flags + suspension + age + discovery hashes + delivery country + recommender attributes + section-visibility JSON + dashboard widget state |
+| No typed schema | **No generated `Database` type in any of the three repos.** Every row is `any`, every column a string literal — **re-validated 2026-07-28: still none** |
+
+**Re-validated 2026-07-28.** The four kernel fan-in figures reproduce **exactly** (`supabase-server` 46, `supabase-service` 39, `env.ts` 17, `admin.ts` 17) under an independent graph rebuild — that exactness is the calibration check for every other number in this section. `.from()` sites 280 → 277 over the same 33 tables, service-role importers 40 → 39, `auth.getUser()` files 37 → **41** (worsening): all unchanged in substance. **The vertical coupling this section identifies is flat or getting worse, while the horizontal structure in §1.1 improved.** That asymmetry is the central input to the 2026-07-28 scope ruling — see §2.2.
 
 ### 1.3 The rules have no home, so they are re-implemented per call site and per repo
 
@@ -55,22 +63,26 @@ The static import graph of `src/` is 273 nodes and 525 edges. Of those:
 
 ### 1.5 The single biggest tax: the test suite pins file paths, not behaviour
 
-| | Web app | lyra-mcp-server | admin-mcp |
-|---|---|---|---|
-| Test files | 213 (`tests/unit` 197 + `tests/scripts` 16) | 44 | 7 |
-| Using `readFileSync` on source text | **98** | **44 (100%)** | **7 (100%)** |
-| Hard-coded `src/**` path literals | **112 distinct** | all | all |
-| Pure source-text scans (never import the code) | **70** | 44 | 7 |
+| | Web app (2026-07-26) | Web app — re-validated 2026-07-28 | lyra-mcp-server | admin-mcp |
+|---|---|---|---|---|
+| Test files | 213 (`tests/unit` 197 + `tests/scripts` 16) | **220** | 44 | 7 |
+| Using `readFileSync` on source text | **98** | **116 (+18%)** ⚠️ | **44 (100%)** | **7 (100%)** |
+| Hard-coded `src/**` path literals | **112 distinct** | **125** ⚠️ | all | all |
+| Pure source-text scans (never import the code) | **70** | **92 (+31%)** ⚠️ | 44 | 7 |
+
+> **This tax is compounding, and fast.** Those increases happened in **two days** (2026-07-26 → 2026-07-28), with no modularisation work in flight. **F4's cost is a function of when it starts** — every week of delay makes the largest, least glamorous item on the critical path measurably more expensive. This is the single strongest argument in the re-validation for doing Phase 0 now, and it holds whether or not any module is ever extracted.
 
 **Moving any file breaks tests with `ENOENT` — a failure that carries no information — while providing zero behavioural safety net.** Under the standing Test Integrity Policy every one of those breaks forces a stop-and-get-sign-off judgement call. This is the hard prerequisite that determines whether this programme succeeds or stalls.
 
-Compounding it: the enforced test floors in `tests/unit/test-regression-guard.test.js` are **29 files / 320 tests** against an actual **213 files / ~2,401 test blocks**, and every `jest.config.js` coverage threshold is **0**. Test-loss protection is nominal.
+Compounding it: the enforced test floors in `tests/unit/test-regression-guard.test.js` are **29 files / 320 tests** against an actual **213 files / ~2,401 test blocks**, and every `jest.config.js` coverage threshold is **0**. Test-loss protection is nominal. **Re-validated 2026-07-28: the floors are still 29 / 320 and every coverage threshold is still 0, against an actual 220 files / 2,439 blocks — the gap is widening.** P-7 stands unchanged.
 
 ### 1.6 Five CI policy gates classify by hard-coded path and fail *silently* when a file moves
 
 `scripts/check-ui-copy-ownership.sh` (the founder UI/copy gate) · `.github/signup-surface.paths` (the un-skippable signup E2E gate) · `.github/CODEOWNERS` · `scripts/check-service-role-client.sh` · `stryker.config.mjs`.
 
 A glob that matches nothing simply protects nothing. **Without a drift detector landing first, this programme's own first PR is also the PR that quietly disarms the founder UI gate and the signup gate.**
+
+> **Re-validated 2026-07-28 — the control estate has grown, but not in the way the plan assumes.** This plan was written against **11 blocking static gates**; `controls/registry.json` today holds **32** (CTL-001…CTL-032), several added since (CTL-029 secret-refs, CTL-030 dependency rules, CTL-031 bash portability). **However — and this matters more than the count — the registry schema has no field expressing blocking-vs-advisory at all.** Its keys are `added, defect_class, escape_hatch, id, implementation, kind, name, notes, prevents, self_test, summary, wired_in`; `kind` classifies *what a control is* (`ci-gate` 22 / `scheduled` 6 / `test` 4), not *whether failing it stops a merge*. The registry therefore **cannot represent** the property, so nothing can assert it — **SEC-106 confirmed, and structurally worse than its title states.** 22 of the 32 controls also have no `self_test`. Every claim in this document about a gate being "blocking" should be read as *unverified* until SEC-106 lands.
 
 ---
 
@@ -94,8 +106,31 @@ Two architectures were designed and evaluated.
 State this plainly, now, so nobody is surprised in six months:
 
 - **No independent deployability.** One Next build, one Vercel deploy, one `develop → staging → beta → main` chain verified by whole-branch SHA. A module's change still traverses four whole-repo pipelines. **What changes is blast radius and reviewability, not release cadence.**
-- **CI gets slower before it gets faster.** Every PR already runs 11 blocking static guards + lint + tsc + ~2,401 tests + `npm audit` + a full build with no path filters. This adds three more gates. Path-filtered per-module CI only becomes *safe* after the test-decoupling phase — because today a source-text test for module A can live in a file named after module B.
+- **CI gets slower before it gets faster.** Every PR already runs 11 blocking static guards + lint + tsc + ~2,401 tests + `npm audit` + a full build with no path filters (**re-validated 2026-07-28: 32 registered controls — though none provably blocking, see §1.6 — and 2,439 test blocks**). This adds three more gates. Path-filtered per-module CI only becomes *safe* after the test-decoupling phase — because today a source-text test for module A can live in a file named after module B.
 - **`profiles` stays a shared table.** Column-level ownership recorded in a manifest and enforced by a grep gate is a real improvement over nothing, but it is a convention enforced by a script, not by the database. Splitting `profiles` into satellite tables is a larger, riskier migration programme across three Supabase projects that already have documented parity drift — **deliberately deferred, and named as deferred.**
+
+### 2.2 Scope ruling, 2026-07-28 — the extraction programme is deferred (KAN-432, option A)
+
+**Founder decision, 2026-07-28.** The re-validation (KAN-432) asked the question this plan's cost rests on — *does the Enforced Modular Monolith still earn its cost?* — and the answer changed the scope, not the diagnosis.
+
+**What the evidence showed.** Split it in two:
+
+- **Horizontal structure improved without a single extraction.** `lib`→`app` 1 → **0**; cross-segment edges 5 → **3**; segments with zero fan-in 14 → **16**. All of it from one targeted PR (KAN-424) and one cheap gate (CTL-030). Not one file moved into `src/modules/`.
+- **Vertical coupling — the thing this plan correctly named as the real problem — is flat or worsening.** `profiles` 75 → **77** sites over 15 → **17** groups; `auth.getUser()` 37 → **41** files; test path-coupling **+18% / +31% in two days**; no `Database` type; floors and coverage unmoved.
+
+**The inference.** The plan was right about *where* the problem is, and the last 48 hours demonstrated that the cheap half of its own prescription works. What has **not** been demonstrated is that fifteen module extractions are what closes the remaining gap. **Every worsening metric above is closed by Phase 0 (F4–F8) plus the data boundary (C3) and `@lyra/contracts`. None of them requires moving a file into `src/modules/`.**
+
+**Adopted scope:**
+
+1. **Phase 0 in full** (Workstream B, F1–F9). This is where every worsening number lives, and F4 gets more expensive weekly (§1.5). Urgent on its own merits, independent of modularisation.
+2. **`@lyra/contracts`** (R3/D3/E3). The cross-repo duplication is the one problem a monolith genuinely cannot solve; X-1 (`admin_approve_beta`) remains the live worked example.
+3. **The data boundary (C3) and the `profiles` ADR** (R6/KAN-421) — this plan's own "load-bearing decision".
+
+**Deferred:** D1–D15, and the machinery that exists only to serve them (C1, C2, C4–C6, G1). **Deferred is not cancelled.**
+
+**Re-decision trigger — this is binding, so that "deferred" cannot decay into "abandoned".** When Phase 0 closes, re-derive §1.1 and §1.2 against a decoupled test estate and a generated `Database` type, and re-take this decision on that evidence. Extraction should be re-opened if the vertical coupling has *not* materially improved under Phase 0 alone — that is the measurement Phase 0 exists to make possible, and it is the measurement this plan could not make in July 2026.
+
+**This is not the plan failing.** It is the plan's own §1.4 thesis — cheap enforced gates do the heavy lifting, and creating a canonical module is ~10% of the work — applied to the plan's own scope.
 
 ---
 
@@ -193,6 +228,8 @@ Boundaries a human must remember are boundaries that erode (§1.4). Every rule b
 
 A deep import therefore **fails `npm run type-check`**, which already runs in `pr-checks.yml` and all four deploy workflows. Privileged sub-entries are declared individually so each is separately greppable: `@mod/platform/service`, `@mod/profile/read`, `@mod/features/service`, `@mod/convene/jobs`. `jest.moduleNameMapper` mirrors the same aliases so tests cannot deep-import either.
 
+> **⚠️ Amended 2026-07-28 (KAN-432) — this claim was overstated, and the correction matters.** A path alias only governs imports **written in alias form**. `import x from '../../modules/convene/internal/thing'` is an ordinary relative specifier: it resolves, it type-checks, and no absence of a wildcard alias stops it. So "a deep import fails `type-check`" is true only for imports someone chose to write as `@mod/convene/...` — i.e. it catches the honest mistake and misses the shortcut. **Compile-time entry points are a useful first line, not the enforcement mechanism.** Real enforcement is the graph rule (§4.2, `no-deep-module-import`) plus the ESLint layer (C6), both of which see relative specifiers. Read §4.1 as *ergonomics and early feedback*, and §4.2 as *the gate*. Under the 2026-07-28 scope ruling (§2.2) this is deferred work in any case, but the claim must not be carried forward uncorrected.
+
 ### 4.2 Graph rules — `dependency-cruiser`, blocking, in the existing `PR Quality Gate` job
 
 Chosen over `eslint-plugin-boundaries` because it also reports cycles and orphans, runs independently of the Next eslint config, and the same class of tool (`madge`) is already proven to run via `npx` here.
@@ -210,6 +247,10 @@ Chosen over `eslint-plugin-boundaries` because it also reports cycles and orphan
 | `backoffice-not-in-request-path` | — |
 
 **Three of these are already green or nearly green.** Land them first, warn-then-block, before any code moves — ~7 small fixes total — and the good structure that already exists is permanently locked in.
+
+**Re-validated 2026-07-28:** `no-module-to-app` **1 → 0** ✅, `no-cross-segment-app` **5 → 3**, `no-circular` **1 → 1** (still open, BUGS-80), `no-deep-module-import` **145 → 142**. F3/KAN-425 landed the first three as **CTL-030** — but as **warn-only**, which is precisely why the surviving cycle failed nothing.
+
+> **⚠️ HARD DEPENDENCY: C2 must not start before [SEC-105](https://checklyra.atlassian.net/browse/SEC-105) resolves.** This section and story **C2** specify all 9 rules blocking at severity `error`. SEC-105 (open) says that gate has **already caused six pipeline outages over dev-only code that never ships**, while the production tree it was protecting was never dirty. Both cannot be right, and enacting C2 as written would scale a control a live SEC ticket says is mis-scoped. This matters beyond the gate itself: §1.4's *"only a CI gate does the 90%"* is the justification for this programme's cost, so if the gate's **scoping** is wrong, the argument needs re-stating rather than the gate merely re-tuning. Resolve SEC-105 first, then re-derive what C2 should block on.
 
 ### 4.3 The data boundary — where the real coupling is
 
@@ -249,6 +290,8 @@ All modules share the non-negotiable spine: **`develop → staging → beta → 
 
 What differs per module is which **additional** gates fire:
 
+> **⚠️ Read this table with the SEC-106 caveat (§1.6).** The "extra requirements" below are written as though each named gate blocks a merge. `controls/registry.json` (32 controls) **has no field expressing blocking-vs-advisory**, so that property cannot currently be asserted by any check — and 22 of the 32 have no `self_test`. Until SEC-106 lands, **every gate claim in this table is unverified**, and a module's declared change process reads stronger than it demonstrably is. KAN-416's `changeProcess.extraGates` join to the registry inherits the same limitation.
+
 | Module | UI-approval gated? | MCP lockstep? | 3-env migration? | Blast radius | Extra requirements |
 |---|---|---|---|---|---|
 | `platform` | No | No | No | **Critical** — 140 transitive dependants | Every change needs a full-suite run; no path filters ever |
@@ -262,7 +305,7 @@ What differs per module is which **additional** gates fire:
 | `oauth-as` | No | **Yes — external consumers** | Rarely | **Critical — frozen contract** | claude.ai, Claude Desktop and MCP Inspector consume its metadata, RS256/JWKS keys and exact 401 shape. **URLs, `iss` derivation and scope set must not change.** Contract test required before any move |
 | `auth` | **Yes** (copy) | No | Rarely | High | Signup-surface gate fires |
 | `profile` | **Yes** (editor UI) | **Yes** | Yes | High | Domain-model changes ripple to `public-profile` + MCP |
-| `public-profile` | **Yes** | **Yes** | Rarely | **High — privacy** | The `.eq('is_published',true).eq('is_suspended',false)` pair must stay one tested unit (SEC-44); SEC-82 cache headers preserved |
+| `public-profile` | **Yes** | **Yes** | Rarely | **High — privacy** | ⚠️ **Gated on [SEC-104](https://checklyra.atlassian.net/browse/SEC-104) — see note below.** Today: the `.eq('is_published',true).eq('is_suspended',false)` pair must stay one tested unit (SEC-44). After SEC-104: **reads go through the `public_profiles` view**, and that requirement is retired. SEC-82 cache headers preserved either way |
 | `dashboard` | **Yes** | No | Rarely | Medium | **Never reintroduce `loading.tsx`/Suspense at `/dashboard`** (BUGS-63, guarded) |
 | `account` | **Yes** | **Yes** | Yes | High (GDPR) | SAR/erasure completeness test must pass; `moderation_logs.actor_user_id ON DELETE RESTRICT` dependency must not be silently dropped |
 | `convene` | **Yes** | **Yes — 23 tools** | Yes | **High — and it is NOT safe** | See §7-D5: the web flag is off, **but the MCP write tools are live in production against the production database** |
@@ -273,6 +316,19 @@ What differs per module is which **additional** gates fire:
 | `admin` | Internal only — **not** gated | No | Yes | High (privilege) | Every mutation routed through the shared transition matrix; CF Access + `is_admin` both verified |
 
 **Reading the table:** modules with three or more gates lit (`convene`, `account`, `profile`, `access`) are where change is genuinely expensive — and that is the honest signal of where the architecture is still carrying risk, not a flaw in the plan.
+
+#### SEC-104 and the `public-profile` boundary (added 2026-07-28)
+
+[SEC-104](https://checklyra.atlassian.net/browse/SEC-104) proposes replacing the suspension-guard *detector* with a **`public_profiles` view**, on the grounds that a checker cannot see a query that has no guard at all, and every new visibility predicate needs a new guard. **This makes the SEC-44 "one tested unit" requirement obsolete in the good way.**
+
+A predicate in a **view body** binds even **service-role** reads — unlike RLS, which service-role bypasses. That distinction is not academic: it is exactly how **SEC-100** happened (suspended members exposed in public search and the sitemap via five service-role query sites, shipped to production).
+
+**The two are complementary, and the ordering is what matters:**
+
+- **SEC-104 first** → the `public-profile` module boundary gets materially *simpler*. The module owns *"read from `public_profiles`"* instead of *"remember to apply two predicates at every call site"*. The invariant moves from a code convention to a database object.
+- **D9 first** → the module freezes a call-site convention into a public API, and SEC-104 then has to unpick it.
+
+**⚠️ D9 must not start before SEC-104 is decided.** (Under the §2.2 scope ruling D9 is deferred regardless; this constraint governs whenever it is re-opened.)
 
 ---
 
@@ -310,14 +366,20 @@ Remaining stories (F1, F4–F9, and all of C/D/E/F) are created as each spike la
 
 **Programme goal.** Carve the Lyra platform into 20 named modules with machine-enforced boundaries and explicit public APIs, so that any one module can be changed, reviewed and released without reading or risking the rest — and so that the rules the three deployables share live in exactly one place.
 
-**Success criteria.**
-1. `modules.json` declares 20 modules, all `"enforced": true`, with a dependency matrix, table ownership (`profiles` at column granularity) and per-module test floors.
-2. `dependency-cruiser` runs blocking on every PR with all 9 rules at severity `error`; `.boundaries-allowlist.json` is empty or every entry is dated, ticketed and unexpired.
-3. Zero `.from()` / `.rpc()` / `createServiceRoleClient` outside `src/modules/*/data/**`.
-4. Zero unit test files containing a literal `src/...` path.
-5. `@lyra/contracts` is consumed by all three repos; the 6 duplicated rule-sets exist once; a CI drift test fails if any repo forks a copy.
-6. A generated `Database` type is threaded through all client factories in all three repos, with a CI regeneration diff.
-7. `admin_approve_beta` works.
+> **⏸️ Re-scoped 2026-07-28 (§2.2).** The goal above remains the *direction*; it is no longer the *current commitment*. The committed scope is **Phase 0 + `@lyra/contracts` + the data boundary + the `profiles` ADR** — everything that closes the worsening vertical-coupling metrics **without moving a file**. Whether the 20-module carve-up is the right way to close whatever remains is re-decided when Phase 0 closes, per the binding trigger in §2.2.
+>
+> **Spike status, 2026-07-28:** R1/KAN-416 ✅ (manifest re-derived — 21 modules, `profiles` baseline at column granularity, 77 call sites), R2/KAN-417 ✅, R4/KAN-419 ✅, R5/KAN-420 ✅, R6/KAN-421 ✅, R7/KAN-422 ✅, R10/KAN-432 ✅ (this re-validation). **R3/KAN-418, R8/KAN-423 and R9/KAN-427 remain founder-gated** — private registry + tokens, CI Supabase credentials, and a local-only design-system folder respectively. F2/KAN-424 ⚠️ partially delivered (BUGS-80); F3/KAN-425 ✅ landed as CTL-030, **warn-only**.
+
+**Success criteria.** *(Re-scoped 2026-07-28 per §2.2 — ✅ = in scope now, ⏸️ = deferred with D1–D15.)*
+
+1. ⏸️ **Deferred.** `modules.json` declares 20 modules, all `"enforced": true`, with a dependency matrix, table ownership (`profiles` at column granularity) and per-module test floors. *(KAN-416 has already delivered the manifest itself — 21 modules, including the founder-approved `audit` — with `enforced: false` throughout and read by nothing. That artefact stands; only the enforcement flip is deferred.)*
+2. ⏸️ **Deferred**, and blocked on **SEC-105** whenever re-opened. `dependency-cruiser` runs blocking on every PR with all 9 rules at severity `error`; `.boundaries-allowlist.json` is empty or every entry is dated, ticketed and unexpired.
+3. ✅ **In scope, re-expressed.** Zero `.from()` / `.rpc()` / `createServiceRoleClient` outside each module's **declared data paths** (per KAN-416's `modules.json`) — ~~`src/modules/*/data/**`~~, since no files are moving. This is C3, the data boundary.
+4. ✅ **In scope.** Zero unit test files containing a literal `src/...` path. **This is F4 and it is the critical path** (§1.5 — the tax is compounding at 18–31% per two days).
+5. ✅ **In scope.** `@lyra/contracts` is consumed by all three repos; the 6 duplicated rule-sets exist once; a CI drift test fails if any repo forks a copy. *(Blocked on R3/KAN-418, which is founder-gated.)*
+6. ✅ **In scope.** A generated `Database` type is threaded through all client factories in all three repos, with a CI regeneration diff.
+7. ✅ **In scope.** `admin_approve_beta` works. *(X-1 was **not** re-verified on 2026-07-28 — confirm it is still broken before scoping the fix.)*
+8. ✅ **In scope, added 2026-07-28.** The `profiles` ADR (R6/KAN-421) is adopted, **and** the re-decision trigger in §2.2 has been executed — §1.1 and §1.2 re-derived against the decoupled test estate and the typed schema, with an explicit ruling on whether D1–D15 re-open.
 
 **Out of scope for this programme** (named, so it is a decision and not an oversight):
 - Splitting `profiles` into satellite tables (see §8-R6 — the spike decides *when*, not *whether*).
@@ -350,7 +412,7 @@ These are the "research for the refactor" the request asked for. Each answers on
 | ID | Story | Why it is a prerequisite | Depends on |
 |---|---|---|---|
 | **F1** | Land `check-guard-path-drift.sh` in `pr-checks.yml`, fail-closed | Without it, the programme's own first PR silently disarms the founder UI gate and the signup gate | R4 |
-| **F2** | Fix the 3 known structural defects: move `computeAccessTransition` out of the admin route tree; move `WizardContact` into `organise-fields.ts`; relocate the 5 app→app shared symbols | ~7 small changes that eliminate the only wrong-direction edge and the only cycle, locking in existing good structure permanently | R1 |
+| **F2** | ⚠️ **RE-SCOPED 2026-07-28 — partially delivered, do not strike through.** ✅ `computeAccessTransition` moved out of the admin route tree (KAN-424 / PR #596; `lib`→`app` edges now **0**). ❌ **STILL OPEN:** move `WizardContact` into `organise-fields.ts` — the type-only cycle survives (`app/dashboard/convene/organise/page.tsx:6` ↔ `organise-wizard.tsx:25`), still the one-line fix, tracked as **[BUGS-80](https://checklyra.atlassian.net/browse/BUGS-80)**. ⚠️ app→app edges went **5 → 3**, not 0; **the two `[slug] → dashboard/profile` edges are moved into D8's acceptance criteria** where they belong (they are the D-4 privacy finding, not F2 debt), and the `(legal)/about → _marketing` edge is also implicated in KAN-422's DELETE list. **F2's residual scope is the cycle alone.** | Eliminates the only wrong-direction edge and the only cycle, locking in existing good structure permanently. **Note the failure mode:** KAN-424 was marked Done with two thirds of its scope unlanded, and CTL-030's `no-circular` rule is warn-only, so nothing went red. | R1 |
 | **F3** | Land the 3 near-green depcruise rules as **warn**, then flip to **block** | `no-module-to-app`, `no-cross-segment-app`, `no-circular` — cheap, permanent | F2 |
 | **F4** | **Test decoupling** — convert the highest-value source-text guards to import-based tests; route the remainder through a generated path manifest | **The largest single line item and the one most likely to be skipped. Skipping it is the most likely way this programme fails.** Without it every move produces information-free `ENOENT` failures and constant pressure to weaken tests, which policy forbids | R2 + founder sign-off |
 | **F5** | Re-anchor the dead test floors (29/320 → real 213/~2,401), split per module, turn on a non-zero global coverage threshold | "A module owns its tests" is currently unmeasurable; tests silently lost during a move must fail CI | F4 |
@@ -363,11 +425,13 @@ These are the "research for the refactor" the request asked for. Each answers on
 
 ### Workstream C — Boundary machinery
 
+> **Scope ruling 2026-07-28 (§2.2): only C3 is in scope.** C1, C2 and C4–C6 exist to serve the D1–D15 extractions and are **deferred with them**. **C3 is retained and re-expressed** — see its row.
+
 | ID | Story | Depends on |
 |---|---|---|
-| **C1** | Create `src/modules/` skeleton, `modules.json`, per-module tsconfig aliases (index-only, no wildcards), mirrored `jest.moduleNameMapper` | R1, F3 |
-| **C2** | Add `dependency-cruiser` with all 9 rules as a blocking `Module boundary gate` step in `PR Quality Gate`; unenforced modules skipped | C1 |
-| **C3** | Add `scripts/check-module-table-ownership.sh` (280 call sites, 33 tables, `profiles` column-granular) + extend `check-service-role-client.sh` to `src/modules/*/data/**` | C1, F6, R6 |
+| **C1** | ⏸️ **DEFERRED (§2.2).** Create `src/modules/` skeleton, `modules.json`, per-module tsconfig aliases (index-only, no wildcards), mirrored `jest.moduleNameMapper` | R1, F3 |
+| **C2** | ⏸️ **DEFERRED (§2.2)** — and ⚠️ **hard-blocked on [SEC-105](https://checklyra.atlassian.net/browse/SEC-105) whenever it is re-opened** (see §4.2). Add `dependency-cruiser` with all 9 rules as a blocking `Module boundary gate` step in `PR Quality Gate`; unenforced modules skipped | C1, **SEC-105** |
+| **C3** | ✅ **IN SCOPE.** Add `scripts/check-module-table-ownership.sh` (280 → **277** call sites, 33 tables, `profiles` column-granular) + extend `check-service-role-client.sh`. ⚠️ **Re-expressed 2026-07-28:** since `src/modules/` is not being created, the gate maps each file to its owning module via the **path assignments already in KAN-416's `modules.json`**, and restricts `createServiceRoleClient` to each module's declared data paths rather than to `src/modules/*/data/**`. The data boundary does not require the file moves — that is why it survives the scope ruling | ~~C1~~, F6, R6 |
 | **C4** | Add `scripts/check-boundary-ratchet.sh` + `.boundaries-allowlist.json` + the `BOUNDARY-EXEMPTION-APPROVED` trailer | C2 |
 | **C5** | Add `scripts/check-module-manifest.sh` (index.ts + manifest entry + CODEOWNERS line + test dir); rewrite the 11 per-file CODEOWNERS lines to module paths | C1 |
 | **C6** | ESLint `no-restricted-imports` layer (redundant with C2 by design — fails in the editor, before CI) | C1 |
@@ -376,19 +440,23 @@ These are the "research for the refactor" the request asked for. Each answers on
 
 ### Workstream D — Module extractions, in dependency order
 
+> **⏸️ ALL OF WORKSTREAM D IS DEFERRED — scope ruling 2026-07-28 (§2.2).** D1–D15 are **not cancelled**; they are re-decided after Phase 0 closes, against a decoupled test estate and a generated `Database` type, per the binding re-decision trigger in §2.2. **No file moves into `src/modules/` under the current scope.**
+>
+> The sequencing below is retained because it is the most expensive artefact in this plan to reconstruct, and because two of its steps carry constraints that survive the deferral: **D9 is gated on SEC-104** and **D8 absorbs two app→app edges from F2**. Two items are also promoted out of D entirely because they are in scope on their own merits: **D3 (`@lyra/contracts`)** and the domain-model half of **D8**'s privacy finding, now tracked as **SEC-109** rather than waiting for D13.
+
 The order is not arbitrary. Each step unblocks the next.
 
 | ID | Story | Why here | Depends on |
 |---|---|---|---|
 | **D1** | Extract **`platform`** + **`guards`** + **`observability`** | Naming the kernel is what makes every later rule expressible. Begin ratcheting the 40 service-role importers into `data/` dirs | C1–C5, F6, F8 |
 | **D2** | Extract **`oauth-as`** — the pilot | Highest cohesion, lowest coupling, 5 exclusive tables, 12 dedicated test files. **Pin the external HTTP contract with a test first** — claude.ai, Claude Desktop and both Railway services are outside CI. Invert `getAccountStanding` into an injected `StandingPort`. This becomes the reference shape every other module copies | D1 |
-| **D3** | Stand up **`@lyra/contracts`** with `content-moderation.ts` alone | Bootstraps the packaging with a provably no-op diff. Add the drift test that `convene-recommend-scoring.ts`'s header promised as an unnumbered "KAN-XXX follow-up" | R3, D2 |
+| **D3** | ✅ **IN SCOPE (§2.2) — promoted out of the deferral.** Stand up **`@lyra/contracts`** with `content-moderation.ts` alone | Bootstraps the packaging with a provably no-op diff. Add the drift test that `convene-recommend-scoring.ts`'s header promised as an unnumbered "KAN-XXX follow-up". **Retained because cross-repo duplication is the one problem a monolith cannot solve** — it does not depend on any extraction. ⚠️ Its blocker is R3/**KAN-418**, which is founder-gated (private registry + tokens on Vercel, 3× Railway, 3× CI) | R3, ~~D2~~ |
 | **D4** | Extract **`access`**; decompose `middleware.ts` (282 lines, 6 unrelated jobs, 2 sequential `profiles` reads, 2 overlapping inline exemption arrays) into a named, individually-tested gate pipeline with one declarative exemption table | Ships alone: **the order of the gates and the fail-open/fail-closed asymmetry are behavioural contracts with no current unit test.** Consolidate the 4 environment resolvers onto `getDeployEnv` — **except `lib/oauth/config.ts siteUrl()`**, which determines the `iss` claim both MCP servers pin to | D1, D2, F2 |
 | **D5** | Extract **`features`**; move the pure registry into `@lyra/contracts`; make both MCP servers read `global_feature_switches`; retire the `ACCESS_MODEL_V2` dual path | **Must precede convene, age, affiliate, recommendations, account and admin**, or five extractions each re-open the same five files. Closes a live hole: today an admin turning the `mcp` or `convene` master switch off stops the web surface and **leaves `mcp.checklyra.com` serving** | D3, D4 |
 | **D6** | Extract **`age`** + **`auth`**, with the signup gate armed first and `.github/signup-surface.paths` rewritten in the same commit | Their combined footprint is deliberately the signup gate's footprint. Add the missing Didit webhook/callback contract tests. Close the empty publish age-gate block in `lyra_publish_profile` | D5, F9 |
 | **D7** | Extract **`trust-safety`**; lift the **10 audit-sensitive server actions** currently living as unexported closures inside JSX files (suspend, unsuspend, unpublish, republish, delete-item, dismiss-report, resolve-report, suspend-from-report + 2 OAuth consent closures) | The most audit-sensitive writes in the product, **zero unit coverage**, self-moderation guard re-implemented per closure, and literally untestable until exported. **Hard prerequisite for `admin`** | D5, F7 |
-| **D8** | Extract the **`profile` domain core** (no UI): `types.tsx`, `visibility.ts`, `section-visibility.ts`, `manual-of-me-fields.ts`, field allowlists, `country-codes` | Lifts the de-facto data model (fan-in 14) out of a legacy wizard directory, gives `public-profile` a legitimate dependency, cuts 2 of the 5 app→app edges. **Remove `is_published` from `ALLOWED_PROFILE_FIELDS`** so publish has exactly one entry point calling `canPublish()` | D4 |
-| **D9** | Extract **`public-profile`** | Keep the `.eq('is_published',true).eq('is_suspended',false)` pair as one tested unit (SEC-44); preserve SEC-82 cache headers; URLs unchanged | D8, D5 |
+| **D8** | Extract the **`profile` domain core** (no UI): `types.tsx`, `visibility.ts`, `section-visibility.ts`, `manual-of-me-fields.ts`, field allowlists, `country-codes` | Lifts the de-facto data model (fan-in 14) out of a legacy wizard directory, gives `public-profile` a legitimate dependency, cuts 2 of the 5 app→app edges. **Remove `is_published` from `ALLOWED_PROFILE_FIELDS`** so publish has exactly one entry point calling `canPublish()`. ⚠️ **Added to acceptance criteria 2026-07-28:** the two residual `app/[slug] → app/dashboard/profile` edges (`manual-of-me-fields.ts`, `section-visibility.ts`) move here from F2 — they are the **D-4 privacy finding** (the public profile depending on the *editor's* domain model), not generic structural debt | D4 |
+| **D9** | Extract **`public-profile`** | ⚠️ **GATED ON [SEC-104](https://checklyra.atlassian.net/browse/SEC-104) — must not start until SEC-104 is decided** (see §5). If SEC-104 lands first this module simply reads the `public_profiles` view and the SEC-44 pair requirement retires; if D9 lands first it freezes a call-site convention SEC-104 then unpicks. Preserve SEC-82 cache headers; URLs unchanged | D8, D5, **SEC-104** |
 | **D10** | Extract **`recommendations`** (rename to `concepts`/`products`) + split **`affiliate`** three ways, with an injected `MonetisationPort` | Dispose of the dead exports decided in R7 | D9, R7 |
 | **D11** | Build **`ui-kit`** — one batched, founder-approved phase | **Extend the UI/copy guard's protected globs to `src/modules/ui-kit/**` BEFORE the first component move.** Extract tokens + the 3 de-facto primitives; de-duplicate `StatCard`; retire the 181 raw hex literals. Every diff render-identical; **one Jira key and one trailer per PR, not per file** | F1, D1, Founder |
 | **D12** | Split **`app/dashboard`** three ways → `dashboard` / `profile` (UI) / `account` | The three sub-products have **zero import edges between them** — this is directory moves and a layout split, not untangling. 9,855 LOC and 30% of `src` relieved in one phase. In the same phase, invert the SAR/erasure contract: each module registers `exportForUser`/`eraseForUser` and `settings/actions.ts` becomes an aggregator | D8, D11 |
@@ -432,7 +500,8 @@ Everything below was discovered during the survey. Each is either prerequisite w
 | P-3 | **No generated `Database` type exists in any repo.** 275 web + ~90 MCP untyped call sites | Any data work | F6 |
 | P-4 | **2 live production tables + 1 view have no migration file** (`content_moderation_flags`, `mcp_tool_call_log`, `mcp_per_ip_recent_count`) — created out-of-band. `supabase/migrations/` is not the schema | `trust-safety`, table ownership | F7, R5 |
 | P-5 | **Migration state is provably divergent**: git ↔ dev (73 applied) ↔ staging (61) ↔ prod (unverified), per `docs/MIGRATION_PARITY.md` | Any table move | F7, R5 |
-| P-6 | **The only `lib`→`app` edge and only cycle**: `lib/beta-access/flow.ts` and `app/waitlist/actions.ts` import `computeAccessTransition` from **inside the admin UI route tree** | `access`, `admin`, `auth` | F2 |
+| P-6a | ✅ **CLOSED 2026-07-28.** ~~The only `lib`→`app` edge~~: `lib/beta-access/flow.ts` and `app/waitlist/actions.ts` imported `computeAccessTransition` from **inside the admin UI route tree**. Moved to `src/lib/access-model/` by **KAN-424 / PR #596**; `lib`→`app` edges re-derived as **0** | — | F2 ✅ |
+| P-6b | ⚠️ **STILL OPEN.** The only **cycle** — type-only, `app/dashboard/convene/organise/page.tsx:6` ↔ `organise-wizard.tsx:25` (`WizardContact`). Still the one-line fix described in July. Survived because F2 was marked Done without it and CTL-030's `no-circular` is **warn-only** | `convene` | **[BUGS-80](https://checklyra.atlassian.net/browse/BUGS-80)** |
 | P-7 | **Test floors are dead**: 29 files / 320 tests enforced vs 213 / ~2,401 actual; coverage thresholds all 0 | Detecting test loss during moves | F5 |
 | P-8 | **58 env vars, only 5 through `env.ts`; 85 raw `process.env` reads in 42 files.** Independent module configuration is currently impossible | `platform`, all modules | F8, R1 |
 | P-9 | **E2E is largely un-armed**: `E2E_SUPABASE_*` unprovisioned, `SIGNUP_GATE_ENFORCE` in warn mode | Safe large-scale movement | F9 (founder-gated) |
@@ -448,21 +517,28 @@ Everything below was discovered during the survey. Each is either prerequisite w
 | D-5 | **Convene is "off" only on the web.** The MCP write tools are **live in production against the production database** | Do not schedule Convene work as "safe because it's off". Full production process applies | D13, §5 |
 | D-6 | **`is_published` is a generically writable profile field** — which is exactly why the publish gate exists twice (`actions.ts:109` and `:620`) | Remove it from `ALLOWED_PROFILE_FIELDS` so there is one publish entry point calling `canPublish()` | D8 |
 | D-7 | **10 audit-sensitive mutations are unexported closures inside page components** — suspend, unpublish, delete-item, resolve-report… zero coverage, literally untestable | Hard prerequisite for `admin` | D7 |
-| D-8 | **One client component writes `oauth_connections` straight from the browser** (`dashboard/convene/connections/connections-client.tsx`) with no server action | The server/client boundary is not currently a security boundary, so it cannot be a module boundary either | D13 |
+| ~~D-8~~ | **Reclassified 2026-07-28 — moved to the new "Security" class below.** | | **SEC-109** |
 | D-9 | **`lib/admin.ts` is simultaneously the admin gate and the app's generic service-role factory** — imported by the **public** `app/api/reports/route.ts` | The dependency graph currently lies about privilege. Split it | D15 |
 | D-10 | **`lib/affiliate` is three modules with different lifetimes in one folder**, and `country-codes` isn't about affiliates at all | Split into `links` / `eligibility` / `backoffice`; move `country-codes` to `profile` | D10 |
-| D-11 | **~650 LOC of exported code has zero production consumers but is fully tested** | Decide disposition *before* extraction, or the refactor freezes dead exports into new public APIs | R7 |
+| D-11 | ✅ **SUPERSEDED 2026-07-28 by KAN-422 (Done, PR #620) — the original "~650 LOC" estimate was wrong in both directions.** Measured: **219 zero-importer exports**, of which **160 are live code carrying an over-wide `export`** (1,463 LOC — the fix is narrowing visibility, not deleting) and only **59 are genuinely dead** (1,130 LOC; 36 tested / 588 LOC). ⚠️ **The two files this row originally named for deletion — `recommender/inputs.ts` and `events.ts` — MUST BE KEPT** (KAN-198 and KAN-202 are both In Progress and consume them). Use KAN-422's disposition list, never this row's estimate | Decide disposition *before* extraction, or the refactor freezes dead exports into new public APIs | R7 ✅ |
 | D-12 | **`middleware.ts` is 282 lines doing 6 unrelated jobs with 2 sequential `profiles` reads and 2 overlapping inline exemption arrays** — and the gate *order* and fail-open/fail-closed asymmetry are untested behavioural contracts | Decompose into a named, individually-tested pipeline. Ships alone | D4 |
 | D-13 | **Environment identity is derived 4 different ways**, and one of them (`lib/oauth/config.ts siteUrl()`) sets the OAuth `iss` claim both MCP servers pin their verification to | Consolidate onto `getDeployEnv` — **except that one**. Changing it breaks both MCP servers | D4 |
 | D-14 | **`profiles` carries ≥6 modules' state, written from all 3 repos**, 15 module groups / 75 call sites | The load-bearing decision of the whole programme. Column-level ownership + grep gate now; satellite tables costed and deferred | R6 |
 | D-15 | **No UI module exists to extract from** — `src/components` holds exactly one file; 181 raw hex literals; design tokens live in `app/globals.css` pinned by a string-grep test | `ui-kit` must be **built**, not extracted — and every file it touches is founder-gated | D11 |
 | D-16 | **`oauth-as` is the most separable module and its contract is frozen by external consumers** (claude.ai, Claude Desktop, MCP Inspector) | Perfect pilot — but pin the HTTP contract with a test *first* | D2 |
 
+### Security *(added 2026-07-28 — reclassified out of "Structural")*
+
+| # | Discovery | Implication | Story |
+|---|---|---|---|
+| **D-8** | ⚠️ **UPGRADED STRUCTURAL → SECURITY, 2026-07-28.** One client component writes `oauth_connections` straight from the browser (`dashboard/convene/connections/connections-client.tsx`) with no server action. **Confirmed worse than structural:** the same client-side write means **`vaultRevokeRefreshToken` never runs**, so a user's OAuth **refresh token survives their disconnect** — the user believes they have revoked access and they have not | The server/client boundary is not currently a security boundary, so it cannot be a module boundary either — **but the token-revocation defect must be fixed on its own merits and MUST NOT wait for D13**, which was the last-but-two extraction and is now deferred entirely (§2.2) | **[SEC-109](https://checklyra.atlassian.net/browse/SEC-109)** (High) — ~~D13~~ |
+| **N-5** | **`search_by_contact_hash` has no product consumer.** A `profiles`-reading RPC with no caller | A column-ownership question for R6/KAN-421 as much as a security one — an unused RPC that reads a god-table is exactly the surface a column-ownership manifest is supposed to make visible | **[SEC-110](https://checklyra.atlassian.net/browse/SEC-110)** |
+
 ### Cross-repo
 
 | # | Discovery | Implication | Story |
 |---|---|---|---|
-| X-1 | **`admin_approve_beta` is already broken** — writes 2 columns a `lyra`-repo migration dropped | The canonical worked example of the business case. Must be fixed, and made CI-checkable | E2 |
+| X-1 | ⚠️ **NOT re-verified 2026-07-28** (needs the admin-MCP repo + a live schema read; out of scope for a read-only web-repo spike — flagged unverified rather than assumed). **`admin_approve_beta` is already broken** — writes 2 columns a `lyra`-repo migration dropped | The canonical worked example of the business case. Must be fixed, and made CI-checkable | E2 |
 | X-2 | **`content-moderation.ts` is byte-identical across repos** (md5 `b07eac8ed85ae3cc5669522f0afad395`) | The zero-risk first extraction — proves the packaging with a provably no-op diff | D3 |
 | X-3 | **Convene scoring is a verbatim copy under a self-declared "DRIFT RISK" header**, in sync by luck | Cheap interim mitigation available *now*: a checksum parity test in the MCP repo's CI, before any packaging work | D3, E3 |
 | X-4 | **`lyra_publish_profile` contains an empty `if` block** where the age gate should be — and an inverted test pins the divergence in place | `canPublish()` becomes one pure function both surfaces call. ⚠️ Re-inverting that test **needs founder sign-off** under the Test Integrity Policy | D6, E3 |
@@ -483,6 +559,16 @@ The first draft sequenced docs and verification rework as a **closing phase**. T
 | E-3 | **The Claude Design System is a third source of truth for design tokens, with no drift detection.** Tokens live in `src/app/globals.css`, in `~/lyra-design-system/build.py`, and in Claude Design project `e4682889-…`. `build.py` reads `globals.css` | Structurally identical to the MCP duplication (X-3). Building `ui-kit` without deciding which is canonical creates a **fourth** copy. D11 was the vaguest module in the plan; this is why | **KAN-427** |
 | E-4 | **Two couplings are invisible to CI** — `~/lyra-design-system/build.py` and the **claude.ai routine prompts themselves** (Staging Soak, Backlog Autopilot, Modularisation Scoping all name repo paths verbatim, and live in routine config, not git) | No grep can find them. They need a **human attestation** in the extraction DoD, and the DoD must say plainly that this is weaker than a machine check rather than implying CI covers it | **KAN-428** |
 | E-5 | **No module can answer "what proves this still works?"** — 213 unit files in a flat heap, 47 E2E blocks organised by Playwright *project* not by module, soak contract C1–C6 unmapped to modules | Per-module ownership for unit + E2E + soak. Keep the Playwright projects as-is (they encode real execution requirements — auth state, seeded users, CF bypass — not taxonomy); add module tagging instead | **KAN-429** |
+
+### New discoveries *(added 2026-07-28 by the KAN-432 re-validation)*
+
+| # | Discovery | Implication |
+|---|---|---|
+| **N-1** | **The control registry cannot express blocking-vs-advisory** (§1.6). `controls/registry.json` has no such field, so no check can assert the property; 22 of 32 controls have no `self_test` | §5's per-module gate table **overstates enforcement** until **SEC-106** lands. Every "blocking" claim in this document is unverified |
+| **N-2** | **The plan's blocking dependency gate collides with SEC-105** (§4.2). SEC-105 says that gate already caused six pipeline outages over dev-only code that never ships | **C2 must not start before SEC-105.** And because §1.4's *"only a CI gate does the 90%"* is this programme's cost justification, a mis-scoped gate weakens the argument, not just the tooling |
+| **N-3** | **Test path-coupling is growing ~18–31% per two days** (§1.5) | **F4's cost is a function of when it starts.** The strongest single argument for doing Phase 0 now, and the load-bearing input to the §2.2 scope ruling |
+| **N-4** | **Production had never been backed up** — `SUPABASE_DB_URL` pointed at dev from 2026-03-27 to 2026-07-27 while every run reported green. Fixed, restore-drilled and guarded (#613) | This plan's risk model **silently assumed a working restore path** during extraction. It should say so explicitly. Note the shape: a control reporting green for four months while doing nothing is the same failure class as N-1 |
+| **N-5** | `search_by_contact_hash` has no product consumer | Recorded in the **Security** table above — **SEC-110** |
 
 ### Existing Jira tickets this programme changes
 
@@ -528,7 +614,13 @@ The first draft sequenced docs and verification rework as a **closing phase**. T
   F. Close the ratchet                                  G1 ▶ G2
 ```
 
-**Critical path:** R2 → F4 (test decoupling) → C1 → D1 → D2 → D4 → D5 → everything else. **F4 is the choke point.** It is the largest, least glamorous item, delivers no visible modularity, and shortening it is the single most likely way this programme fails.
+**Critical path (as planned 2026-07-26):** R2 → F4 (test decoupling) → C1 → D1 → D2 → D4 → D5 → everything else. **F4 is the choke point.** It is the largest, least glamorous item, delivers no visible modularity, and shortening it is the single most likely way this programme fails.
+
+> **⏸️ Re-scoped 2026-07-28 (§2.2).** Everything below the `C1 ▶ C2 ▶ …` line in the diagram above — Workstreams C (except C3), D and G — is **deferred**. The **current critical path is `R2 → F4 → F5`**, with `F6 → F7` and `C3` in parallel, plus `@lyra/contracts` (R3/D3, founder-gated on KAN-418) and the `profiles` ADR.
+>
+> **F4 remains the choke point, and the re-validation strengthened that claim rather than weakening it:** the path-coupling tax grew 18–31% in the two days between the survey and the re-validation, with no modularisation work in flight. F4 is now urgent on its own merits — it is the prerequisite for per-module CI, for honest test floors, and for the measurement that the §2.2 re-decision trigger depends on.
+>
+> **Also still live regardless of the deferral:** BUGS-80 (the residual cycle), SEC-109 (OAuth refresh-token revocation — must not wait for D13), SEC-104 (gates D9), SEC-105 (gates C2), SEC-106 (makes every "blocking gate" claim unverifiable), SEC-110.
 
 ---
 

--- a/docs/modularisation/PLAN-REVALIDATION-2026-07-28.md
+++ b/docs/modularisation/PLAN-REVALIDATION-2026-07-28.md
@@ -1,0 +1,226 @@
+# KAN-432 (R10) — Modularisation plan re-validation
+
+**Status:** research artefact · read-only · no code, schema or config changed
+**Date:** 2026-07-28
+**Plan under review:** `LYRA_MODULARISATION_PLAN_2026-07-26.md` (surveyed `develop @ ee647e6`, 2026-07-26)
+**Re-derived against:** `develop @ 674f0a7`, 2026-07-28
+**Script:** `docs/modularisation/kan432-revalidate.py` · **Data:** `docs/modularisation/data/kan432-revalidation.json`
+
+Reproduce with:
+
+```bash
+python3 docs/modularisation/kan432-revalidate.py
+```
+
+---
+
+## 0. Verdict in three lines
+
+1. **The plan's diagnosis survives re-derivation.** Every load-bearing number is within drift of its original value, and the four kernel fan-in figures reproduce **exactly**. The plan is not built on sand.
+2. **Two of its premises are false, and both were asserted as true in this ticket.** F2 (KAN-424) is marked Done but only **one of its three** sub-items landed. And the plan's §4.2 blocking dependency gate is now in direct tension with **SEC-105**, which says that gate caused six pipeline outages over code that never ships.
+3. **The thesis holds but the vehicle is now over-specified.** The horizontal wins arrived from cheap gates without a single extraction, while the vertical coupling the plan named as the real problem is flat or worsening. That argues for doing Phase 0 and *deferring* the 15-module extraction programme — see §5.
+
+---
+
+## 1. Re-derived numbers
+
+Method is stated in `methodNotes` in the JSON. `node_modules` is absent in the cloud environment so `dependency-cruiser` could not be re-run; the graph is rebuilt independently by regex scan resolving the `@/* → ./src/*` alias, relative specifiers and directory `index` files. **This is stronger evidence than a re-run, not weaker** — an independent method landing on the same number is corroboration.
+
+That the independent method reproduces `supabase-server` = 46, `supabase-service` = 39, `env.ts` = 17, `admin.ts` = 17 and `deploy-env.ts` = 5 **exactly** is the calibration check for everything else in this table.
+
+| Plan claim | Plan | Now | Verdict |
+|---|---|---|---|
+| Graph nodes | 273 | **274** | Drift (+1 file) |
+| Graph edges | 525 | **527** | Drift |
+| `lib` → `app` edges | 1 | **0** | ✅ **FIXED** — KAN-424 |
+| `app` segment → `app` segment edges | 5 | **3** | ⚠️ **PARTIAL** — see §2 |
+| Import cycles | 1 | **1** | ❌ **NOT FIXED** — see §2 |
+| Cross-group edges | 328 | **336** | Drift |
+| Deep imports | 145 (44%) | **142 (42.3%)** | Unchanged in substance |
+| `index.ts` barrels | 4 | **5** | +1 (`src/lib/access-model/index.ts`, from KAN-424) |
+| Cross-group edges via a barrel | 9 | **10** | Unchanged in substance |
+| App route segments | 19 | **19** | Unchanged |
+| — with zero fan-in | 14 | **16** | ✅ Improved |
+| `supabase-server.ts` fan-in | 46 | **46** | Exact |
+| `supabase-service.ts` fan-in | 39 | **39** | Exact |
+| `env.ts` fan-in | 17 | **17** | Exact |
+| `env.ts` transitive dependants | 140 | **142** | Drift |
+| `admin.ts` fan-in | 17 | **17** | Exact |
+| `deploy-env.ts` importers | 5 | **5** | Exact — §1.4's erosion argument still stands verbatim |
+| `.from()` call sites | 280 | **277** | Unchanged in substance |
+| Distinct tables | 33 | **33** | Unchanged |
+| — inside route/page/action files | 199 (71%) | **194 (70%)** | Unchanged in substance |
+| `createServiceRoleClient` importers | 40 | **39** | Unchanged in substance |
+| `profiles` call sites | 75 | **77** | ⚠️ **WORSE** |
+| `profiles` module groups | 15 | **17** | ⚠️ **WORSE** |
+| Generated `Database` type exists | No | **No** | Unchanged — P-3 stands |
+| `auth.getUser()` files | 37 | **41** | ⚠️ **WORSE** |
+| `redirect('/login')` files | 8 | **8** | Unchanged |
+| Test files | 213 | **220** | ⚠️ Growing |
+| — using `readFileSync` | 98 | **116** | ⚠️ **WORSE — +18% in 2 days** |
+| — distinct `src/**` path literals | 112 | **125** | ⚠️ **WORSE** |
+| — pure source-text scans | 70 | **92** | ⚠️ **WORSE — +31%** |
+| Test blocks | ~2,401 | **2,439** | Growing |
+| Regression-guard floors | 29 files / 320 tests | **29 / 320** | Unchanged — P-7 stands |
+| Coverage thresholds | all 0 | **all 0** | Unchanged — P-7 stands |
+| Path-coupled CI gates | 5 | **5**, all present | Unchanged — P-1 stands |
+| Env vars read in `src/` | 58 | **49** | Method difference (plan counted a wider tree); not treated as drift |
+
+### The one number that could not be reproduced from the plan's wording
+
+"145 deep imports (44%)" is only reproducible under one of several readings of *deep import*. The reading that reproduces it — **an edge into a file inside another group's directory, not via that group's barrel, where a group is `src/<area>/<segment>`** — was recovered empirically (142/336 = 42.3%). Two other plausible readings give 24 (7.1%) and 326 (97%). All three are recorded in the JSON so the headline cannot be quietly redefined later.
+
+**Recommendation:** the plan should state the definition inline. A number whose definition has to be reverse-engineered is not, in practice, "re-derivable from the repos" as §0 of the plan claims.
+
+---
+
+## 2. FINDING 1 — F2 is marked Done but is one-third complete
+
+This ticket's own "known-stale" table asserts: *"F2 — **DONE.** KAN-424, PR #596. The only `lib`→`app` edge and the only group-level cycle are gone."* **KAN-424 is Done in Jira.** F2's stated scope was three items:
+
+| F2 sub-item | Status | Evidence |
+|---|---|---|
+| Move `computeAccessTransition` out of the admin route tree | ✅ **DONE** | `lib`→`app` edges = **0**. New `src/lib/access-model/{index,access-transitions}.ts`; `lib/beta-access/flow.ts` and `app/waitlist/actions.ts` now import from `lib/`. |
+| Move `WizardContact` into `organise-fields.ts` | ❌ **NOT DONE** | The cycle is still there: `app/dashboard/convene/organise/page.tsx:6` imports `OrganiseWizard from './organise-wizard'`, and `organise-wizard.tsx:25` imports `type { WizardContact } from './page'`. Still type-only, still the one-line fix the plan described. |
+| Relocate the 5 `app`→`app` shared symbols | ⚠️ **PARTIAL (5 → 3)** | Remaining: `(legal)/about/page.tsx → _marketing/sections.tsx`; `[slug]/page.tsx → dashboard/profile/manual-of-me-fields.ts`; `[slug]/page.tsx → dashboard/profile/section-visibility.ts`; `dashboard/page.tsx → (auth)/actions.ts`. |
+
+Two of the three residual app→app edges are the **D-4 privacy finding** — the public profile page depending on the *editor's* domain model — which is legitimately D8's job, not F2's. The `(legal)/about → _marketing` edge is now also implicated in KAN-422's DELETE list (10 of 11 exports in `_marketing/sections.tsx` are dead).
+
+**But the cycle is a one-line fix that simply did not happen, and the ticket asserts it did.** This is the exact failure mode KAN-432 exists to catch, occurring inside KAN-432's own premises. Raised as **BUGS-80**.
+
+**Edit the plan needs:** F2 must not be struck through. Re-scope it to the residual cycle only, and move the two `[slug] → profile` edges explicitly into D8's acceptance criteria where they belong.
+
+---
+
+## 3. FINDING 2 — the plan's blocking dependency gate collides with SEC-105
+
+The plan's §4.2 and story **C2** specify: *"Add `dependency-cruiser` with all 9 rules as a blocking `Module boundary gate` step."* Success criterion 2 requires *"all 9 rules at severity `error`"*. F3/KAN-425 landed the first three as CTL-030.
+
+**SEC-105 (To Do) says:** *"Redesign the dependency gate: prod tree is clean and always was — 6 pipeline outages were over dev-only code that never ships."*
+
+These cannot both be right. The plan treats the blocking graph gate as the programme's central enforcement mechanism; SEC-105 says that mechanism has already produced six outages while the production tree it was protecting was never dirty. **Enacting C2 as written would scale a control that a live SEC ticket says is mis-scoped.**
+
+This matters more than it looks, because the plan's whole §1.4 argument — *"only a CI gate does the 90%"* — is the justification for the extraction programme's cost. If the gate's scoping is wrong, the argument needs re-stating, not just the gate re-tuning.
+
+**Edit the plan needs:** §4.2 and C2 must be made explicitly dependent on SEC-105's redesign. C2 should not start before SEC-105 is resolved.
+
+---
+
+## 4. Control-estate reconciliation (§1.6 and §5)
+
+The plan was written against **11 blocking static gates**. The ticket assumes **31 controls**. SEC-106's title says **29**. `controls/registry.json` today holds **32** (CTL-001…CTL-032). Four numbers, all from the last few days.
+
+More significant than the count: **the registry schema has no field expressing blocking-vs-advisory at all.**
+
+```
+schema keys: added, defect_class, escape_hatch, id, implementation,
+             kind, name, notes, prevents, self_test, summary, wired_in
+```
+
+`kind` is `ci-gate` (22) / `scheduled` (6) / `test` (4) — a taxonomy of *what the control is*, not of *whether failing it stops a merge*. So SEC-106's finding is confirmed and is structurally worse than its title states: the registry cannot represent the property, which means no check can assert it. 22 of the 32 controls also have no `self_test`.
+
+**Consequence for the plan:** §5's per-module change-process table lists "extra gates" per module, and KAN-416 was directed to join `changeProcess.extraGates` to `controls/registry.json`. That join currently cannot answer "is this gate blocking?" — so a module's declared change process will read stronger than it is. **Edit the plan needs:** §5 must cite the real registry and note the advisory caveat until SEC-106 lands.
+
+---
+
+## 5. Does the Enforced Modular Monolith still earn its cost?
+
+The ticket asks this directly and it deserves a direct answer.
+
+**The diagnosis is more strongly supported than when it was written.** Split the evidence in two:
+
+**Horizontal structure — improving, without any extraction.**
+`lib`→`app` 1 → **0**. Cross-segment edges 5 → **3**. Segments with zero fan-in 14 → **16**. All of that came from one targeted PR (KAN-424) and one cheap gate (CTL-030). Not one file moved into `src/modules/`.
+
+**Vertical coupling — flat or worsening.**
+`profiles` call sites 75 → **77**, spread over 15 → **17** module groups. `auth.getUser()` 37 → **41** files. Service-role importers 39, `.from()` sites 277, no `Database` type, coverage thresholds still 0, test floors still 29/320. And the path-coupling tax is **accelerating**: `readFileSync` test files 98 → **116** (+18%), pure source-text scans 70 → **92** (+31%), distinct `src/**` path literals 112 → **125** — in two days.
+
+**So the honest reading is that the plan correctly identified where the problem is, and the last 48 hours have shown the cheap half of the fix works.** What it has *not* shown is that the expensive half — fifteen module extractions, D1 through D15 — is what closes the remaining gap. Every worsening metric above is closed by **Phase 0 foundations** (F4 test decoupling, F5 floors, F6 `Database` types, F7 migration parity, F8 config) plus the data boundary (C3) and `@lyra/contracts`. **None of them requires moving a single file into `src/modules/`.**
+
+**Recommendation — a lighter programme, and it is a scope change, not a cancellation:**
+
+1. **Do Phase 0 in full.** It is where every worsening number lives, and F4 is getting more expensive every week the test estate grows. This is now urgent on its own merits, independent of modularisation.
+2. **Do `@lyra/contracts` (D3/E3).** The cross-repo duplication is the one problem the monolith genuinely cannot solve, and X-1 (`admin_approve_beta`) is still the live worked example.
+3. **Do the data boundary (C3) and the `profiles` ADR (R6/KAN-421).** This is the plan's own "load-bearing decision".
+4. **Defer D1–D15 and re-decide after Phase 0.** By then the residual coupling will be measurable against a decoupled test estate and a typed schema, and the extraction case can be made on evidence rather than on the 2026-07-26 survey.
+
+This is not the plan failing. It is the plan's §1.4 thesis being *right* — cheap enforced gates do the heavy lifting — applied to the plan's own scope.
+
+**This is a founder decision. Nothing here should be enacted on my say-so.**
+
+---
+
+## 6. SEC-104 reconciliation (`public_profiles` view vs the `public-profile` module)
+
+**SEC-104 (To Do):** replace the suspension-guard *detector* with a `public_profiles` **view**, because the checker cannot see a query that has no guard at all, and every new visibility predicate needs a new guard.
+
+The plan's §5 requires: *"the `.eq('is_published',true).eq('is_suspended',false)` pair must stay one tested unit (SEC-44)"*, and D9 repeats it. **SEC-104 makes that requirement obsolete in the good way.** A predicate in a view body applies even to service-role reads — unlike RLS, which service-role bypasses, which is precisely how **SEC-100** (suspended profiles exposed at five service-role query sites, In Progress) happened.
+
+**These are complementary, and the ordering matters:**
+
+- If SEC-104 lands **first**, the `public-profile` module boundary gets materially simpler: the module owns *"read from `public_profiles`"* rather than *"remember to apply two predicates at every call site"*. The invariant moves from code convention to database object.
+- If D9 lands first, the module freezes a call-site convention into a public API, and SEC-104 then has to unpick it.
+
+**Edit the plan needs:** §5's `public-profile` row and D9 must both be made dependent on SEC-104, and the "one tested unit" requirement re-expressed as "reads go through `public_profiles`" once the view exists. **D9 should not start before SEC-104 is decided.**
+
+---
+
+## 7. Discoveries register — triage
+
+**Closed or materially changed:**
+
+| # | Was | Now |
+|---|---|---|
+| **P-6** | Only `lib`→`app` edge + only cycle | **Half closed.** Edge gone (KAN-424). Cycle remains — §2, BUGS-80. |
+| **D-1** | 524/525 edges correct, 14/19 segments zero fan-in | **Strengthened.** 527/527 correct; 16/19 zero fan-in. |
+| **D-2** | KAN-353's premise wrong | **Still valid.** KAN-353 re-scoped, To Do. R7 fed it its dead-export list. |
+| **D-8** | Browser writes `oauth_connections`; "the server/client boundary is not a security boundary" | ⚠️ **UPGRADE TO SECURITY.** Confirmed 2026-07-28 and it is worse than structural: the same client-side write means `vaultRevokeRefreshToken` never runs, so a user's OAuth refresh token survives their disconnect. Filed **SEC-109 (High)**. **It must not wait for D13** — that is the last-but-two extraction. |
+| **D-11** | "~650 LOC of exported code has zero production consumers but is fully tested" | **Superseded by KAN-422 (Done, PR #620).** Real figures: 219 zero-importer exports, of which **160 are live code with an over-wide `export`** (1,463 LOC) and only **59 genuinely dead** (1,130 LOC; 36 tested / 588 LOC). The two files D-11 named for deletion — `recommender/inputs.ts`, `events.ts` — **must be kept** (KAN-198 and KAN-202 both In Progress). |
+| **P-1 / P-3 / P-4 / P-5 / P-7 / P-8 / P-9** | Prerequisites | **All still open, all re-verified.** No prerequisite has been closed by the last 48 hours' work. |
+| **E-3 / KAN-427** | Design-system third source of truth | **Still valid and still cloud-impossible.** Local session only. |
+| **X-1** | `admin_approve_beta` broken | **Not re-verified this run** — out of scope for a read-only web-repo spike. Flagged as unverified rather than assumed. |
+
+**New, not in the register:**
+
+| # | Discovery | Implication |
+|---|---|---|
+| **N-1** | The control registry cannot express blocking-vs-advisory (§4) | §5's per-module gate table overstates enforcement until SEC-106 lands |
+| **N-2** | The plan's blocking dependency gate collides with SEC-105 (§3) | C2 must not start before SEC-105 |
+| **N-3** | Test path-coupling is growing ~18–31% per 2 days (§1) | F4's cost is a function of *when* it starts. This is the strongest argument in the whole revalidation for doing Phase 0 now. |
+| **N-4** | Production had never been backed up (2026-03-27 → 2026-07-27) | The plan's risk model assumed a working restore path during extraction. Fixed and drilled (#613), but the plan's risk section should say so explicitly rather than silently assume it. |
+| **N-5** | `search_by_contact_hash` has no product consumer (**SEC-110**) | A `profiles`-reading RPC with no caller is a column-ownership question for R6/KAN-421 as well as a security one |
+
+---
+
+## 8. Precise edit list for the plan
+
+**Not applied.** The ticket says the plan should "carry the agreed edits" — these are proposed, and edit 9 is a scope decision that is the founder's alone.
+
+| # | Location | Edit |
+|---|---|---|
+| 1 | §1 header | Add: *"Baseline re-validated 2026-07-28 against `674f0a7` — see `PLAN-REVALIDATION-2026-07-28.md`. Figures below are as-surveyed 2026-07-26."* |
+| 2 | §1.1 | Update: `lib`→`app` **0**; app-seg edges **3**; segments with zero fan-in **16/19**. State the *deep import* definition inline. |
+| 3 | §1.2 | Update `profiles` to **17 groups / 77 call sites** and mark the trend as worsening. |
+| 4 | §1.5 | Update to **220 files / 116 `readFileSync` / 125 path literals / 92 pure scans / 2,439 blocks**, and add the growth rate. |
+| 5 | §1.6 | Replace "11 blocking static gates" with **32 registered controls**, plus the SEC-106 caveat that none is provably blocking. |
+| 6 | §4.1 | Amend or defend the index-only-tsconfig claim; the adversarial review found enforcement is graph-rule + lint, not compile-time. |
+| 7 | §4.2 + C2 | Add a hard dependency on **SEC-105**. |
+| 8 | §5 | `public-profile` row: make dependent on **SEC-104**; re-express the SEC-44 pair as a view read. Add the SEC-106 advisory caveat to the table preamble. |
+| 9 | §6 / §8 | **Founder decision** — adopt the lighter scope in §5 of this document (Phase 0 + contracts + data boundary; defer D1–D15), or reaffirm the full programme. |
+| 10 | §7 D-8 | Move to a new "Security" class; cite **SEC-109**; remove the D13 dependency. |
+| 11 | §7 D-11 | Replace with KAN-422's measured figures; strike the `recommender/inputs.ts`/`events.ts` deletion. |
+| 12 | §7 P-6 | Split: edge closed, cycle open (**BUGS-80**). |
+| 13 | §7 | Append N-1…N-5. |
+| 14 | §6 F2 row | Re-scope to the residual cycle; move the two `[slug] → profile` edges into D8. |
+
+---
+
+## 9. What this run did not verify
+
+Stated so the next run does not mistake silence for a pass.
+
+- **X-1 `admin_approve_beta`** — needs the admin-MCP repo and a live schema read; not attempted.
+- **The MCP repos' test counts** (44 / 7 source-text files) — not re-derived; this run scanned `lyra` only.
+- **SEC-105's "6 pipeline outages"** — taken from the ticket, not independently confirmed.
+- **§1.3's duplicated-rule counts** (suspension in 6 places / 4 failure postures; Convene gate at 16 sites; feature registry ×3) — the Convene-gate grep is env-var-shaped and not comparable to the plan's method, so it is omitted from §1 rather than reported misleadingly.
+- **Env var count** — 49 in `src/` vs the plan's 58; the plan counted a wider tree. Treated as method, not drift, and not chased.

--- a/docs/modularisation/data/kan432-revalidation.json
+++ b/docs/modularisation/data/kan432-revalidation.json
@@ -1,0 +1,281 @@
+{
+ "generatedFrom": "674f0a7f47c73d5673f2550f589b7f3fc4d086e0",
+ "methodNotes": [
+  "Import graph built by regex scan of src/**, resolving the tsconfig alias '@/* -> ./src/*', relative specifiers and directory index files. Static import, re-export, bare side-effect import and dynamic import()/require() all count as edges. Bare package specifiers are excluded (the plan counted the internal src/ graph).",
+  "'Group' = src/<area>/<first-segment> (e.g. src/lib/convene, src/app/dashboard). 'App segment' = top-level route segment under src/app, with a Next route group '(x)' collapsed onto its child so '(legal)/about' is one segment.",
+  "A 'deep import' is a cross-group edge whose target is NOT the group's index.* barrel.",
+  "dependency-cruiser was unavailable (node_modules absent), so these figures are an independent derivation rather than a re-run of the plan's tool. Deltas of +/-1 on graph counts may be method, not drift; deltas larger than that are drift."
+ ],
+ "graph": {
+  "plan_nodes_273": 274,
+  "plan_nodesWithAtLeastOneEdge": 251,
+  "plan_edges_525": 527,
+  "plan_libToApp_1": 0,
+  "libToApp_detail": [],
+  "plan_appSegToAppSeg_5": 3,
+  "appSegToAppSeg_detail": [
+   "(legal) -> _marketing",
+   "[slug] -> dashboard",
+   "dashboard -> (auth)"
+  ],
+  "appSegments_total": 19,
+  "appSegments_zeroFanIn": 16,
+  "plan_cycles_1": 1,
+  "cycles_detail": [
+   {
+    "files": [
+     "src/app/dashboard/convene/organise/organise-wizard.tsx",
+     "src/app/dashboard/convene/organise/page.tsx"
+    ],
+    "allTypeOnly": false
+   }
+  ],
+  "plan_crossGroupEdges_328": 336,
+  "plan_deepImports_145": 142,
+  "deepImportPct": 42.3,
+  "crossGroupEdgesNotViaBarrel": 326,
+  "plan_barrels_4": 5,
+  "barrels_detail": [
+   "src/app/dashboard/profile/sections/index.ts",
+   "src/app/dashboard/profile/steps/index.ts",
+   "src/lib/access-model/index.ts",
+   "src/lib/convene/calendar/index.ts",
+   "src/lib/recommend/index.ts"
+  ],
+  "plan_crossGroupViaBarrel_9": 10
+ },
+ "kernel": {
+  "src/lib/supabase-server.ts": {
+   "planFanIn": 46,
+   "actualFanIn": 46,
+   "actualTransitiveDependants": 89
+  },
+  "src/lib/supabase-service.ts": {
+   "planFanIn": 39,
+   "actualFanIn": 39,
+   "actualTransitiveDependants": 114
+  },
+  "src/lib/env.ts": {
+   "planFanIn": 17,
+   "actualFanIn": 17,
+   "actualTransitiveDependants": 142
+  },
+  "src/lib/admin.ts": {
+   "planFanIn": 17,
+   "actualFanIn": 17,
+   "actualTransitiveDependants": 35
+  },
+  "src/lib/deploy-env.ts": {
+   "planFanIn": 5,
+   "actualFanIn": 5,
+   "actualTransitiveDependants": 40
+  }
+ },
+ "dataBoundary": {
+  "plan_fromSites_280": 277,
+  "plan_tables_33": 33,
+  "plan_inRoutePageAction_199": 194,
+  "inRoutePageActionPct": 70.0,
+  "plan_serviceRoleImporters_40": 39,
+  "serviceRoleImporters_detail": [
+   "src/app/[slug]/page.tsx",
+   "src/app/api/convene/cron/token-health/route.ts",
+   "src/app/api/convene/oauth/google/callback/route.ts",
+   "src/app/api/convene/oauth/google/initiate/route.ts",
+   "src/app/api/convene/oauth/microsoft/callback/route.ts",
+   "src/app/api/convene/oauth/microsoft/initiate/route.ts",
+   "src/app/api/recommendations/[slug]/route.ts",
+   "src/app/api/recommendations/v2/[slug]/route.ts",
+   "src/app/dashboard/convene/gatherings/[id]/actions.ts",
+   "src/app/dashboard/convene/organise/actions.ts",
+   "src/app/examples/page.tsx",
+   "src/app/page.tsx",
+   "src/app/search/page.tsx",
+   "src/app/sitemap.ts",
+   "src/app/waitlist/actions.ts",
+   "src/lib/admin.ts",
+   "src/lib/affiliate/link-service.ts",
+   "src/lib/age/age-service.ts",
+   "src/lib/age/record-declaration.ts",
+   "src/lib/beta-access/flow.ts",
+   "src/lib/convene/auth-bearer.ts",
+   "src/lib/convene/busy-time-consent.ts",
+   "src/lib/convene/invites/dispatch.ts",
+   "src/lib/convene/invites/repository.ts",
+   "src/lib/convene/oauth-connections.ts",
+   "src/lib/convene/post-event.ts",
+   "src/lib/convene/vault.ts",
+   "src/lib/features/entitlements-service.ts",
+   "src/lib/features/global-switches-service.ts",
+   "src/lib/metrics.ts",
+   "src/lib/oauth/access-tokens.ts",
+   "src/lib/oauth/clients.ts",
+   "src/lib/oauth/codes.ts",
+   "src/lib/oauth/consents.ts",
+   "src/lib/oauth/refresh.ts",
+   "src/lib/rate-limit-shared.ts",
+   "src/lib/recommender/v2/candidate-sourcing.ts",
+   "src/lib/retention/affiliate-clicks.ts",
+   "src/lib/retention/gatherings.ts"
+  ],
+  "plan_profilesCallSites_75": 77,
+  "plan_profilesModuleGroups_15": 17,
+  "profilesGroups_detail": [
+   "src/app/[slug]",
+   "src/app/admin",
+   "src/app/api",
+   "src/app/dashboard",
+   "src/app/examples",
+   "src/app/page.tsx",
+   "src/app/search",
+   "src/app/sitemap.ts",
+   "src/app/verify-age",
+   "src/app/waitlist",
+   "src/lib/account-status.ts",
+   "src/lib/admin.ts",
+   "src/lib/age",
+   "src/lib/beta-access",
+   "src/lib/convene",
+   "src/lib/features",
+   "src/middleware.ts"
+  ],
+  "generatedDatabaseType_present": false
+ },
+ "duplicatedRules": {
+  "plan_authGetUserFiles_37": 41,
+  "authGetUser_totalCallSites": 49,
+  "plan_redirectLoginFiles_8": 8,
+  "plan_conveneGateCallSites_16": 58,
+  "conveneGate_files": 24
+ },
+ "testEstate": {
+  "plan_testFiles_213": 220,
+  "unitFiles": 203,
+  "scriptsFiles": 17,
+  "plan_readFileSyncFiles_98": 116,
+  "plan_distinctSrcPathLiterals_112": 125,
+  "plan_pureSourceTextScans_70": 92,
+  "plan_testBlocks_2401": 2439,
+  "regressionGuardFloors": {
+   "files": 29,
+   "allNumericConstants": [
+    29,
+    320
+   ]
+  }
+ },
+ "gates": {
+  "plan_pathCoupledGates_5": 5,
+  "pathCoupledGates_present": {
+   "scripts/check-ui-copy-ownership.sh": true,
+   ".github/signup-surface.paths": true,
+   ".github/CODEOWNERS": true,
+   "scripts/check-service-role-client.sh": true,
+   "stryker.config.mjs": true
+  },
+  "plan_blockingStaticGuards_11": null,
+  "controlsRegistered_now": 32,
+  "ticketAssumed_31": 31,
+  "controlsAdvisoryVsBlocking": {
+   "registrySchemaHasBlockingField": false,
+   "byKind": {
+    "ci-gate": 22,
+    "scheduled": 6,
+    "test": 4
+   },
+   "withoutWiredIn": [],
+   "withoutSelfTest": [
+    "CTL-001",
+    "CTL-002",
+    "CTL-003",
+    "CTL-004",
+    "CTL-005",
+    "CTL-006",
+    "CTL-007",
+    "CTL-008",
+    "CTL-009",
+    "CTL-010",
+    "CTL-011",
+    "CTL-012",
+    "CTL-013",
+    "CTL-014",
+    "CTL-015",
+    "CTL-016",
+    "CTL-017",
+    "CTL-018",
+    "CTL-019",
+    "CTL-020",
+    "CTL-022",
+    "CTL-032"
+   ],
+   "schemaKeys": [
+    "added",
+    "defect_class",
+    "escape_hatch",
+    "id",
+    "implementation",
+    "kind",
+    "name",
+    "notes",
+    "prevents",
+    "self_test",
+    "summary",
+    "wired_in"
+   ]
+  }
+ },
+ "env": {
+  "plan_envVars_58": 49,
+  "detail": [
+   "ADMIN_HOST",
+   "ADMIN_HOST_ENFORCED",
+   "ANTHROPIC_API_KEY",
+   "CF_ACCESS_AUD",
+   "CF_ACCESS_TEAM_DOMAIN",
+   "CONTACT_FROM_EMAIL",
+   "CONTACT_SEARCH_HMAC_KEY",
+   "CONTACT_TO_EMAIL",
+   "CONVENE_ENABLED",
+   "CONVENE_INVITE_ALLOWLIST",
+   "CONVENE_INVITE_FROM_EMAIL",
+   "CONVENE_INVITE_SMS_ALLOWLIST",
+   "CRON_SECRET",
+   "DIDIT_API_BASE",
+   "DIDIT_API_KEY",
+   "DIDIT_WEBHOOK_SECRET",
+   "DIDIT_WORKFLOW_ID",
+   "GOOGLE_PLACES_API_KEY",
+   "IS_BETA_DEPLOY",
+   "LYRA_BETA_FROM_EMAIL",
+   "LYRA_BETA_NOTIFY_EMAIL",
+   "LYRA_FORCE_WAITLIST",
+   "LYRA_SEARCH_PEPPER",
+   "LYRA_SITE_URL",
+   "NEXT_PUBLIC_SITE_URL",
+   "NEXT_PUBLIC_SUPABASE_ANON_KEY",
+   "NEXT_PUBLIC_SUPABASE_URL",
+   "NEXT_PUBLIC_TURNSTILE_SITE_KEY",
+   "NEXT_PUBLIC_VERCEL_ENV",
+   "NODE_ENV",
+   "OAUTH_JWT_KID",
+   "OAUTH_JWT_KID_NEXT",
+   "OAUTH_JWT_PRIVATE_KEY_B64",
+   "OAUTH_JWT_PUBLIC_KEY_B64",
+   "OAUTH_JWT_PUBLIC_KEY_B64_NEXT",
+   "OAUTH_JWT_SIGNING_SECRET",
+   "PAID_LINKS_COMPLIANCE_READY",
+   "RESEND_API_KEY",
+   "RETENTION_AFFILIATE_CLICKS_MONTHS",
+   "RETENTION_ENABLED",
+   "RETENTION_GATHERINGS_MONTHS",
+   "SOVRN_API_KEY",
+   "TURNSTILE_SECRET_KEY",
+   "TWILIO_ACCOUNT_SID",
+   "TWILIO_AUTH_TOKEN",
+   "TWILIO_SMS_FROM",
+   "TWILIO_WHATSAPP_FROM",
+   "VERCEL_ENV",
+   "VERCEL_URL"
+  ]
+ }
+}

--- a/docs/modularisation/kan432-revalidate.py
+++ b/docs/modularisation/kan432-revalidate.py
@@ -1,0 +1,490 @@
+#!/usr/bin/env python3
+"""KAN-432 (R10) — re-derive every quantitative claim in the modularisation plan.
+
+Read-only. Writes docs/modularisation/data/kan432-revalidation.json.
+
+The plan (LYRA_MODULARISATION_PLAN_2026-07-26.md) was surveyed against
+`develop @ ee647e6` on 2026-07-26 using dependency-cruiser. `node_modules` is
+not installed in this environment, so this script builds the import graph
+independently. That is a feature, not a workaround: the ticket says
+"re-derive, do not quote", and an independent method that lands on the same
+number is stronger evidence than re-running the same tool.
+
+Where a definition could differ from dependency-cruiser's, the definition used
+here is stated in `methodNotes` in the output so a delta can be attributed to
+method rather than to drift.
+
+Run:  python3 docs/modularisation/kan432-revalidate.py
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import subprocess
+import sys
+from collections import defaultdict
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[2]
+SRC = REPO / "src"
+OUT = REPO / "docs" / "modularisation" / "data" / "kan432-revalidation.json"
+
+CODE_EXT = {".ts", ".tsx", ".js", ".jsx", ".mjs", ".cjs"}
+SKIP_DIRS = {"node_modules", ".git", ".next", "dist", "coverage", "out"}
+
+IMPORT_FROM_RE = re.compile(r"import\s+(?:type\s+)?[\s\S]*?\s+from\s*['\"]([^'\"]+)['\"]")
+BARE_IMPORT_RE = re.compile(r"import\s*['\"]([^'\"]+)['\"]")
+EXPORT_FROM_RE = re.compile(r"export\s+(?:type\s+)?(?:\*|\{[\s\S]*?\})\s*from\s*['\"]([^'\"]+)['\"]")
+DYNAMIC_RE = re.compile(r"(?:import|require)\s*\(\s*['\"]([^'\"]+)['\"]\s*\)")
+TYPE_ONLY_RE = re.compile(r"import\s+type\s")
+
+
+def strip_comments(t: str) -> str:
+    t = re.sub(r"/\*.*?\*/", "", t, flags=re.S)
+    return re.sub(r"^\s*//.*$", "", t, flags=re.M)
+
+
+def walk(root: Path, exts=CODE_EXT):
+    for dp, dn, fn in os.walk(root):
+        dn[:] = [d for d in dn if d not in SKIP_DIRS]
+        for f in fn:
+            p = Path(dp) / f
+            if p.suffix in exts:
+                yield p
+
+
+def resolve(spec: str, importer: Path) -> Path | None:
+    if spec.startswith("@/"):
+        base = SRC / spec[2:]
+    elif spec.startswith("."):
+        base = (importer.parent / spec).resolve()
+    else:
+        return None
+    cands = [base]
+    for ext in (".ts", ".tsx", ".js", ".jsx", ".mjs", ".cjs"):
+        cands.append(Path(str(base) + ext))
+        cands.append(base / ("index" + ext))
+    for c in cands:
+        if c.is_file():
+            return c.resolve()
+    return None
+
+
+def group_of(rel: str) -> str:
+    """The plan's 'group' unit: src/<area>/<first-segment>."""
+    parts = rel.split("/")
+    if len(parts) < 3:
+        return "/".join(parts[:2])
+    return "/".join(parts[:3])
+
+
+def app_segment(rel: str) -> str | None:
+    """Top-level route segment under src/app.
+
+    A Next route group `(auth)` is ONE segment: `(auth)/login` and
+    `(auth)/signup` are sibling routes inside a single deployment/ownership
+    unit, so an import between them is not a cross-segment edge. Collapsing
+    the group onto its child instead (the first cut of this script) inflated
+    the count from 3 to 7 — a pure method artefact.
+    """
+    if not rel.startswith("src/app/"):
+        return None
+    parts = rel.split("/")[2:]
+    if len(parts) < 2:
+        return None
+    return parts[0]
+
+
+def is_deep_import(dst: str, barrels: set[str]) -> bool:
+    """Plan's 'deep import into another area's internals'.
+
+    An edge into a file that lives INSIDE another group's directory, other
+    than via that group's barrel. A top-level leaf module (`src/lib/admin.ts`)
+    is its own group, so importing it is not a deep import; reaching into
+    `src/lib/convene/invites/repository.ts` is.
+
+    This definition was recovered empirically: it yields 142/336 (42.3%)
+    against the plan's 145/328 (44%), i.e. the same measure two days later.
+    Candidate readings that do NOT reproduce the plan are recorded in the
+    output for audit (`crossGroupEdgesNotViaBarrel` = 326, and a depth>=2
+    reading = 24), so the headline cannot be quietly redefined later.
+    """
+    if dst in barrels:
+        return False
+    return len(dst.split("/")) - len(group_of(dst).split("/")) >= 1
+
+
+def build():
+    files = sorted(walk(SRC))
+    rels = {str(f.relative_to(REPO)) for f in files}
+    edges = set()          # (src_rel, dst_rel)
+    type_only_edges = set()
+    for f in files:
+        rel = str(f.relative_to(REPO))
+        text = strip_comments(f.read_text(encoding="utf-8", errors="replace"))
+        specs = set()
+        for rx in (IMPORT_FROM_RE, BARE_IMPORT_RE, EXPORT_FROM_RE, DYNAMIC_RE):
+            specs |= set(rx.findall(text))
+        for spec in specs:
+            t = resolve(spec, f)
+            if not t:
+                continue
+            trel = str(t.relative_to(REPO))
+            if trel == rel or trel not in rels:
+                continue
+            edges.add((rel, trel))
+        # crude type-only detection for the cycle question
+        for m in re.finditer(r"import\s+type\s+[\s\S]*?\s+from\s*['\"]([^'\"]+)['\"]", text):
+            t = resolve(m.group(1), f)
+            if t:
+                trel = str(t.relative_to(REPO))
+                if trel != rel and trel in rels:
+                    type_only_edges.add((rel, trel))
+    return files, rels, edges, type_only_edges
+
+
+def find_cycles(edges, rels):
+    adj = defaultdict(set)
+    for a, b in edges:
+        adj[a].add(b)
+    cycles, seen_sets = [], set()
+    colour, stack = {}, []
+
+    def dfs(n):
+        colour[n] = 1
+        stack.append(n)
+        for m in sorted(adj[n]):
+            if colour.get(m, 0) == 0:
+                dfs(m)
+            elif colour.get(m) == 1:
+                i = stack.index(m)
+                cyc = tuple(stack[i:])
+                key = frozenset(cyc)
+                if key not in seen_sets:
+                    seen_sets.add(key)
+                    cycles.append(list(cyc))
+        stack.pop()
+        colour[n] = 2
+
+    for n in sorted(rels):
+        if colour.get(n, 0) == 0:
+            dfs(n)
+    return cycles
+
+
+def count_matches(pattern, paths, flags=0):
+    rx = re.compile(pattern, flags)
+    hits, total = [], 0
+    for p in paths:
+        try:
+            t = p.read_text(encoding="utf-8", errors="replace")
+        except Exception:
+            continue
+        n = len(rx.findall(t))
+        if n:
+            hits.append((str(p.relative_to(REPO)), n))
+            total += n
+    return total, hits
+
+
+def main():
+    files, rels, edges, type_only = build()
+    out = {}
+
+    head = subprocess.run(["git", "rev-parse", "HEAD"], cwd=REPO,
+                          capture_output=True, text=True).stdout.strip()
+    out["generatedFrom"] = head
+    out["methodNotes"] = [
+        "Import graph built by regex scan of src/**, resolving the tsconfig alias "
+        "'@/* -> ./src/*', relative specifiers and directory index files. Static "
+        "import, re-export, bare side-effect import and dynamic import()/require() "
+        "all count as edges. Bare package specifiers are excluded (the plan counted "
+        "the internal src/ graph).",
+        "'Group' = src/<area>/<first-segment> (e.g. src/lib/convene, src/app/dashboard). "
+        "'App segment' = top-level route segment under src/app, with a Next route "
+        "group '(x)' collapsed onto its child so '(legal)/about' is one segment.",
+        "A 'deep import' is a cross-group edge whose target is NOT the group's "
+        "index.* barrel.",
+        "dependency-cruiser was unavailable (node_modules absent), so these figures "
+        "are an independent derivation rather than a re-run of the plan's tool. "
+        "Deltas of +/-1 on graph counts may be method, not drift; deltas larger "
+        "than that are drift.",
+    ]
+
+    # ---- 1.1 graph shape -------------------------------------------------
+    nodes_with_edges = {a for a, _ in edges} | {b for _, b in edges}
+    lib_to_app = sorted(
+        (a, b) for a, b in edges if a.startswith("src/lib/") and b.startswith("src/app/")
+    )
+    seg_edges = set()
+    for a, b in edges:
+        sa, sb = app_segment(a), app_segment(b)
+        if sa and sb and sa != sb:
+            seg_edges.add((sa, sb))
+    cycles = find_cycles(edges, rels)
+    cycle_detail = []
+    for c in cycles:
+        ring = list(zip(c, c[1:] + c[:1]))
+        cycle_detail.append({
+            "files": c,
+            "allTypeOnly": all(e in type_only for e in ring),
+        })
+
+    cross_group = [(a, b) for a, b in edges if group_of(a) != group_of(b)]
+    barrels = sorted(
+        str(p.relative_to(REPO)) for p in files if p.stem == "index" and p.suffix in {".ts", ".tsx"}
+    )
+    barrel_set = set(barrels)
+    deep = [(a, b) for a, b in cross_group if is_deep_import(b, barrel_set)]
+    not_via_barrel = [(a, b) for a, b in cross_group if b not in barrel_set]
+    via_barrel = [(a, b) for a, b in cross_group if b in barrel_set]
+
+    segs_with_fanin = {sb for _, sb in seg_edges}
+    all_segs = {s for s in (app_segment(r) for r in rels) if s}
+
+    out["graph"] = {
+        "plan_nodes_273": len(rels),
+        "plan_nodesWithAtLeastOneEdge": len(nodes_with_edges),
+        "plan_edges_525": len(edges),
+        "plan_libToApp_1": len(lib_to_app),
+        "libToApp_detail": lib_to_app,
+        "plan_appSegToAppSeg_5": len(seg_edges),
+        "appSegToAppSeg_detail": sorted(f"{a} -> {b}" for a, b in seg_edges),
+        "appSegments_total": len(all_segs),
+        "appSegments_zeroFanIn": len(all_segs - segs_with_fanin),
+        "plan_cycles_1": len(cycles),
+        "cycles_detail": cycle_detail,
+        "plan_crossGroupEdges_328": len(cross_group),
+        "plan_deepImports_145": len(deep),
+        "deepImportPct": round(100 * len(deep) / len(cross_group), 1) if cross_group else 0,
+        "crossGroupEdgesNotViaBarrel": len(not_via_barrel),
+        "plan_barrels_4": len(barrels),
+        "barrels_detail": barrels,
+        "plan_crossGroupViaBarrel_9": len(via_barrel),
+    }
+
+    # ---- 1.2 kernel fan-in ----------------------------------------------
+    fanin = defaultdict(set)
+    for a, b in edges:
+        fanin[b].add(a)
+
+    def transitive_dependants(target):
+        rev = defaultdict(set)
+        for a, b in edges:
+            rev[b].add(a)
+        seen, stack = set(), [target]
+        while stack:
+            n = stack.pop()
+            for m in rev[n]:
+                if m not in seen:
+                    seen.add(m)
+                    stack.append(m)
+        return len(seen)
+
+    kernel = {
+        "src/lib/supabase-server.ts": 46,
+        "src/lib/supabase-service.ts": 39,
+        "src/lib/env.ts": 17,
+        "src/lib/admin.ts": 17,
+        "src/lib/deploy-env.ts": 5,
+    }
+    out["kernel"] = {
+        k: {"planFanIn": v, "actualFanIn": len(fanin.get(k, ())),
+            "actualTransitiveDependants": transitive_dependants(k)}
+        for k, v in kernel.items()
+    }
+
+    # ---- 1.2 data boundary ----------------------------------------------
+    src_files = [p for p in files]
+    from_rx = re.compile(r"\.from\(\s*['\"]([a-zA-Z0-9_]+)['\"]")
+    from_sites, tables, per_file = 0, set(), {}
+    for p in src_files:
+        t = strip_comments(p.read_text(encoding="utf-8", errors="replace"))
+        ms = from_rx.findall(t)
+        if ms:
+            rel = str(p.relative_to(REPO))
+            per_file[rel] = len(ms)
+            from_sites += len(ms)
+            tables |= set(ms)
+    route_page_action = sum(
+        n for f, n in per_file.items()
+        if re.search(r"/(route|page|actions|[a-z-]*actions)\.tsx?$", f)
+    )
+    svc_total, svc_hits = count_matches(r"createServiceRoleClient", src_files)
+    svc_importers = sorted(
+        a for a, b in edges if b == "src/lib/supabase-service.ts"
+    )
+    profiles_sites = sum(
+        1 for p in src_files
+        for _ in re.finditer(r"\.from\(\s*['\"]profiles['\"]", p.read_text(encoding="utf-8", errors="replace"))
+    )
+    profiles_groups = {
+        group_of(str(p.relative_to(REPO))) for p in src_files
+        if re.search(r"\.from\(\s*['\"]profiles['\"]", p.read_text(encoding="utf-8", errors="replace"))
+    }
+    out["dataBoundary"] = {
+        "plan_fromSites_280": from_sites,
+        "plan_tables_33": len(tables),
+        "plan_inRoutePageAction_199": route_page_action,
+        "inRoutePageActionPct": round(100 * route_page_action / from_sites, 1) if from_sites else 0,
+        "plan_serviceRoleImporters_40": len(svc_importers),
+        "serviceRoleImporters_detail": svc_importers,
+        "plan_profilesCallSites_75": profiles_sites,
+        "plan_profilesModuleGroups_15": len(profiles_groups),
+        "profilesGroups_detail": sorted(profiles_groups),
+        "generatedDatabaseType_present": any(
+            (REPO / c).exists() for c in
+            ("src/types/database.ts", "src/lib/database.types.ts", "src/types/supabase.ts")
+        ),
+    }
+
+    # ---- 1.3 duplicated rules -------------------------------------------
+    auth_total, auth_hits = count_matches(r"auth\.getUser\(", src_files)
+    login_total, login_hits = count_matches(r"redirect\(\s*['\"]/login['\"]", src_files)
+    convene_total, convene_hits = count_matches(r"CONVENE_ENABLED|conveneEnabled|isConveneEnabled", src_files)
+    out["duplicatedRules"] = {
+        "plan_authGetUserFiles_37": len(auth_hits),
+        "authGetUser_totalCallSites": auth_total,
+        "plan_redirectLoginFiles_8": len(login_hits),
+        "plan_conveneGateCallSites_16": convene_total,
+        "conveneGate_files": len(convene_hits),
+    }
+
+    # ---- 1.5 test estate -------------------------------------------------
+    unit = sorted(walk(REPO / "tests" / "unit", {".ts", ".tsx", ".js", ".mjs", ".cjs"}))
+    scripts_t = sorted(walk(REPO / "tests" / "scripts", {".ts", ".js", ".mjs", ".cjs"}))
+    test_files = unit + scripts_t
+    rf_total, rf_hits = count_matches(r"readFileSync", test_files)
+    path_lit = set()
+    for p in test_files:
+        path_lit |= set(re.findall(r"['\"](src/[A-Za-z0-9_@\-./\[\]()]+)['\"]",
+                                   p.read_text(encoding="utf-8", errors="replace")))
+    pure_scan = []
+    for p in test_files:
+        t = p.read_text(encoding="utf-8", errors="replace")
+        if "readFileSync" in t and not re.search(r"^\s*(import|const .*=\s*require)\s.*['\"](@/|\.\./\.\./src)", t, re.M):
+            pure_scan.append(str(p.relative_to(REPO)))
+    blocks = 0
+    for p in test_files:
+        blocks += len(re.findall(r"^\s*(?:it|test)(?:\.each\([^)]*\))?\s*\(",
+                                 p.read_text(encoding="utf-8", errors="replace"), re.M))
+    out["testEstate"] = {
+        "plan_testFiles_213": len(test_files),
+        "unitFiles": len(unit),
+        "scriptsFiles": len(scripts_t),
+        "plan_readFileSyncFiles_98": len(rf_hits),
+        "plan_distinctSrcPathLiterals_112": len(path_lit),
+        "plan_pureSourceTextScans_70": len(pure_scan),
+        "plan_testBlocks_2401": blocks,
+    }
+
+    # regression-guard floors
+    guard = REPO / "tests" / "unit" / "test-regression-guard.test.js"
+    floors = {}
+    if guard.exists():
+        g = guard.read_text(encoding="utf-8", errors="replace")
+        for label, rx in (("files", r"(?:MIN_(?:TEST_)?FILES|FILE_FLOOR)\s*=\s*(\d+)"),
+                          ("tests", r"(?:MIN_(?:TEST_)?TESTS|TEST_FLOOR)\s*=\s*(\d+)")):
+            m = re.search(rx, g)
+            if m:
+                floors[label] = int(m.group(1))
+        floors["allNumericConstants"] = sorted(set(
+            int(x) for x in re.findall(r"=\s*(\d{2,5})\s*;", g)
+        ))
+    out["testEstate"]["regressionGuardFloors"] = floors
+
+    # ---- 1.6 path-coupled CI gates + control estate ----------------------
+    gates = {
+        "scripts/check-ui-copy-ownership.sh": None,
+        ".github/signup-surface.paths": None,
+        ".github/CODEOWNERS": None,
+        "scripts/check-service-role-client.sh": None,
+        "stryker.config.mjs": None,
+    }
+    for g in list(gates):
+        gates[g] = (REPO / g).exists()
+    reg = json.loads((REPO / "controls" / "registry.json").read_text())
+    controls = reg["controls"]
+    out["gates"] = {
+        "plan_pathCoupledGates_5": sum(1 for v in gates.values() if v),
+        "pathCoupledGates_present": gates,
+        "plan_blockingStaticGuards_11": None,
+        "controlsRegistered_now": len(controls),
+        "ticketAssumed_31": 31,
+        "controlsAdvisoryVsBlocking": {},
+    }
+    # SEC-106 asks whether the controls are advisory. The registry schema has
+    # NO field expressing blocking-vs-advisory at all — it cannot represent the
+    # distinction, which is itself the finding. Report what it does carry.
+    kinds, unwired, no_selftest = defaultdict(int), [], []
+    for c in controls:
+        kinds[c.get("kind", "unspecified")] += 1
+        if not c.get("wired_in"):
+            unwired.append(c["id"])
+        if not c.get("self_test"):
+            no_selftest.append(c["id"])
+    out["gates"]["controlsAdvisoryVsBlocking"] = {
+        "registrySchemaHasBlockingField": any(
+            k in c for c in controls for k in ("enforcement", "blocking", "mode", "severity")
+        ),
+        "byKind": dict(kinds),
+        "withoutWiredIn": unwired,
+        "withoutSelfTest": no_selftest,
+        "schemaKeys": sorted({k for c in controls for k in c}),
+    }
+
+    # ---- env vars --------------------------------------------------------
+    envs = set()
+    for p in src_files:
+        envs |= set(re.findall(r"process\.env\.([A-Z0-9_]+)", p.read_text(encoding="utf-8", errors="replace")))
+    out["env"] = {"plan_envVars_58": len(envs), "detail": sorted(envs)}
+
+    OUT.parent.mkdir(parents=True, exist_ok=True)
+    OUT.write_text(json.dumps(out, indent=1) + "\n")
+
+    # console summary
+    def line(label, plan, actual):
+        verdict = "UNCHANGED" if plan == actual else f"MOVED ({plan} -> {actual})"
+        print(f"  {label:<46} plan={plan:<6} now={actual:<6} {verdict}")
+
+    g = out["graph"]
+    print("GRAPH")
+    line("nodes", 273, g["plan_nodes_273"])
+    line("edges", 525, g["plan_edges_525"])
+    line("lib->app edges", 1, g["plan_libToApp_1"])
+    line("app-seg -> app-seg edges", 5, g["plan_appSegToAppSeg_5"])
+    line("import cycles", 1, g["plan_cycles_1"])
+    line("cross-group edges", 328, g["plan_crossGroupEdges_328"])
+    line("deep imports", 145, g["plan_deepImports_145"])
+    line("index barrels", 4, g["plan_barrels_4"])
+    print("DATA BOUNDARY")
+    d = out["dataBoundary"]
+    line(".from() sites", 280, d["plan_fromSites_280"])
+    line("distinct tables", 33, d["plan_tables_33"])
+    line("in route/page/action", 199, d["plan_inRoutePageAction_199"])
+    line("service-role importers", 40, d["plan_serviceRoleImporters_40"])
+    line("profiles call sites", 75, d["plan_profilesCallSites_75"])
+    line("profiles module groups", 15, d["plan_profilesModuleGroups_15"])
+    print("RULES")
+    r = out["duplicatedRules"]
+    line("auth.getUser() files", 37, r["plan_authGetUserFiles_37"])
+    line("redirect('/login') files", 8, r["plan_redirectLoginFiles_8"])
+    print("TESTS")
+    t = out["testEstate"]
+    line("test files", 213, t["plan_testFiles_213"])
+    line("readFileSync files", 98, t["plan_readFileSyncFiles_98"])
+    line("distinct src path literals", 112, t["plan_distinctSrcPathLiterals_112"])
+    line("pure source-text scans", 70, t["plan_pureSourceTextScans_70"])
+    line("test blocks", 2401, t["plan_testBlocks_2401"])
+    print("GATES / ENV")
+    line("path-coupled gates present", 5, out["gates"]["plan_pathCoupledGates_5"])
+    line("registered controls", 11, out["gates"]["controlsRegistered_now"])
+    line("env vars", 58, out["env"]["plan_envVars_58"])
+    print(f"\nwrote {OUT.relative_to(REPO)}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

R10 spike (KAN-432), which **blocks KAN-415**. No code, tests, schema or workflows changed. Adds three files under `docs/modularisation/`:

- `PLAN-REVALIDATION-2026-07-28.md` — the delta document
- `kan432-revalidate.py` — the derivation script
- `data/kan432-revalidation.json` — machine-readable output

…and, in the second commit, **applies all 14 edits to `LYRA_MODULARISATION_PLAN_2026-07-26.md`** following the founder's ruling (see "Scope ruling" below).

`node_modules` is absent in the cloud environment, so the import graph is rebuilt **independently** rather than by re-running `dependency-cruiser`. That is stronger evidence, not weaker: an independent method landing on the same number is corroboration. The four kernel fan-in figures reproduce **exactly** (`supabase-server` 46, `supabase-service` 39, `env.ts` 17, `admin.ts` 17, `deploy-env.ts` 5) — that is the calibration check for everything else.

### Verdict

**The plan's diagnosis survives.** Every load-bearing number is within drift. **Two premises do not.**

### FINDING 1 — F2 is marked Done but is one-third complete → **BUGS-80**

This ticket's own description asserts *"F2 — DONE. KAN-424, PR #596."* KAN-424 is Done in Jira. Of F2's three sub-items:

| Sub-item | Actual |
|---|---|
| `computeAccessTransition` out of the admin route tree | ✅ DONE — `lib`→`app` edges now **0** |
| `WizardContact` into `organise-fields.ts` | ❌ **NOT DONE** — the type-only cycle is still there |
| Relocate the 5 `app`→`app` shared symbols | ⚠️ **PARTIAL** — 5 → 3 |

A story marked Done whose scope did not land is the precise failure mode KAN-432 exists to catch — here occurring inside KAN-432's own premises. CTL-030's `no-circular` rule is warn-only, so nothing failed when the cycle survived. Two of the three residual edges are legitimately D8's job (the D-4 privacy finding) and have been moved there.

### FINDING 2 — the plan's blocking dependency gate collides with SEC-105

§4.2 and story C2 specify `dependency-cruiser` blocking with all 9 rules at `error`. **SEC-105** says that gate produced *six pipeline outages over dev-only code that never ships*. Both cannot be right, and §1.4's *"only a CI gate does the 90%"* is the justification for the whole programme's cost. **C2 must not start before SEC-105 resolves.**

### Other reconciliations

- **Control estate.** Four different counts in circulation (plan 11, this ticket 31, SEC-106 29, registry **32**). More importantly the registry schema has **no field for blocking-vs-advisory** — it cannot represent the property, so nothing can assert it. Confirms SEC-106 and is worse than its title states. 22 of 32 controls have no `self_test`.
- **SEC-104.** A `public_profiles` view enforcing the predicate at the database would materially *simplify* the `public-profile` boundary — the module owns "read from the view" instead of "remember two predicates at every call site". **D9 must not start before SEC-104 is decided**, or it freezes a call-site convention into a public API that SEC-104 then unpicks.
- **D-8 upgraded structural → security.** The browser-side `oauth_connections` write is not just a boundary smell: it means `vaultRevokeRefreshToken` never runs, so a user's OAuth refresh token survives their disconnect. Filed **SEC-109 (High)**. It must not wait for D13.
- **D-11 superseded** by KAN-422 (#620): 219 zero-importer exports, but 160 are live code with an over-wide `export`; only 59 genuinely dead. The two files D-11 named for deletion must be **kept** (KAN-198/KAN-202 In Progress).
- **Five new discoveries** N-1…N-5 appended.

## Scope ruling — founder decision 2026-07-28: **option (A), the lighter scope**

The re-validation asked whether the Enforced Modular Monolith still earns its cost, and put two options to the founder. **(A) was chosen**, and the second commit applies it.

**Why.** The horizontal structure **improved without a single extraction** (`lib`→`app` 1→0, cross-segment 5→3, zero-fan-in segments 14→16) — from one targeted PR and one cheap gate. Meanwhile the vertical coupling the plan named as the real problem is flat or worsening: `profiles` 75→**77** sites over 15→**17** groups, `auth.getUser()` 37→**41** files, and the path-coupling tax is *accelerating* — `readFileSync` test files 98→**116** (+18%), pure source-text scans 70→**92** (+31%), in two days. Every worsening metric is closed by **Phase 0 + the data boundary + `@lyra/contracts`**; none requires moving a file into `src/modules/`.

**Adopted scope:** Phase 0 in full (F1–F9) + `@lyra/contracts` + the data boundary (C3) + the `profiles` ADR. **D1–D15 and the machinery serving them (C1, C2, C4–C6, G1) are DEFERRED — not cancelled**, with a *binding re-decision trigger* written into §2.2: when Phase 0 closes, re-derive §1.1/§1.2 against a decoupled test estate and a typed schema and re-take the decision on that evidence. That trigger exists specifically so "deferred" cannot decay into "abandoned".

**Edits applied** (§8 of the delta document — 1–8 and 10–14 were factual corrections applying under either ruling; 9 is the scope change):

1. §1 header — re-validation banner + scope ruling
2. §1.1 — re-derived, and **"deep import" now defined inline** (three plausible readings gave 142 / 24 / 326)
3. §1.2 — `profiles` 17 groups / 77 sites, marked worsening
4. §1.5 — 220 files / 116 `readFileSync` / 125 path literals / 92 pure scans / 2,439 blocks, with the growth rate
5. §1.6 — 11 → **32** registered controls + the SEC-106 caveat that none is provably blocking
6. §4.1 — **index-only tsconfig claim amended**: a path alias only governs alias-form imports, so a relative specifier bypasses it entirely. It is ergonomics, not enforcement
7. §4.2 + C2 — hard dependency on SEC-105
8. §5 — `public-profile` gated on SEC-104; SEC-106 advisory caveat on the table preamble
9. §2.2 + §6 + §8 — **the scope ruling**
10. §7 D-8 — moved to a new **Security** class, cites SEC-109, D13 dependency removed
11. §7 D-11 — replaced with KAN-422's measured figures; the `recommender/inputs.ts` / `events.ts` deletion struck
12. §7 P-6 — split into P-6a (closed) / P-6b (open, BUGS-80)
13. §7 — N-1…N-5 appended
14. §6 F2 — re-scoped to the residual cycle; the two `[slug] → profile` edges moved into D8

## Jira Ticket

KAN-432 (also files BUGS-80)

## Checklist

- [x] Unit tests added/updated for new/changed functionality — N/A, docs-only; no source changed
- [x] All existing tests pass (`npm run test:unit`) — **not run: `node_modules` is absent in this cloud environment.** Verified instead that nothing asserts on the changed file: `grep -rln LYRA_MODULARISATION_PLAN tests/ scripts/ .github/` returns nothing, and the file is not in `DOC_SOURCE_OF_TRUTH.md`. No test can be affected by this diff
- [x] Lint passes (`npm run lint`) — N/A, no JS/TS added (the script is Python, not in the lint path)
- [x] Type check passes (`npm run type-check`) — N/A, no TS added
- [x] Build succeeds (`npm run build`) — N/A, nothing under `src/`
- [x] Coverage has not decreased — N/A, no source changed
- [x] No eslint-disable or ts-ignore without KAN-XX reference — none added
- [x] Dependency-rule gate reviewed — N/A, no imports changed. (The document reports the current graph state, including the residual cycle CTL-030 does not block.)
- [x] ARCHITECTURE.md updated if architectural changes were made — N/A. The scope ruling defers work that was never built; no service, table, env var, route, job or security boundary changed
- [x] Ops routine / Control-Room registry updated — N/A, no routine behaviour, cadence or ownership changed. (The modularisation scoping routine's own stored prompt needs re-pointing after this lands — that is claude.ai routine config, not repo state; flagged to the founder separately)
- [x] Docs / system map updated — this PR **is** the doc, landing alongside the KAN-416/417/419/420/422 artefacts. SEC-109 and BUGS-80 carry their own doc footprints