### PR TITLE
feat(KAN-428): Extraction Definition-of-Done gate — estate rework ships with the move

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -19,3 +19,19 @@ KAN-XX
 - [ ] ARCHITECTURE.md updated if architectural changes were made
 - [ ] Ops routine / Control-Room registry updated if scheduled-routine behaviour, cadence, or ownership changed — `docs/OPS_ROUTINES_CONTROL_ROOM.md` + the Confluence Control Room (or N/A) (KAN-359)
 - [ ] Docs / system map updated — Architecture & Infrastructure and/or Data Model & Security (+ ADR for any design decision), or N/A with reason (KAN-359 Documentation Definition-of-Done; see `docs/RUNBOOK.md` and `docs/DOC_SYNC_HEALTHCHECK_ROUTINE.md`)
+
+## Extraction Definition-of-Done (KAN-428)
+
+**Only applies if this PR moves (deletes or renames) a file under `src/`.** If it
+does not, delete this section — `scripts/check-extraction-dod.sh` is inert and
+these lines are not read. If it does, an extraction carries its own estate
+rework in the SAME PR: see `docs/MODULARISATION_EXTRACTION_DOD.md` for the
+per-path checklist and `docs/modularisation/KAN-419-path-coupling.md` for why.
+
+CI checks the rest of the estate for you (`.github/`, `scripts/`, `docs/`,
+`modules.json`, `tests/`). The three lines below are the part CI **cannot**
+check, so answer them honestly — replace `FILL-IN`, which fails the gate as-is.
+
+- [ ] EXTRACTION-DOD-DESIGN-SYSTEM: FILL-IN — `done` if this PR moves `src/app/globals.css` or a `ui-kit` file and the source pointer in `~/lyra-design-system/build.py` was updated + the generator re-run; else `n/a — <reason>`. Out of repo: no CI can see this.
+- [ ] EXTRACTION-DOD-ROUTINE-PROMPTS: FILL-IN — `done` if this PR renames a script or changes a protected-surface path list named verbatim in a claude.ai routine prompt and Luisa updated the prompt; else `n/a — <reason>`. Out of repo: no CI can see this. Name the routine + its `trig_…` ID (`docs/OPS_ROUTINES_CONTROL_ROOM.md`).
+- [ ] EXTRACTION-DOD-COVERAGE: FILL-IN — the Playwright project and soak contract clause (C1–C6) covering the moved module, e.g. ``playwright project `authed`, soak clause C4``; or `no coverage`, which is an acceptable answer and a finding to raise.

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -94,6 +94,29 @@ jobs:
         # list so guard and robot agree. Fail-open ONLY when the diff base can't be
         # resolved (CODEOWNERS still hard-gates these paths). See KAN-411.
         run: BASE_REF="origin/${{ github.base_ref }}" bash scripts/check-ui-copy-ownership.sh
+      - name: Extraction Definition-of-Done (KAN-428)
+        # Guard #13. INERT unless the PR deletes or renames a file under src/
+        # (an "extraction"). When it fires, every artefact that classifies a
+        # file BY PATH must have moved with it in the same PR: the signup
+        # manifest, CODEOWNERS, the shell guards' path lists, stryker's mutate
+        # globs, docs/, modules.json and tests/. A glob that matches nothing
+        # protects nothing while CI stays green — KAN-419 measured the docs
+        # layer at 18% dead path literals BEFORE anyone moved a file on
+        # purpose. It also requires the PR body to answer the two couplings CI
+        # can never see (~/lyra-design-system/build.py and the claude.ai
+        # routine prompts, neither in any repo CI can read) plus the covering
+        # Playwright project / soak clause.
+        #
+        # Fails CLOSED (exit 2) when it cannot verify — unresolvable diff base,
+        # missing artefact, or an extraction PR with no readable body. Stricter
+        # than KAN-411's UI guard on purpose: that one has CODEOWNERS
+        # underneath it, this one is the gate that protects the other gates.
+        # Escape hatch: `EXTRACTION-DOD-OK: <JIRA-KEY> <check-id>` on a commit,
+        # suppressing exactly one named check, printed on every run and counted.
+        # See docs/MODULARISATION_EXTRACTION_DOD.md.
+        env:
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: BASE_REF="origin/${{ github.base_ref }}" bash scripts/check-extraction-dod.sh
       - name: macOS Finder-duplicate file check (KAN-357)
         # Reject any committed " <n>"-suffixed file/dir (e.g. "[slug] 2/" or
         # "profile-sections 2.cjs"). These Finder-copy duplicates shadow the

--- a/controls/registry.json
+++ b/controls/registry.json
@@ -593,6 +593,22 @@
       ],
       "escape_hatch": "None. Every ecosystem must target develop so its PRs flow through the develop -> staging -> beta -> main chain like any other change.",
       "added": "2026-07-28"
+    },
+    {
+      "id": "CTL-033",
+      "name": "Extraction Definition-of-Done",
+      "defect_class": "path-coupling-drift",
+      "summary": "Fails any PR that deletes or renames a file under src/ while an artefact that classifies files BY PATH still names the old path: .github/ (signup-surface manifest, CODEOWNERS, workflows), scripts/ guard path-lists, docs/ (incl. the mirror manifest), modules.json and tests/. A glob that matches nothing protects nothing while CI stays green \u2014 KAN-419 measured the docs layer at 18% dead path literals before a single file was moved on purpose. Also requires the PR body to answer the two couplings CI can never see (~/lyra-design-system/build.py and the claude.ai routine prompts, neither in any repo CI can read) and to name the covering Playwright project + soak clause, or record 'no coverage' as a finding. Fails closed (exit 2) when it cannot verify.",
+      "implementation": "scripts/check-extraction-dod.sh",
+      "kind": "ci-gate",
+      "wired_in": [
+        ".github/workflows/pr-checks.yml"
+      ],
+      "prevents": [
+        "KAN-428"
+      ],
+      "escape_hatch": "EXTRACTION-DOD-OK: <JIRA-KEY> <check-id> on a commit in the PR. Suppresses exactly one named check, requires a Jira key, every active exception is printed on every run, and more than three in one PR emits a ::warning:: that the hatch is papering over drift.",
+      "added": "2026-07-28"
     }
   ]
 }

--- a/docs/MODULARISATION_EXTRACTION_DOD.md
+++ b/docs/MODULARISATION_EXTRACTION_DOD.md
@@ -1,0 +1,217 @@
+# Extraction Definition-of-Done
+
+**Ticket:** KAN-428 (F11) · **Epic:** KAN-414 (modularisation scoping) ·
+**Derived from:** `docs/modularisation/KAN-419-path-coupling.md` (the
+path-coupling register) · **Guard:** `scripts/check-extraction-dod.sh`
+(guard #13, blocking in `pr-checks.yml`) · **Extends:** the KAN-359
+Documentation Definition-of-Done, it does not replace it.
+
+---
+
+## 0. The rule
+
+> **An extraction carries its own estate rework in the SAME PR.**
+
+The modularisation plan originally sequenced documentation and verification
+rework as a closing phase (G2). That is the classic way a refactor programme
+leaves a trail of stale runbooks and inert gates behind it: the estate degrades
+module by module while CI stays green, and nobody finds out until something
+ships that should not have.
+
+This is not a theoretical worry. KAN-419 measured the baseline before a single
+file was moved on purpose:
+
+| Measurement | Result |
+|---|---|
+| Path literals across `docs/**/*.md` | **110** |
+| Of those, matching nothing today | **20 (18%)** |
+| `.github/signup-surface.paths` | **100% path globs — every entry moves in the first two extractions** |
+| Runnable guards, exit status at scan time | all green |
+
+An unguarded path-reference layer rots at ~18% *without* a refactor. The
+estate is healthy today — which is exactly why the gate lands before the first
+extraction, not after.
+
+---
+
+## 1. What counts as an extraction
+
+Any PR that **deletes or renames a file under `src/`**. That is the guard's
+trigger and this document's scope. A PR that only edits files in place is not
+an extraction and the gate is inert for it.
+
+---
+
+## 2. The checklist — for each moved path, what must move with it
+
+Read this as: *"I am moving `<old>` to `<new>`. Which artefacts in this repo
+name `<old>` and must be updated in this same PR?"* Every row is derived from
+the KAN-419 register; the section reference points at the evidence.
+
+### 2.1 Machine-checked — the guard fails the PR
+
+| Artefact | Why it breaks | Register |
+|---|---|---|
+| `.github/signup-surface.paths` | 14 patterns, 100% path globs. The signup E2E gate is the **only** thing proving account creation works before staging — the daily soak deliberately does not test signup. A dead glob here is the single highest-consequence failure in the estate. | §1 A1, §4 |
+| `.github/CODEOWNERS` | 17 patterns, incl. per-file security paths. A dead entry means a security-critical file merges unreviewed. | §1 A2 |
+| `scripts/check-ui-copy-ownership.sh` | 20 protected-path patterns. A dead entry means UI/copy ships without Luisa's sign-off. | §1 A3 |
+| `scripts/check-service-role-client.sh` | 2 allow-list literals. Dead ⇒ inline RLS-bypassing clients reappear. | §1 A4 |
+| `stryker.config.mjs` | `mutate` globs. Dead ⇒ mutation coverage of the security modules silently drops to nothing. | §1 A5 |
+| `scripts/check-routine-ownership.sh` | **Doubly coupled** — 11 `check_marker` calls each pair a file literal with a verbatim *content* needle. A move breaks the path half; a rewording breaks the content half. One of its needles asserts a signup-manifest glob verbatim. | §1 D |
+| `docs/DOC_SOURCE_OF_TRUTH.md` | The mirror manifest. `check-doc-mirror-manifest.sh` already fails the PR when a listed path vanishes — this is the existing precedent the new guard generalises. | §1 D |
+| `docs/ARCHITECTURE.md`, `RUNBOOK.md`, `OPS_ROUTINES_CONTROL_ROOM.md`, `TEST_AUDIT_2026Q2.md`, and every other `docs/**` prose reference | The system map goes stale. This is the 18% layer. | §1 D |
+| `modules.json` | The module's `paths` entry. If it does not move, the module manifest describes a codebase that no longer exists. | §1 D |
+| `tests/**` | The module's tests. A test left behind is a test that no longer covers the module it names. | §1 D, KAN-417 |
+| `.github/workflows/*.yml` | 30 `bash scripts/X` literals + Actions `paths:` filters + one anchored `grep -E` on changed paths in `pr-checks.yml`. | §1 D |
+| `tsconfig.json`, `jest.config.js`, `package.json`, `eslint.config.mjs`, `playwright.config.ts` | TS path mapping, `collectCoverageFrom`, `--testPathPatterns`, flat-config globs, `testDir` / `testMatch` / `testIgnore`. | §1 D |
+
+### 2.2 Human-attested — CI can never check these
+
+Two couplings live outside every repository this CI can read. **No grep will
+ever find them.** A ticked box is a weaker control than a machine check, and
+this document is not going to pretend otherwise — it is simply the only control
+available for these two.
+
+| Coupling | What breaks | PR-body line |
+|---|---|---|
+| `~/lyra-design-system/build.py` — on Luisa's machine, in no git repo. Generates 21 `@dsCard` previews and reads `src/app/globals.css` for design tokens. | When `ui-kit` extraction moves `globals.css`, the generator's source pointer breaks — loudly, but on her machine, hours later, and nothing warns the agent that moved the file. (The token *duplication* question — `globals.css` vs `build.py` vs the published Design project, with no drift detection between them — is **KAN-427**, not this document.) | `EXTRACTION-DOD-DESIGN-SYSTEM:` |
+| The claude.ai **routine prompts** — routine config, not git. | The Staging Soak and Backlog Autopilot prompts name `scripts/staging-soak.sh` and protected-surface path lists **verbatim**. `check-ui-copy-ownership.sh` says in its own header that its list is "mirrored 1:1 from the autopilot's protected-surface list so the guard and the robot agree" — so the repo-side guard and the out-of-repo prompt are a manually-maintained duplicate pair, and CI can only see one half. | `EXTRACTION-DOD-ROUTINE-PROMPTS:` |
+
+### 2.3 Coverage — state it or record the gap
+
+Every extraction PR states which **Playwright project** and which **soak
+contract clause (C1–C6)** cover the moved module:
+
+```
+EXTRACTION-DOD-COVERAGE: playwright project `authed`, soak clause C4
+EXTRACTION-DOD-COVERAGE: no coverage
+```
+
+`no coverage` is an acceptable answer and a **finding** — raise it as a ticket.
+Recording the gap is the point; leaving the line vague is what hides it.
+
+KAN-419 §6 confirmed the good news here: `scripts/staging-soak.sh` and the
+Playwright specs are coupled to **URLs** (`/status`, `/join`, `/api/health`,
+`/login`, `/signup`, `/dashboard`, `/{slug}`), not file paths, and the
+extraction plan freezes URLs as a live external API. So the soak's C1/C2/C4
+layer and most E2E are **resilient** to a move. The checked exceptions are
+`tests/e2e/support/*` helper imports and `playwright.config.ts`'s
+`AUTHED_MATCH` / `SOAK_MATCH` / `SIGNUP_MATCH` patterns.
+
+### 2.4 Routine-prompt review
+
+When a moved path is one the routine prompts name verbatim, the PR body must
+**name the affected routine and its trigger ID**, because no PR can update a
+prompt — Luisa does, in the routine config.
+
+| Routine | Trigger ID | Why it is coupled |
+|---|---|---|
+| Staging Soak | `trig_018MWFmc7LSzj15egayKJNrt` | Names `scripts/staging-soak.sh` verbatim. |
+| Backlog Autopilot | `trig_01HniS6vXfGEFR4gvJaLNTM9` | Carries the protected-surface path list verbatim (the `LOOK AND TEXT` surface). |
+| Modularisation Scoping | **not recorded in this repo** — see below | Names repo paths verbatim (plan §E-4). |
+
+> **Open item.** `docs/OPS_ROUTINES_CONTROL_ROOM.md` indexes every routine by
+> trigger ID except the **Modularisation Scoping** routine, which the
+> modularisation plan (§E-4) names as the third path-coupled prompt. Its trigger
+> ID is not recorded anywhere in the repo. Until Luisa adds it to the Control
+> Room table, this row cannot be verified by anyone reading the repo alone —
+> which is precisely the failure mode §2.2 is about. Flagged on KAN-428.
+
+The paths currently known to be named in a prompt are listed in
+`ROUTINE_COUPLED` at the top of `scripts/check-extraction-dod.sh`. Keep that
+array and the prompts in step; it is a manually-maintained mirror, like the
+protected-surface list it partly duplicates.
+
+---
+
+## 3. The PR body
+
+The PR template supplies the three lines. They are machine-read, so the
+markers must appear verbatim; the answer after the colon is free text and must
+be non-empty.
+
+```
+- [ ] EXTRACTION-DOD-DESIGN-SYSTEM: done | n/a — <reason>
+- [ ] EXTRACTION-DOD-ROUTINE-PROMPTS: done | n/a — <reason>
+- [ ] EXTRACTION-DOD-COVERAGE: playwright project `<name>`, soak clause C<n> | no coverage
+```
+
+An extraction PR whose body is **empty or unreadable** fails the gate with
+exit 2. An unverifiable human attestation is a failed one.
+
+---
+
+## 4. The escape hatch
+
+A commit in the PR may carry:
+
+```
+EXTRACTION-DOD-OK: <JIRA-KEY> <check-id>
+```
+
+* It suppresses **exactly one** named check and nothing else.
+* A **Jira key is required**. A bare `EXTRACTION-DOD-OK:` is itself a failure.
+* Every active exception is **printed on every run**, passing or failing —
+  the `UI-Change-Approved` loudness standard. An escape hatch you cannot
+  enumerate is an escape hatch you cannot audit.
+* Exceptions are **counted**. More than three in one PR emits a `::warning::`
+  that the hatch is papering over estate drift rather than recording a
+  considered exception.
+
+Check ids: `stale-refs`, `doc-manifest`, `module-manifest`, `test-estate`,
+`out-of-repo`, `coverage`, `routine-prompts`.
+
+---
+
+## 5. Exit codes and the fail-closed contract
+
+| Exit | Meaning |
+|---:|---|
+| 0 | Pass — including "not an extraction PR", which is the common case. |
+| 1 | A DoD violation: a stale reference, or a missing/unanswered attestation. |
+| 2 | **Cannot verify — fail closed.** |
+
+Exit 2 fires when the diff base cannot be resolved, when an artefact the guard
+must sweep is missing, when a search command itself fails, or when an
+extraction PR has no readable body.
+
+This is deliberately stricter than KAN-411's UI/copy guard, which fails *open*
+on an unresolvable diff base. That guard can afford to: CODEOWNERS still
+hard-gates every path it protects. **There is no second gate underneath this
+one** — it is the control that protects the other controls — so "unknown" must
+never read as "fine". This is the KAN-167 Workflow & Backup Integrity Policy
+applied to a guard rather than a workflow.
+
+---
+
+## 6. What this does *not* catch
+
+Stated plainly, because a control whose limits are undocumented gets trusted
+past them:
+
+1. **Glob deadness.** The guard matches **literal** old paths. If `docs/` names
+   `src/lib/age/**` and you move `src/lib/age/gate.ts`, the literal does not
+   match and this guard stays quiet. That is `check-guard-path-drift.sh`'s job
+   (F1 / KAN-419 §7) — it evaluates every pattern in the estate and fails the
+   ones matching nothing. The two are complements: **F1 catches an inert gate;
+   this catches the move that would make it inert.**
+2. **Test *floors*.** The register asks that the module's floor entry in
+   `modules.json` move with its paths. `modules.json` today (KAN-416 v1) carries
+   `paths` but not floors — floor re-anchoring is F5 and has not landed. The
+   guard therefore checks the `paths` half only. When F5 lands, extend
+   `module-manifest` to the floor entry rather than assuming it is covered.
+3. **The two out-of-repo couplings**, by construction (§2.2).
+4. **Confluence.** The *Architecture & Infrastructure* and *Data Model &
+   Security* pages go stale on a move and no CI can see it. That is the KAN-359
+   Documentation Definition-of-Done's item, already on the PR template.
+
+---
+
+## 7. Provenance
+
+| Source | What it gave this document |
+|---|---|
+| `docs/modularisation/KAN-419-path-coupling.md` | The register — every artefact in §2.1, the 18% measurement, §7.8's companion rule (which is what the `stale-refs` check implements), and both out-of-repo couplings. |
+| `docs/modularisation/LYRA_MODULARISATION_PLAN_2026-07-26.md` §6 Workstream F | The promotion of G2 from a closing phase to a per-extraction gate. |
+| `docs/OPS_ROUTINES_CONTROL_ROOM.md` | The routine trigger IDs in §2.4. |
+| KAN-359 | The Documentation Definition-of-Done this extends. |

--- a/docs/RUNBOOK.md
+++ b/docs/RUNBOOK.md
@@ -213,6 +213,50 @@ The first run produced 20 "violations" of which 15 were false. A gate that cries
 wolf gets switched off; `tests/scripts/check-dependency-rules.test.js` keeps a
 fixture for exactly that blind spot.
 
+## Extraction Definition-of-Done gate (KAN-428)
+
+`scripts/check-extraction-dod.sh` — guard #13, blocking in `pr-checks.yml`,
+registered as `CTL-033`. Full checklist: `docs/MODULARISATION_EXTRACTION_DOD.md`.
+
+**It is inert unless a PR deletes or renames a file under `src/`.** Ordinary PRs
+see one line of output and pass. When it does fire, it enforces the rule that an
+**extraction carries its own estate rework in the same PR**: every artefact that
+classifies a file by its PATH must have moved with it.
+
+Machine-checked (`stale-refs`, `doc-manifest`, `module-manifest`, `test-estate`):
+no literal reference to a moved-from path may remain in `.github/`, `scripts/`,
+`docs/`, `docs/DOC_SOURCE_OF_TRUTH.md`, `modules.json` or `tests/`.
+
+Attested in the PR body, because CI can never check them (`out-of-repo`,
+`coverage`, `routine-prompts`): `~/lyra-design-system/build.py` and the claude.ai
+routine prompts live outside every repository this CI can read, and the covering
+Playwright project + soak clause must be named or `no coverage` recorded as a
+finding. The PR template supplies the three `EXTRACTION-DOD-*` lines, shipped
+with a `FILL-IN` placeholder that fails the gate until it is replaced.
+
+**Why the estate needs a gate at all:** KAN-419 measured `docs/**/*.md` at 110
+path literals, **20 of them (18%) matching nothing**, before a single file was
+moved on purpose. `.github/signup-surface.paths` is 100% path globs and every
+entry moves in the first two extractions — and the signup E2E gate is the only
+thing proving account creation works before staging.
+
+**Exit codes: 0 pass · 1 violation · 2 cannot verify.** It fails *closed* on an
+unresolvable diff base, a missing artefact, or an extraction PR with no readable
+body — deliberately stricter than the KAN-411 UI/copy guard, which can fail open
+because CODEOWNERS still hard-gates its paths. Nothing sits underneath this one.
+
+**Escape hatch:** `EXTRACTION-DOD-OK: <JIRA-KEY> <check-id>` on a commit in the
+PR suppresses exactly one named check. A Jira key is required, every active
+exception is printed on every run, and more than three in one PR emits a
+`::warning::`. Check ids: `stale-refs`, `doc-manifest`, `module-manifest`,
+`test-estate`, `out-of-repo`, `coverage`, `routine-prompts`.
+
+**What it does not catch** (stated so it is not trusted past its limits): dead
+*globs* — it matches literal paths only, so `src/lib/age/**` surviving a move of
+`src/lib/age/gate.ts` is `check-guard-path-drift.sh`'s job (F1); test *floors*,
+which are not in `modules.json` until F5 lands; the two out-of-repo couplings, by
+construction; and Confluence, which the KAN-359 DoD covers.
+
 ## Self-Healing Flows (KAN-233)
 
 The KAN-63 epic established a tiered self-healing automation. As of KAN-233 the **smoke-failure auto-rollback** and **abuse-log foundation** are in place; auto-restart and auto-block at the network edge are tracked under KAN-246 / KAN-247 and require user-provisioned secrets.

--- a/scripts/check-extraction-dod.sh
+++ b/scripts/check-extraction-dod.sh
@@ -1,0 +1,393 @@
+#!/usr/bin/env bash
+# scripts/check-extraction-dod.sh
+#
+# KAN-428 — the Extraction Definition-of-Done gate (guard #13).
+#
+# The modularisation programme's primary activity is MOVING FILES. Everything
+# that classifies a file by its PATH — CI gates, manifests, docs, runbooks,
+# mutation globs, the signup-surface list — keeps reporting green after a move
+# while protecting nothing. KAN-419's inventory measured the baseline: the
+# unguarded doc layer had already rotted to 18% dead path literals before
+# anybody moved a file on purpose.
+#
+# So the estate rework is not a closing phase. It ships in the SAME PR as the
+# move, and this guard is what makes that non-optional.
+#
+# WHAT IT DOES
+#   The guard is INERT unless the PR deletes or renames a file under `src/`
+#   (an "extraction PR"). When it fires, for every moved-FROM path it requires:
+#
+#     stale-refs      no literal reference to the old path remains in
+#                     `.github/`, `scripts/` or `docs/`
+#     doc-manifest    no literal reference remains in
+#                     `docs/DOC_SOURCE_OF_TRUTH.md` (called out separately
+#                     because the doc-mirror guards key off that file)
+#     module-manifest no literal reference remains in `modules.json` — the
+#                     module's path entry moved with it
+#     test-estate     no literal reference remains under `tests/` — the
+#                     module's tests moved with it
+#
+#   and, from the PR body (the template supplies the lines):
+#
+#     out-of-repo     both out-of-repo attestations are answered
+#     coverage        the covering Playwright project + soak clause are named,
+#                     or `no coverage` is recorded as a finding
+#     routine-prompts when a moved path is named verbatim in a claude.ai
+#                     routine prompt, the PR body names the routine + trigger ID
+#
+#   `out-of-repo` and `routine-prompts` are HUMAN attestations, and the DoD doc
+#   says so plainly: `~/lyra-design-system/build.py` and the routine prompts
+#   live outside every repository this CI can read, so no grep will ever see
+#   their drift (KAN-419 §5). A ticked box is weaker than a machine check. It
+#   is not dressed up as equivalent — it is simply the only control available.
+#
+# FAIL-CLOSED (exit 2, never a silent pass — Workflow & Backup Integrity Policy)
+#   * the diff base cannot be resolved, so we cannot tell if this is an
+#     extraction PR at all (unlike KAN-411's UI guard there is no CODEOWNERS
+#     backstop underneath this one, so "unknown" must not mean "fine");
+#   * an artefact we must read is missing or unparseable;
+#   * an extraction PR whose body is unavailable — an unverifiable human
+#     attestation is a failed one.
+#
+# ESCAPE HATCH
+#   A commit in the range may carry:
+#       EXTRACTION-DOD-OK: <JIRA-KEY> <check-id>
+#   It suppresses EXACTLY the named check and nothing else, requires a Jira
+#   key, and every active exception is printed on every run — the
+#   `UI-Change-Approved` loudness standard. Exceptions are counted; more than
+#   3 emits a ::warning:: that the hatch is papering over drift.
+#
+# EXIT CODES
+#   0  pass (including: not an extraction PR)
+#   1  DoD violation
+#   2  cannot verify — fail closed
+#
+# ENV
+#   BASE_REF      default origin/develop
+#   HEAD_REF      default HEAD
+#   PR_BODY       the pull-request description
+#   PR_BODY_FILE  file holding it (takes precedence; used by CI and the tests)
+#
+# See docs/MODULARISATION_EXTRACTION_DOD.md for the per-path checklist this
+# enforces, and docs/modularisation/KAN-419-path-coupling.md for the register
+# it is derived from.
+set -uo pipefail
+
+BASE_REF="${BASE_REF:-origin/develop}"
+HEAD_REF="${HEAD_REF:-HEAD}"
+
+SWEEP_DIRS=(.github scripts docs)
+MANIFEST_DOC="docs/DOC_SOURCE_OF_TRUTH.md"
+MODULE_MANIFEST="modules.json"
+TEST_DIR="tests"
+
+# Paths named verbatim inside claude.ai routine prompts (KAN-419 §5.2). These
+# are prefixes: any moved path at or under one of them needs a routine-prompt
+# review, because the prompt's copy of it cannot be updated by any PR.
+ROUTINE_COUPLED=(
+  "scripts/staging-soak.sh"
+  "scripts/check-ui-copy-ownership.sh"
+  "src/app/globals.css"
+  "src/components"
+  "src/lib/invite-text.ts"
+  "src/lib/convene/invites"
+  "src/lib/beta-access/email.ts"
+  "src/app/dashboard/profile/affiliation-fields.ts"
+  "src/app/dashboard/convene/organise/organise-fields.ts"
+)
+
+die_unverifiable() {
+  echo "::error::check-extraction-dod: $1"
+  echo "::error::  Failing closed (exit 2): this gate protects other gates, so 'cannot verify' must never read as 'fine'."
+  exit 2
+}
+
+# Run a search and print its hits. grep exits 1 for "no match" — which is the
+# answer we want — but >=2 for "the search itself failed", and THAT must never
+# be laundered into a clean result. Hence no error-swallowing fallback anywhere
+# in this script: on a verification command, swallowing an error is
+# indistinguishable from a pass (KAN-167).
+search() {
+  local desc="$1"; shift
+  local out rc
+  out="$("$@" 2>&1)"; rc=$?
+  if [ "$rc" -gt 1 ]; then
+    die_unverifiable "${desc}: the search command failed (exit ${rc}): ${out}"
+  fi
+  [ "$rc" -eq 0 ] && printf '%s\n' "$out"
+  return 0
+}
+
+# Run a git command that must succeed; anything else is unverifiable.
+git_or_die() {
+  local desc="$1"; shift
+  local out rc
+  out="$(git "$@" 2>&1)"; rc=$?
+  if [ "$rc" -ne 0 ]; then
+    die_unverifiable "${desc}: \`git $*\` failed (exit ${rc}): ${out}"
+  fi
+  printf '%s\n' "$out"
+}
+
+# ---------------------------------------------------------------- diff range
+if ! git rev-parse --verify --quiet "$BASE_REF" >/dev/null; then
+  die_unverifiable "base ref '$BASE_REF' not found — cannot compute the change range."
+fi
+MERGE_BASE="$(git merge-base "$BASE_REF" "$HEAD_REF" 2>/dev/null)" || MERGE_BASE=""
+if [ -z "$MERGE_BASE" ]; then
+  die_unverifiable "no merge-base for ${BASE_REF}..${HEAD_REF} — cannot compute the change range."
+fi
+
+# Moved-FROM paths under src/: D (deleted) and R (renamed) entries.
+MOVED=()
+while IFS=$'\t' read -r st old _rest; do
+  [ -z "${st:-}" ] && continue
+  case "$st" in
+    D*|R*) ;;
+    *) continue ;;
+  esac
+  case "$old" in
+    src/*) MOVED+=("$old") ;;
+  esac
+done <<<"$(git_or_die "computing the change range" diff --name-status -M "$MERGE_BASE" "$HEAD_REF")"
+
+if [ "${#MOVED[@]}" -eq 0 ]; then
+  echo "check-extraction-dod: no file under src/ was deleted or renamed in this range — not an extraction PR. OK."
+  exit 0
+fi
+
+echo "check-extraction-dod: extraction PR detected — ${#MOVED[@]} moved path(s) under src/:"
+printf '  moved: %s\n' "${MOVED[@]}"
+
+# ------------------------------------------------------------- escape hatches
+COMMIT_MSGS="$(git_or_die "reading commit messages" log "${MERGE_BASE}..${HEAD_REF}" --format=%B)"
+HATCH_RE='^EXTRACTION-DOD-OK:[[:space:]]*[A-Z][A-Z0-9]+-[0-9]+[[:space:]]+[a-z-]+[[:space:]]*$'
+BARE_HATCH_RE='^EXTRACTION-DOD-OK:'
+
+SUPPRESSED=()
+HATCH_LINES=()
+while IFS= read -r line; do
+  [ -z "$line" ] && continue
+  HATCH_LINES+=("$line")
+done <<<"$(search "escape-hatch scan" grep -E "$BARE_HATCH_RE" - <<<"$COMMIT_MSGS")"
+
+VALID_CHECKS=(stale-refs doc-manifest module-manifest test-estate out-of-repo coverage routine-prompts)
+is_valid_check() {
+  local c="$1" v
+  for v in "${VALID_CHECKS[@]}"; do [ "$c" = "$v" ] && return 0; done
+  return 1
+}
+
+HATCH_BAD=0
+for line in "${HATCH_LINES[@]}"; do
+  # strip trailing CR / whitespace
+  line="${line%$'\r'}"
+  if ! grep -Eq "$HATCH_RE" <<<"$line"; then
+    echo "::error::check-extraction-dod: malformed escape hatch: '${line}'"
+    echo "::error::  required form: 'EXTRACTION-DOD-OK: <JIRA-KEY> <check-id>' — a bare marker, a missing Jira key or a missing check-id is itself a failure."
+    HATCH_BAD=1
+    continue
+  fi
+  key="$(awk '{print $2}' <<<"$line")"
+  chk="$(awk '{print $3}' <<<"$line")"
+  if ! is_valid_check "$chk"; then
+    echo "::error::check-extraction-dod: escape hatch names unknown check '${chk}' (${key}). Known: ${VALID_CHECKS[*]}"
+    HATCH_BAD=1
+    continue
+  fi
+  SUPPRESSED+=("$chk")
+  echo "check-extraction-dod: ACTIVE EXCEPTION — check '${chk}' suppressed by ${key}"
+done
+
+if [ "${#SUPPRESSED[@]}" -gt 3 ]; then
+  echo "::warning::check-extraction-dod: ${#SUPPRESSED[@]} checks suppressed in one PR — the escape hatch is being used to paper over estate drift, not to record a considered exception."
+fi
+
+is_suppressed() {
+  local c="$1" s
+  for s in "${SUPPRESSED[@]:-}"; do [ "$s" = "$c" ] && return 0; done
+  return 1
+}
+
+FAILED=0
+[ "$HATCH_BAD" -eq 1 ] && FAILED=1
+
+# -------------------------------------------------------- reference sweeps
+# Report every remaining literal reference to a moved-from path, with file:line.
+sweep() {
+  local check="$1"; shift
+  local -a targets=("$@")
+  local -a present=()
+  local t
+  for t in "${targets[@]}"; do
+    [ -e "$t" ] && present+=("$t")
+  done
+  if [ "${#present[@]}" -eq 0 ]; then
+    die_unverifiable "check '${check}': none of the artefacts [${targets[*]}] exist — the estate cannot be swept."
+  fi
+  if is_suppressed "$check"; then
+    echo "check-extraction-dod: [${check}] SKIPPED by an active exception."
+    return 0
+  fi
+  local hits=0 old
+  for old in "${MOVED[@]}"; do
+    local out
+    out="$(search "${check} sweep for '${old}'" grep -rnF --exclude-dir=node_modules -- "$old" "${present[@]}")"
+    if [ -n "$out" ]; then
+      hits=1
+      echo "::error::check-extraction-dod: [${check}] stale reference to moved path '${old}':"
+      while IFS= read -r hit; do
+        [ -z "$hit" ] && continue
+        echo "::error::    ${hit}"
+      done <<<"$out"
+    fi
+  done
+  if [ "$hits" -eq 1 ]; then
+    FAILED=1
+  else
+    echo "check-extraction-dod: [${check}] clean — no moved path is still referenced."
+  fi
+}
+
+# `stale-refs` owns .github/ + scripts/ + docs/, minus the mirror manifest,
+# which `doc-manifest` owns so the two can be excepted independently.
+SWEEP_PRESENT=()
+for d in "${SWEEP_DIRS[@]}"; do [ -d "$d" ] && SWEEP_PRESENT+=("$d"); done
+if [ "${#SWEEP_PRESENT[@]}" -eq 0 ]; then
+  die_unverifiable "none of the estate directories [${SWEEP_DIRS[*]}] exist — the estate cannot be swept."
+fi
+if is_suppressed stale-refs; then
+  echo "check-extraction-dod: [stale-refs] SKIPPED by an active exception."
+else
+  hits=0
+  for old in "${MOVED[@]}"; do
+    out="$(search "stale-refs sweep for '${old}'" grep -rnF --exclude-dir=node_modules -- "$old" "${SWEEP_PRESENT[@]}")"
+    out="$(search "stale-refs manifest split" grep -vF "${MANIFEST_DOC}:" - <<<"$out")"
+    [ -z "${out//[[:space:]]/}" ] && out=""
+    if [ -n "$out" ]; then
+      hits=1
+      echo "::error::check-extraction-dod: [stale-refs] stale reference to moved path '${old}':"
+      while IFS= read -r hit; do
+        [ -z "$hit" ] && continue
+        echo "::error::    ${hit}"
+      done <<<"$out"
+    fi
+  done
+  if [ "$hits" -eq 1 ]; then FAILED=1; else
+    echo "check-extraction-dod: [stale-refs] clean — no moved path is still referenced in ${SWEEP_PRESENT[*]}."
+  fi
+fi
+
+sweep doc-manifest "$MANIFEST_DOC"
+sweep module-manifest "$MODULE_MANIFEST"
+sweep test-estate "$TEST_DIR"
+
+# ------------------------------------------------------- PR-body attestations
+PR_BODY_TEXT=""
+if [ -n "${PR_BODY_FILE:-}" ]; then
+  [ -f "$PR_BODY_FILE" ] || die_unverifiable "PR_BODY_FILE '$PR_BODY_FILE' does not exist."
+  PR_BODY_TEXT="$(cat "$PR_BODY_FILE")"
+else
+  PR_BODY_TEXT="${PR_BODY:-}"
+fi
+
+if [ -z "${PR_BODY_TEXT//[[:space:]]/}" ]; then
+  die_unverifiable "this is an extraction PR but the PR body is empty or unavailable — the out-of-repo attestations cannot be read, and an unverifiable human attestation is a failed one."
+fi
+
+# An attestation line must carry a non-empty answer after the colon.
+attest() {
+  local check="$1" marker="$2" what="$3"
+  if is_suppressed "$check"; then
+    echo "check-extraction-dod: [${check}] SKIPPED by an active exception."
+    return 0
+  fi
+  local line
+  line="$(search "${check} attestation scan" grep -m1 -E "^[[:space:]]*[-*]?[[:space:]]*(\[[ xX]\][[:space:]]*)?${marker}" - <<<"$PR_BODY_TEXT")"
+  if [ -z "$line" ]; then
+    echo "::error::check-extraction-dod: [${check}] the PR body has no '${marker}' line. ${what}"
+    FAILED=1
+    return 0
+  fi
+  local answer="${line#*${marker}}"
+  answer="${answer#:}"
+  answer="$(sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//' <<<"$answer")"
+  if [ -z "$answer" ]; then
+    echo "::error::check-extraction-dod: [${check}] '${marker}' is present but unanswered. ${what}"
+    FAILED=1
+    return 0
+  fi
+  # An unedited template placeholder is not an attestation. The PR template
+  # ships `FILL-IN` as the answer precisely so that leaving it fails.
+  case "$answer" in
+    *FILL-IN*)
+      echo "::error::check-extraction-dod: [${check}] '${marker}' still carries the unedited template placeholder (FILL-IN). ${what}"
+      FAILED=1
+      return 0
+      ;;
+  esac
+  echo "check-extraction-dod: [${check}] attested — ${marker} ${answer}"
+  return 0
+}
+
+attest out-of-repo "EXTRACTION-DOD-DESIGN-SYSTEM" \
+  "If this PR moves src/app/globals.css or any ui-kit file, the source pointer in ~/lyra-design-system/build.py must be updated and the generator re-run before merge (KAN-419 §5.1). Answer 'done' or 'n/a — <reason>'. CI cannot check this: build.py is on Luisa's machine and in no git repo."
+
+attest out-of-repo "EXTRACTION-DOD-ROUTINE-PROMPTS" \
+  "If this PR renames a script or changes a protected-surface path list named verbatim in a claude.ai routine prompt, the prompt must be updated in the same session (KAN-419 §5.2). Answer 'done' or 'n/a — <reason>'. CI cannot check this: routine prompts are not in git."
+
+attest coverage "EXTRACTION-DOD-COVERAGE" \
+  "Name the Playwright project and the soak contract clause (C1-C6) covering the moved module, or write 'no coverage' — recording the gap is a finding, hiding it is a regression."
+
+# routine-prompts: only fires when a moved path is one the prompts name verbatim.
+ROUTINE_HITS=()
+for old in "${MOVED[@]}"; do
+  for rc in "${ROUTINE_COUPLED[@]}"; do
+    case "$old" in
+      "$rc"|"$rc"/*) ROUTINE_HITS+=("$old") ;;
+    esac
+  done
+done
+
+if [ "${#ROUTINE_HITS[@]}" -eq 0 ]; then
+  echo "check-extraction-dod: [routine-prompts] no moved path is named in a routine prompt — not applicable."
+elif is_suppressed routine-prompts; then
+  echo "check-extraction-dod: [routine-prompts] SKIPPED by an active exception."
+else
+  printf '::warning::check-extraction-dod: moved path is named verbatim in a claude.ai routine prompt: %s\n' "${ROUTINE_HITS[@]}"
+  if grep -qE 'trig_[A-Za-z0-9]+' <<<"$PR_BODY_TEXT"; then
+    echo "check-extraction-dod: [routine-prompts] PR body names a routine trigger ID. OK."
+  else
+    echo "::error::check-extraction-dod: [routine-prompts] this PR moves a path named verbatim in a claude.ai routine prompt, but the PR body names no routine trigger ID."
+    echo "::error::  Name the affected routine and its trig_… ID (see docs/OPS_ROUTINES_CONTROL_ROOM.md). Luisa updates the prompt; no PR can."
+    FAILED=1
+  fi
+fi
+
+# ------------------------------------------------------------------- verdict
+if [ "${#SUPPRESSED[@]}" -gt 0 ]; then
+  echo "check-extraction-dod: ${#SUPPRESSED[@]} active exception(s) this run: ${SUPPRESSED[*]}"
+fi
+
+if [ "$FAILED" -eq 0 ]; then
+  echo "check-extraction-dod: extraction Definition-of-Done satisfied. OK."
+  exit 0
+fi
+
+cat <<'EOF'
+
+The Extraction Definition-of-Done (KAN-428) is not satisfied. An extraction
+carries its own estate rework in the SAME PR — see
+docs/MODULARISATION_EXTRACTION_DOD.md for the per-path checklist, and
+docs/modularisation/KAN-419-path-coupling.md for why (an unguarded path layer
+rots at 18% before anyone moves a file on purpose).
+
+Fix the references, or record a considered exception on a commit in this PR:
+
+  EXTRACTION-DOD-OK: <JIRA-KEY> <check-id>
+
+which suppresses exactly one check. Known check-ids:
+  stale-refs  doc-manifest  module-manifest  test-estate
+  out-of-repo  coverage  routine-prompts
+EOF
+exit 1

--- a/scripts/check-extraction-dod.sh
+++ b/scripts/check-extraction-dod.sh
@@ -232,7 +232,7 @@ sweep() {
   local hits=0 old
   for old in "${MOVED[@]}"; do
     local out
-    out="$(search "${check} sweep for '${old}'" grep -rnF --exclude-dir=node_modules -- "$old" "${present[@]}")"
+    out="$(search "${check} sweep for '${old}'" grep -rnHF --exclude-dir=node_modules -- "$old" "${present[@]}")"
     if [ -n "$out" ]; then
       hits=1
       echo "::error::check-extraction-dod: [${check}] stale reference to moved path '${old}':"
@@ -261,7 +261,7 @@ if is_suppressed stale-refs; then
 else
   hits=0
   for old in "${MOVED[@]}"; do
-    out="$(search "stale-refs sweep for '${old}'" grep -rnF --exclude-dir=node_modules -- "$old" "${SWEEP_PRESENT[@]}")"
+    out="$(search "stale-refs sweep for '${old}'" grep -rnHF --exclude-dir=node_modules -- "$old" "${SWEEP_PRESENT[@]}")"
     out="$(search "stale-refs manifest split" grep -vF "${MANIFEST_DOC}:" - <<<"$out")"
     [ -z "${out//[[:space:]]/}" ] && out=""
     if [ -n "$out" ]; then

--- a/tests/scripts/check-extraction-dod.test.js
+++ b/tests/scripts/check-extraction-dod.test.js
@@ -1,0 +1,379 @@
+const { execSync } = require('child_process');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const REPO_ROOT = path.resolve(__dirname, '../../');
+const SCRIPT = path.resolve(REPO_ROOT, 'scripts/check-extraction-dod.sh');
+
+// A PR body that answers every attestation. Individual tests override it.
+const FULL_BODY = [
+  '## Summary',
+  'Move the age module.',
+  '- [x] EXTRACTION-DOD-DESIGN-SYSTEM: n/a — no ui-kit path moved',
+  '- [x] EXTRACTION-DOD-ROUTINE-PROMPTS: n/a — no prompt-named path moved',
+  '- [x] EXTRACTION-DOD-COVERAGE: playwright project `authed`, soak clause C4',
+].join('\n');
+
+// Build a throwaway repo carrying a minimal version of the real estate:
+// .github/, scripts/, docs/ (incl. the mirror manifest), modules.json, tests/.
+// `estate` lets a test plant a stale reference in exactly one artefact.
+function makeRepo({ estate = {}, extra = {} } = {}) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'extrdod-'));
+  const write = (rel, content) => {
+    const abs = path.join(dir, rel);
+    fs.mkdirSync(path.dirname(abs), { recursive: true });
+    fs.writeFileSync(abs, content);
+  };
+  const git = (args) => execSync(`git ${args}`, { cwd: dir, stdio: 'pipe' }).toString();
+
+  git('init -q');
+  git('config user.email test@example.com');
+  git('config user.name tester');
+  git('config commit.gpgsign false');
+
+  // --- baseline estate on develop, all pointing at the pre-move path ---
+  write('src/lib/age/gate.ts', 'export const gate = 1;\n');
+  write('.github/CODEOWNERS', '* @luisa\n/src/lib/age/gate.ts @luisa\n');
+  write('scripts/some-guard.sh', '#!/usr/bin/env bash\ngrep -q x src/lib/age/gate.ts\n');
+  write('docs/ARCHITECTURE.md', 'The age gate lives at `src/lib/age/gate.ts`.\n');
+  write(
+    'docs/DOC_SOURCE_OF_TRUTH.md',
+    '<!-- doc-mirror-manifest:start -->\n| `src/lib/age/gate.ts` | wiki |\n<!-- doc-mirror-manifest:end -->\n'
+  );
+  write('modules.json', JSON.stringify({ modules: { age: { paths: ['src/lib/age/gate.ts'] } } }, null, 2));
+  write('tests/unit/age-gate.test.js', "require('../../src/lib/age/gate.ts');\n");
+  for (const [rel, content] of Object.entries(extra)) write(rel, content);
+  git('add -A');
+  git('commit -q -m "chore: baseline estate"');
+  git('branch -M develop');
+
+  return { dir, write, git };
+}
+
+// Perform the move on a feature branch. `estate` maps artefact path -> the
+// content it should hold AFTER the move; anything omitted keeps its stale
+// reference, which is exactly what the guard should catch.
+function runMove({
+  estate = {},
+  body = FULL_BODY,
+  commitMessage = 'refactor: extract age module',
+  from = 'src/lib/age/gate.ts',
+  to = 'modules/age/gate.ts',
+  baseRef = 'develop',
+  omitBody = false,
+  deleteArtefact = null,
+  noMove = false,
+} = {}) {
+  const { dir, write, git } = makeRepo();
+  git('checkout -q -b feature');
+
+  if (noMove) {
+    write('src/lib/age/gate.ts', 'export const gate = 2;\n');
+  } else {
+    const absFrom = path.join(dir, from);
+    const absTo = path.join(dir, to);
+    fs.mkdirSync(path.dirname(absTo), { recursive: true });
+    fs.renameSync(absFrom, absTo);
+  }
+
+  // Default: every artefact is updated to the new path (the passing case).
+  const updated = {
+    '.github/CODEOWNERS': `* @luisa\n/${to} @luisa\n`,
+    'scripts/some-guard.sh': `#!/usr/bin/env bash\ngrep -q x ${to}\n`,
+    'docs/ARCHITECTURE.md': `The age gate lives at \`${to}\`.\n`,
+    'docs/DOC_SOURCE_OF_TRUTH.md': `<!-- doc-mirror-manifest:start -->\n| \`${to}\` | wiki |\n<!-- doc-mirror-manifest:end -->\n`,
+    'modules.json': JSON.stringify({ modules: { age: { paths: [to] } } }, null, 2),
+    'tests/unit/age-gate.test.js': `require('../../${to}');\n`,
+    ...estate,
+  };
+  if (!noMove) for (const [rel, content] of Object.entries(updated)) write(rel, content);
+  if (deleteArtefact) fs.rmSync(path.join(dir, deleteArtefact), { recursive: true, force: true });
+
+  git('add -A');
+  const msgFile = path.join(dir, '.msg');
+  fs.writeFileSync(msgFile, commitMessage);
+  git(`commit -q -F ${JSON.stringify(msgFile)}`);
+  fs.rmSync(msgFile, { force: true });
+
+  const env = { ...process.env, BASE_REF: baseRef, HEAD_REF: 'HEAD' };
+  if (omitBody) {
+    delete env.PR_BODY;
+  } else {
+    env.PR_BODY = body;
+  }
+
+  let status = 0;
+  let output = '';
+  try {
+    output = execSync(`bash "${SCRIPT}"`, { cwd: dir, stdio: 'pipe', env }).toString();
+  } catch (err) {
+    status = err.status || 1;
+    output = `${err.stdout || ''}${err.stderr || ''}`;
+  }
+  fs.rmSync(dir, { recursive: true, force: true });
+  return { status, output };
+}
+
+describe('scripts/check-extraction-dod.sh', () => {
+  let source = '';
+  beforeAll(() => {
+    source = fs.readFileSync(SCRIPT, 'utf8');
+  });
+
+  it('exists and is a bash script', () => {
+    expect(fs.existsSync(SCRIPT)).toBe(true);
+    expect(source.startsWith('#!/usr/bin/env bash')).toBe(true);
+  });
+
+  it('is syntactically valid (bash -n)', () => {
+    expect(() => execSync(`bash -n "${SCRIPT}"`, { stdio: 'pipe' })).not.toThrow();
+  });
+
+  it('is hardened against unset vars and pipe failures', () => {
+    expect(source).toMatch(/set -uo pipefail/);
+  });
+
+  it('carries no forbidden silent-skip pattern (KAN-167)', () => {
+    expect(source).not.toMatch(/continue-on-error/);
+    expect(source).not.toMatch(/\|\|\s*true\b/);
+    expect(source).not.toMatch(/if:\s*env\./);
+  });
+
+  it('documents its three exit codes and the escape hatch', () => {
+    expect(source).toMatch(/EXTRACTION-DOD-OK/);
+    expect(source).toMatch(/exit 2/);
+  });
+
+  // ---------------------------------------------------------------- inert
+  it('passes and does nothing when no src/ file was moved', () => {
+    const { status, output } = runMove({ noMove: true });
+    expect(status).toBe(0);
+    expect(output).toMatch(/not an extraction PR/);
+  });
+
+  // ---------------------------------------------------------------- happy
+  it('passes when every artefact was updated and the PR body attests', () => {
+    const { status, output } = runMove();
+    expect(status).toBe(0);
+    expect(output).toMatch(/extraction Definition-of-Done satisfied/);
+    expect(output).toMatch(/\[stale-refs\] clean/);
+    expect(output).toMatch(/\[module-manifest\] clean/);
+    expect(output).toMatch(/\[test-estate\] clean/);
+  });
+
+  // ------------------------------------------------------------ violations
+  it('fails, naming file and line, when a stale reference remains in .github/', () => {
+    const { status, output } = runMove({
+      estate: { '.github/CODEOWNERS': '* @luisa\n/src/lib/age/gate.ts @luisa\n' },
+    });
+    expect(status).toBe(1);
+    expect(output).toMatch(/\[stale-refs\] stale reference to moved path 'src\/lib\/age\/gate\.ts'/);
+    expect(output).toMatch(/\.github\/CODEOWNERS:2:/);
+  });
+
+  it('fails when a stale reference remains in scripts/ or docs/', () => {
+    const { status, output } = runMove({
+      estate: { 'docs/ARCHITECTURE.md': 'The age gate lives at `src/lib/age/gate.ts`.\n' },
+    });
+    expect(status).toBe(1);
+    expect(output).toMatch(/docs\/ARCHITECTURE\.md:1:/);
+  });
+
+  it('fails when the moved path is still named in DOC_SOURCE_OF_TRUTH.md', () => {
+    const { status, output } = runMove({
+      estate: {
+        'docs/DOC_SOURCE_OF_TRUTH.md':
+          '<!-- doc-mirror-manifest:start -->\n| `src/lib/age/gate.ts` | wiki |\n<!-- doc-mirror-manifest:end -->\n',
+      },
+    });
+    expect(status).toBe(1);
+    expect(output).toMatch(/\[doc-manifest\] stale reference/);
+  });
+
+  it("fails when the module's entry in modules.json did not move with it", () => {
+    const { status, output } = runMove({
+      estate: {
+        'modules.json': JSON.stringify({ modules: { age: { paths: ['src/lib/age/gate.ts'] } } }, null, 2),
+      },
+    });
+    expect(status).toBe(1);
+    expect(output).toMatch(/\[module-manifest\] stale reference/);
+  });
+
+  it("fails when the module's tests did not move with it", () => {
+    const { status, output } = runMove({
+      estate: { 'tests/unit/age-gate.test.js': "require('../../src/lib/age/gate.ts');\n" },
+    });
+    expect(status).toBe(1);
+    expect(output).toMatch(/\[test-estate\] stale reference/);
+  });
+
+  it('fails when an out-of-repo attestation line is absent from the PR body', () => {
+    const { status, output } = runMove({
+      body: '## Summary\n- [x] EXTRACTION-DOD-COVERAGE: playwright `authed`, C4\n',
+    });
+    expect(status).toBe(1);
+    expect(output).toMatch(/\[out-of-repo\] the PR body has no 'EXTRACTION-DOD-DESIGN-SYSTEM' line/);
+  });
+
+  it('fails when an attestation line is present but unanswered', () => {
+    const { status, output } = runMove({
+      body: FULL_BODY.replace('EXTRACTION-DOD-DESIGN-SYSTEM: n/a — no ui-kit path moved', 'EXTRACTION-DOD-DESIGN-SYSTEM:'),
+    });
+    expect(status).toBe(1);
+    expect(output).toMatch(/present but unanswered/);
+  });
+
+  it('fails when the template placeholder was never edited', () => {
+    const { status, output } = runMove({
+      body: FULL_BODY.replace(
+        'EXTRACTION-DOD-ROUTINE-PROMPTS: n/a — no prompt-named path moved',
+        'EXTRACTION-DOD-ROUTINE-PROMPTS: FILL-IN'
+      ),
+    });
+    expect(status).toBe(1);
+    expect(output).toMatch(/still carries the unedited template placeholder/);
+  });
+
+  it('fails when the coverage line names neither a project nor "no coverage"', () => {
+    const { status, output } = runMove({
+      body: FULL_BODY.split('\n').filter((l) => !l.includes('COVERAGE')).join('\n'),
+    });
+    expect(status).toBe(1);
+    expect(output).toMatch(/\[coverage\] the PR body has no 'EXTRACTION-DOD-COVERAGE' line/);
+  });
+
+  it('accepts "no coverage" as an honest finding', () => {
+    const { status } = runMove({
+      body: FULL_BODY.replace(/EXTRACTION-DOD-COVERAGE:.*/, 'EXTRACTION-DOD-COVERAGE: no coverage'),
+    });
+    expect(status).toBe(0);
+  });
+
+  // ---------------------------------------------------- routine-prompt rule
+  it('reports routine-prompts as not applicable when no coupled path moved', () => {
+    const { status, output } = runMove();
+    expect(status).toBe(0);
+    expect(output).toMatch(/\[routine-prompts\] no moved path is named in a routine prompt/);
+  });
+
+  // --------------------------------------------------------- fail-closed
+  it('exits 2 when the diff base cannot be resolved', () => {
+    const { status, output } = runMove({ baseRef: 'origin/nope' });
+    expect(status).toBe(2);
+    expect(output).toMatch(/cannot compute the change range/);
+  });
+
+  it('exits 2 when an extraction PR has no readable body', () => {
+    const { status, output } = runMove({ omitBody: true });
+    expect(status).toBe(2);
+    expect(output).toMatch(/PR body is empty or unavailable/);
+  });
+
+  it('exits 2 when an artefact it must sweep is missing', () => {
+    const { status, output } = runMove({ deleteArtefact: 'modules.json' });
+    expect(status).toBe(2);
+    expect(output).toMatch(/check 'module-manifest'.*cannot be swept/s);
+  });
+
+  // -------------------------------------------------------- escape hatch
+  it('suppresses exactly the named check and nothing else', () => {
+    const { status, output } = runMove({
+      estate: {
+        '.github/CODEOWNERS': '* @luisa\n/src/lib/age/gate.ts @luisa\n',
+        'modules.json': JSON.stringify({ modules: { age: { paths: ['src/lib/age/gate.ts'] } } }, null, 2),
+      },
+      commitMessage: 'refactor: extract age module\n\nEXTRACTION-DOD-OK: KAN-428 stale-refs\n',
+    });
+    expect(status).toBe(1);
+    expect(output).toMatch(/\[stale-refs\] SKIPPED by an active exception/);
+    expect(output).toMatch(/\[module-manifest\] stale reference/);
+  });
+
+  it('prints every active exception even on a passing run', () => {
+    const { status, output } = runMove({
+      commitMessage: 'refactor: extract age module\n\nEXTRACTION-DOD-OK: KAN-428 coverage\n',
+    });
+    expect(status).toBe(0);
+    expect(output).toMatch(/ACTIVE EXCEPTION — check 'coverage' suppressed by KAN-428/);
+    expect(output).toMatch(/1 active exception\(s\) this run: coverage/);
+  });
+
+  it('rejects an escape hatch with no Jira key', () => {
+    const { status, output } = runMove({
+      commitMessage: 'refactor: extract age module\n\nEXTRACTION-DOD-OK: stale-refs\n',
+    });
+    expect(status).toBe(1);
+    expect(output).toMatch(/malformed escape hatch/);
+  });
+
+  it('rejects an escape hatch naming an unknown check', () => {
+    const { status, output } = runMove({
+      commitMessage: 'refactor: extract age module\n\nEXTRACTION-DOD-OK: KAN-428 everything\n',
+    });
+    expect(status).toBe(1);
+    expect(output).toMatch(/unknown check 'everything'/);
+  });
+});
+
+// The routine-prompt rule needs a move of a path the prompts actually name.
+describe('scripts/check-extraction-dod.sh — routine-prompt coupling', () => {
+  function runCoupledMove({ body }) {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'extrdod-rc-'));
+    const write = (rel, content) => {
+      const abs = path.join(dir, rel);
+      fs.mkdirSync(path.dirname(abs), { recursive: true });
+      fs.writeFileSync(abs, content);
+    };
+    const git = (args) => execSync(`git ${args}`, { cwd: dir, stdio: 'pipe' }).toString();
+    git('init -q');
+    git('config user.email test@example.com');
+    git('config user.name tester');
+    git('config commit.gpgsign false');
+    write('src/components/Card.tsx', 'export const Card = () => null;\n');
+    write('.github/CODEOWNERS', '* @luisa\n');
+    write('scripts/keep.sh', '#!/usr/bin/env bash\ntrue\n');
+    write('docs/ARCHITECTURE.md', 'docs\n');
+    write('docs/DOC_SOURCE_OF_TRUTH.md', '<!-- doc-mirror-manifest:start -->\n<!-- doc-mirror-manifest:end -->\n');
+    write('modules.json', '{"modules":{}}\n');
+    write('tests/unit/keep.test.js', 'test("x", () => {});\n');
+    git('add -A');
+    git('commit -q -m "chore: baseline"');
+    git('branch -M develop');
+    git('checkout -q -b feature');
+    fs.mkdirSync(path.join(dir, 'modules/ui-kit'), { recursive: true });
+    fs.renameSync(path.join(dir, 'src/components/Card.tsx'), path.join(dir, 'modules/ui-kit/Card.tsx'));
+    git('add -A');
+    git('commit -q -m "refactor: extract ui-kit"');
+
+    let status = 0;
+    let output = '';
+    try {
+      output = execSync(`bash "${SCRIPT}"`, {
+        cwd: dir,
+        stdio: 'pipe',
+        env: { ...process.env, BASE_REF: 'develop', HEAD_REF: 'HEAD', PR_BODY: body },
+      }).toString();
+    } catch (err) {
+      status = err.status || 1;
+      output = `${err.stdout || ''}${err.stderr || ''}`;
+    }
+    fs.rmSync(dir, { recursive: true, force: true });
+    return { status, output };
+  }
+
+  it('fails when a prompt-named path moves and the PR body names no trigger ID', () => {
+    const { status, output } = runCoupledMove({ body: FULL_BODY });
+    expect(status).toBe(1);
+    expect(output).toMatch(/\[routine-prompts\].*names no routine trigger ID/);
+  });
+
+  it('passes once the PR body names the affected routine by trigger ID', () => {
+    const { status, output } = runCoupledMove({
+      body: `${FULL_BODY}\nAffected routine: Backlog Autopilot trig_01HniS6vXfGEFR4gvJaLNTM9\n`,
+    });
+    expect(status).toBe(0);
+    expect(output).toMatch(/\[routine-prompts\] PR body names a routine trigger ID/);
+  });
+});


### PR DESCRIPTION
## Summary

KAN-428 (F11). **An extraction carries its own estate rework in the SAME PR.** The modularisation plan sequenced docs/verification rework as a closing phase (G2) — that is how a refactor leaves stale runbooks and inert gates behind it while CI stays green.

KAN-419 measured the baseline *before* a single file was moved on purpose: **110 path literals across `docs/**/*.md`, 20 of them (18%) matching nothing.** `.github/signup-surface.paths` is 100% path globs and every entry moves in the first two extractions — and the signup E2E gate is the only thing proving account creation works before staging.

**New: `scripts/check-extraction-dod.sh`** (guard #13, `CTL-033`, blocking in `pr-checks.yml`). **Inert unless a PR deletes or renames a file under `src/`** — ordinary PRs get one line of output and pass (verified against this PR itself).

When it fires:
- **Machine-checked** — no literal reference to a moved-from path may remain in `.github/`, `scripts/`, `docs/`, `docs/DOC_SOURCE_OF_TRUTH.md`, `modules.json` or `tests/`.
- **Human-attested** — the PR body must answer the two couplings CI can *never* see: `~/lyra-design-system/build.py` and the claude.ai routine prompts, neither of which lives in any repo this CI can read (KAN-419 §5). The doc says plainly that a ticked box is weaker than a machine check rather than dressing it up as equivalent.
- **Coverage** — name the Playwright project + soak clause (C1–C6), or record `no coverage`, which is an acceptable answer and a finding.

**Fails closed (exit 2)** on an unresolvable diff base, a missing artefact, a failed search, or an extraction PR with no readable body. Deliberately stricter than KAN-411's UI guard, which can fail *open* because CODEOWNERS still hard-gates its paths — nothing sits underneath this one. No error-swallowing fallback anywhere: grep exit 1 is "no match", exit ≥2 is a failure that must never be laundered into a clean result (KAN-167).

**Escape hatch** `EXTRACTION-DOD-OK: <JIRA-KEY> <check-id>` suppresses exactly one named check, requires a Jira key, is printed on every run and counted (>3 ⇒ `::warning::`).

### Proved by mutation, not asserted

A real extraction on a throwaway branch (`git mv src/lib/deploy-env.ts …`) took the guard red, naming **five** artefacts that would otherwise have rotted silently — `pr-checks.yml`, `kan416-derive.py`, the modularisation plan, `RUNBOOK.md`, and 4 entries in `modules.json`. That run also surfaced a cosmetic defect the unit fixtures missed (single-file sweeps omitted the filename), fixed in the second commit.

### Stated limits

`docs/MODULARISATION_EXTRACTION_DOD.md` §6 records what this does **not** catch, so it is not trusted past them: dead *globs* (literal matching only — that is F1's `check-guard-path-drift.sh`); test **floors** (`modules.json` carries `paths` but not floors until F5 lands); the two out-of-repo couplings by construction; and Confluence, which the KAN-359 DoD already covers.

**One open item for Luisa:** the DoD lists the routine trigger IDs for Staging Soak and Backlog Autopilot, but the **Modularisation Scoping** routine — named in plan §E-4 as the third path-coupled prompt — has **no trigger ID recorded anywhere in the repo**. Until it is added to `docs/OPS_ROUTINES_CONTROL_ROOM.md`, that row can't be verified from the repo alone, which is exactly the failure mode §2.2 is about.

## Jira Ticket

KAN-428

## Checklist

- [x] Unit tests added/updated for new/changed functionality — 27 new in `tests/scripts/check-extraction-dod.test.js`, incl. both fail-closed cases and the suppresses-exactly-one case. **No existing test modified, weakened or skipped.**
- [x] All existing tests pass (`npm run test:unit`) — **2604 passed / 221 suites**
- [x] Lint passes (`npm run lint`) — 0 errors (25 pre-existing warnings, unchanged)
- [x] Type check passes — N/A, no TypeScript changed
- [x] Build succeeds — N/A, no application code changed
- [x] Coverage has not decreased — net new tests only
- [x] No eslint-disable or ts-ignore without KAN-XX reference
- [x] Dependency-rule gate reviewed — no `src/` import changed, so no new `no-module-to-app` / `no-cross-segment-app` / `no-circular` violation
- [ ] ARCHITECTURE.md updated if architectural changes were made — N/A: no service, route, table or env var added
- [x] Ops routine / Control-Room registry updated — N/A for cadence/ownership; the gate **reads** the routine trigger IDs and flags the missing Modularisation Scoping entry above
- [x] Docs / system map updated — `docs/MODULARISATION_EXTRACTION_DOD.md` (new), `docs/RUNBOOK.md` (new gate section), `controls/registry.json` (CTL-033), PR template

Also verified: `check-control-registry.py` ✓, `check-bash-portability.py` ✓ (bash 3.2-clean, gotcha #28), `check-workflow-integrity.sh` ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NzJ9D5oZZKH1KHNKMAD9aE

---
_Generated by [Claude Code](https://claude.ai/code/session_01NzJ9D5oZZKH1KHNKMAD9aE)_