### PR TITLE
feat(KAN-414 F1): guard-path-drift gate — a dead path pattern is a dead control

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -117,6 +117,29 @@ jobs:
         env:
           PR_BODY: ${{ github.event.pull_request.body }}
         run: BASE_REF="origin/${{ github.base_ref }}" bash scripts/check-extraction-dod.sh
+      - name: Guard-path-drift check (KAN-414 F1)
+        # Guard #12, and the companion to #13 above. Where the DoD gate looks at
+        # THIS PR's diff, this one audits the WHOLE registry on every run: every
+        # path pattern in all 18 registered artefacts must match at least one
+        # TRACKED file. A pattern that matches nothing does not fail — it
+        # silently protects nothing while the gate keeps reporting green, which
+        # is the SEC-79 shape.
+        #
+        # Tracked files, not the filesystem: a pattern matching only an
+        # untracked or gitignored file must FAIL, because CI checks out tracked
+        # content and the pattern would be inert there.
+        #
+        # Proven by mutation (KAN-414): moving src/lib/supabase-service.ts into
+        # a module — literally D1's work — disarms TWO controls at once, the
+        # signup E2E gate and the service-role containment. Before this guard
+        # that move was green.
+        #
+        # Fails CLOSED (exit 2) when an artefact is missing or unparseable.
+        # Escape hatch: `guard-path-ok: <JIRA-KEY> <reason>` on the pattern's
+        # own line, suppressing exactly one pattern, printed on every run and
+        # counted. Artefacts whose syntax forbids comments (package.json)
+        # declare theirs in the script's DECLARED_EXCEPTIONS.
+        run: python3 scripts/check-guard-path-drift.py
       - name: macOS Finder-duplicate file check (KAN-357)
         # Reject any committed " <n>"-suffixed file/dir (e.g. "[slug] 2/" or
         # "profile-sections 2.cjs"). These Finder-copy duplicates shadow the

--- a/controls/registry.json
+++ b/controls/registry.json
@@ -5,7 +5,7 @@
     "Machine-readable index of every preventive control in this repo, and the",
     "defect it exists to stop. This is the memory of the Defect Feedback Loop:",
     "when a BUGS or SEC ticket closes, its root cause is traced to a control",
-    "here \u2014 either one that already exists (and failed to fire, which is itself",
+    "here — either one that already exists (and failed to fire, which is itself",
     "a finding) or a new one that gets added.",
     "",
     "Enforced by scripts/check-control-registry.py, which fails the build if a",
@@ -23,7 +23,7 @@
       "id": "CTL-001",
       "name": "Workflow integrity check",
       "defect_class": "false-green-ci",
-      "summary": "Static scan for workflow patterns that report SUCCESS while doing nothing \u2014 GITHUB_TOKEN pushes that suppress downstream triggers, --limit 1 deploy verification, 401 acceptance without SHA verification, rollback steps that never roll back.",
+      "summary": "Static scan for workflow patterns that report SUCCESS while doing nothing — GITHUB_TOKEN pushes that suppress downstream triggers, --limit 1 deploy verification, 401 acceptance without SHA verification, rollback steps that never roll back.",
       "implementation": "scripts/check-workflow-integrity.sh",
       "kind": "ci-gate",
       "wired_in": [
@@ -127,7 +127,7 @@
       "id": "CTL-007",
       "name": "Doc mirror content check",
       "defect_class": "doc-drift",
-      "summary": "Fails the PR if a listed mirror exists but is an empty or stub file \u2014 the 'backup that looks successful but contains placeholder content' failure mode.",
+      "summary": "Fails the PR if a listed mirror exists but is an empty or stub file — the 'backup that looks successful but contains placeholder content' failure mode.",
       "implementation": "scripts/check-doc-mirror-content.sh",
       "kind": "ci-gate",
       "wired_in": [
@@ -192,7 +192,7 @@
       "id": "CTL-011",
       "name": "Auto-heal pattern catalogue self-test",
       "defect_class": "false-green-ci",
-      "summary": "Verifies every auto-fix pattern still matches its fixture and does not false-positive on a sibling \u2014 the regression guard that stops the auto-fix workflow silently breaking.",
+      "summary": "Verifies every auto-fix pattern still matches its fixture and does not false-positive on a sibling — the regression guard that stops the auto-fix workflow silently breaking.",
       "implementation": "scripts/auto-fix-known-failures.py",
       "kind": "ci-gate",
       "wired_in": [
@@ -240,7 +240,7 @@
       "id": "CTL-014",
       "name": "Backup integrity check",
       "defect_class": "false-green-ci",
-      "summary": "Fails if a backup artefact is a placeholder rather than real data \u2014 a dump that does not start with '--', contains no CREATE statements, or is suspiciously short.",
+      "summary": "Fails if a backup artefact is a placeholder rather than real data — a dump that does not start with '--', contains no CREATE statements, or is suspiciously short.",
       "implementation": "scripts/check-backup-integrity.sh",
       "kind": "scheduled",
       "wired_in": [
@@ -307,7 +307,7 @@
       "id": "CTL-018",
       "name": "Main-chain guard",
       "defect_class": "release-control",
-      "summary": "Fails loud if main gains any commit not present on beta \u2014 i.e. a change that did not arrive through develop \u2192 staging \u2192 beta \u2192 main \u2014 and blocks any PR targeting main.",
+      "summary": "Fails loud if main gains any commit not present on beta — i.e. a change that did not arrive through develop → staging → beta → main — and blocks any PR targeting main.",
       "implementation": ".github/workflows/main-chain-guard.yml",
       "kind": "ci-gate",
       "wired_in": [
@@ -319,13 +319,13 @@
       ],
       "escape_hatch": "BYPASS CONTROLS commit marker",
       "added": "2026-07-25",
-      "notes": "NOT yet in main's required status checks \u2014 see docs/DEFECT_FEEDBACK_LOOP.md open gaps."
+      "notes": "NOT yet in main's required status checks — see docs/DEFECT_FEEDBACK_LOOP.md open gaps."
     },
     {
       "id": "CTL-019",
       "name": "Dashboard loading.tsx guard",
       "defect_class": "framework-footgun",
-      "summary": "Fails any PR that reintroduces a src/app/**/loading.* without an explicit marker \u2014 the Next 16 Suspense boundary that never reveals on hard load and blanks the dashboard.",
+      "summary": "Fails any PR that reintroduces a src/app/**/loading.* without an explicit marker — the Next 16 Suspense boundary that never reveals on hard load and blanks the dashboard.",
       "implementation": "tests/unit/bugs66-dashboard-loading-guard.test.js",
       "kind": "test",
       "wired_in": [
@@ -395,7 +395,7 @@
       "id": "CTL-023",
       "name": "Migration privilege lint",
       "defect_class": "postgres-privilege-drift",
-      "summary": "Every migration must revoke a SECURITY DEFINER function from public, anon AND authenticated. Revoking from PUBLIC alone is a no-op on Supabase, which grants anon/authenticated directly via ALTER DEFAULT PRIVILEGES \u2014 the first version of this rule required only the PUBLIC revoke and passed a fixture shipping an anon-callable function. That mis-specified revoke in 20260622120000_two_axis_access_model.sql is the actual root cause of SEC-28/29/42/43. Also pins search_path, forbids GRANT to anon, requires RLS on new public tables, and (R5) blocks duplicate migration version timestamps. Ratcheted against a baseline that may only shrink.",
+      "summary": "Every migration must revoke a SECURITY DEFINER function from public, anon AND authenticated. Revoking from PUBLIC alone is a no-op on Supabase, which grants anon/authenticated directly via ALTER DEFAULT PRIVILEGES — the first version of this rule required only the PUBLIC revoke and passed a fixture shipping an anon-callable function. That mis-specified revoke in 20260622120000_two_axis_access_model.sql is the actual root cause of SEC-28/29/42/43. Also pins search_path, forbids GRANT to anon, requires RLS on new public tables, and (R5) blocks duplicate migration version timestamps. Ratcheted against a baseline that may only shrink.",
       "implementation": "scripts/check-migration-privileges.py",
       "kind": "ci-gate",
       "wired_in": [
@@ -468,7 +468,7 @@
       "id": "CTL-026",
       "name": "Control registry integrity",
       "defect_class": "control-rot",
-      "summary": "The meta-control. Fails if a registered control's implementation is missing, if it is no longer referenced by any workflow (the SEC-79 'silently disabled for weeks' mode), or if a check script exists in the repo but is not registered \u2014 so the registry cannot drift away from reality.",
+      "summary": "The meta-control. Fails if a registered control's implementation is missing, if it is no longer referenced by any workflow (the SEC-79 'silently disabled for weeks' mode), or if a check script exists in the repo but is not registered — so the registry cannot drift away from reality.",
       "implementation": "scripts/check-control-registry.py",
       "kind": "ci-gate",
       "wired_in": [
@@ -506,7 +506,7 @@
       "id": "CTL-028",
       "name": "Suspension-guard coverage",
       "defect_class": "authz-coverage-drift",
-      "summary": "Any query filtering is_published = true is selecting content for public consumption and must also filter is_suspended = false. Stated on the QUERY rather than the file or the client, so it enumerates the surface instead of sampling it \u2014 the property every previous fix in this class lacked. Found three unguarded sites beyond the two identified by review, including the homepage and the sitemap.",
+      "summary": "Any query filtering is_published = true is selecting content for public consumption and must also filter is_suspended = false. Stated on the QUERY rather than the file or the client, so it enumerates the surface instead of sampling it — the property every previous fix in this class lacked. Found three unguarded sites beyond the two identified by review, including the homepage and the sitemap.",
       "implementation": "scripts/check-suspension-guard-coverage.py",
       "kind": "ci-gate",
       "wired_in": [
@@ -548,7 +548,7 @@
       "id": "CTL-030",
       "name": "Structural dependency rules (module/segment/cycle)",
       "defect_class": "regression-risk",
-      "summary": "Three structural import rules, enforced so the codebase cannot regress while the modularisation programme (KAN-415) runs: nothing under src/lib/** may import src/app/** (a library owned by a route folder is how the access-transition matrix ended up inside the admin console, KAN-424 Defect 1); one top-level src/app segment may not import another (a cross-segment edge couples two features so neither can be changed or extracted alone); and no import cycles. The precedent for needing a gate rather than a convention is src/lib/deploy-env.ts \u2014 built to be the single environment resolver, it never displaced the six inline derivations because nothing stopped new ones being written. Ships at severity warn and flips to error once the outstanding findings clear.",
+      "summary": "Three structural import rules, enforced so the codebase cannot regress while the modularisation programme (KAN-415) runs: nothing under src/lib/** may import src/app/** (a library owned by a route folder is how the access-transition matrix ended up inside the admin console, KAN-424 Defect 1); one top-level src/app segment may not import another (a cross-segment edge couples two features so neither can be changed or extracted alone); and no import cycles. The precedent for needing a gate rather than a convention is src/lib/deploy-env.ts — built to be the single environment resolver, it never displaced the six inline derivations because nothing stopped new ones being written. Ships at severity warn and flips to error once the outstanding findings clear.",
       "implementation": "scripts/check-dependency-rules.sh",
       "kind": "ci-gate",
       "wired_in": [
@@ -565,7 +565,7 @@
       "id": "CTL-031",
       "name": "Bash 3.2 portability",
       "defect_class": "dev-ci-environment-parity",
-      "summary": "Fails any script under scripts/ using a bash-4-only construct (mapfile/readarray, declare -A, ${v^^}/${v,,}, &>>, coproc, shopt -s globstar). macOS ships bash 3.2 and CI ships bash 5, so these work in CI and exit 127 where releases are prepared. staging-soak.sh documented the rule in a comment from day one and two scripts shipped with mapfile anyway, making the whole unit suite unpassable on macOS \u2014 a convention without a gate erodes. Comments are stripped before matching so the fix's own explanatory prose does not trip it; that case is pinned in the self-test. Workflow YAML is out of scope by design: inline run: blocks execute only on the runner, so findings there would only ever be allow-listed, and standing noise is what teaches people to wave a gate through.",
+      "summary": "Fails any script under scripts/ using a bash-4-only construct (mapfile/readarray, declare -A, ${v^^}/${v,,}, &>>, coproc, shopt -s globstar). macOS ships bash 3.2 and CI ships bash 5, so these work in CI and exit 127 where releases are prepared. staging-soak.sh documented the rule in a comment from day one and two scripts shipped with mapfile anyway, making the whole unit suite unpassable on macOS — a convention without a gate erodes. Comments are stripped before matching so the fix's own explanatory prose does not trip it; that case is pinned in the self-test. Workflow YAML is out of scope by design: inline run: blocks execute only on the runner, so findings there would only ever be allow-listed, and standing noise is what teaches people to wave a gate through.",
       "implementation": "scripts/check-bash-portability.py",
       "kind": "ci-gate",
       "wired_in": [
@@ -598,7 +598,7 @@
       "id": "CTL-033",
       "name": "Extraction Definition-of-Done",
       "defect_class": "path-coupling-drift",
-      "summary": "Fails any PR that deletes or renames a file under src/ while an artefact that classifies files BY PATH still names the old path: .github/ (signup-surface manifest, CODEOWNERS, workflows), scripts/ guard path-lists, docs/ (incl. the mirror manifest), modules.json and tests/. A glob that matches nothing protects nothing while CI stays green \u2014 KAN-419 measured the docs layer at 18% dead path literals before a single file was moved on purpose. Also requires the PR body to answer the two couplings CI can never see (~/lyra-design-system/build.py and the claude.ai routine prompts, neither in any repo CI can read) and to name the covering Playwright project + soak clause, or record 'no coverage' as a finding. Fails closed (exit 2) when it cannot verify.",
+      "summary": "Fails any PR that deletes or renames a file under src/ while an artefact that classifies files BY PATH still names the old path: .github/ (signup-surface manifest, CODEOWNERS, workflows), scripts/ guard path-lists, docs/ (incl. the mirror manifest), modules.json and tests/. A glob that matches nothing protects nothing while CI stays green — KAN-419 measured the docs layer at 18% dead path literals before a single file was moved on purpose. Also requires the PR body to answer the two couplings CI can never see (~/lyra-design-system/build.py and the claude.ai routine prompts, neither in any repo CI can read) and to name the covering Playwright project + soak clause, or record 'no coverage' as a finding. Fails closed (exit 2) when it cannot verify.",
       "implementation": "scripts/check-extraction-dod.sh",
       "kind": "ci-gate",
       "wired_in": [
@@ -609,6 +609,23 @@
       ],
       "escape_hatch": "EXTRACTION-DOD-OK: <JIRA-KEY> <check-id> on a commit in the PR. Suppresses exactly one named check, requires a Jira key, every active exception is printed on every run, and more than three in one PR emits a ::warning:: that the hatch is papering over drift.",
       "added": "2026-07-28"
+    },
+    {
+      "id": "CTL-035",
+      "name": "Guard-path-drift",
+      "defect_class": "path-coupling-drift",
+      "summary": "Audits the WHOLE registry on every PR: every path pattern in all 18 registered artefacts must match at least one TRACKED file. Companion to CTL-033, which looks only at the current PR's diff. A pattern matching nothing does not fail - it silently protects nothing while the gate keeps reporting green (the SEC-79 shape). Resolution set is `git ls-files`, so a pattern matching only an untracked or gitignored file FAILS, because CI checks out tracked content and the pattern would be inert there. Implements all seven matching syntaxes separately (bash-case, bash-dbl-bracket, codeowners, literal, glob, regex, basename-regex) because collapsing them produces false verdicts both ways - notably bash's '*' crosses '/' while fnmatch's does not, which would report the largest protected pattern in the estate as dead.",
+      "implementation": "scripts/check-guard-path-drift.py",
+      "kind": "ci-gate",
+      "wired_in": [
+        ".github/workflows/pr-checks.yml"
+      ],
+      "prevents": [
+        "KAN-414",
+        "KAN-419"
+      ],
+      "escape_hatch": "guard-path-ok: <JIRA-KEY> <reason>",
+      "added": "2026-07-29"
     }
   ]
 }

--- a/scripts/check-guard-path-drift.py
+++ b/scripts/check-guard-path-drift.py
@@ -1,0 +1,735 @@
+#!/usr/bin/env python3
+"""KAN-414 F1 — the guard-path-drift gate (guard #12 in pr-checks.yml).
+
+WHY THIS EXISTS
+---------------
+Almost every control in this repo classifies files by their PATH: the founder
+UI/copy gate matches `src/app/**/*.tsx`, the un-skippable signup gate reads
+`.github/signup-surface.paths`, CODEOWNERS anchors review on security-critical
+paths, Stryker mutates a literal file list. A path pattern that matches nothing
+does not fail — it silently protects nothing, and the gate keeps reporting
+green. That is the SEC-79 shape: a control that reports success while not
+operating.
+
+The modularisation programme's primary activity is MOVING FILES. So the first
+extraction PR is also the most likely event ever to disarm these gates, and it
+would do so invisibly. KAN-419 measured the baseline before anyone moved a file
+on purpose and found the unguarded doc layer had already rotted to ~18% dead
+path literals. This guard closes the machine-checkable half.
+
+THE CONTRACT (KAN-419 §7.1)
+---------------------------
+  Every path pattern in a registered artefact must match at least one TRACKED
+  file, unless explicitly and individually excepted.
+
+WHY `git ls-files` AND NOT THE FILESYSTEM (§7.4)
+------------------------------------------------
+Tracked files only. This is what makes the subtle case work: a pattern matching
+only an untracked or .gitignore'd file FAILS, because CI checks out tracked
+content and the pattern would be inert there. Checking the filesystem would pass
+it locally and leave the gate dead in CI — the worst of both.
+
+MATCHING IS PER-ARTEFACT, NOT ONE-SIZE-FITS-ALL (§7.3)
+-------------------------------------------------------
+The registered artefacts genuinely use different syntaxes, and collapsing them
+into one "close enough" matcher produces false verdicts in both directions. Two
+that must not be got wrong:
+
+  * `bash-case` / `bash-dbl-bracket`: bash's `*` matches ACROSS '/'. Standard
+    fnmatch does not. Using fnmatch would report `src/app/*.tsx` as matching 0
+    files instead of ~97 — a false DEAD on the largest protected pattern in the
+    estate, which would then be "fixed" by weakening the real gate.
+  * `bash-case` additionally applies the trailing-`/**`-prefix rule from
+    check-signup-surface-gate.sh's matches_glob().
+
+Ported from `docs/modularisation/kan419-scan.py`, the executable reference
+implementation of all seven syntaxes, rather than re-derived (§7.3).
+
+FAIL-CLOSED (§7.5) — exit 2
+---------------------------
+An artefact that is missing, unreadable or unparseable exits 2, never 0. Per the
+Workflow & Backup Integrity Policy a guard that cannot read its input must fail
+the build, never skip. There is no `if: env.X != ''` and no `continue-on-error`
+on this step. `check-guard-path-drift` reporting green because it could not find
+its own inputs would be the exact defect it exists to detect.
+
+ESCAPE HATCH (§7.7)
+-------------------
+    guard-path-ok: <JIRA-KEY> <reason>
+
+as a trailing comment on the pattern's own line, or — where the artefact's
+syntax forbids comments entirely (package.json is JSON) — declared in
+DECLARED_EXCEPTIONS below, which is reviewable in exactly the same way.
+
+  1. Suppresses EXACTLY one pattern. Never a file, never a directory, never a
+     wildcard.
+  2. Requires a Jira key. A bare `guard-path-ok` is itself a failure.
+  3. Every active exception is PRINTED on every run, passing or failing — the
+     `UI-Change-Approved` loudness standard. An escape hatch you cannot
+     enumerate is one you cannot audit.
+  4. More than MAX_EXCEPTIONS emits a ::warning:: that the register is being
+     used to paper over drift.
+
+DELIBERATE DEVIATIONS FROM THE §7 SPEC — stated, not silent
+------------------------------------------------------------
+  * **Python, not bash.** §7 says "a bash script". The seven matching syntaxes
+    are intricate and the spec itself flags two as easy to get wrong; the
+    reference implementation it says to port from is Python. Bash 3.2 (what
+    macOS ships — gotcha #28) has no associative arrays, so an 18-artefact
+    registry with per-entry syntax/severity/extractor would need parallel arrays
+    and string-splitting. That is a lot of surface for a control whose whole
+    job is to be trustworthy. Python matches the idiom of the repo's other
+    recent guards (check-migration-privileges.py, check-partial-write-safety.py,
+    check-bash-portability.py) and runs identically on macOS and CI.
+  * **§7.8 is NOT implemented here.** The companion "no stale reference to a
+    moved path" rule already shipped in KAN-428's
+    `scripts/check-extraction-dod.sh` as its `stale-refs` / `doc-manifest` /
+    `module-manifest` / `test-estate` checks. Re-implementing it would create
+    two controls for one concern (KAN-361). This guard owns the whole-registry
+    direction; the DoD gate owns the per-PR-diff direction.
+  * Test file is `tests/scripts/check-guard-path-drift.test.js`, not `.cjs` —
+    every existing file in `tests/scripts/` is `.js`.
+
+USAGE
+-----
+    python3 scripts/check-guard-path-drift.py            # the gate
+    python3 scripts/check-guard-path-drift.py --list     # every pattern + verdict
+    python3 scripts/check-guard-path-drift.py --self-test
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+import sys
+from pathlib import Path
+from typing import Callable, NamedTuple
+
+REPO = Path(__file__).resolve().parents[1]
+
+MAX_EXCEPTIONS = 5
+
+EXIT_OK = 0
+EXIT_DRIFT = 1
+EXIT_FAIL_CLOSED = 2
+
+# The escape-hatch marker. A Jira key is mandatory — `guard-path-ok` on its own
+# is a failure, not a pass (§7.7 rule 2).
+HATCH_RE = re.compile(r"guard-path-ok:\s*(?P<key>[A-Z]+-\d+)?\s*(?P<reason>.*)$")
+
+
+class Unparseable(Exception):
+    """An artefact exists but does not have the shape we must read.
+
+    Distinct from a missing file only in the message — both are exit 2. Raised
+    rather than returning an empty pattern list, because "no patterns found"
+    read as success is precisely the vacuous pass this guard exists to prevent.
+    """
+
+
+class Pattern(NamedTuple):
+    pattern: str
+    source: str  # repo-relative file the pattern was read from
+    line: int  # 1-indexed, for the ::error file=,line=:: annotation
+    hatch_key: str | None = None  # Jira key from an inline marker, if any
+    hatch_reason: str = ""
+    hatch_present: bool = False  # a marker was seen, with or without a valid key
+
+
+# ---------------------------------------------------------------------------
+# Resolution set — tracked files only (§7.4). Read once, reused for every
+# pattern; no per-pattern shelling out (§7.10 keeps this well under 1% of the
+# existing shell-guard block).
+# ---------------------------------------------------------------------------
+
+
+def tracked_files() -> list[str]:
+    try:
+        out = subprocess.run(
+            ["git", "-C", str(REPO), "ls-files"],
+            capture_output=True,
+            text=True,
+            check=True,
+        ).stdout
+    except (subprocess.CalledProcessError, FileNotFoundError) as exc:
+        raise Unparseable(f"could not enumerate tracked files via git ls-files: {exc}")
+    files = [ln for ln in out.splitlines() if ln]
+    if not files:
+        raise Unparseable("git ls-files returned nothing — refusing to pass vacuously")
+    return files
+
+
+# ---------------------------------------------------------------------------
+# The seven matching syntaxes (§7.3), ported from kan419-scan.py.
+# ---------------------------------------------------------------------------
+
+
+def _bash_pat_to_re(pattern: str) -> re.Pattern[str]:
+    """bash glob -> regex. The load-bearing detail is that '*' becomes '.*',
+    i.e. it CROSSES '/', which is bash's behaviour and not fnmatch's."""
+    out: list[str] = []
+    i = 0
+    while i < len(pattern):
+        c = pattern[i]
+        if c == "*":
+            out.append(".*")
+        elif c == "?":
+            out.append(".")
+        elif c == "[":
+            j = pattern.find("]", i + 1)
+            if j == -1:
+                out.append(re.escape(c))
+            else:
+                out.append(pattern[i : j + 1])
+                i = j
+        else:
+            out.append(re.escape(c))
+        i += 1
+    return re.compile("".join(out))
+
+
+def m_bash_case(pattern: str, files: list[str]) -> list[str]:
+    """`case $f in $g)` as used by check-signup-surface-gate.sh, including its
+    extra rule: a trailing `/**` also matches the directory prefix at any depth."""
+    rx = _bash_pat_to_re(pattern)
+    hits = [f for f in files if rx.fullmatch(f)]
+    if pattern.endswith("/**"):
+        pref = pattern[: -len("/**")] + "/"
+        hits += [f for f in files if f.startswith(pref) and f not in hits]
+    return hits
+
+
+def m_bash_dbl_bracket(pattern: str, files: list[str]) -> list[str]:
+    """`[[ $f == pat ]]` — same globbing as m_bash_case, without the /** rule."""
+    rx = _bash_pat_to_re(pattern)
+    return [f for f in files if rx.fullmatch(f)]
+
+
+def m_codeowners(pattern: str, files: list[str]) -> list[str]:
+    """gitignore-style CODEOWNERS: a leading '/' anchors at the repo root."""
+    p = pattern.lstrip("/")
+    if p == "*":
+        return list(files)
+    if p.endswith("/"):
+        return [f for f in files if f.startswith(p)]
+    return [f for f in files if f == p or f.startswith(p + "/")]
+
+
+def m_literal(pattern: str, files: list[str]) -> list[str]:
+    """An exact repo-relative path, or a directory prefix."""
+    return [f for f in files if f == pattern or f.startswith(pattern.rstrip("/") + "/")]
+
+
+def m_regex(pattern: str, files: list[str]) -> list[str]:
+    try:
+        rx = re.compile(pattern)
+    except re.error as exc:
+        raise Unparseable(f"registered pattern is not a valid regex: {pattern!r} ({exc})")
+    return [f for f in files if rx.search(f)]
+
+
+def m_basename_regex(pattern: str, files: list[str]) -> list[str]:
+    """Playwright testMatch/testIgnore — pinned to the basename in practice, so
+    it survives a directory move. Deliberately the same engine as m_regex; the
+    distinction is documentary (it tells a reader why a move does not break it)."""
+    return m_regex(pattern, files)
+
+
+def m_glob(pattern: str, files: list[str]) -> list[str]:
+    """eslint / jest / tsconfig style: '**' = any depth, '*' = within a segment."""
+    rx = re.compile(
+        pattern.replace(".", r"\.")
+        .replace("**/", "\x00")
+        .replace("**", ".*")
+        .replace("*", "[^/]*")
+        .replace("\x00", "(?:.*/)?")
+        .replace("{ts,tsx}", "(?:ts|tsx)")
+    )
+    return [f for f in files if rx.fullmatch(f)]
+
+
+MATCHERS: dict[str, Callable[[str, list[str]], list[str]]] = {
+    "bash-case": m_bash_case,
+    "bash-dbl-bracket": m_bash_dbl_bracket,
+    "codeowners": m_codeowners,
+    "literal": m_literal,
+    "regex": m_regex,
+    "basename-regex": m_basename_regex,
+    "glob": m_glob,
+}
+
+
+# ---------------------------------------------------------------------------
+# Extractors. Each reads patterns OUT OF the live artefact, so the registry
+# cannot drift from what the guards actually enforce. Every extractor returns
+# (pattern, source-file, line) so a failure can name a precise location.
+# ---------------------------------------------------------------------------
+
+
+def _read(rel: str) -> str:
+    p = REPO / rel
+    if not p.is_file():
+        raise Unparseable(f"registered artefact is missing: {rel}")
+    try:
+        return p.read_text(encoding="utf-8")
+    except OSError as exc:
+        raise Unparseable(f"registered artefact is unreadable: {rel} ({exc})")
+
+
+def _hatch(line: str) -> tuple[str | None, str, bool]:
+    """Parse an inline escape-hatch marker.
+
+    Returns (jira_key, reason, marker_present). A marker with no Jira key comes
+    back as (None, ..., True) so the caller can fail it — silently ignoring a
+    malformed hatch would let `guard-path-ok` alone suppress a dead pattern.
+    """
+    if "guard-path-ok" not in line:
+        return None, "", False
+    m = HATCH_RE.search(line)
+    if not m:
+        return None, "", True
+    return m.group("key"), (m.group("reason") or "").strip(), True
+
+
+def _strip_comment(line: str, marker: str = "#") -> str:
+    return line.split(marker, 1)[0].strip()
+
+
+def ex_signup_globs() -> list[Pattern]:
+    rel = ".github/signup-surface.paths"
+    out: list[Pattern] = []
+    for n, raw in enumerate(_read(rel).splitlines(), 1):
+        key, reason, present = _hatch(raw)
+        body = _strip_comment(raw)
+        if body:
+            out.append(Pattern(body, rel, n, key if present else None, reason, present))
+    if not out:
+        raise Unparseable(f"{rel} declared no patterns — the signup gate would be inert")
+    return out
+
+
+def ex_codeowners() -> list[Pattern]:
+    rel = ".github/CODEOWNERS"
+    out: list[Pattern] = []
+    for n, raw in enumerate(_read(rel).splitlines(), 1):
+        key, reason, present = _hatch(raw)
+        body = _strip_comment(raw)
+        if not body:
+            continue
+        out.append(Pattern(body.split()[0], rel, n, key if present else None, reason, present))
+    if not out:
+        raise Unparseable(f"{rel} declared no owner rules")
+    return out
+
+
+def ex_ui_copy() -> list[Pattern]:
+    """The founder UI/copy gate's is_protected() globs (KAN-411).
+
+    Both carve-outs (`return 1`) and protected patterns (`return 0`) are
+    registered: a dead carve-out is as much a silent behaviour change as a dead
+    protection, it just fails the other way.
+    """
+    rel = "scripts/check-ui-copy-ownership.sh"
+    src = _read(rel)
+    if "is_protected() {" not in src:
+        raise Unparseable(f"{rel}: is_protected() not found — the gate has been restructured")
+    lines = src.splitlines()
+    out: list[Pattern] = []
+    inside = False
+    for n, raw in enumerate(lines, 1):
+        if "is_protected() {" in raw:
+            inside = True
+            continue
+        if inside and raw.startswith("}"):
+            break
+        if not inside:
+            continue
+        m = re.search(r"\[\[\s*\$f\s*==\s*(\S+?)\s*\]\]\s*&&\s*return\s*[01]", raw)
+        if m:
+            key, reason, present = _hatch(raw)
+            out.append(Pattern(m.group(1), rel, n, key if present else None, reason, present))
+    if not out:
+        raise Unparseable(f"{rel}: is_protected() matched no glob rules")
+    return out
+
+
+def ex_stryker() -> list[Pattern]:
+    rel = "stryker.config.mjs"
+    src = _read(rel)
+    if "mutate: [" not in src:
+        raise Unparseable(f"{rel}: no `mutate: [` array found")
+    lines = src.splitlines()
+    out: list[Pattern] = []
+    inside = False
+    for n, raw in enumerate(lines, 1):
+        if "mutate: [" in raw:
+            inside = True
+        if inside:
+            for m in re.finditer(r"'([^']+)'", raw):
+                key, reason, present = _hatch(raw)
+                out.append(Pattern(m.group(1), rel, n, key if present else None, reason, present))
+            if "]" in raw.split("mutate: [", 1)[-1]:
+                break
+    if not out:
+        raise Unparseable(f"{rel}: mutate array is empty — nothing would be mutation-tested")
+    return out
+
+
+def ex_routine_ownership() -> list[Pattern]:
+    rel = "scripts/check-routine-ownership.sh"
+    out: list[Pattern] = []
+    for n, raw in enumerate(_read(rel).splitlines(), 1):
+        m = re.match(r'^check_marker "([^"]+)"', raw)
+        if m:
+            key, reason, present = _hatch(raw)
+            out.append(Pattern(m.group(1), rel, n, key if present else None, reason, present))
+    if not out:
+        raise Unparseable(f"{rel}: no check_marker entries found")
+    return out
+
+
+def ex_doc_manifest() -> list[Pattern]:
+    rel = "docs/DOC_SOURCE_OF_TRUTH.md"
+    src = _read(rel)
+    start, end = "<!-- doc-mirror-manifest:start -->", "<!-- doc-mirror-manifest:end -->"
+    if start not in src or end not in src:
+        raise Unparseable(f"{rel}: doc-mirror-manifest block delimiters missing")
+    head = src.split(start, 1)[0]
+    base = head.count("\n") + 1
+    block = src.split(start, 1)[1].split(end, 1)[0]
+    out: list[Pattern] = []
+    for off, raw in enumerate(block.splitlines()):
+        for m in re.finditer(r"`([^`]+)`", raw):
+            t = m.group(1)
+            if re.match(r"^(docs|scripts|\.github|src|tests)/", t):
+                key, reason, present = _hatch(raw)
+                out.append(Pattern(t, rel, base + off, key if present else None, reason, present))
+    if not out:
+        raise Unparseable(f"{rel}: manifest block declared no repo paths")
+    return out
+
+
+def ex_workflow_script_refs() -> list[Pattern]:
+    """Every `scripts/...` path a workflow shells out to.
+
+    NOTE the trailing-punctuation strip. The reference scanner's character class
+    includes '.', so prose like "see scripts/check-db-invariants.py." captured
+    the sentence's full stop and reported a DEAD pattern for a file that plainly
+    exists. Two of the six DEAD findings at implementation time were this bug.
+    Standing false positives are exactly what teaches a team to wave a gate
+    through, so the extractor is fixed here rather than the findings excepted.
+    """
+    out: list[Pattern] = []
+    wf_dir = REPO / ".github/workflows"
+    if not wf_dir.is_dir():
+        raise Unparseable(".github/workflows/ is missing")
+    seen: set[tuple[str, str]] = set()
+    for wf in sorted(wf_dir.glob("*.yml")):
+        rel = str(wf.relative_to(REPO))
+        for n, raw in enumerate(wf.read_text(encoding="utf-8").splitlines(), 1):
+            for m in re.finditer(r"scripts/[A-Za-z0-9._/-]+", raw):
+                ref = m.group(0).rstrip(".,;:)\"'")
+                if (rel, ref) in seen:
+                    continue
+                seen.add((rel, ref))
+                key, reason, present = _hatch(raw)
+                out.append(Pattern(ref, rel, n, key if present else None, reason, present))
+    if not out:
+        raise Unparseable(".github/workflows/*.yml referenced no scripts/ paths")
+    return out
+
+
+def _fixed(rel: str, patterns: list[str]) -> Callable[[], list[Pattern]]:
+    """For artefacts whose relevant patterns are structural rather than listed —
+    the file must still exist, so a rename is still caught."""
+
+    def _inner() -> list[Pattern]:
+        _read(rel)
+        return [Pattern(p, rel, 0) for p in patterns]
+
+    return _inner
+
+
+class Artefact(NamedTuple):
+    name: str
+    syntax: str
+    extract: Callable[[], list[Pattern]]
+    note: str
+    severity: str = "blocking"
+
+
+REGISTRY: list[Artefact] = [
+    # --- the CI policy gates: a dead pattern here is a disarmed control ------
+    Artefact(".github/signup-surface.paths", "bash-case", ex_signup_globs,
+             "un-skippable signup E2E gate (KAN-413)"),
+    Artefact(".github/CODEOWNERS", "codeowners", ex_codeowners,
+             "review requirement on security-critical paths (SEC-3)"),
+    Artefact("scripts/check-ui-copy-ownership.sh", "bash-dbl-bracket", ex_ui_copy,
+             "founder UI/copy approval gate (KAN-411)"),
+    Artefact("scripts/check-service-role-client.sh", "literal",
+             _fixed("scripts/check-service-role-client.sh",
+                    ["src/", "src/lib/supabase-service.ts"]),
+             "RLS-bypass containment (KAN-352)"),
+    Artefact("stryker.config.mjs", "literal", ex_stryker,
+             "mutation coverage of security modules"),
+    Artefact("scripts/check-routine-ownership.sh", "literal", ex_routine_ownership,
+             "KAN-361 one-concern-one-owner markers"),
+    Artefact("scripts/check-server-action-exports.sh", "literal",
+             _fixed("scripts/check-server-action-exports.sh", ["src/"]),
+             "BUGS-12 'use server' export guard"),
+    Artefact("scripts/check-codeowners-single.sh", "literal",
+             _fixed("scripts/check-codeowners-single.sh",
+                    [".github/CODEOWNERS", "CODEOWNERS", "docs/CODEOWNERS"]),
+             "SEC-3; 2 of the 3 candidates are EXPECTED absent — the guard's job is "
+             "to prove there is exactly one CODEOWNERS, so those two are excepted"),
+    Artefact("docs/DOC_SOURCE_OF_TRUTH.md", "literal", ex_doc_manifest,
+             "doc mirror manifest (KAN-363)"),
+    Artefact(".github/workflows/*.yml", "literal", ex_workflow_script_refs,
+             "a workflow shelling out to a moved script fails loudly"),
+    Artefact(".github/workflows/lyra-maintenance-deploy.yml", "glob",
+             _fixed(".github/workflows/lyra-maintenance-deploy.yml",
+                    ["scripts/lyra-maintenance-worker.js", "wrangler.toml",
+                     ".github/workflows/lyra-maintenance-deploy.yml"]),
+             "silent-skip on drift: a moved worker file means the deploy never runs"),
+    Artefact(".github/workflows/pr-checks.yml", "regex",
+             _fixed(".github/workflows/pr-checks.yml",
+                    [r"^(src/app/|src/middleware|supabase/migrations/|\.github/workflows/"
+                     r"|public/\.well-known/|scripts/)"]),
+             "architecture-doc freshness check"),
+    # --- build / test tooling ------------------------------------------------
+    Artefact("tsconfig.json", "glob", _fixed("tsconfig.json", ["src/**"]),
+             "@/* -> ./src/* — every '@/' import in the repo"),
+    Artefact("jest.config.js", "glob", _fixed("jest.config.js", ["src/**/*.{ts,tsx}"]),
+             "collectCoverageFrom"),
+    Artefact("eslint.config.mjs", "glob",
+             _fixed("eslint.config.mjs",
+                    ["tests/**/*.js", "tests/**/*.ts", "scripts/**/*.js"]), ""),
+    Artefact("playwright.config.ts", "literal",
+             _fixed("playwright.config.ts", ["tests/e2e"]), "testDir"),
+    Artefact("playwright.config.ts", "basename-regex",
+             _fixed("playwright.config.ts",
+                    [r"journey\.authed\.spec\.ts", r"journey\.soak\.spec\.ts",
+                     r"signup\.e2e\.spec\.ts"]),
+             "AUTHED_MATCH / SOAK_MATCH / SIGNUP_MATCH — resilient to directory moves"),
+    Artefact("package.json", "regex",
+             _fixed("package.json", [r"tests/(unit|scripts)", r"tests/integration",
+                                     r"tests/scripts"]),
+             "test:unit is the gate that enforces the test floor"),
+]
+
+
+# ---------------------------------------------------------------------------
+# Exceptions declared here rather than inline, for artefacts whose syntax
+# forbids comments outright (JSON). Same review surface, same loudness: every
+# entry is printed on every run.
+# ---------------------------------------------------------------------------
+
+DECLARED_EXCEPTIONS: dict[tuple[str, str], tuple[str, str]] = {
+    ("scripts/check-ui-copy-ownership.sh", "tailwind.config.*"): (
+        "KAN-419", "Tailwind v4 is CSS-first; defensive stub for a config that may return"),
+    ("scripts/check-codeowners-single.sh", "CODEOWNERS"): (
+        "KAN-419", "asserted-absent by design — the guard proves there is only one"),
+    ("scripts/check-codeowners-single.sh", "docs/CODEOWNERS"): (
+        "KAN-419", "asserted-absent by design — the guard proves there is only one"),
+    ("package.json", "tests/integration"): (
+        "KAN-417", "dead dir, but `npm run test:integration` is called by "
+                   "weekly-health-regression.sh:51 — removal is KAN-417's call, not F1's"),
+}
+
+
+def resolve(files: list[str]) -> tuple[list[dict], list[dict], list[dict]]:
+    """Returns (dead, excepted, live). Raises Unparseable -> exit 2."""
+    dead: list[dict] = []
+    excepted: list[dict] = []
+    live: list[dict] = []
+
+    for art in REGISTRY:
+        matcher = MATCHERS[art.syntax]
+        for pat in art.extract():
+            hits = matcher(pat.pattern, files)
+            row = {
+                "artefact": art.name,
+                "syntax": art.syntax,
+                "severity": art.severity,
+                "pattern": pat.pattern,
+                "source": pat.source,
+                "line": pat.line,
+                "matches": len(hits),
+                "note": art.note,
+            }
+
+            if hits:
+                live.append(row)
+                continue
+
+            # Dead. Is it excepted?
+            declared = DECLARED_EXCEPTIONS.get((art.name, pat.pattern))
+            if pat.hatch_key:
+                row["key"], row["reason"] = pat.hatch_key, pat.hatch_reason
+                excepted.append(row)
+            elif declared:
+                row["key"], row["reason"] = declared
+                excepted.append(row)
+            elif pat.hatch_present:
+                # A marker was present but carried no Jira key (§7.7 rule 2).
+                # This is a failure, not a pass: an unattributable exception is
+                # how a permanent suppression gets in without anyone owning it.
+                row["reason"] = "escape-hatch marker present but carries no Jira key"
+                dead.append(row)
+            else:
+                dead.append(row)
+
+    return dead, excepted, live
+
+
+def stale_exceptions(excepted: list[dict]) -> list[tuple[str, str]]:
+    """Declared exceptions that no longer suppress anything.
+
+    An exception outliving the pattern it excused is drift in its own right —
+    it makes the register look busier than it is and hides that the underlying
+    problem was fixed. Reported as a warning, never a failure: a stale entry is
+    untidy, not unsafe.
+    """
+    used = {(r["artefact"], r["pattern"]) for r in excepted}
+    return [k for k in DECLARED_EXCEPTIONS if k not in used]
+
+
+def report(dead: list[dict], excepted: list[dict], live: list[dict]) -> int:
+    by_artefact: dict[str, list[dict]] = {}
+    for row in live + excepted + dead:
+        by_artefact.setdefault(row["artefact"], []).append(row)
+
+    for name in [a.name for a in REGISTRY]:
+        rows = by_artefact.get(name)
+        if rows is None:
+            continue
+        n_live = sum(1 for r in rows if r["matches"])
+        print(f"OK  {name} — {n_live}/{len(rows)} live")
+        by_artefact.pop(name, None)
+
+    # §7.7 rule 3 — every active exception, every run.
+    if excepted:
+        print(f"\nActive guard-path-ok exceptions ({len(excepted)}):")
+        for r in excepted:
+            print(f"  - {r['artefact']}: {r['pattern']}  [{r.get('key')}] {r.get('reason','')}")
+        if len(excepted) > MAX_EXCEPTIONS:
+            print(f"::warning::{len(excepted)} guard-path-ok exceptions active "
+                  f"(threshold {MAX_EXCEPTIONS}) — the register is being used to "
+                  f"paper over drift rather than fix it.")
+
+    for artefact, pattern in stale_exceptions(excepted):
+        print(f"::warning::stale guard-path-ok exception — '{pattern}' in {artefact} "
+              f"is excepted but is no longer dead (or no longer registered). Remove it: "
+              f"an exception that outlives its cause makes the register unreadable.")
+
+    blocking = [r for r in dead if r["severity"] == "blocking"]
+    advisory = [r for r in dead if r["severity"] != "blocking"]
+
+    def loc(r: dict) -> str:
+        # line 0 means "structural, not read from a specific line" — GitHub
+        # rejects line=0, so emit a file-scoped annotation instead of a bad one.
+        return f"file={r['source']},line={r['line']}" if r["line"] else f"file={r['source']}"
+
+    for r in advisory:
+        print(f"::warning {loc(r)}::guard-path-drift: "
+              f"pattern matches no tracked file — '{r['pattern']}' (advisory)")
+
+    for r in blocking:
+        extra = f" [{r['reason']}]" if r.get("reason") else ""
+        print(f"::error {loc(r)}::guard-path-drift: pattern "
+              f"matches no tracked file — '{r['pattern']}'. This control is not "
+              f"operating.{extra} If the path moved, update it here in the SAME PR as "
+              f"the move. If it is deliberately forward-looking, add: "
+              f"# guard-path-ok: <JIRA-KEY> <reason>")
+
+    total = len(live) + len(excepted) + len(dead)
+    print(f"\n{total} registered patterns — {len(live)} live, "
+          f"{len(excepted)} excepted, {len(dead)} dead.")
+
+    if blocking:
+        print(f"::error::{len(blocking)} path pattern(s) match nothing. Each one is a "
+              f"control that reports green while protecting nothing (KAN-414 F1).")
+        return EXIT_DRIFT
+    return EXIT_OK
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--list", action="store_true", help="print every pattern and its verdict")
+    ap.add_argument("--self-test", action="store_true", help="run the built-in matcher fixtures")
+    args = ap.parse_args()
+
+    if args.self_test:
+        return self_test()
+
+    try:
+        files = tracked_files()
+        dead, excepted, live = resolve(files)
+    except Unparseable as exc:
+        # §7.5 — fail closed. Never 0, never 1.
+        print(f"::error::guard-path-drift cannot verify the estate: {exc}")
+        print("::error::Failing closed: a guard that cannot read its own inputs must "
+              "not report green (Workflow & Backup Integrity Policy).")
+        return EXIT_FAIL_CLOSED
+
+    if args.list:
+        for r in sorted(live + excepted + dead, key=lambda x: (x["artefact"], x["pattern"])):
+            state = "LIVE" if r["matches"] else ("EXCEPT" if r.get("key") else "DEAD")
+            print(f"{state:7} {r['matches']:5}  {r['artefact']}  ->  {r['pattern']}")
+        return EXIT_OK
+
+    return report(dead, excepted, live)
+
+
+def self_test() -> int:
+    """Fixtures for the matcher semantics §7.3 says must not be got wrong."""
+    files = [
+        "src/app/page.tsx", "src/app/a/b/c.tsx", "src/lib/age/record.ts",
+        "src/lib/env.ts", "src/modules/x/env.ts", "tests/unit/a.ts",
+        "tests/unit/deep/b.ts", "tests/e2e/authed/journey.authed.spec.ts",
+    ]
+    cases: list[tuple[str, bool]] = []
+
+    # bash '*' crosses '/' — the false-DEAD trap.
+    cases.append(("bash-case * crosses /",
+                  len(m_bash_case("src/app/*.tsx", files)) == 2))
+    # trailing /** prefix rule.
+    cases.append(("bash-case trailing /** prefix",
+                  m_bash_case("src/lib/age/**", files) == ["src/lib/age/record.ts"]))
+    # fnmatch would match only the top-level file — prove we are not fnmatch.
+    cases.append(("bash-dbl-bracket * crosses /",
+                  len(m_bash_dbl_bracket("src/app/*.tsx", files)) == 2))
+    # CODEOWNERS leading-'/' anchoring: /src/lib/env.ts is one file, not any nested env.ts.
+    cases.append(("codeowners root anchoring",
+                  m_codeowners("/src/lib/env.ts", files) == ["src/lib/env.ts"]))
+    # glob '**' vs '*' depth. The contrast is the point: `**` reaches every
+    # nested .ts under tests/ (3 of them, including the 3-deep e2e spec), while
+    # `*` stays inside one segment and therefore reaches none, since no .ts sits
+    # directly in tests/.
+    cases.append(("glob ** spans depth", len(m_glob("tests/**/*.ts", files)) == 3))
+    cases.append(("glob * is one segment", len(m_glob("tests/*.ts", files)) == 0))
+    # basename regex survives a directory move.
+    cases.append(("basename-regex survives move",
+                  len(m_basename_regex(r"journey\.authed\.spec\.ts", files)) == 1))
+    # literal directory prefix.
+    cases.append(("literal dir prefix", len(m_literal("src/lib", files)) == 2))
+    # hatch parsing: key required.
+    cases.append(("hatch with key", _hatch("foo # guard-path-ok: KAN-419 because")[0] == "KAN-419"))
+    cases.append(("hatch without key rejected", _hatch("foo # guard-path-ok: because")[0] is None))
+    cases.append(("no hatch", _hatch("plain line")[2] is False))
+    # the trailing-punctuation strip that fixed two false DEADs.
+    cases.append(("trailing dot stripped", "scripts/x.py." .rstrip(".,;:)\"'") == "scripts/x.py"))
+
+    failed = [n for n, ok in cases if not ok]
+    for n, ok in cases:
+        print(f"  {'ok  ' if ok else 'FAIL'} {n}")
+    if failed:
+        print(f"::error::self-test: {len(failed)} case(s) failed: {', '.join(failed)}")
+        return EXIT_DRIFT
+    print(f"self-test: {len(cases)}/{len(cases)} passed")
+    return EXIT_OK
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/scripts/check-guard-path-drift.test.js
+++ b/tests/scripts/check-guard-path-drift.test.js
@@ -1,0 +1,242 @@
+/**
+ * KAN-414 F1 — tests for scripts/check-guard-path-drift.py.
+ *
+ * The required case list is KAN-419 §7.9. Cases 12–13 (fail-closed) are called
+ * out there as "the ones most likely to be skipped under time pressure. They
+ * are not optional."
+ *
+ * WHY THE DESTRUCTIVE CASES RUN IN A CLONE
+ * ----------------------------------------
+ * Proving drift detection means actually moving a file or corrupting an
+ * artefact. Doing that in the working tree would be a live hazard: Jest runs
+ * test FILES in parallel workers, and at least five other suites read the exact
+ * files these cases mutate — supabase-service-factory, metrics-admin-window,
+ * check-extraction-dod, check-routine-ownership, check-doc-mirror-manifest. A
+ * `finally` that restores the file does not help a suite that read it mid-flight.
+ * Flaky tests get muted, and a muted test is a deleted test.
+ *
+ * So the mutating cases run against a throwaway `git clone --local` of the repo,
+ * which is a real tree with all 18 registered artefacts present (so exit 2 does
+ * not mask the assertion) and is invisible to every other worker. Read-only
+ * cases still run against the real repo, because there the live estate IS the
+ * thing under test.
+ */
+
+const { execFileSync } = require('node:child_process');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const ROOT = path.resolve(__dirname, '../..');
+const SCRIPT_REL = 'scripts/check-guard-path-drift.py';
+const SCRIPT = path.join(ROOT, SCRIPT_REL);
+
+let SANDBOX = null;
+let SANDBOX_SCRIPT = null;
+
+function runAt(scriptPath, args = [], cwd = ROOT) {
+  try {
+    const stdout = execFileSync('python3', [scriptPath, ...args], {
+      encoding: 'utf-8',
+      cwd,
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    return { stdout, exitCode: 0 };
+  } catch (err) {
+    return { stdout: err.stdout ?? '', exitCode: err.status ?? 1 };
+  }
+}
+
+const run = (args = []) => runAt(SCRIPT, args);
+const runSandbox = (args = []) => runAt(SANDBOX_SCRIPT, args, SANDBOX);
+
+/** Edit a file inside the sandbox. No restore needed — the clone is disposable. */
+function sandboxWrite(rel, transform) {
+  const p = path.join(SANDBOX, rel);
+  fs.writeFileSync(p, transform(fs.readFileSync(p, 'utf-8')));
+}
+
+beforeAll(() => {
+  SANDBOX = fs.mkdtempSync(path.join(os.tmpdir(), 'guard-path-drift-'));
+  execFileSync('git', ['clone', '--local', '--quiet', ROOT, SANDBOX], { stdio: 'ignore' });
+  // The guard resolves its repo root from __file__, so copying it into the
+  // clone is what points it at the clone. It is untracked in ROOT, so the
+  // clone does not carry it.
+  SANDBOX_SCRIPT = path.join(SANDBOX, SCRIPT_REL);
+  fs.copyFileSync(SCRIPT, SANDBOX_SCRIPT);
+}, 120000);
+
+afterAll(() => {
+  if (SANDBOX) fs.rmSync(SANDBOX, { recursive: true, force: true });
+});
+
+describe('check-guard-path-drift.py — matcher semantics (§7.9 cases 4–11)', () => {
+  test('self-test passes in full', () => {
+    const r = run(['--self-test']);
+    expect(r.stdout).toMatch(/self-test: \d+\/\d+ passed/);
+    expect(r.stdout).not.toMatch(/FAIL/);
+    expect(r.exitCode).toBe(0);
+  });
+
+  test('bash * crossing / is proven, not assumed (case 4)', () => {
+    // The false-DEAD trap: fnmatch reports 0 here. If this case is ever removed
+    // the guard can silently start calling the largest protected pattern in the
+    // estate dead — and the "fix" would be to weaken the real gate.
+    const r = run(['--self-test']);
+    expect(r.stdout).toMatch(/ok +bash-case \* crosses \//);
+    expect(r.stdout).toMatch(/ok +bash-case trailing \/\*\* prefix/);
+    expect(r.stdout).toMatch(/ok +codeowners root anchoring/);
+    expect(r.stdout).toMatch(/ok +glob \*\* spans depth/);
+  });
+});
+
+describe('check-guard-path-drift.py — the live estate (read-only)', () => {
+  test('every registered pattern in the real repo matches something', () => {
+    const r = run();
+    expect(r.exitCode).toBe(0);
+    expect(r.stdout).toMatch(/\d+ registered patterns — \d+ live, \d+ excepted, 0 dead\./);
+  });
+
+  test('a passing run still shows the estate was actually checked', () => {
+    // A guard that prints nothing on success is indistinguishable from one that
+    // did not run.
+    const r = run();
+    expect(r.stdout).toMatch(/OK {2}\.github\/signup-surface\.paths — \d+\/\d+ live/);
+    expect(r.stdout).toMatch(/OK {2}scripts\/check-ui-copy-ownership\.sh/);
+  });
+
+  test('every active exception is printed, and each carries a Jira key (case 16)', () => {
+    const r = run();
+    expect(r.stdout).toMatch(/Active guard-path-ok exceptions \(\d+\)/);
+    const block = r.stdout.split('Active guard-path-ok exceptions')[1] || '';
+    const lines = block.split('\n').filter((l) => l.trim().startsWith('- '));
+    expect(lines.length).toBeGreaterThan(0);
+    for (const line of lines) expect(line).toMatch(/\[[A-Z]+-\d+\]/);
+  });
+});
+
+describe('check-guard-path-drift.py — drift detection (sandboxed)', () => {
+  test('the sandbox starts clean, so any failure below is caused by the mutation', () => {
+    const r = runSandbox();
+    expect(r.exitCode).toBe(0);
+  });
+
+  // §7.9 case 2.
+  test('a moved file that disarms a control fails with exit 1 and names it', () => {
+    const from = path.join(SANDBOX, 'src/lib/supabase-service.ts');
+    const toDir = path.join(SANDBOX, 'src/modules/platform/data');
+    fs.mkdirSync(toDir, { recursive: true });
+    execFileSync('git', ['mv', from, path.join(toDir, 'supabase-service.ts')], { cwd: SANDBOX });
+
+    const r = runSandbox();
+    expect(r.exitCode).toBe(1);
+    expect(r.stdout).toMatch(/guard-path-drift: pattern matches no tracked file/);
+    expect(r.stdout).toMatch(/src\/lib\/supabase-service\.ts/);
+    expect(r.stdout).toMatch(/This control is not operating/);
+    // The remedy must be in the message, not just the failure.
+    expect(r.stdout).toMatch(/guard-path-ok: <JIRA-KEY>/);
+  });
+
+  test('that one move disarms MORE THAN ONE control', () => {
+    // Recorded because it is the whole argument for the guard: the blast radius
+    // of a single `git mv` is not obvious by inspection. This is literally D1's
+    // work — moving the platform factory into src/modules/platform/data.
+    const r = runSandbox();
+    expect(r.stdout).toMatch(/signup-surface\.paths/);
+    expect(r.stdout).toMatch(/check-service-role-client\.sh/);
+    expect(r.stdout).toMatch(/2 path pattern\(s\) match nothing/);
+  });
+
+  // §7.9 case 3 — the subtle one.
+  test('a pattern matching ONLY an untracked file still fails', () => {
+    // git ls-files is the resolution set precisely so this fails: CI checks out
+    // tracked content, so such a pattern is inert there even though it looks
+    // alive on the author's machine.
+    const dir = path.join(SANDBOX, 'src/untracked-probe');
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(path.join(dir, 'thing.ts'), 'export {};\n');
+    sandboxWrite('.github/signup-surface.paths', (s) => `${s}\nsrc/untracked-probe/**\n`);
+
+    const r = runSandbox();
+    expect(r.exitCode).toBe(1);
+    expect(r.stdout).toMatch(/src\/untracked-probe/);
+  });
+
+  // §7.9 case 15.
+  test('an escape-hatch marker without a Jira key does NOT suppress', () => {
+    sandboxWrite('.github/signup-surface.paths', (s) =>
+      `${s}\nsrc/nope/a/**   # guard-path-ok: no key here\n`);
+    const r = runSandbox();
+    expect(r.exitCode).toBe(1);
+    expect(r.stdout).toMatch(/carries no Jira key/);
+  });
+
+  // §7.9 case 14.
+  test('a valid hatch suppresses exactly its own pattern, not its neighbour', () => {
+    sandboxWrite('.github/signup-surface.paths', (s) =>
+      `${s}\nsrc/nope/b/**   # guard-path-ok: KAN-414 fixture\nsrc/nope/c/**\n`);
+    const r = runSandbox();
+    expect(r.exitCode).toBe(1);
+    expect(r.stdout).toMatch(/src\/nope\/b\/\*\*.*\[KAN-414\]/);
+    expect(r.stdout).toMatch(/pattern matches no tracked file — 'src\/nope\/c\/\*\*'/);
+  });
+});
+
+describe('check-guard-path-drift.py — fail-closed (§7.9 cases 12–13, NOT optional)', () => {
+  test('a MISSING artefact exits 2 — not 0, and not 1', () => {
+    const sb = fs.mkdtempSync(path.join(os.tmpdir(), 'gpd-missing-'));
+    try {
+      execFileSync('git', ['clone', '--local', '--quiet', ROOT, sb], { stdio: 'ignore' });
+      const script = path.join(sb, SCRIPT_REL);
+      fs.copyFileSync(SCRIPT, script);
+      fs.rmSync(path.join(sb, 'stryker.config.mjs'));
+
+      const r = runAt(script, [], sb);
+      expect(r.exitCode).toBe(2);
+      expect(r.exitCode).not.toBe(0);
+      expect(r.exitCode).not.toBe(1);
+      expect(r.stdout).toMatch(/cannot verify the estate/);
+      expect(r.stdout).toMatch(/Failing closed/);
+    } finally {
+      fs.rmSync(sb, { recursive: true, force: true });
+    }
+  }, 120000);
+
+  test('an artefact present but UNPARSEABLE exits 2', () => {
+    const sb = fs.mkdtempSync(path.join(os.tmpdir(), 'gpd-unparseable-'));
+    try {
+      execFileSync('git', ['clone', '--local', '--quiet', ROOT, sb], { stdio: 'ignore' });
+      const script = path.join(sb, SCRIPT_REL);
+      fs.copyFileSync(SCRIPT, script);
+      const doc = path.join(sb, 'docs/DOC_SOURCE_OF_TRUTH.md');
+      fs.writeFileSync(
+        doc,
+        fs.readFileSync(doc, 'utf-8').replace('<!-- doc-mirror-manifest:end -->', ''),
+      );
+
+      const r = runAt(script, [], sb);
+      expect(r.exitCode).toBe(2);
+      expect(r.stdout).toMatch(/delimiters missing/);
+    } finally {
+      fs.rmSync(sb, { recursive: true, force: true });
+    }
+  }, 120000);
+
+  test('an empty pattern list is unparseable, never a vacuous pass', () => {
+    // The defect class this whole programme exists to kill: "found nothing to
+    // check" must never read as "everything is fine".
+    const sb = fs.mkdtempSync(path.join(os.tmpdir(), 'gpd-vacuous-'));
+    try {
+      execFileSync('git', ['clone', '--local', '--quiet', ROOT, sb], { stdio: 'ignore' });
+      const script = path.join(sb, SCRIPT_REL);
+      fs.copyFileSync(SCRIPT, script);
+      fs.writeFileSync(path.join(sb, '.github/signup-surface.paths'), '# all commented out\n');
+
+      const r = runAt(script, [], sb);
+      expect(r.exitCode).toBe(2);
+      expect(r.stdout).toMatch(/declared no patterns/);
+    } finally {
+      fs.rmSync(sb, { recursive: true, force: true });
+    }
+  }, 120000);
+});


### PR DESCRIPTION
## Summary

Almost every control in this repo classifies files **by path**: the founder UI/copy gate, the un-skippable signup gate, CODEOWNERS, stryker's mutate list, the doc mirror manifest. A path pattern that matches nothing **does not fail** — it silently protects nothing while the gate keeps reporting green. That is the SEC-79 shape.

The modularisation programme's primary activity is **moving files**, so its first extraction PR is also the single event most likely to disarm those gates, invisibly. This is F1, the Phase 0 item the plan describes as *"without it, the programme's own first PR silently disarms the founder UI gate and the signup gate."*

Implements the **KAN-419 §7 specification**: 18 registered artefacts, **141 patterns**, all seven matching syntaxes kept separate. Resolution set is `git ls-files` — a pattern matching only an untracked file **fails**, because CI checks out tracked content where it would be inert.

## Proven by mutation, not by inspection

Moving `src/lib/supabase-service.ts` into `src/modules/platform/data/` — **literally D1's first step** — disarms **two** controls at once:

```
::error file=.github/signup-surface.paths,line=37::guard-path-drift: pattern matches
no tracked file — 'src/lib/supabase-service.ts'. This control is not operating.
::error file=scripts/check-service-role-client.sh::guard-path-drift: pattern matches
no tracked file — 'src/lib/supabase-service.ts'. This control is not operating.
```

**Before this guard, that move was green.** That blast radius is not obvious by inspection, which is the whole argument for the gate.

Fail-closed proven too — a missing artefact and an unparseable one each exit **2**, never 0 and never 1.

### It caught its own author

Wiring the script into `pr-checks.yml` while the file was still untracked made the workflow reference a path `git ls-files` could not see. The guard failed the build until it was staged — case 3 of the spec working on its first live subject.

## A defect fixed, not inherited

The reference scanner's workflow extractor uses a character class containing `.`, so prose like *"see `scripts/check-db-invariants.py`."* captured the sentence's full stop and reported **DEAD** for a file that plainly exists. **Two of the six DEAD findings were this bug.** Standing false positives are exactly what teach a team to wave a gate through, so the extractor is fixed rather than the findings excepted.

Estate now reads **137 live / 4 excepted / 0 dead** (was 130/0/6).

The 4 exceptions are all ticketed and printed on every run:

| Pattern | Key | Why |
|---|---|---|
| `tailwind.config.*` | KAN-419 | Tailwind v4 is CSS-first; defensive stub |
| `CODEOWNERS`, `docs/CODEOWNERS` | KAN-419 | asserted-absent by design — the guard proves there is exactly one |
| `tests/integration` | KAN-417 | dead dir, but `npm run test:integration` is called by `weekly-health-regression.sh:51` — removal is KAN-417's call, not F1's |

## Deviations from §7 — stated, not silent

- **Python, not bash.** The seven syntaxes are intricate, §7.3 flags two as easy to get wrong, and the reference it says to port from is Python. macOS bash 3.2 has no associative arrays (gotcha #28), so an 18-artefact registry would need parallel arrays — a lot of surface for a control whose whole job is to be trustworthy.
- **§7.8 is NOT re-implemented.** The per-PR stale-reference rule already ships in KAN-428's `check-extraction-dod.sh`. Two controls for one concern breaks KAN-361. This guard owns the whole-registry sweep; the DoD gate owns the diff.
- **CTL-035, not CTL-034** — CTL-034 is claimed by the unmerged SEC-109 branch; colliding ids would fight at merge.
- Test file is `.test.js`, not `.cjs` — matches every existing file in `tests/scripts/`.

## Note on the test design

The destructive cases run against a throwaway `git clone --local`, **not** the working tree. Jest runs test files in parallel and five other suites read the exact files those cases mutate (`supabase-service-factory`, `metrics-admin-window`, `check-extraction-dod`, `check-routine-ownership`, `check-doc-mirror-manifest`). A `finally` that restores a file does not help a suite that read it mid-flight — and a flaky test is a muted test.

## Pre-existing failures, flagged not fixed

`tests/scripts/guard-fail-closed.test.js` and `tests/scripts/check-extraction-dod.test.js` fail **on macOS** and pass in CI. Verified pre-existing against a clean `origin/develop` clone — **not caused by this PR**. The first asserts the SEC-111 fail-closed contract and gets exit 0 where it expects 2, so either that fix is Linux-only or the test's shim is. Raised separately; not touched here.

## Jira Ticket

KAN-414 (F1)

## Checklist

- [x] Unit tests added/updated — 14 cases in `tests/scripts/check-guard-path-drift.test.js` covering KAN-419 §7.9, including the non-optional fail-closed cases 12–13
- [x] All existing tests pass — `2607 passed / 223 suites`; the only 2 failing suites are the pre-existing macOS ones above, identical on clean `develop`
- [x] Lint passes — no JS/TS source changed
- [x] Type check passes — no TS changed
- [x] Build succeeds — no buildable code changed
- [x] Coverage has not decreased — net new tests only
- [x] No eslint-disable or ts-ignore without KAN-XX reference — none added
- [x] ARCHITECTURE.md updated if architectural changes were made — N/A: adds a CI gate, changes no architecture
- [x] Ops routine / Control-Room registry updated — **CTL-035 registered** in `controls/registry.json`; `check-control-registry.py` clean
- [x] Docs / system map updated — the guard's rationale header is the doc; the spec it implements is already in `docs/modularisation/KAN-419-path-coupling.md` §7

🤖 Generated with [Claude Code](https://claude.com/claude-code)