### PR TITLE
fix(SEC-111): three CI guards reported a green tick on a scan that never ran

### DIFF
--- a/scripts/check-server-action-exports.sh
+++ b/scripts/check-server-action-exports.sh
@@ -19,12 +19,37 @@
 
 set -euo pipefail
 
+# Run a search and put its hits in SEARCH_OUT. grep exits 1 for "no match" — the
+# answer we want — but >=2 when the search ITSELF failed, and that must never be
+# laundered into a clean result. This scan's clean result is "exit 0, nothing to
+# see", so a bare `|| true` here turns an unreadable src/ into a green build with
+# the BUGS-12 control silently absent — the KAN-167 false-green class, and the
+# same defect KAN-428's guard shipped with in its first cut. Exit 2 = unverified.
+SEARCH_OUT=""
+search_or_die() {
+  local desc="$1"; shift
+  local rc=0
+  if SEARCH_OUT="$("$@" 2>&1)"; then rc=0; else rc=$?; fi
+  if [ "$rc" -gt 1 ]; then
+    echo "::error::check-server-action-exports: ${desc}: the search command failed (exit ${rc}): ${SEARCH_OUT}"
+    echo "::error::  Failing closed (exit 2) rather than reporting a clean scan that never ran."
+    exit 2
+  fi
+  [ "$rc" -eq 1 ] && SEARCH_OUT=""
+  return 0
+}
+
 # All files in src/ whose first non-empty line is a `'use server'` directive.
 # (Some `'use server'` directives appear inline in client files for actions —
 # we restrict to module-level by checking the first ~5 lines.)
 # Written portably for bash 3.2 (macOS) and bash 5.x (Ubuntu CI).
+search_or_die "listing 'use server' files under src/" \
+  grep -rl --include='*.ts' --include='*.tsx' "'use server'" src/
+CANDIDATE_FILES="$SEARCH_OUT"
+
 USE_SERVER_FILES=$(
-  grep -rln --include='*.ts' --include='*.tsx' "'use server'" src/ 2>/dev/null | while read -r f; do
+  printf '%s\n' "$CANDIDATE_FILES" | while read -r f; do
+    [ -z "$f" ] && continue
     if head -5 "$f" | grep -qE "^['\"]use server['\"];?[[:space:]]*$"; then
       echo "$f"
     fi
@@ -54,6 +79,12 @@ while IFS= read -r f; do
   #   export type X         ← types are erased at compile time
   #   export async function ← the only legal runtime export
   #   export { foo }        ← re-exports are runtime checked at the source module
+  # NB: search_or_die must run in THIS shell, not inside $( ), or its exit 2
+  # would only leave the subshell and the scan would carry on regardless.
+  # `export async function` does not match — that is the one legal export.
+  search_or_die "scanning $f for non-async exports" \
+    grep -nE '^export (const|let|var|class|enum|interface|function) [A-Za-z_]' "$f"
+  EXPORT_LINES="$SEARCH_OUT"
   while IFS=: read -r linenum content; do
     [ -z "$linenum" ] && continue
     # Allow-list comment
@@ -62,10 +93,9 @@ while IFS= read -r f; do
     fi
     echo "::error file=$f,line=$linenum::Non-async-function export in 'use server' file. Move to a sibling module. → $content"
     VIOLATIONS=$((VIOLATIONS + 1))
-  done < <(
-    grep -nE '^export (const|let|var|class|enum|interface) [A-Za-z_]' "$f" || true
-    grep -nE '^export function [A-Za-z_]' "$f" || true
-  )
+  done <<EXPORTS
+$EXPORT_LINES
+EXPORTS
 done <<EOF
 $USE_SERVER_FILES
 EOF

--- a/scripts/check-service-role-client.sh
+++ b/scripts/check-service-role-client.sh
@@ -23,9 +23,23 @@ FACTORY='src/lib/supabase-service.ts'
 # src/lib/env.ts is `supabaseServiceRoleKey: () => …` (no leading dot), so the
 # `\.` anchor matches only *calls* (`env.supabaseServiceRoleKey()`), never the
 # definition.
-MATCHES=$(
-  grep -rnE '\.supabaseServiceRoleKey\(\)' --include='*.ts' --include='*.tsx' src/ 2>/dev/null || true
-)
+# grep exits 1 for "no match" — the answer we want — but >=2 when the search
+# ITSELF failed. A bare `|| true` here makes those two indistinguishable, and
+# this control's clean result is an EMPTY match list: an unreadable src/ would
+# print "All service-role clients go through the factory" and pass a
+# security gate that never ran. That is the KAN-167 false-green class (and the
+# SEC-79 shape: a control reporting green while disabled). Exit 2 = unverified.
+if MATCHES="$(grep -rnE '\.supabaseServiceRoleKey\(\)' --include='*.ts' --include='*.tsx' src/ 2>&1)"; then
+  GREP_RC=0
+else
+  GREP_RC=$?
+fi
+if [ "$GREP_RC" -gt 1 ]; then
+  echo "::error::check-service-role-client: the search command failed (exit ${GREP_RC}): ${MATCHES}"
+  echo "::error::  Failing closed (exit 2) rather than reporting a clean scan that never ran."
+  exit 2
+fi
+[ "$GREP_RC" -eq 1 ] && MATCHES=""
 
 VIOLATIONS=0
 while IFS=: read -r file linenum content; do

--- a/scripts/check-workflow-integrity.sh
+++ b/scripts/check-workflow-integrity.sh
@@ -37,6 +37,23 @@ set -euo pipefail
 WORKFLOW_DIR=".github/workflows"
 PROBLEMS=0
 
+# Count matches in a file, setting MATCH_COUNT. `grep -c` exits 1 on zero
+# matches (printing "0") but >=2 when the search itself fails (printing
+# nothing) — so a bare `|| true` collapses "this file is clean" and "we could
+# not read this file" into the same empty string. Exit 2 = could not verify.
+MATCH_COUNT=0
+count_matches() {
+  local f="$1"; shift
+  local out rc
+  if out="$(grep -c "$@" -- "$f" 2>&1)"; then rc=0; else rc=$?; fi
+  if [ "$rc" -gt 1 ]; then
+    echo "::error::check-workflow-integrity: could not scan ${f} (grep exit ${rc}): ${out}"
+    echo "::error::  Failing closed (exit 2) rather than clearing a workflow that was never read."
+    exit 2
+  fi
+  MATCH_COUNT="${out:-0}"
+}
+
 if [ ! -d "$WORKFLOW_DIR" ]; then
   echo "::error::No $WORKFLOW_DIR directory found"
   exit 1
@@ -52,9 +69,18 @@ for f in "$WORKFLOW_DIR"/*.yml; do
   [ -f "$f" ] || continue
   basename=$(basename "$f")
 
-  # Workflow must (a) use GITHUB_TOKEN AND (b) push to a deploy branch
-  uses_github_token=$(grep -c "secrets.GITHUB_TOKEN" "$f" || true)
-  pushes_to_deploy=$(grep -cE 'git push origin (staging|main|production|develop)' "$f" || true)
+  # Workflow must (a) use GITHUB_TOKEN AND (b) push to a deploy branch.
+  # `grep -c` exits 1 on zero matches (printing "0") but >=2 when the search
+  # itself fails, printing nothing — and a bare `|| true` collapses that into an
+  # empty string, i.e. "no GITHUB_TOKEN here", silently clearing the workflow.
+  # This gate exists because that exact false-green cost ~32 days of dead
+  # promotes (BUGS-4). Count it properly; an unreadable workflow file is exit 2.
+  # NB: called as plain commands, not inside $( ) — a subshell's exit 2 would
+  # only leave the subshell and the scan would carry on regardless.
+  count_matches "$f" -F "secrets.GITHUB_TOKEN"
+  uses_github_token=$MATCH_COUNT
+  count_matches "$f" -E 'git push origin (staging|main|production|develop)'
+  pushes_to_deploy=$MATCH_COUNT
 
   if [ "$uses_github_token" -gt 0 ] && [ "$pushes_to_deploy" -gt 0 ]; then
     # Verify it isn't allow-listed

--- a/tests/scripts/guard-fail-closed.test.js
+++ b/tests/scripts/guard-fail-closed.test.js
@@ -1,0 +1,129 @@
+const { execSync } = require('child_process');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const REPO_ROOT = path.resolve(__dirname, '../../');
+
+// SEC-109 — the "clean scan that never ran" class.
+//
+// grep exits 1 for "no match" and >=2 when the SEARCH ITSELF failed. Three
+// guards collapsed the two with `|| true`, and because each one's clean result
+// is an EMPTY match list, a failed search read as a pass:
+//
+//   check-service-role-client.sh   printed "All service-role clients go through
+//                                  the factory ✓" and exited 0
+//   check-workflow-integrity.sh    printed "No workflow integrity issues found"
+//                                  and exited 0
+//   check-server-action-exports.sh aborted with a bare exit 2 and NO message —
+//                                  indistinguishable from a broken harness
+//
+// That is the SEC-79 shape (a control reporting green while not operating) and
+// the KAN-167 false-green policy. These tests pin the fixed contract: a search
+// that could not run exits 2 and says why. They are written as behaviour, not
+// source-text assertions, so a future rewrite cannot quietly regress them.
+//
+// Exit codes for all three: 0 clean · 1 violation found · 2 could not verify.
+
+function runIn(dir, script, { pathPrefix } = {}) {
+  const env = { ...process.env };
+  if (pathPrefix) env.PATH = `${pathPrefix}:${process.env.PATH}`;
+  let status = 0;
+  let output = '';
+  try {
+    output = execSync(`bash ${JSON.stringify(path.join(REPO_ROOT, 'scripts', script))}`, {
+      cwd: dir,
+      stdio: 'pipe',
+      env,
+    }).toString();
+  } catch (err) {
+    status = err.status || 1;
+    output = `${err.stdout || ''}${err.stderr || ''}`;
+  }
+  return { status, output };
+}
+
+// A tree with the estate directories present but NO src/ — the realistic
+// "run from the wrong directory, or src/ moved" failure.
+function makeTreeWithoutSrc() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'failclosed-'));
+  fs.mkdirSync(path.join(dir, '.github/workflows'), { recursive: true });
+  fs.writeFileSync(path.join(dir, '.github/workflows/a.yml'), 'on: push\njobs: {}\n');
+  return dir;
+}
+
+// A PATH shim whose `grep` always exits 2 — deterministic proof of the
+// "the search command itself failed" branch, independent of filesystem quirks
+// (notably: running as root bypasses chmod, so unreadable-file mutations
+// silently do not reproduce).
+function makeFailingGrepShim(dir) {
+  const bin = path.join(dir, 'shimbin');
+  fs.mkdirSync(bin, { recursive: true });
+  fs.writeFileSync(path.join(bin, 'grep'), '#!/bin/sh\nexit 2\n');
+  fs.chmodSync(path.join(bin, 'grep'), 0o755);
+  return bin;
+}
+
+describe('guard fail-closed contract (SEC-109)', () => {
+  let dir;
+  beforeEach(() => {
+    dir = makeTreeWithoutSrc();
+  });
+  afterEach(() => {
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  describe('check-service-role-client.sh', () => {
+    it('exits 2 — not 0 with a green tick — when src/ cannot be searched', () => {
+      const { status, output } = runIn(dir, 'check-service-role-client.sh');
+      expect(status).toBe(2);
+      expect(output).toMatch(/the search command failed/);
+      // The exact regression: it must NOT claim the codebase is clean.
+      expect(output).not.toMatch(/All service-role clients go through/);
+    });
+
+    it('exits 2 when grep itself fails', () => {
+      fs.mkdirSync(path.join(dir, 'src'), { recursive: true });
+      const { status, output } = runIn(dir, 'check-service-role-client.sh', {
+        pathPrefix: makeFailingGrepShim(dir),
+      });
+      expect(status).toBe(2);
+      expect(output).toMatch(/Failing closed/);
+    });
+  });
+
+  describe('check-server-action-exports.sh', () => {
+    it('exits 2 with an explanatory message when src/ cannot be searched', () => {
+      const { status, output } = runIn(dir, 'check-server-action-exports.sh');
+      expect(status).toBe(2);
+      // Previously this aborted with exit 2 and NO output at all, which reads
+      // as a broken harness rather than an unverified control.
+      expect(output).toMatch(/the search command failed/);
+      expect(output).not.toMatch(/No 'use server' module files found/);
+    });
+  });
+
+  describe('check-workflow-integrity.sh', () => {
+    it('exits 2 — not 0 with a green tick — when a workflow file cannot be scanned', () => {
+      const { status, output } = runIn(dir, 'check-workflow-integrity.sh', {
+        pathPrefix: makeFailingGrepShim(dir),
+      });
+      expect(status).toBe(2);
+      expect(output).toMatch(/could not scan/);
+      // The exact regression: it must NOT report the workflows clean. This gate
+      // exists because a false green here cost ~32 days of dead promotes (BUGS-4).
+      expect(output).not.toMatch(/No workflow integrity issues found/);
+    });
+  });
+
+  describe('all three still pass on the real repo', () => {
+    it.each([
+      'check-service-role-client.sh',
+      'check-server-action-exports.sh',
+      'check-workflow-integrity.sh',
+    ])('%s exits 0 against the actual tree', (script) => {
+      const { status } = runIn(REPO_ROOT, script);
+      expect(status).toBe(0);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

`grep` exits **1** for "no match" — the answer these guards want — and **≥2** when the *search itself* failed. Three guards collapsed the two with `|| true`. Because each one's clean result is an **empty match list**, a failed search read as a pass.

Proved by mutation, running each guard in a tree with no `src/` (the realistic "wrong cwd / `src` moved away" case) and under a `PATH` shim whose `grep` exits 2:

| Guard | Before | After |
|---|---|---|
| `check-service-role-client.sh` | **exit 0** — `All service-role clients go through src/lib/supabase-service.ts. ✓` | exit 2, names the failure |
| `check-workflow-integrity.sh` | **exit 0** — `✓ No workflow integrity issues found` | exit 2, names the file |
| `check-server-action-exports.sh` | exit 2 but with **no output at all** — indistinguishable from a broken harness | exit 2, names the failure |

The first two are **true false-greens on security-relevant controls**: one stops inline RLS-bypassing service-role clients reappearing; the other stops the `GITHUB_TOKEN`-suppresses-downstream-triggers pattern that cost ~32 days of silently dead promotes (BUGS-4). This is the **SEC-79 shape** — a control reporting green while not operating — and KAN-167 applied to a guard rather than a workflow.

Found while building the KAN-428 extraction gate (#622), whose own first cut contained exactly this defect. Fixing it there prompted the sweep that found it in three more.

### Two traps worth recording

1. **The helper must not be called inside `$( )`.** A subshell's `exit 2` only leaves the subshell — the scan then carries on regardless, which looks like a fix but isn't. Hit for real during this change.
2. **Root bypasses `chmod`.** The obvious mutation (make a file unreadable) silently does *not* reproduce in CI or a container running as root. Use a missing directory or a `grep` shim.

### Deliberately not changed

- `check-doc-mirror-manifest.sh` / `check-doc-mirror-content.sh` use `|| true` on the manifest extraction but follow it with `if [ -z "$PATHS" ]; then … exit 2`, so they were **already fail-closed**. Checked, left alone.
- `check-ui-copy-ownership.sh` fails **open** on an unresolvable diff base **by design**, documented in its own header, because CODEOWNERS still hard-gates every path it protects. Left alone.

No repo-wide `|| true` gate is proposed: the pattern is legitimate in non-verification uses (cleanup `rm`, `curl` with explicit status handling), so a blanket grep would be standing noise — and standing noise is what teaches people to wave a gate through. Reasoning recorded on SEC-111.

## Jira Ticket

SEC-111

## Checklist

- [x] Unit tests added/updated — `tests/scripts/guard-fail-closed.test.js`, 7 tests asserting **behaviour** (exit codes + the absence of the green-tick strings), not source text, so a rewrite cannot quietly regress them. **No existing test modified, weakened or skipped.**
- [x] All existing tests pass (`npm run test:unit`) — **2611 passed / 222 suites**
- [x] Lint passes — no JS/TS behaviour changed beyond the new test file
- [x] Type check passes — N/A, no TypeScript changed
- [x] Build succeeds — N/A, no application code changed
- [x] Coverage has not decreased — net new tests only
- [x] No eslint-disable or ts-ignore without KAN-XX reference
- [x] Dependency-rule gate reviewed — no `src/` import changed; gate still reports the same 5 pre-existing violations, unchanged by this PR
- [x] ARCHITECTURE.md updated if architectural changes were made — N/A: failure *reporting* only, no service, route, table or env var
- [x] Ops routine / Control-Room registry updated — N/A: no routine cadence or ownership changed
- [x] Docs / system map updated — N/A with reason: all three guards are already documented and registered in `controls/registry.json`; this changes their behaviour on an unverifiable scan, not their contract or wiring

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NzJ9D5oZZKH1KHNKMAD9aE

---
_Generated by [Claude Code](https://claude.ai/code/session_01NzJ9D5oZZKH1KHNKMAD9aE)_