### PR TITLE
SEC-109: server-side Convene disconnect that actually revokes the vaulted token

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -46,6 +46,16 @@ jobs:
         # (build does NOT catch it), so without this guard a regression
         # ships green and breaks every form on the affected page.
         run: bash scripts/check-server-action-exports.sh
+      - name: Client-side privileged-write check (SEC-109)
+        # Static scan forbidding any `'use client'` module from writing directly
+        # to a table whose invariant is enforced server-side. The Convene
+        # Disconnect button soft-deleted oauth_connections from the browser and
+        # so never revoked the vaulted OAuth refresh token — the UI promised
+        # "we'll forget your tokens immediately" and the code did not. RLS does
+        # not catch this class: it governs which row you may write, not what
+        # else was supposed to happen alongside. Allow-list a genuinely
+        # invariant-free write with `// client-write-ok: <JIRA-KEY> <reason>`.
+        run: bash scripts/check-client-side-privileged-writes.sh
       - name: Service-role client centralisation check (KAN-352)
         # Static scan forbidding any call to env.supabaseServiceRoleKey()
         # outside src/lib/supabase-service.ts. The service-role client

--- a/controls/registry.json
+++ b/controls/registry.json
@@ -5,7 +5,7 @@
     "Machine-readable index of every preventive control in this repo, and the",
     "defect it exists to stop. This is the memory of the Defect Feedback Loop:",
     "when a BUGS or SEC ticket closes, its root cause is traced to a control",
-    "here \u2014 either one that already exists (and failed to fire, which is itself",
+    "here — either one that already exists (and failed to fire, which is itself",
     "a finding) or a new one that gets added.",
     "",
     "Enforced by scripts/check-control-registry.py, which fails the build if a",
@@ -23,7 +23,7 @@
       "id": "CTL-001",
       "name": "Workflow integrity check",
       "defect_class": "false-green-ci",
-      "summary": "Static scan for workflow patterns that report SUCCESS while doing nothing \u2014 GITHUB_TOKEN pushes that suppress downstream triggers, --limit 1 deploy verification, 401 acceptance without SHA verification, rollback steps that never roll back.",
+      "summary": "Static scan for workflow patterns that report SUCCESS while doing nothing — GITHUB_TOKEN pushes that suppress downstream triggers, --limit 1 deploy verification, 401 acceptance without SHA verification, rollback steps that never roll back.",
       "implementation": "scripts/check-workflow-integrity.sh",
       "kind": "ci-gate",
       "wired_in": [
@@ -127,7 +127,7 @@
       "id": "CTL-007",
       "name": "Doc mirror content check",
       "defect_class": "doc-drift",
-      "summary": "Fails the PR if a listed mirror exists but is an empty or stub file \u2014 the 'backup that looks successful but contains placeholder content' failure mode.",
+      "summary": "Fails the PR if a listed mirror exists but is an empty or stub file — the 'backup that looks successful but contains placeholder content' failure mode.",
       "implementation": "scripts/check-doc-mirror-content.sh",
       "kind": "ci-gate",
       "wired_in": [
@@ -192,7 +192,7 @@
       "id": "CTL-011",
       "name": "Auto-heal pattern catalogue self-test",
       "defect_class": "false-green-ci",
-      "summary": "Verifies every auto-fix pattern still matches its fixture and does not false-positive on a sibling \u2014 the regression guard that stops the auto-fix workflow silently breaking.",
+      "summary": "Verifies every auto-fix pattern still matches its fixture and does not false-positive on a sibling — the regression guard that stops the auto-fix workflow silently breaking.",
       "implementation": "scripts/auto-fix-known-failures.py",
       "kind": "ci-gate",
       "wired_in": [
@@ -240,7 +240,7 @@
       "id": "CTL-014",
       "name": "Backup integrity check",
       "defect_class": "false-green-ci",
-      "summary": "Fails if a backup artefact is a placeholder rather than real data \u2014 a dump that does not start with '--', contains no CREATE statements, or is suspiciously short.",
+      "summary": "Fails if a backup artefact is a placeholder rather than real data — a dump that does not start with '--', contains no CREATE statements, or is suspiciously short.",
       "implementation": "scripts/check-backup-integrity.sh",
       "kind": "scheduled",
       "wired_in": [
@@ -307,7 +307,7 @@
       "id": "CTL-018",
       "name": "Main-chain guard",
       "defect_class": "release-control",
-      "summary": "Fails loud if main gains any commit not present on beta \u2014 i.e. a change that did not arrive through develop \u2192 staging \u2192 beta \u2192 main \u2014 and blocks any PR targeting main.",
+      "summary": "Fails loud if main gains any commit not present on beta — i.e. a change that did not arrive through develop → staging → beta → main — and blocks any PR targeting main.",
       "implementation": ".github/workflows/main-chain-guard.yml",
       "kind": "ci-gate",
       "wired_in": [
@@ -319,13 +319,13 @@
       ],
       "escape_hatch": "BYPASS CONTROLS commit marker",
       "added": "2026-07-25",
-      "notes": "NOT yet in main's required status checks \u2014 see docs/DEFECT_FEEDBACK_LOOP.md open gaps."
+      "notes": "NOT yet in main's required status checks — see docs/DEFECT_FEEDBACK_LOOP.md open gaps."
     },
     {
       "id": "CTL-019",
       "name": "Dashboard loading.tsx guard",
       "defect_class": "framework-footgun",
-      "summary": "Fails any PR that reintroduces a src/app/**/loading.* without an explicit marker \u2014 the Next 16 Suspense boundary that never reveals on hard load and blanks the dashboard.",
+      "summary": "Fails any PR that reintroduces a src/app/**/loading.* without an explicit marker — the Next 16 Suspense boundary that never reveals on hard load and blanks the dashboard.",
       "implementation": "tests/unit/bugs66-dashboard-loading-guard.test.js",
       "kind": "test",
       "wired_in": [
@@ -395,7 +395,7 @@
       "id": "CTL-023",
       "name": "Migration privilege lint",
       "defect_class": "postgres-privilege-drift",
-      "summary": "Every migration must revoke a SECURITY DEFINER function from public, anon AND authenticated. Revoking from PUBLIC alone is a no-op on Supabase, which grants anon/authenticated directly via ALTER DEFAULT PRIVILEGES \u2014 the first version of this rule required only the PUBLIC revoke and passed a fixture shipping an anon-callable function. That mis-specified revoke in 20260622120000_two_axis_access_model.sql is the actual root cause of SEC-28/29/42/43. Also pins search_path, forbids GRANT to anon, requires RLS on new public tables, and (R5) blocks duplicate migration version timestamps. Ratcheted against a baseline that may only shrink.",
+      "summary": "Every migration must revoke a SECURITY DEFINER function from public, anon AND authenticated. Revoking from PUBLIC alone is a no-op on Supabase, which grants anon/authenticated directly via ALTER DEFAULT PRIVILEGES — the first version of this rule required only the PUBLIC revoke and passed a fixture shipping an anon-callable function. That mis-specified revoke in 20260622120000_two_axis_access_model.sql is the actual root cause of SEC-28/29/42/43. Also pins search_path, forbids GRANT to anon, requires RLS on new public tables, and (R5) blocks duplicate migration version timestamps. Ratcheted against a baseline that may only shrink.",
       "implementation": "scripts/check-migration-privileges.py",
       "kind": "ci-gate",
       "wired_in": [
@@ -468,7 +468,7 @@
       "id": "CTL-026",
       "name": "Control registry integrity",
       "defect_class": "control-rot",
-      "summary": "The meta-control. Fails if a registered control's implementation is missing, if it is no longer referenced by any workflow (the SEC-79 'silently disabled for weeks' mode), or if a check script exists in the repo but is not registered \u2014 so the registry cannot drift away from reality.",
+      "summary": "The meta-control. Fails if a registered control's implementation is missing, if it is no longer referenced by any workflow (the SEC-79 'silently disabled for weeks' mode), or if a check script exists in the repo but is not registered — so the registry cannot drift away from reality.",
       "implementation": "scripts/check-control-registry.py",
       "kind": "ci-gate",
       "wired_in": [
@@ -506,7 +506,7 @@
       "id": "CTL-028",
       "name": "Suspension-guard coverage",
       "defect_class": "authz-coverage-drift",
-      "summary": "Any query filtering is_published = true is selecting content for public consumption and must also filter is_suspended = false. Stated on the QUERY rather than the file or the client, so it enumerates the surface instead of sampling it \u2014 the property every previous fix in this class lacked. Found three unguarded sites beyond the two identified by review, including the homepage and the sitemap.",
+      "summary": "Any query filtering is_published = true is selecting content for public consumption and must also filter is_suspended = false. Stated on the QUERY rather than the file or the client, so it enumerates the surface instead of sampling it — the property every previous fix in this class lacked. Found three unguarded sites beyond the two identified by review, including the homepage and the sitemap.",
       "implementation": "scripts/check-suspension-guard-coverage.py",
       "kind": "ci-gate",
       "wired_in": [
@@ -548,7 +548,7 @@
       "id": "CTL-030",
       "name": "Structural dependency rules (module/segment/cycle)",
       "defect_class": "regression-risk",
-      "summary": "Three structural import rules, enforced so the codebase cannot regress while the modularisation programme (KAN-415) runs: nothing under src/lib/** may import src/app/** (a library owned by a route folder is how the access-transition matrix ended up inside the admin console, KAN-424 Defect 1); one top-level src/app segment may not import another (a cross-segment edge couples two features so neither can be changed or extracted alone); and no import cycles. The precedent for needing a gate rather than a convention is src/lib/deploy-env.ts \u2014 built to be the single environment resolver, it never displaced the six inline derivations because nothing stopped new ones being written. Ships at severity warn and flips to error once the outstanding findings clear.",
+      "summary": "Three structural import rules, enforced so the codebase cannot regress while the modularisation programme (KAN-415) runs: nothing under src/lib/** may import src/app/** (a library owned by a route folder is how the access-transition matrix ended up inside the admin console, KAN-424 Defect 1); one top-level src/app segment may not import another (a cross-segment edge couples two features so neither can be changed or extracted alone); and no import cycles. The precedent for needing a gate rather than a convention is src/lib/deploy-env.ts — built to be the single environment resolver, it never displaced the six inline derivations because nothing stopped new ones being written. Ships at severity warn and flips to error once the outstanding findings clear.",
       "implementation": "scripts/check-dependency-rules.sh",
       "kind": "ci-gate",
       "wired_in": [
@@ -565,7 +565,7 @@
       "id": "CTL-031",
       "name": "Bash 3.2 portability",
       "defect_class": "dev-ci-environment-parity",
-      "summary": "Fails any script under scripts/ using a bash-4-only construct (mapfile/readarray, declare -A, ${v^^}/${v,,}, &>>, coproc, shopt -s globstar). macOS ships bash 3.2 and CI ships bash 5, so these work in CI and exit 127 where releases are prepared. staging-soak.sh documented the rule in a comment from day one and two scripts shipped with mapfile anyway, making the whole unit suite unpassable on macOS \u2014 a convention without a gate erodes. Comments are stripped before matching so the fix's own explanatory prose does not trip it; that case is pinned in the self-test. Workflow YAML is out of scope by design: inline run: blocks execute only on the runner, so findings there would only ever be allow-listed, and standing noise is what teaches people to wave a gate through.",
+      "summary": "Fails any script under scripts/ using a bash-4-only construct (mapfile/readarray, declare -A, ${v^^}/${v,,}, &>>, coproc, shopt -s globstar). macOS ships bash 3.2 and CI ships bash 5, so these work in CI and exit 127 where releases are prepared. staging-soak.sh documented the rule in a comment from day one and two scripts shipped with mapfile anyway, making the whole unit suite unpassable on macOS — a convention without a gate erodes. Comments are stripped before matching so the fix's own explanatory prose does not trip it; that case is pinned in the self-test. Workflow YAML is out of scope by design: inline run: blocks execute only on the runner, so findings there would only ever be allow-listed, and standing noise is what teaches people to wave a gate through.",
       "implementation": "scripts/check-bash-portability.py",
       "kind": "ci-gate",
       "wired_in": [
@@ -598,7 +598,7 @@
       "id": "CTL-033",
       "name": "Extraction Definition-of-Done",
       "defect_class": "path-coupling-drift",
-      "summary": "Fails any PR that deletes or renames a file under src/ while an artefact that classifies files BY PATH still names the old path: .github/ (signup-surface manifest, CODEOWNERS, workflows), scripts/ guard path-lists, docs/ (incl. the mirror manifest), modules.json and tests/. A glob that matches nothing protects nothing while CI stays green \u2014 KAN-419 measured the docs layer at 18% dead path literals before a single file was moved on purpose. Also requires the PR body to answer the two couplings CI can never see (~/lyra-design-system/build.py and the claude.ai routine prompts, neither in any repo CI can read) and to name the covering Playwright project + soak clause, or record 'no coverage' as a finding. Fails closed (exit 2) when it cannot verify.",
+      "summary": "Fails any PR that deletes or renames a file under src/ while an artefact that classifies files BY PATH still names the old path: .github/ (signup-surface manifest, CODEOWNERS, workflows), scripts/ guard path-lists, docs/ (incl. the mirror manifest), modules.json and tests/. A glob that matches nothing protects nothing while CI stays green — KAN-419 measured the docs layer at 18% dead path literals before a single file was moved on purpose. Also requires the PR body to answer the two couplings CI can never see (~/lyra-design-system/build.py and the claude.ai routine prompts, neither in any repo CI can read) and to name the covering Playwright project + soak clause, or record 'no coverage' as a finding. Fails closed (exit 2) when it cannot verify.",
       "implementation": "scripts/check-extraction-dod.sh",
       "kind": "ci-gate",
       "wired_in": [
@@ -609,6 +609,22 @@
       ],
       "escape_hatch": "EXTRACTION-DOD-OK: <JIRA-KEY> <check-id> on a commit in the PR. Suppresses exactly one named check, requires a Jira key, every active exception is printed on every run, and more than three in one PR emits a ::warning:: that the hatch is papering over drift.",
       "added": "2026-07-28"
+    },
+    {
+      "id": "CTL-034",
+      "name": "Client-side privileged-write guard",
+      "defect_class": "client-write-bypasses-server-invariant",
+      "summary": "Fails any PR in which a 'use client' module calls .update/.insert/.delete/.upsert on a table whose invariant is enforced server-side. SEC-109: the Convene Disconnect button soft-deleted oauth_connections straight from the browser, so the vaulted OAuth refresh token was never revoked — the UI promised 'we'll forget your tokens immediately' and the code did not, a consent withdrawal (GDPR Art.7(3)/17) that silently did not happen. A browser-side write can only touch the row; anything owed alongside it — revoking a secret, notifying the provider, writing an audit row — is lost. RLS does not catch this class: it governs WHICH ROW you may write, not what else was supposed to happen. Reads are not flagged; they carry no invariant. Guarded-table list is the knob — add a table whenever a write to it has a server-side counterpart that must not be skipped.",
+      "implementation": "scripts/check-client-side-privileged-writes.sh",
+      "kind": "ci-gate",
+      "wired_in": [
+        ".github/workflows/pr-checks.yml"
+      ],
+      "prevents": [
+        "SEC-109"
+      ],
+      "escape_hatch": "// client-write-ok: <JIRA-KEY> <reason> in the client module. Use only when the write genuinely carries no server-side invariant.",
+      "added": "2026-07-29"
     }
   ]
 }

--- a/scripts/check-client-side-privileged-writes.sh
+++ b/scripts/check-client-side-privileged-writes.sh
@@ -1,0 +1,184 @@
+#!/usr/bin/env bash
+# scripts/check-client-side-privileged-writes.sh
+#
+# SEC-109 — regression guard for "a client component writes directly to a table
+# whose invariant is enforced server-side".
+#
+# The defect this exists for: the Convene Disconnect button soft-deleted
+# `oauth_connections` straight from the browser under the user's own JWT. The
+# row was marked revoked, but the vaulted OAuth refresh token was never revoked,
+# because the only code that calls `vaultRevokeRefreshToken` is
+# `disconnectConnection` on the server. The UI promised the user "we'll forget
+# your tokens immediately" and the code did not keep that promise — a consent
+# withdrawal (GDPR Art.7(3)/17) that silently did not happen.
+#
+# The general shape is what matters, not this one table: a browser-side write
+# can only ever touch the row. Any invariant that needs a second action — revoke
+# a secret, notify a provider, write an audit row, cascade a soft-delete — is
+# lost the moment the write bypasses its server-side owner. RLS does not save
+# you here: RLS decides WHO may write WHICH ROW, and has nothing to say about
+# what else was supposed to happen alongside.
+#
+# So: no `'use client'` module may call `.from('<guarded table>').update(`,
+# `.insert(`, `.delete(` or `.upsert(`. Reads are fine — they carry no
+# invariant. Server actions and route handlers are fine; they are where the
+# paired logic lives.
+#
+# Adding a table here is cheap and is the right move whenever a write to it has
+# a server-side counterpart that must not be skipped.
+#
+# Escape hatch: `// client-write-ok: <reason>` plus a Jira key, on the line or
+# the line before. Use it only when the write genuinely carries no invariant.
+#
+# Run with --self-test to prove the detector still detects.
+set -euo pipefail
+
+# Tables whose writes carry a server-side invariant.
+GUARDED_TABLES=(
+  oauth_connections   # SEC-109: vault refresh-token revoke on disconnect
+)
+
+SEARCH_ROOT="${SEARCH_ROOT:-src}"
+
+scan() {
+  local root="$1"
+  local -a hits=()
+  local f table
+
+  # Only 'use client' modules can issue a browser-side write.
+  local -a client_files=()
+  while IFS= read -r f || [ -n "$f" ]; do
+    [ -z "$f" ] && continue
+    if head -5 "$f" | grep -Eq "^[[:space:]]*['\"]use client['\"]"; then
+      client_files+=("$f")
+    fi
+  done < <(find "$root" -type f \( -name '*.tsx' -o -name '*.ts' \) 2>/dev/null | sort)
+
+  [ "${#client_files[@]}" -eq 0 ] && return 0
+
+  for f in "${client_files[@]}"; do
+    for table in "${GUARDED_TABLES[@]}"; do
+      # `.from('table')` followed — possibly across a chained newline — by a
+      # write verb. -A2 keeps it readable without a full parser.
+      local matched
+      matched="$(grep -n -A2 -E "\.from\(['\"]${table}['\"]\)" "$f" 2>/dev/null \
+        | grep -E "\.(update|insert|delete|upsert)\(" || true)"
+      [ -z "$matched" ] && continue
+
+      # Allow-list: the marker may sit anywhere in the file's guarded block.
+      if grep -Eq "client-write-ok:[[:space:]]*.*[A-Z][A-Z0-9]+-[0-9]+" "$f"; then
+        continue
+      fi
+      hits+=("${f}: client-side write to '${table}'")
+    done
+  done
+
+  if [ "${#hits[@]}" -gt 0 ]; then
+    printf '%s\n' "${hits[@]}"
+    return 1
+  fi
+  return 0
+}
+
+if [ "${1:-}" = "--self-test" ]; then
+  tmp="$(mktemp -d)"
+  trap 'rm -rf "$tmp"' EXIT
+  mkdir -p "$tmp/src"
+
+  # Fixture 1: the exact SEC-109 defect. MUST be detected.
+  cat >"$tmp/src/bad-client.tsx" <<'EOF'
+'use client';
+import { createClient } from '@/lib/supabase-browser';
+export function C({ id }: { id: string }) {
+  async function go() {
+    const sb = createClient();
+    await sb
+      .from('oauth_connections')
+      .update({ deleted_at: new Date().toISOString(), status: 'revoked' })
+      .eq('id', id);
+  }
+  return <button onClick={go}>x</button>;
+}
+EOF
+
+  # Fixture 2: a server module doing the same write. MUST NOT be detected.
+  cat >"$tmp/src/good-server.ts" <<'EOF'
+'use server';
+export async function go(id: string, sb: { from: (t: string) => never }) {
+  await sb.from('oauth_connections').update({ status: 'revoked' }).eq('id', id);
+}
+EOF
+
+  # Fixture 3: a client-side READ. MUST NOT be detected.
+  cat >"$tmp/src/good-client-read.tsx" <<'EOF'
+'use client';
+export function R({ sb }: { sb: { from: (t: string) => never } }) {
+  return sb.from('oauth_connections').select('id');
+}
+EOF
+
+  # Fixture 4: allow-listed client write. MUST NOT be detected.
+  cat >"$tmp/src/allowed-client.tsx" <<'EOF'
+'use client';
+// client-write-ok: SEC-109 no server-side invariant on this path
+export function A({ sb, id }: { sb: { from: (t: string) => never }; id: string }) {
+  return sb.from('oauth_connections').update({ status: 'revoked' }).eq('id', id);
+}
+EOF
+
+  fail=0
+
+  out="$(scan "$tmp/src" || true)"
+  case "$out" in
+    *bad-client.tsx*) ;;
+    *) echo "SELF-TEST FAIL: did not detect the SEC-109 defect fixture"; fail=1 ;;
+  esac
+  for must_not in good-server.ts good-client-read.tsx allowed-client.tsx; do
+    case "$out" in
+      *"$must_not"*) echo "SELF-TEST FAIL: false positive on $must_not"; fail=1 ;;
+    esac
+  done
+
+  # And the clean case must exit 0.
+  rm "$tmp/src/bad-client.tsx"
+  if ! scan "$tmp/src" >/dev/null; then
+    echo "SELF-TEST FAIL: clean tree did not pass"
+    fail=1
+  fi
+
+  if [ "$fail" -ne 0 ]; then
+    echo "::error::check-client-side-privileged-writes self-test FAILED"
+    exit 1
+  fi
+  echo "check-client-side-privileged-writes: self-test passed (4 fixtures)."
+  exit 0
+fi
+
+echo "check-client-side-privileged-writes: scanning ${SEARCH_ROOT} for client-side writes to ${#GUARDED_TABLES[@]} guarded table(s)…"
+if out="$(scan "$SEARCH_ROOT")"; then
+  echo "No client-side writes to guarded tables. ✓"
+  exit 0
+fi
+
+echo "::error::check-client-side-privileged-writes: a 'use client' module writes directly to a table whose invariant is enforced server-side."
+while IFS= read -r line || [ -n "$line" ]; do
+  [ -z "$line" ] && continue
+  echo "::error::  $line"
+done <<EOF
+$out
+EOF
+cat <<'MSG'
+
+A browser-side write can only touch the row. Anything that must happen
+alongside it — revoking a vaulted secret, notifying the provider, writing an
+audit row — is silently skipped. RLS does not help: it governs which row you
+may write, not what else was supposed to happen.
+
+Route the write through the server action or API route that owns the
+invariant. If this particular write genuinely carries none, allow-list it:
+
+  // client-write-ok: <JIRA-KEY> <reason>
+
+See SEC-109 for the original defect.
+MSG
+exit 1

--- a/src/app/dashboard/convene/connections/connections-client.tsx
+++ b/src/app/dashboard/convene/connections/connections-client.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useTransition } from 'react';
 import Link from 'next/link';
-import { createClient } from '@/lib/supabase-browser';
+import { disconnectOAuthConnection } from './disconnect-actions';
 
 interface ConnectionRow {
   id: string;
@@ -55,12 +55,8 @@ export function ConnectionsClient({ connections }: { connections: ConnectionRow[
     setBusy(connectionId);
     setError(null);
     try {
-      const sb = createClient();
-      const { error: updErr } = await sb
-        .from('oauth_connections')
-        .update({ deleted_at: new Date().toISOString(), status: 'revoked' })
-        .eq('id', connectionId);
-      if (updErr) throw new Error(updErr.message);
+      const res = await disconnectOAuthConnection(connectionId);
+      if (!res.ok) throw new Error(res.error);
       startTransition(() => {
         window.location.reload();
       });

--- a/src/app/dashboard/convene/connections/disconnect-actions.ts
+++ b/src/app/dashboard/convene/connections/disconnect-actions.ts
@@ -1,0 +1,75 @@
+'use server';
+
+/**
+ * SEC-109 — server-side disconnect for Convene OAuth connections.
+ *
+ * The Disconnect button used to soft-delete `oauth_connections` straight from
+ * the browser under the user's own JWT and stop there, so the vaulted Google
+ * refresh token stayed live indefinitely after the user asked us to forget it.
+ * The connections page promises the opposite ("we'll forget your tokens
+ * immediately"), which makes it a consent-withdrawal defect, not just an
+ * untidy code path.
+ *
+ * `disconnectConnection` in `@/lib/convene/oauth-connections` already does the
+ * right thing — soft-delete plus `vaultRevokeRefreshToken` — but it runs on a
+ * service-role client and deliberately performs NO ownership check (see the
+ * `ownership-ok` note on `getConnection`: the caller owns that check). This
+ * action is that caller: it authenticates, proves ownership on the user's own
+ * RLS-scoped client, and only then hands the id to the repository.
+ *
+ * Two deliberate choices:
+ *
+ * - **No suspension guard.** The SEC-57 family gates write paths on
+ *   `is_suspended`, but withdrawing consent is not a privileged write — a
+ *   suspended user who cannot disconnect is a user whose calendar token we keep
+ *   against their wishes. Disconnect stays available to any authenticated owner.
+ *
+ * - **One generic failure message.** "Not yours", "already gone" and "never
+ *   existed" all return the same string, so the action cannot be used to probe
+ *   whether a given connection id exists.
+ */
+
+import { revalidatePath } from 'next/cache';
+import { createClient } from '@/lib/supabase-server';
+import { disconnectConnection } from '@/lib/convene/oauth-connections';
+
+const GENERIC_ERROR = 'Could not disconnect that account';
+
+export async function disconnectOAuthConnection(
+  connectionId: string
+): Promise<{ ok: true } | { ok: false; error: string }> {
+  if (typeof connectionId !== 'string' || connectionId.trim() === '') {
+    return { ok: false, error: GENERIC_ERROR };
+  }
+
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) return { ok: false, error: 'Not authenticated' };
+
+  // Ownership is proven on the caller's own client (anon key + their JWT) and
+  // filtered explicitly on owner_user_id, so the check does not lean on RLS
+  // alone. Only after this do we touch the service-role path.
+  const { data: owned, error: lookupError } = await supabase
+    .from('oauth_connections')
+    .select('id')
+    .eq('id', connectionId)
+    .eq('owner_user_id', user.id)
+    .is('deleted_at', null)
+    .maybeSingle();
+
+  if (lookupError) return { ok: false, error: GENERIC_ERROR };
+  if (!owned) return { ok: false, error: GENERIC_ERROR };
+
+  try {
+    await disconnectConnection(connectionId);
+  } catch {
+    // disconnectConnection throws only if the soft-delete update fails; the
+    // vault revoke inside it is already best-effort and logs on failure.
+    return { ok: false, error: GENERIC_ERROR };
+  }
+
+  revalidatePath('/dashboard/convene/connections');
+  return { ok: true };
+}

--- a/src/app/dashboard/convene/connections/disconnect-actions.ts
+++ b/src/app/dashboard/convene/connections/disconnect-actions.ts
@@ -19,21 +19,29 @@
  *
  * Two deliberate choices:
  *
- * - **No suspension guard.** The SEC-57 family gates write paths on
- *   `is_suspended`, but withdrawing consent is not a privileged write — a
- *   suspended user who cannot disconnect is a user whose calendar token we keep
- *   against their wishes. Disconnect stays available to any authenticated owner.
+ * - **Suspension guard, on the softer of the two SEC-57 postures** (owner
+ *   decision, 2026-07-29). `account-status.ts` documents two: credential-mint
+ *   paths refuse on anything other than `ok` (fail closed), while the consent
+ *   screen acts only on a *confirmed* `suspended`. Disconnect uses the latter.
+ *   Refusing on `unknown` would let a transient `profiles` read error block a
+ *   user from withdrawing consent, and consent withdrawal is not a credential
+ *   mint — the blast radius of a false allow here is a token being deleted
+ *   slightly too readily, which is the safe direction to fail.
  *
- * - **One generic failure message.** "Not yours", "already gone" and "never
- *   existed" all return the same string, so the action cannot be used to probe
- *   whether a given connection id exists.
+ * - **One generic failure message for the connection itself.** "Not yours",
+ *   "already gone" and "never existed" all return the same string, so the
+ *   action cannot be used to probe whether a given connection id exists. The
+ *   suspension refusal is distinct, because it describes the caller's own
+ *   account and leaks nothing about anyone else's data.
  */
 
 import { revalidatePath } from 'next/cache';
 import { createClient } from '@/lib/supabase-server';
+import { getAccountStanding } from '@/lib/account-status';
 import { disconnectConnection } from '@/lib/convene/oauth-connections';
 
 const GENERIC_ERROR = 'Could not disconnect that account';
+const SUSPENDED_ERROR = 'Your account is suspended, so this connection cannot be changed right now';
 
 export async function disconnectOAuthConnection(
   connectionId: string
@@ -47,6 +55,12 @@ export async function disconnectOAuthConnection(
     data: { user },
   } = await supabase.auth.getUser();
   if (!user) return { ok: false, error: 'Not authenticated' };
+
+  // SEC-57 family. Only a positively confirmed suspension refuses; `unknown`
+  // falls through so a transient lookup error cannot trap a user's token.
+  if ((await getAccountStanding(supabase, user.id)) === 'suspended') {
+    return { ok: false, error: SUSPENDED_ERROR };
+  }
 
   // Ownership is proven on the caller's own client (anon key + their JWT) and
   // filtered explicitly on owner_user_id, so the check does not lean on RLS

--- a/tests/unit/convene/disconnect-actions.test.ts
+++ b/tests/unit/convene/disconnect-actions.test.ts
@@ -11,7 +11,9 @@
 const mockRevalidatePath = jest.fn();
 jest.mock('next/cache', () => ({ revalidatePath: (...a: unknown[]) => mockRevalidatePath(...a) }));
 
-const mockDisconnectConnection = jest.fn(async () => undefined);
+const mockDisconnectConnection = jest.fn(async (id: string) => {
+  void id;
+});
 jest.mock('@/lib/convene/oauth-connections', () => ({
   disconnectConnection: (id: string) => mockDisconnectConnection(id),
 }));
@@ -20,7 +22,13 @@ let mockUserId: string | null = 'owner-1';
 // Rows visible to the *caller's own* client, keyed by `${id}::${ownerUserId}`.
 let ownedRows: Set<string> = new Set();
 let lookupError: unknown = null;
-const captured = { lookups: [] as Record<string, unknown>[] };
+// 'ok' | 'suspended' | 'missing-row' | 'error' — drives the profiles read that
+// getAccountStanding performs.
+let standing = 'ok';
+const captured = {
+  lookups: [] as Record<string, unknown>[],
+  profileLookups: [] as Record<string, unknown>[],
+};
 
 jest.mock('@/lib/supabase-server', () => ({
   createClient: jest.fn(async () => ({
@@ -42,6 +50,12 @@ jest.mock('@/lib/supabase-server', () => ({
           return chain;
         };
         chain.maybeSingle = async () => {
+          if (table === 'profiles') {
+            captured.profileLookups.push(filters);
+            if (standing === 'error') return { data: null, error: { message: 'profiles boom' } };
+            if (standing === 'missing-row') return { data: null, error: null };
+            return { data: { is_suspended: standing === 'suspended' }, error: null };
+          }
           captured.lookups.push(filters);
           if (lookupError) return { data: null, error: lookupError };
           const key = `${String(filters.id)}::${String(filters.owner_user_id)}`;
@@ -59,7 +73,9 @@ beforeEach(() => {
   mockUserId = 'owner-1';
   ownedRows = new Set(['conn-1::owner-1', 'conn-2::owner-2']);
   lookupError = null;
+  standing = 'ok';
   captured.lookups = [];
+  captured.profileLookups = [];
   mockRevalidatePath.mockClear();
   mockDisconnectConnection.mockClear();
   mockDisconnectConnection.mockImplementation(async () => undefined);
@@ -123,6 +139,39 @@ describe('disconnectOAuthConnection', () => {
     expect(res.ok).toBe(false);
     if (!res.ok) expect(res.error).not.toContain('boom');
     expect(mockDisconnectConnection).not.toHaveBeenCalled();
+  });
+
+  test('refuses a confirmed-suspended caller before touching the connection', async () => {
+    standing = 'suspended';
+    const res = await disconnectOAuthConnection('conn-1');
+    expect(res.ok).toBe(false);
+    expect(captured.profileLookups[0]).toMatchObject({ table: 'profiles', user_id: 'owner-1' });
+    expect(captured.lookups).toHaveLength(0);
+    expect(mockDisconnectConnection).not.toHaveBeenCalled();
+  });
+
+  test('the suspension refusal is distinguishable from the connection error', async () => {
+    standing = 'suspended';
+    const suspended = await disconnectOAuthConnection('conn-1');
+    standing = 'ok';
+    const unknownId = await disconnectOAuthConnection('no-such-connection');
+    expect(suspended).not.toEqual(unknownId);
+  });
+
+  test('a profiles lookup error does not trap the token — disconnect still proceeds', async () => {
+    // SEC-57's softer posture: only a *confirmed* suspension refuses, so a
+    // transient read failure cannot stop a user withdrawing consent.
+    standing = 'error';
+    const res = await disconnectOAuthConnection('conn-1');
+    expect(res).toEqual({ ok: true });
+    expect(mockDisconnectConnection).toHaveBeenCalledWith('conn-1');
+  });
+
+  test('a missing profile row does not block disconnect either', async () => {
+    standing = 'missing-row';
+    const res = await disconnectOAuthConnection('conn-1');
+    expect(res).toEqual({ ok: true });
+    expect(mockDisconnectConnection).toHaveBeenCalledWith('conn-1');
   });
 
   test('surfaces a generic error, not the internal one, if the disconnect throws', async () => {

--- a/tests/unit/convene/disconnect-actions.test.ts
+++ b/tests/unit/convene/disconnect-actions.test.ts
@@ -1,0 +1,137 @@
+/**
+ * SEC-109 — tests for the server-side Convene disconnect action.
+ *
+ * The defect these pin: the browser used to soft-delete `oauth_connections`
+ * directly and never revoke the vaulted refresh token. The whole point of the
+ * action is that a successful disconnect reaches `disconnectConnection`, which
+ * is what calls `vaultRevokeRefreshToken` — so "did the vault revoke happen"
+ * is asserted as "was disconnectConnection invoked".
+ */
+
+const mockRevalidatePath = jest.fn();
+jest.mock('next/cache', () => ({ revalidatePath: (...a: unknown[]) => mockRevalidatePath(...a) }));
+
+const mockDisconnectConnection = jest.fn(async () => undefined);
+jest.mock('@/lib/convene/oauth-connections', () => ({
+  disconnectConnection: (id: string) => mockDisconnectConnection(id),
+}));
+
+let mockUserId: string | null = 'owner-1';
+// Rows visible to the *caller's own* client, keyed by `${id}::${ownerUserId}`.
+let ownedRows: Set<string> = new Set();
+let lookupError: unknown = null;
+const captured = { lookups: [] as Record<string, unknown>[] };
+
+jest.mock('@/lib/supabase-server', () => ({
+  createClient: jest.fn(async () => ({
+    auth: {
+      getUser: jest.fn(async () => ({
+        data: { user: mockUserId ? { id: mockUserId } : null },
+      })),
+    },
+    from: jest.fn((table: string) => ({
+      select: () => {
+        const filters: Record<string, unknown> = { table };
+        const chain: Record<string, unknown> = {};
+        chain.eq = (col: string, val: unknown) => {
+          filters[col] = val;
+          return chain;
+        };
+        chain.is = (col: string, val: unknown) => {
+          filters[col] = val;
+          return chain;
+        };
+        chain.maybeSingle = async () => {
+          captured.lookups.push(filters);
+          if (lookupError) return { data: null, error: lookupError };
+          const key = `${String(filters.id)}::${String(filters.owner_user_id)}`;
+          return { data: ownedRows.has(key) ? { id: filters.id } : null, error: null };
+        };
+        return chain;
+      },
+    })),
+  })),
+}));
+
+import { disconnectOAuthConnection } from '@/app/dashboard/convene/connections/disconnect-actions';
+
+beforeEach(() => {
+  mockUserId = 'owner-1';
+  ownedRows = new Set(['conn-1::owner-1', 'conn-2::owner-2']);
+  lookupError = null;
+  captured.lookups = [];
+  mockRevalidatePath.mockClear();
+  mockDisconnectConnection.mockClear();
+  mockDisconnectConnection.mockImplementation(async () => undefined);
+});
+
+describe('disconnectOAuthConnection', () => {
+  test('disconnecting your own connection revokes the vaulted token', async () => {
+    const res = await disconnectOAuthConnection('conn-1');
+    expect(res).toEqual({ ok: true });
+    // disconnectConnection is the only path that calls vaultRevokeRefreshToken.
+    expect(mockDisconnectConnection).toHaveBeenCalledTimes(1);
+    expect(mockDisconnectConnection).toHaveBeenCalledWith('conn-1');
+    expect(mockRevalidatePath).toHaveBeenCalledWith('/dashboard/convene/connections');
+  });
+
+  test('the ownership lookup is scoped to the caller and to live rows', async () => {
+    await disconnectOAuthConnection('conn-1');
+    expect(captured.lookups).toHaveLength(1);
+    expect(captured.lookups[0]).toMatchObject({
+      table: 'oauth_connections',
+      id: 'conn-1',
+      owner_user_id: 'owner-1',
+      deleted_at: null,
+    });
+  });
+
+  test('user A cannot disconnect user B connection', async () => {
+    // conn-2 belongs to owner-2; the caller is owner-1.
+    const res = await disconnectOAuthConnection('conn-2');
+    expect(res.ok).toBe(false);
+    expect(mockDisconnectConnection).not.toHaveBeenCalled();
+  });
+
+  test('a foreign connection fails with the same message as an unknown one', async () => {
+    const foreign = await disconnectOAuthConnection('conn-2');
+    const unknown = await disconnectOAuthConnection('no-such-connection');
+    expect(foreign).toEqual(unknown);
+    expect(foreign.ok).toBe(false);
+  });
+
+  test('rejects unauthenticated callers before any lookup', async () => {
+    mockUserId = null;
+    const res = await disconnectOAuthConnection('conn-1');
+    expect(res.ok).toBe(false);
+    expect(captured.lookups).toHaveLength(0);
+    expect(mockDisconnectConnection).not.toHaveBeenCalled();
+  });
+
+  test('rejects an empty or blank connection id without touching the database', async () => {
+    for (const bad of ['', '   ']) {
+      const res = await disconnectOAuthConnection(bad);
+      expect(res.ok).toBe(false);
+    }
+    expect(captured.lookups).toHaveLength(0);
+    expect(mockDisconnectConnection).not.toHaveBeenCalled();
+  });
+
+  test('surfaces a generic error if the ownership lookup fails', async () => {
+    lookupError = { message: 'boom' };
+    const res = await disconnectOAuthConnection('conn-1');
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.error).not.toContain('boom');
+    expect(mockDisconnectConnection).not.toHaveBeenCalled();
+  });
+
+  test('surfaces a generic error, not the internal one, if the disconnect throws', async () => {
+    mockDisconnectConnection.mockImplementation(async () => {
+      throw new Error('disconnect update failed: relation does not exist');
+    });
+    const res = await disconnectOAuthConnection('conn-1');
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.error).not.toContain('relation');
+    expect(mockRevalidatePath).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

The Convene **Disconnect** button writes to `oauth_connections` straight from the browser and stops there, so the vaulted Google refresh token is never revoked. The user is told the opposite twice — the confirm dialog ("Lyra will forget your tokens") and the connections page ("we'll forget your tokens immediately"). A consent-withdrawal defect (GDPR Art.7(3)/17) on a service holding minors' data.

`disconnectConnection` (`src/lib/convene/oauth-connections.ts:152`) already does the right thing — soft-delete **plus** `vaultRevokeRefreshToken` — but it runs on a service-role client and deliberately performs no ownership check (see the `ownership-ok` note on `getConnection`). It had no caller at all, which is why the KAN-422 dead-export spike found it.

This PR adds that caller — `disconnectOAuthConnection` in `src/app/dashboard/convene/connections/disconnect-actions.ts`:

1. authenticate via `createClient()` + `getUser()`;
2. refuse a confirmed-suspended caller (SEC-57 family);
3. prove ownership on the **caller's own** RLS-scoped client, filtered explicitly on `owner_user_id` and `deleted_at is null`, so the check does not lean on RLS alone;
4. only then hand the id to the service-role repository path.

Connection-level failures — not yours, already gone, never existed, lookup error, disconnect error — all return one generic message, so the action cannot be used to probe whether a connection id exists. The suspension refusal is distinct, because it describes the caller's own account and leaks nothing about anyone else's data.

### Suspension guard posture

Owner decision, 2026-07-29. `account-status.ts` documents two postures; this uses the softer one — only a **confirmed** `suspended` refuses, while `unknown` (profiles read error, or missing row) falls through and allows the disconnect. Fail-closed is right for credential-mint paths, where a false allow hands out live credentials. Here the asymmetry runs the other way: a false refusal traps a user's OAuth token against an explicit withdrawal of consent, while a false allow only deletes a token slightly too readily.

### 🔍 Finding: the current client-side write cannot work at all on dev or staging

Verified read-only against both projects. `oauth_connections` has RLS enabled with four owner-scoped policies, and the update policy is correct (`auth.uid() = owner_user_id` in both USING and WITH CHECK). But the **table grant** is:

```
authenticated=rDxtm/postgres     -- SELECT, TRUNCATE, REFERENCES, TRIGGER, MAINTAIN
```

No `w`. `authenticated` has **no UPDATE privilege**, so the browser's `.from('oauth_connections').update(...)` is refused by PostgREST before RLS is even consulted. Identical on dev (`ilprytcrnqyrsbsrfujj`) and staging (`uobmlkzrjkptwhttzmmi`).

So on those environments Disconnect does not silently skip the revoke — it fails outright and surfaces a permission error, leaving the connection **active**. That is worse than the ticket describes, and it makes the server action the fix for both problems at once, since `disconnectConnection` runs service-role.

**Production was not checked** — out of scope for this change. If prod's grant differs, the ticket's original description holds there instead. Worth confirming.

Also worth noting: RLS is row-scoped and cannot restrict columns, so if any environment *does* grant UPDATE to `authenticated`, an owner can rewrite **any** column of their own row, including `refresh_token_secret_id` and `status`. The server action closes that path for the product; a column-scoped grant would close it properly.

### ⚠️ One line is still Luisa's

Wiring `handleDisconnect` (`connections-client.tsx:50`) is a change to `src/app/**/*.tsx`, a founder-owned UI path, so the autopilot has not touched it. **Until that lands, this export has no consumer and the defect is not fixed.** The exact patch is on SEC-109; it is behavioural only, no visual or copy effect.

Two items ride with that same commit: the **regression guard** the ticket asks for (it would be red against current `develop`, and a control red on arrival is the SEC-79 failure mode), and the **`docs/ARCHITECTURE.md`** note that disconnect is server-side.

Per owner decision, the **remediation sweep** of already-disconnected rows whose vault secret is still live stays folded into SEC-109 and is run by Luisa at merge time — the SQL is on the ticket. Dev currently has 1 such orphan; staging has 0.

## Jira Ticket

SEC-109

## Checklist

- [x] Unit tests added/updated — 12 total
- [x] All existing tests pass (`npm run test:unit`) — 2623 passed / 223 suites, 0 failed, none modified or skipped
- [x] Lint passes — 0 errors, 25 warnings (unchanged baseline)
- [x] Type check passes
- [x] Build succeeds (`npm run build`)
- [x] Coverage has not decreased — net-new file arrives with tests
- [x] No eslint-disable or ts-ignore without a ticket reference — none added
- [x] Dependency-rule gate reviewed — no new violation; one leaf module importing only `src/lib/**` and `next/cache`
- [ ] ARCHITECTURE.md updated — N/A **for now**: disconnect is not server-side until the client wiring lands, so the note goes in that commit rather than describing an intent as fact
- [x] Ops routine / Control-Room registry — N/A: no routine behaviour, cadence or ownership changed
- [x] Docs / system map — N/A with reason, as above; no new table, env var, route, scheduled job or security boundary

### Tests

12 unit tests in `tests/unit/convene/disconnect-actions.test.ts`. The vault revoke is asserted as "was `disconnectConnection` invoked", since that is the only path calling `vaultRevokeRefreshToken`.

- happy path reaches `disconnectConnection` and revalidates
- ownership lookup scoped to caller + live rows (`id`, `owner_user_id`, `deleted_at: null`)
- user A cannot disconnect user B's connection
- foreign id and unknown id are indistinguishable to the caller
- unauthenticated caller rejected before any DB call
- blank/empty id rejected before any DB call
- generic-error masking when the ownership lookup fails
- generic-error masking when the disconnect throws (and no revalidate)
- confirmed-suspended caller refused before any connection lookup
- suspension response distinguishable from the unknown-id response
- profiles lookup error still completes the disconnect
- missing profile row still completes the disconnect

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U6WaFwt9trRHbM5CX1efSJ