### PR TITLE
feat(KAN-414 F6): generated Database types for all 3 projects + a shrink-only drift ratchet

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -117,6 +117,30 @@ jobs:
         env:
           PR_BODY: ${{ github.event.pull_request.body }}
         run: BASE_REF="origin/${{ github.base_ref }}" bash scripts/check-extraction-dod.sh
+      - name: Schema-drift ratchet (KAN-414 F6)
+        # The three Supabase projects do NOT have identical schemas (KAN-420):
+        # prod lacks the KAN-153 columns, the KAN-143 `draft` label and two
+        # functions; dev lacks BUGS-62's claimed_at. The app compiles against
+        # dev, so TypeScript actively asserts prod has columns it does not —
+        # a deliberate, documented trade that means the type system cannot be
+        # the control here. This gate is.
+        #
+        # Diffs the three committed schemas as SEMANTIC FACTS (column, enum
+        # label, function) rather than lines: the generator wraps a 5-label
+        # union and inlines a 4-label one, so a line diff reports 16
+        # differences for the single fact "prod is missing `draft`". Noise is
+        # how a gate earns the right to be ignored.
+        #
+        # The baseline is SHRINK-ONLY. New drift fails; so does a baseline
+        # entry that has STOPPED drifting, because a list you may only add to
+        # is a suppression list, not a ratchet. Fails closed (exit 2) if a
+        # schema file or the baseline is missing or unparseable.
+        #
+        # It deliberately does NOT regenerate from Supabase: that needs
+        # credentials CI does not have, and a step that skips when a secret is
+        # absent is the silent-skip pattern KAN-167 forbids. Regeneration is a
+        # documented manual step.
+        run: python3 scripts/check-schema-type-parity.py
       - name: macOS Finder-duplicate file check (KAN-357)
         # Reject any committed " <n>"-suffixed file/dir (e.g. "[slug] 2/" or
         # "profile-sections 2.cjs"). These Finder-copy duplicates shadow the

--- a/controls/registry.json
+++ b/controls/registry.json
@@ -5,7 +5,7 @@
     "Machine-readable index of every preventive control in this repo, and the",
     "defect it exists to stop. This is the memory of the Defect Feedback Loop:",
     "when a BUGS or SEC ticket closes, its root cause is traced to a control",
-    "here \u2014 either one that already exists (and failed to fire, which is itself",
+    "here — either one that already exists (and failed to fire, which is itself",
     "a finding) or a new one that gets added.",
     "",
     "Enforced by scripts/check-control-registry.py, which fails the build if a",
@@ -23,7 +23,7 @@
       "id": "CTL-001",
       "name": "Workflow integrity check",
       "defect_class": "false-green-ci",
-      "summary": "Static scan for workflow patterns that report SUCCESS while doing nothing \u2014 GITHUB_TOKEN pushes that suppress downstream triggers, --limit 1 deploy verification, 401 acceptance without SHA verification, rollback steps that never roll back.",
+      "summary": "Static scan for workflow patterns that report SUCCESS while doing nothing — GITHUB_TOKEN pushes that suppress downstream triggers, --limit 1 deploy verification, 401 acceptance without SHA verification, rollback steps that never roll back.",
       "implementation": "scripts/check-workflow-integrity.sh",
       "kind": "ci-gate",
       "wired_in": [
@@ -127,7 +127,7 @@
       "id": "CTL-007",
       "name": "Doc mirror content check",
       "defect_class": "doc-drift",
-      "summary": "Fails the PR if a listed mirror exists but is an empty or stub file \u2014 the 'backup that looks successful but contains placeholder content' failure mode.",
+      "summary": "Fails the PR if a listed mirror exists but is an empty or stub file — the 'backup that looks successful but contains placeholder content' failure mode.",
       "implementation": "scripts/check-doc-mirror-content.sh",
       "kind": "ci-gate",
       "wired_in": [
@@ -192,7 +192,7 @@
       "id": "CTL-011",
       "name": "Auto-heal pattern catalogue self-test",
       "defect_class": "false-green-ci",
-      "summary": "Verifies every auto-fix pattern still matches its fixture and does not false-positive on a sibling \u2014 the regression guard that stops the auto-fix workflow silently breaking.",
+      "summary": "Verifies every auto-fix pattern still matches its fixture and does not false-positive on a sibling — the regression guard that stops the auto-fix workflow silently breaking.",
       "implementation": "scripts/auto-fix-known-failures.py",
       "kind": "ci-gate",
       "wired_in": [
@@ -240,7 +240,7 @@
       "id": "CTL-014",
       "name": "Backup integrity check",
       "defect_class": "false-green-ci",
-      "summary": "Fails if a backup artefact is a placeholder rather than real data \u2014 a dump that does not start with '--', contains no CREATE statements, or is suspiciously short.",
+      "summary": "Fails if a backup artefact is a placeholder rather than real data — a dump that does not start with '--', contains no CREATE statements, or is suspiciously short.",
       "implementation": "scripts/check-backup-integrity.sh",
       "kind": "scheduled",
       "wired_in": [
@@ -307,7 +307,7 @@
       "id": "CTL-018",
       "name": "Main-chain guard",
       "defect_class": "release-control",
-      "summary": "Fails loud if main gains any commit not present on beta \u2014 i.e. a change that did not arrive through develop \u2192 staging \u2192 beta \u2192 main \u2014 and blocks any PR targeting main.",
+      "summary": "Fails loud if main gains any commit not present on beta — i.e. a change that did not arrive through develop → staging → beta → main — and blocks any PR targeting main.",
       "implementation": ".github/workflows/main-chain-guard.yml",
       "kind": "ci-gate",
       "wired_in": [
@@ -319,13 +319,13 @@
       ],
       "escape_hatch": "BYPASS CONTROLS commit marker",
       "added": "2026-07-25",
-      "notes": "NOT yet in main's required status checks \u2014 see docs/DEFECT_FEEDBACK_LOOP.md open gaps."
+      "notes": "NOT yet in main's required status checks — see docs/DEFECT_FEEDBACK_LOOP.md open gaps."
     },
     {
       "id": "CTL-019",
       "name": "Dashboard loading.tsx guard",
       "defect_class": "framework-footgun",
-      "summary": "Fails any PR that reintroduces a src/app/**/loading.* without an explicit marker \u2014 the Next 16 Suspense boundary that never reveals on hard load and blanks the dashboard.",
+      "summary": "Fails any PR that reintroduces a src/app/**/loading.* without an explicit marker — the Next 16 Suspense boundary that never reveals on hard load and blanks the dashboard.",
       "implementation": "tests/unit/bugs66-dashboard-loading-guard.test.js",
       "kind": "test",
       "wired_in": [
@@ -395,7 +395,7 @@
       "id": "CTL-023",
       "name": "Migration privilege lint",
       "defect_class": "postgres-privilege-drift",
-      "summary": "Every migration must revoke a SECURITY DEFINER function from public, anon AND authenticated. Revoking from PUBLIC alone is a no-op on Supabase, which grants anon/authenticated directly via ALTER DEFAULT PRIVILEGES \u2014 the first version of this rule required only the PUBLIC revoke and passed a fixture shipping an anon-callable function. That mis-specified revoke in 20260622120000_two_axis_access_model.sql is the actual root cause of SEC-28/29/42/43. Also pins search_path, forbids GRANT to anon, requires RLS on new public tables, and (R5) blocks duplicate migration version timestamps. Ratcheted against a baseline that may only shrink.",
+      "summary": "Every migration must revoke a SECURITY DEFINER function from public, anon AND authenticated. Revoking from PUBLIC alone is a no-op on Supabase, which grants anon/authenticated directly via ALTER DEFAULT PRIVILEGES — the first version of this rule required only the PUBLIC revoke and passed a fixture shipping an anon-callable function. That mis-specified revoke in 20260622120000_two_axis_access_model.sql is the actual root cause of SEC-28/29/42/43. Also pins search_path, forbids GRANT to anon, requires RLS on new public tables, and (R5) blocks duplicate migration version timestamps. Ratcheted against a baseline that may only shrink.",
       "implementation": "scripts/check-migration-privileges.py",
       "kind": "ci-gate",
       "wired_in": [
@@ -468,7 +468,7 @@
       "id": "CTL-026",
       "name": "Control registry integrity",
       "defect_class": "control-rot",
-      "summary": "The meta-control. Fails if a registered control's implementation is missing, if it is no longer referenced by any workflow (the SEC-79 'silently disabled for weeks' mode), or if a check script exists in the repo but is not registered \u2014 so the registry cannot drift away from reality.",
+      "summary": "The meta-control. Fails if a registered control's implementation is missing, if it is no longer referenced by any workflow (the SEC-79 'silently disabled for weeks' mode), or if a check script exists in the repo but is not registered — so the registry cannot drift away from reality.",
       "implementation": "scripts/check-control-registry.py",
       "kind": "ci-gate",
       "wired_in": [
@@ -506,7 +506,7 @@
       "id": "CTL-028",
       "name": "Suspension-guard coverage",
       "defect_class": "authz-coverage-drift",
-      "summary": "Any query filtering is_published = true is selecting content for public consumption and must also filter is_suspended = false. Stated on the QUERY rather than the file or the client, so it enumerates the surface instead of sampling it \u2014 the property every previous fix in this class lacked. Found three unguarded sites beyond the two identified by review, including the homepage and the sitemap.",
+      "summary": "Any query filtering is_published = true is selecting content for public consumption and must also filter is_suspended = false. Stated on the QUERY rather than the file or the client, so it enumerates the surface instead of sampling it — the property every previous fix in this class lacked. Found three unguarded sites beyond the two identified by review, including the homepage and the sitemap.",
       "implementation": "scripts/check-suspension-guard-coverage.py",
       "kind": "ci-gate",
       "wired_in": [
@@ -548,7 +548,7 @@
       "id": "CTL-030",
       "name": "Structural dependency rules (module/segment/cycle)",
       "defect_class": "regression-risk",
-      "summary": "Three structural import rules, enforced so the codebase cannot regress while the modularisation programme (KAN-415) runs: nothing under src/lib/** may import src/app/** (a library owned by a route folder is how the access-transition matrix ended up inside the admin console, KAN-424 Defect 1); one top-level src/app segment may not import another (a cross-segment edge couples two features so neither can be changed or extracted alone); and no import cycles. The precedent for needing a gate rather than a convention is src/lib/deploy-env.ts \u2014 built to be the single environment resolver, it never displaced the six inline derivations because nothing stopped new ones being written. Ships at severity warn and flips to error once the outstanding findings clear.",
+      "summary": "Three structural import rules, enforced so the codebase cannot regress while the modularisation programme (KAN-415) runs: nothing under src/lib/** may import src/app/** (a library owned by a route folder is how the access-transition matrix ended up inside the admin console, KAN-424 Defect 1); one top-level src/app segment may not import another (a cross-segment edge couples two features so neither can be changed or extracted alone); and no import cycles. The precedent for needing a gate rather than a convention is src/lib/deploy-env.ts — built to be the single environment resolver, it never displaced the six inline derivations because nothing stopped new ones being written. Ships at severity warn and flips to error once the outstanding findings clear.",
       "implementation": "scripts/check-dependency-rules.sh",
       "kind": "ci-gate",
       "wired_in": [
@@ -565,7 +565,7 @@
       "id": "CTL-031",
       "name": "Bash 3.2 portability",
       "defect_class": "dev-ci-environment-parity",
-      "summary": "Fails any script under scripts/ using a bash-4-only construct (mapfile/readarray, declare -A, ${v^^}/${v,,}, &>>, coproc, shopt -s globstar). macOS ships bash 3.2 and CI ships bash 5, so these work in CI and exit 127 where releases are prepared. staging-soak.sh documented the rule in a comment from day one and two scripts shipped with mapfile anyway, making the whole unit suite unpassable on macOS \u2014 a convention without a gate erodes. Comments are stripped before matching so the fix's own explanatory prose does not trip it; that case is pinned in the self-test. Workflow YAML is out of scope by design: inline run: blocks execute only on the runner, so findings there would only ever be allow-listed, and standing noise is what teaches people to wave a gate through.",
+      "summary": "Fails any script under scripts/ using a bash-4-only construct (mapfile/readarray, declare -A, ${v^^}/${v,,}, &>>, coproc, shopt -s globstar). macOS ships bash 3.2 and CI ships bash 5, so these work in CI and exit 127 where releases are prepared. staging-soak.sh documented the rule in a comment from day one and two scripts shipped with mapfile anyway, making the whole unit suite unpassable on macOS — a convention without a gate erodes. Comments are stripped before matching so the fix's own explanatory prose does not trip it; that case is pinned in the self-test. Workflow YAML is out of scope by design: inline run: blocks execute only on the runner, so findings there would only ever be allow-listed, and standing noise is what teaches people to wave a gate through.",
       "implementation": "scripts/check-bash-portability.py",
       "kind": "ci-gate",
       "wired_in": [
@@ -598,7 +598,7 @@
       "id": "CTL-033",
       "name": "Extraction Definition-of-Done",
       "defect_class": "path-coupling-drift",
-      "summary": "Fails any PR that deletes or renames a file under src/ while an artefact that classifies files BY PATH still names the old path: .github/ (signup-surface manifest, CODEOWNERS, workflows), scripts/ guard path-lists, docs/ (incl. the mirror manifest), modules.json and tests/. A glob that matches nothing protects nothing while CI stays green \u2014 KAN-419 measured the docs layer at 18% dead path literals before a single file was moved on purpose. Also requires the PR body to answer the two couplings CI can never see (~/lyra-design-system/build.py and the claude.ai routine prompts, neither in any repo CI can read) and to name the covering Playwright project + soak clause, or record 'no coverage' as a finding. Fails closed (exit 2) when it cannot verify.",
+      "summary": "Fails any PR that deletes or renames a file under src/ while an artefact that classifies files BY PATH still names the old path: .github/ (signup-surface manifest, CODEOWNERS, workflows), scripts/ guard path-lists, docs/ (incl. the mirror manifest), modules.json and tests/. A glob that matches nothing protects nothing while CI stays green — KAN-419 measured the docs layer at 18% dead path literals before a single file was moved on purpose. Also requires the PR body to answer the two couplings CI can never see (~/lyra-design-system/build.py and the claude.ai routine prompts, neither in any repo CI can read) and to name the covering Playwright project + soak clause, or record 'no coverage' as a finding. Fails closed (exit 2) when it cannot verify.",
       "implementation": "scripts/check-extraction-dod.sh",
       "kind": "ci-gate",
       "wired_in": [
@@ -609,6 +609,24 @@
       ],
       "escape_hatch": "EXTRACTION-DOD-OK: <JIRA-KEY> <check-id> on a commit in the PR. Suppresses exactly one named check, requires a Jira key, every active exception is printed on every run, and more than three in one PR emits a ::warning:: that the hatch is papering over drift.",
       "added": "2026-07-28"
+    },
+    {
+      "id": "CTL-036",
+      "name": "Schema-drift ratchet",
+      "defect_class": "schema-parity-drift",
+      "summary": "Diffs the three committed Supabase schemas (src/types/database/{dev,staging,prod}.ts) as semantic facts - column, enum label, function - against a shrink-only baseline at supabase/schema-drift-baseline.json. New drift fails; a baseline entry that has stopped drifting ALSO fails, so the list cannot quietly over-state the problem. Exists because the app compiles against the dev schema while production genuinely lacks the KAN-153 columns, the KAN-143 'draft' visibility label and two functions - so TypeScript asserts prod has columns it does not, and the type system cannot be its own control. Compares facts rather than lines because the generator wraps a 5-label union and inlines a 4-label one, making a line diff report 16 differences for one fact.",
+      "implementation": "scripts/check-schema-type-parity.py",
+      "kind": "ci-gate",
+      "wired_in": [
+        ".github/workflows/pr-checks.yml"
+      ],
+      "prevents": [
+        "KAN-414",
+        "SEC-107",
+        "BUGS-62"
+      ],
+      "escape_hatch": "none - add the drift to supabase/schema-drift-baseline.json with a ticket",
+      "added": "2026-07-29"
     }
   ]
 }

--- a/docs/modularisation/KAN-414-F6-threading-fallout.md
+++ b/docs/modularisation/KAN-414-F6-threading-fallout.md
@@ -1,0 +1,114 @@
+# KAN-414 F6 — what threading `Database` through the client factories exposes
+
+**Measured 2026-07-29** against `develop`, by adding `<Database>` to the three
+client factories (`supabase-server.ts`, `supabase-browser.ts`,
+`supabase-service.ts`) and running `npx tsc --noEmit`.
+
+**Result: 31 type errors across 10 files.** The threading was then reverted, so
+this document — not the code — is the deliverable. `develop` typechecks clean.
+
+## Why this is split out of F6
+
+F6 landed the generated schemas and the drift gate. Threading is deliberately a
+separate change, for three reasons:
+
+1. **These are 31 judgement calls, not a mechanical edit.** Each one is
+   "does this column genuinely never contain NULL, or has this code been
+   quietly wrong?" Answering that wrong in bulk introduces real defects, and
+   two of the files are in the profile write path — the exact territory of
+   BUGS-74, where a partial-write bug destroyed members' saved text on all four
+   environments.
+2. **Two of the ten files are founder-gated.**
+   `src/app/dashboard/profile/page.tsx` and
+   `src/app/dashboard/profile/legacy/page.tsx` match the KAN-411 UI/copy
+   protection, so the change cannot merge without a founder trailer regardless
+   of how good the fix is. (`src/app/admin/**` is an explicit carve-out and is
+   not gated.)
+3. The programme's own repeated lesson: land the cheap enforced gate first, and
+   do the expensive part with its own review.
+
+## The fallout
+
+| File | Errors |
+|---|---|
+| `src/app/admin/users/page.tsx` | 6 |
+| `src/app/admin/users/actions.ts` | 5 |
+| `src/app/dashboard/profile/actions.ts` | 5 |
+| `src/app/dashboard/profile/legacy/page.tsx` | 5 |
+| `src/app/dashboard/profile/page.tsx` | 4 |
+| `src/lib/metrics.ts` | 2 |
+| `src/app/dashboard/convene/contacts/actions.ts` | 1 |
+| `src/app/dashboard/settings/actions.ts` | 1 |
+| `src/app/dashboard/settings/discoverability-actions.ts` | 1 |
+| `src/app/dashboard/widgets/actions.ts` | 1 |
+
+By TypeScript code: **24 × TS2322** (type not assignable), **4 × TS2345**
+(argument not assignable), **3 × TS2352** (unsafe cast).
+
+## The three defect classes, in order of how much they matter
+
+### 1. Nullable columns consumed as non-null — 24 of 31
+
+The dominant pattern, and the one worth taking seriously. The database declares
+a column nullable; the application's own interface declares it required; the
+untyped client let the two disagree in silence.
+
+```
+Types of property 'created_at' are incompatible.
+  Type 'string | null' is not assignable to type 'string'.
+```
+
+Affected properties seen: `created_at`, `is_published`, `visibility`,
+`sort_order`, `relationship`, `link_type`.
+
+**`is_published` and `visibility` are the ones to look at first.** Both feed
+publication and visibility decisions. Code that declares them non-null will not
+have a branch for NULL, so a NULL row takes whichever path the truthiness
+happens to fall into — and on the privacy-relevant side of the app, "whichever
+path it happens to fall into" is not an acceptable answer. This is the same
+shape as SEC-44/SEC-100, where a suspension guard was present at one call site
+and absent at its siblings.
+
+Each needs a decision, not a cast:
+- if the column genuinely cannot be NULL → add a `NOT NULL` constraint (a
+  migration), and the type follows;
+- if it can → handle NULL explicitly at the call site.
+
+`as string` would make the error disappear and the defect permanent.
+
+### 2. Loosely-typed update payloads — 4 of 31
+
+```
+src/app/dashboard/settings/discoverability-actions.ts(115,13): error TS2345:
+  Argument of type 'Record<string, string | boolean | null>' is not assignable
+```
+
+An update built as a bare `Record` rather than a typed row. This is exactly the
+BUGS-74 class the `check-partial-write-safety.py` guard exists for — the typed
+client rejects the shape that guard has to detect by static analysis. Fixing
+these makes the type system enforce what the guard currently approximates,
+which is a strict improvement.
+
+### 3. Unsafe `Json` casts — 3 of 31
+
+`src/lib/metrics.ts` casts a `Json` column straight to `MetricsSnapshot`, and
+`widgets/actions.ts` writes a `Partial<Record<…, WidgetDismissal>>` into a
+`Json` column. Both need a parse/validate step rather than a cast. Lowest risk
+of the three classes, and the most self-contained.
+
+## Recommended sequencing
+
+1. **`src/lib/metrics.ts` + `widgets/actions.ts`** (3 errors) — self-contained,
+   no founder-gated paths, no schema change. Good first slice.
+2. **`admin/**`** (11 errors) — carve-out paths, so no trailer needed, and the
+   admin console has the smallest blast radius.
+3. **`settings/**` + `convene/contacts`** (3 errors).
+4. **`profile/**`** (14 errors) — last, deliberately. Needs the founder trailer,
+   sits in the BUGS-74 write path, and deserves its own review.
+
+Reproduce at any time:
+
+```bash
+# add <Database> to the three factories in src/lib/supabase-*.ts, then:
+npx tsc --noEmit 2>&1 | grep 'error TS'
+```

--- a/scripts/check-schema-type-parity.py
+++ b/scripts/check-schema-type-parity.py
@@ -1,0 +1,389 @@
+#!/usr/bin/env python3
+"""KAN-414 F6 — the schema-drift ratchet over the committed `Database` types.
+
+WHY THIS EXISTS
+---------------
+`src/types/database/{dev,staging,prod}.ts` are the three Supabase projects'
+schemas. They are not identical, and the differences are real (KAN-420 R5):
+production lacks the KAN-153 discoverability columns, the KAN-143 `draft`
+visibility label and two functions; dev lacks BUGS-62's `claimed_at`.
+
+The app compiles against `dev` (see `src/types/database/index.ts` for why), so
+**TypeScript actively asserts that production has columns it does not have.**
+That is a deliberate, documented trade — and it means the type system cannot be
+the control here. This gate is.
+
+WHAT IT DOES
+------------
+Diffs the three committed schemas and compares the drift against a recorded
+baseline (`supabase/schema-drift-baseline.json`). The baseline is SHRINK-ONLY:
+
+  * drift that is in the baseline  -> known, ticketed, allowed
+  * drift that is NOT              -> FAIL. Something diverged unnoticed.
+  * baseline entry no longer drifting -> FAIL. It was fixed; record that by
+    removing the entry, so the baseline cannot quietly over-state the problem.
+
+That last rule is the one that matters. A baseline you may only add to is a
+suppression list; a baseline that must shrink when reality improves is a
+ratchet, and it is the only version that ever reaches zero.
+
+WHY IT DOES NOT REGENERATE
+--------------------------
+The plan's F6 asks for a "CI regeneration diff". Regenerating needs Supabase
+credentials in CI, which do not exist and are founder-gated. Rather than ship a
+step that silently skips when a secret is absent — the exact `if: env.X != ''`
+pattern the Workflow & Backup Integrity Policy forbids — this gate checks what
+it CAN check without credentials, and regeneration stays an explicit documented
+step (`docs/RUNBOOK.md`). A control that only works when a secret happens to be
+present is not a control.
+
+FAIL-CLOSED
+-----------
+Exit 2 if a schema file or the baseline is missing or unparseable. A gate that
+cannot read its inputs must never report green.
+
+USAGE
+    python3 scripts/check-schema-type-parity.py
+    python3 scripts/check-schema-type-parity.py --show     # print current drift
+    python3 scripts/check-schema-type-parity.py --self-test
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[1]
+TYPES_DIR = REPO / "src/types/database"
+BASELINE = REPO / "supabase/schema-drift-baseline.json"
+ENVS = ("dev", "staging", "prod")
+
+EXIT_OK = 0
+EXIT_DRIFT = 1
+EXIT_FAIL_CLOSED = 2
+
+
+class Unparseable(Exception):
+    """An input is missing or not in the shape we must read — always exit 2."""
+
+
+def load_schema(env: str) -> str:
+    p = TYPES_DIR / f"{env}.ts"
+    if not p.is_file():
+        raise Unparseable(f"schema file missing: {p.relative_to(REPO)}")
+    text = p.read_text(encoding="utf-8")
+    if "export type Database" not in text:
+        raise Unparseable(
+            f"{p.relative_to(REPO)} does not declare `export type Database` — "
+            "refusing to diff a file that is not a generated schema"
+        )
+    return text
+
+
+def significant_lines(text: str) -> set[str]:
+    """The schema as a set of SEMANTIC FACTS, not lines.
+
+    A raw line diff is unusable here for two reasons, both of which showed up
+    immediately on the real schemas:
+
+      * Generated types repeat every column three times (Row / Insert /
+        Update), tripling every finding.
+      * Formatting is not stable across environments. `visibility_level` has
+        five labels on staging and four on prod, so the generator wraps the
+        union on one and inlines it on the other — producing SIXTEEN differing
+        lines for what is one fact: "prod is missing the `draft` label".
+
+    Sixteen lines of noise around one real finding is how a gate earns the
+    right to be ignored. So this extracts facts instead:
+
+        column:<table>.<name>        (from the Row block only — Insert/Update
+                                      are the same columns re-stated)
+        enum:<name>=<sorted labels>
+        function:<name>
+        view:<name>
+
+    Indentation-driven rather than regex-over-the-whole-file, because the
+    generated shape is stable and predictable, and because keeping the table
+    context is what makes a column fact meaningful.
+    """
+    facts: set[str] = set()
+    section: str | None = None  # Tables | Views | Functions | Enums | CompositeTypes
+    section_indent = 0
+    current_obj: str | None = None
+    obj_indent = 0
+    in_row = False
+    row_indent = 0
+
+    for raw in text.splitlines():
+        if not raw.strip():
+            continue
+        indent = len(raw) - len(raw.lstrip())
+        line = raw.strip()
+
+        m_section = re.match(r"^(Tables|Views|Functions|Enums|CompositeTypes):\s*\{", line)
+        if m_section:
+            section, section_indent = m_section.group(1), indent
+            current_obj, in_row = None, False
+            continue
+
+        if section and indent <= section_indent and line.startswith("}"):
+            section, current_obj, in_row = None, None, False
+            continue
+
+        if not section:
+            continue
+
+        # Enums are one-liners or wrapped unions; capture labels wherever they sit.
+        if section == "Enums":
+            # ALWAYS emit one fact per label, never an aggregate. The generator
+            # inlines a short union and wraps a long one, so the same enum is
+            # shaped differently in two environments purely because one has an
+            # extra label. Aggregating would make that formatting difference
+            # look like a second, separate finding.
+            m = re.match(r"^(\w+):\s*(.*)$", line)
+            if m:
+                current_obj, obj_indent = m.group(1), indent
+                for lbl in re.findall(r'"([^"]+)"', m.group(2)):
+                    facts.add(f"enum-label:{current_obj}.{lbl}")
+                continue
+            if current_obj and indent > obj_indent:
+                # continuation lines of a wrapped union
+                for lbl in re.findall(r'"([^"]+)"', line):
+                    facts.add(f"enum-label:{current_obj}.{lbl}")
+            continue
+
+        m_obj = re.match(r"^(\w+):\s*\{?\s*$", line)
+        if m_obj and indent == section_indent + 2:
+            current_obj, obj_indent, in_row = m_obj.group(1), indent, False
+            if section == "Functions":
+                facts.add(f"function:{current_obj}")
+            elif section == "Views":
+                facts.add(f"view:{current_obj}")
+            continue
+
+        # Single-line function declarations, e.g.
+        #   e2e_fix_auth_tokens: { Args: { uid: string }; Returns: undefined }
+        m_inline = re.match(r"^(\w+):\s*\{.*\}\s*$", line)
+        if m_inline and indent == section_indent + 2 and section == "Functions":
+            facts.add(f"function:{m_inline.group(1)}")
+            continue
+
+        if section == "Tables" and current_obj:
+            if re.match(r"^Row:\s*\{", line):
+                in_row, row_indent = True, indent
+                continue
+            if in_row and indent <= row_indent and line.startswith("}"):
+                in_row = False
+                continue
+            if in_row:
+                m_col = re.match(r"^(\w+)\??:", line)
+                if m_col:
+                    facts.add(f"column:{current_obj}.{m_col.group(1)}")
+
+    return facts
+
+
+def drift_between(a: str, b: str) -> dict[str, list[str]]:
+    sa, sb = significant_lines(a), significant_lines(b)
+    return {
+        "only_in_first": sorted(sa - sb),
+        "only_in_second": sorted(sb - sa),
+    }
+
+
+def current_drift() -> dict[str, dict[str, list[str]]]:
+    schemas = {e: load_schema(e) for e in ENVS}
+    return {
+        "dev_vs_staging": drift_between(schemas["dev"], schemas["staging"]),
+        "staging_vs_prod": drift_between(schemas["staging"], schemas["prod"]),
+    }
+
+
+def load_baseline() -> dict:
+    if not BASELINE.is_file():
+        raise Unparseable(f"baseline missing: {BASELINE.relative_to(REPO)}")
+    try:
+        data = json.loads(BASELINE.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        raise Unparseable(f"baseline is not valid JSON: {exc}")
+    if "drift" not in data or not isinstance(data["drift"], dict):
+        raise Unparseable("baseline has no `drift` object")
+    return data
+
+
+def flatten(drift: dict[str, dict[str, list[str]]]) -> set[tuple[str, str, str]]:
+    out: set[tuple[str, str, str]] = set()
+    for pair, sides in drift.items():
+        for side, lines in sides.items():
+            for ln in lines:
+                out.add((pair, side, ln))
+    return out
+
+
+def flatten_baseline(baseline: dict) -> tuple[set[tuple[str, str, str]], dict]:
+    entries: set[tuple[str, str, str]] = set()
+    meta: dict = {}
+    for pair, sides in baseline["drift"].items():
+        for side, items in sides.items():
+            for item in items:
+                key = (pair, side, item["line"])
+                entries.add(key)
+                meta[key] = item
+    return entries, meta
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--show", action="store_true", help="print the current drift and exit 0")
+    ap.add_argument("--self-test", action="store_true")
+    args = ap.parse_args()
+
+    if args.self_test:
+        return self_test()
+
+    # --show deliberately does NOT require the baseline: it is how the baseline
+    # gets bootstrapped in the first place, and demanding the output of a file
+    # that does not exist yet is a chicken-and-egg that invites hand-authoring.
+    try:
+        drift = current_drift()
+    except Unparseable as exc:
+        print(f"::error::schema-type-parity cannot verify: {exc}")
+        print("::error::Failing closed — a gate that cannot read its inputs must not "
+              "report green (Workflow & Backup Integrity Policy).")
+        return EXIT_FAIL_CLOSED
+
+    if args.show:
+        print(json.dumps(drift, indent=2))
+        return EXIT_OK
+
+    try:
+        baseline = load_baseline()
+    except Unparseable as exc:
+        print(f"::error::schema-type-parity cannot verify: {exc}")
+        print("::error::Failing closed — a gate that cannot read its inputs must not "
+              "report green (Workflow & Backup Integrity Policy).")
+        return EXIT_FAIL_CLOSED
+
+    actual = flatten(drift)
+    expected, meta = flatten_baseline(baseline)
+
+    unexpected = sorted(actual - expected)
+    resolved = sorted(expected - actual)
+
+    for pair, side, line in unexpected:
+        print(f"::error::NEW schema drift ({pair}, {side}): {line}")
+
+    for pair, side, line in resolved:
+        item = meta[(pair, side, line)]
+        print(f"::error::baseline entry no longer drifting ({pair}, {side}): {line} "
+              f"[{item.get('ticket', 'no ticket')}] — it was fixed. Remove it from "
+              f"supabase/schema-drift-baseline.json so the baseline keeps shrinking.")
+
+    by_ticket: dict[str, int] = {}
+    for key in expected & actual:
+        t = meta[key].get("ticket", "untracked")
+        by_ticket[t] = by_ticket.get(t, 0) + 1
+
+    print(f"\nSchema drift: {len(actual)} differing declarations across 3 environments.")
+    for ticket, n in sorted(by_ticket.items()):
+        print(f"  {n:3}  {ticket}")
+
+    if unexpected or resolved:
+        print(f"::error::{len(unexpected)} new, {len(resolved)} stale. The three "
+              f"Supabase schemas diverged in a way nobody recorded, or converged in "
+              f"a way nobody noticed. Both are findings.")
+        return EXIT_DRIFT
+
+    print("All drift is known, ticketed and unchanged.")
+    return EXIT_OK
+
+
+def _schema(columns: str, enum_labels: str, functions: str = "      do_thing: {\n") -> str:
+    """A minimal but structurally faithful generated-schema fixture."""
+    return (
+        "export type Database = {\n"
+        "  public: {\n"
+        "    Tables: {\n"
+        "      widgets: {\n"
+        "        Row: {\n"
+        f"{columns}"
+        "        }\n"
+        "        Insert: {\n"
+        f"{columns.replace(': ', '?: ')}"
+        "        }\n"
+        "      }\n"
+        "    }\n"
+        "    Enums: {\n"
+        f"      visibility_level: {enum_labels}\n"
+        "    }\n"
+        "    Functions: {\n"
+        f"{functions}"
+        "        Args: { x: string }\n"
+        "        Returns: undefined\n"
+        "      }\n"
+        "    }\n"
+        "  }\n"
+        "}\n"
+    )
+
+
+def self_test() -> int:
+    cases: list[tuple[str, bool]] = []
+
+    base_cols = "          id: string\n          claimed_at: string | null\n"
+    a = _schema(base_cols, '"public" | "draft"')
+
+    facts = significant_lines(a)
+
+    # The Row/Insert(/Update) repetition must collapse to ONE fact, not two.
+    cases.append(("Row/Insert repetition collapses to one fact",
+                  len([f for f in facts if f == "column:widgets.claimed_at"]) == 1
+                  and "column:widgets.claimed_at" in facts))
+    cases.append(("column is qualified by its table",
+                  "column:widgets.id" in facts))
+    cases.append(("function captured", "function:do_thing" in facts))
+    cases.append(("enum labels captured individually",
+                  {"enum-label:visibility_level.public",
+                   "enum-label:visibility_level.draft"} <= facts))
+
+    # Identical schemas produce no drift.
+    cases.append(("identical -> no drift",
+                  drift_between(a, a) == {"only_in_first": [], "only_in_second": []}))
+
+    # A dropped column is detected, in the right direction.
+    b = _schema("          id: string\n", '"public" | "draft"')
+    d = drift_between(a, b)
+    cases.append(("dropped column detected",
+                  d["only_in_first"] == ["column:widgets.claimed_at"]))
+    cases.append(("direction is right", d["only_in_second"] == []))
+
+    # THE ONE THAT MATTERS: an enum losing a label must be exactly ONE fact,
+    # even though the generator wraps the longer union across several lines and
+    # inlines the shorter one. A line diff reports sixteen differences here.
+    wrapped = _schema(base_cols,
+                      '\n        | "public"\n        | "draft"\n        | "tribe_only"')
+    inline = _schema(base_cols, '"public" | "tribe_only"')
+    d2 = drift_between(wrapped, inline)
+    cases.append(("enum label loss is exactly one fact despite reformatting",
+                  d2["only_in_first"] == ["enum-label:visibility_level.draft"]
+                  and d2["only_in_second"] == []))
+
+    # Braces and comments are not schema facts.
+    cases.append(("noise ignored",
+                  significant_lines("{\n}\n},\n// note\n* doc\n") == set()))
+
+    failed = [n for n, ok in cases if not ok]
+    for n, ok in cases:
+        print(f"  {'ok  ' if ok else 'FAIL'} {n}")
+    if failed:
+        print(f"::error::self-test: {len(failed)} failed: {', '.join(failed)}")
+        return EXIT_DRIFT
+    print(f"self-test: {len(cases)}/{len(cases)} passed")
+    return EXIT_OK
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/types/database/dev.ts
+++ b/src/types/database/dev.ts
@@ -1,0 +1,2332 @@
+export type Json =
+  | string
+  | number
+  | boolean
+  | null
+  | { [key: string]: Json | undefined }
+  | Json[]
+
+export type Database = {
+  // Allows to automatically instantiate createClient with right options
+  // instead of createClient<Database, { PostgrestVersion: 'XX' }>(URL, KEY)
+  __InternalSupabase: {
+    PostgrestVersion: "14.4"
+  }
+  public: {
+    Tables: {
+      affiliate_clicks: {
+        Row: {
+          buyer_country: string | null
+          click_id: string
+          commission_amount: number | null
+          commission_currency: string | null
+          commission_gbp: number | null
+          converted_at: string | null
+          created_at: string
+          merchant_id: string | null
+          monetised_url: string
+          provider: string
+          provider_subid: string | null
+          raw_url: string
+          recipient_country: string | null
+          recipient_id: string | null
+          recommendation_id: string | null
+          session_id: string | null
+          source: string
+          user_id: string | null
+        }
+        Insert: {
+          buyer_country?: string | null
+          click_id?: string
+          commission_amount?: number | null
+          commission_currency?: string | null
+          commission_gbp?: number | null
+          converted_at?: string | null
+          created_at?: string
+          merchant_id?: string | null
+          monetised_url: string
+          provider: string
+          provider_subid?: string | null
+          raw_url: string
+          recipient_country?: string | null
+          recipient_id?: string | null
+          recommendation_id?: string | null
+          session_id?: string | null
+          source?: string
+          user_id?: string | null
+        }
+        Update: {
+          buyer_country?: string | null
+          click_id?: string
+          commission_amount?: number | null
+          commission_currency?: string | null
+          commission_gbp?: number | null
+          converted_at?: string | null
+          created_at?: string
+          merchant_id?: string | null
+          monetised_url?: string
+          provider?: string
+          provider_subid?: string | null
+          raw_url?: string
+          recipient_country?: string | null
+          recipient_id?: string | null
+          recommendation_id?: string | null
+          session_id?: string | null
+          source?: string
+          user_id?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "affiliate_clicks_recipient_id_fkey"
+            columns: ["recipient_id"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      affiliate_merchant_eligibility: {
+        Row: {
+          affiliate_network: string
+          affiliate_program_id: string | null
+          commission_rate_pct: number | null
+          country_code: string
+          created_at: string
+          is_active: boolean
+          merchant_display_name: string
+          merchant_id: string
+          notes: string | null
+          updated_at: string
+        }
+        Insert: {
+          affiliate_network: string
+          affiliate_program_id?: string | null
+          commission_rate_pct?: number | null
+          country_code: string
+          created_at?: string
+          is_active?: boolean
+          merchant_display_name: string
+          merchant_id: string
+          notes?: string | null
+          updated_at?: string
+        }
+        Update: {
+          affiliate_network?: string
+          affiliate_program_id?: string | null
+          commission_rate_pct?: number | null
+          country_code?: string
+          created_at?: string
+          is_active?: boolean
+          merchant_display_name?: string
+          merchant_id?: string
+          notes?: string | null
+          updated_at?: string
+        }
+        Relationships: []
+      }
+      api_keys: {
+        Row: {
+          created_at: string | null
+          id: string
+          key_hash: string
+          key_prefix: string
+          last_used_at: string | null
+          name: string
+          revoked_at: string | null
+          user_id: string
+        }
+        Insert: {
+          created_at?: string | null
+          id?: string
+          key_hash: string
+          key_prefix: string
+          last_used_at?: string | null
+          name?: string
+          revoked_at?: string | null
+          user_id: string
+        }
+        Update: {
+          created_at?: string | null
+          id?: string
+          key_hash?: string
+          key_prefix?: string
+          last_used_at?: string | null
+          name?: string
+          revoked_at?: string | null
+          user_id?: string
+        }
+        Relationships: []
+      }
+      consent_log: {
+        Row: {
+          created_at: string
+          event_type: string
+          id: string
+          metadata: Json
+          subject_id: string | null
+          subject_kind: string | null
+          user_id: string
+        }
+        Insert: {
+          created_at?: string
+          event_type: string
+          id?: string
+          metadata?: Json
+          subject_id?: string | null
+          subject_kind?: string | null
+          user_id: string
+        }
+        Update: {
+          created_at?: string
+          event_type?: string
+          id?: string
+          metadata?: Json
+          subject_id?: string | null
+          subject_kind?: string | null
+          user_id?: string
+        }
+        Relationships: []
+      }
+      contact_methods: {
+        Row: {
+          contact_id: string
+          created_at: string
+          id: string
+          is_primary: boolean
+          kind: string
+          updated_at: string
+          value: string
+          verified_at: string | null
+        }
+        Insert: {
+          contact_id: string
+          created_at?: string
+          id?: string
+          is_primary?: boolean
+          kind: string
+          updated_at?: string
+          value: string
+          verified_at?: string | null
+        }
+        Update: {
+          contact_id?: string
+          created_at?: string
+          id?: string
+          is_primary?: boolean
+          kind?: string
+          updated_at?: string
+          value?: string
+          verified_at?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "contact_methods_contact_id_fkey"
+            columns: ["contact_id"]
+            isOneToOne: false
+            referencedRelation: "contacts"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      contacts: {
+        Row: {
+          avatar_url: string | null
+          city: string | null
+          country: string | null
+          created_at: string
+          deleted_at: string | null
+          display_name: string
+          external_id: string | null
+          id: string
+          linked_profile_id: string | null
+          notes: string | null
+          owner_user_id: string
+          source: string
+          updated_at: string
+        }
+        Insert: {
+          avatar_url?: string | null
+          city?: string | null
+          country?: string | null
+          created_at?: string
+          deleted_at?: string | null
+          display_name: string
+          external_id?: string | null
+          id?: string
+          linked_profile_id?: string | null
+          notes?: string | null
+          owner_user_id: string
+          source?: string
+          updated_at?: string
+        }
+        Update: {
+          avatar_url?: string | null
+          city?: string | null
+          country?: string | null
+          created_at?: string
+          deleted_at?: string | null
+          display_name?: string
+          external_id?: string | null
+          id?: string
+          linked_profile_id?: string | null
+          notes?: string | null
+          owner_user_id?: string
+          source?: string
+          updated_at?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "contacts_linked_profile_id_fkey"
+            columns: ["linked_profile_id"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      content_moderation_flags: {
+        Row: {
+          content_snippet: string
+          created_at: string
+          field: string
+          flags: string[]
+          id: string
+          profile_id: string | null
+          severity: string
+          source: string
+        }
+        Insert: {
+          content_snippet: string
+          created_at?: string
+          field: string
+          flags: string[]
+          id?: string
+          profile_id?: string | null
+          severity: string
+          source: string
+        }
+        Update: {
+          content_snippet?: string
+          created_at?: string
+          field?: string
+          flags?: string[]
+          id?: string
+          profile_id?: string | null
+          severity?: string
+          source?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "content_moderation_flags_profile_id_fkey"
+            columns: ["profile_id"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      conversation_starter_prompts: {
+        Row: {
+          category: string | null
+          created_at: string | null
+          id: string
+          is_active: boolean | null
+          prompt: string
+          sort_order: number | null
+        }
+        Insert: {
+          category?: string | null
+          created_at?: string | null
+          id?: string
+          is_active?: boolean | null
+          prompt: string
+          sort_order?: number | null
+        }
+        Update: {
+          category?: string | null
+          created_at?: string | null
+          id?: string
+          is_active?: boolean | null
+          prompt?: string
+          sort_order?: number | null
+        }
+        Relationships: []
+      }
+      erasure_obligations: {
+        Row: {
+          completed_at: string | null
+          created_at: string
+          id: string
+          notes: string | null
+          processors: string[]
+          status: string
+          subject_email: string | null
+          subject_user_id: string
+        }
+        Insert: {
+          completed_at?: string | null
+          created_at?: string
+          id?: string
+          notes?: string | null
+          processors?: string[]
+          status?: string
+          subject_email?: string | null
+          subject_user_id: string
+        }
+        Update: {
+          completed_at?: string | null
+          created_at?: string
+          id?: string
+          notes?: string | null
+          processors?: string[]
+          status?: string
+          subject_email?: string | null
+          subject_user_id?: string
+        }
+        Relationships: []
+      }
+      external_links: {
+        Row: {
+          created_at: string | null
+          description: string | null
+          id: string
+          link_type: Database["public"]["Enums"]["link_type"] | null
+          profile_id: string
+          sort_order: number | null
+          title: string
+          url: string
+        }
+        Insert: {
+          created_at?: string | null
+          description?: string | null
+          id?: string
+          link_type?: Database["public"]["Enums"]["link_type"] | null
+          profile_id: string
+          sort_order?: number | null
+          title: string
+          url: string
+        }
+        Update: {
+          created_at?: string | null
+          description?: string | null
+          id?: string
+          link_type?: Database["public"]["Enums"]["link_type"] | null
+          profile_id?: string
+          sort_order?: number | null
+          title?: string
+          url?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "external_links_profile_id_fkey"
+            columns: ["profile_id"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      feature_entitlements: {
+        Row: {
+          enabled: boolean
+          feature_key: string
+          granted_at: string
+          granted_by: string | null
+          id: string
+          metadata: Json | null
+          profile_id: string
+          updated_at: string
+        }
+        Insert: {
+          enabled?: boolean
+          feature_key: string
+          granted_at?: string
+          granted_by?: string | null
+          id?: string
+          metadata?: Json | null
+          profile_id: string
+          updated_at?: string
+        }
+        Update: {
+          enabled?: boolean
+          feature_key?: string
+          granted_at?: string
+          granted_by?: string | null
+          id?: string
+          metadata?: Json | null
+          profile_id?: string
+          updated_at?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "feature_entitlements_granted_by_fkey"
+            columns: ["granted_by"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "feature_entitlements_profile_id_fkey"
+            columns: ["profile_id"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      gathering_events_log: {
+        Row: {
+          actor_user_id: string | null
+          created_at: string
+          event_type: string
+          gathering_id: string
+          id: string
+          metadata: Json
+          subject_id: string | null
+          subject_kind: string | null
+        }
+        Insert: {
+          actor_user_id?: string | null
+          created_at?: string
+          event_type: string
+          gathering_id: string
+          id?: string
+          metadata?: Json
+          subject_id?: string | null
+          subject_kind?: string | null
+        }
+        Update: {
+          actor_user_id?: string | null
+          created_at?: string
+          event_type?: string
+          gathering_id?: string
+          id?: string
+          metadata?: Json
+          subject_id?: string | null
+          subject_kind?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "gathering_events_log_gathering_id_fkey"
+            columns: ["gathering_id"]
+            isOneToOne: false
+            referencedRelation: "gatherings"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      gathering_invite_messages: {
+        Row: {
+          bounce_reason: string | null
+          channel: string
+          created_at: string
+          delivery_status: string
+          external_message_id: string | null
+          gathering_id: string
+          id: string
+          invitee_id: string
+          sent_at: string | null
+          template_name: string
+        }
+        Insert: {
+          bounce_reason?: string | null
+          channel: string
+          created_at?: string
+          delivery_status?: string
+          external_message_id?: string | null
+          gathering_id: string
+          id?: string
+          invitee_id: string
+          sent_at?: string | null
+          template_name: string
+        }
+        Update: {
+          bounce_reason?: string | null
+          channel?: string
+          created_at?: string
+          delivery_status?: string
+          external_message_id?: string | null
+          gathering_id?: string
+          id?: string
+          invitee_id?: string
+          sent_at?: string | null
+          template_name?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "gathering_invite_messages_gathering_id_fkey"
+            columns: ["gathering_id"]
+            isOneToOne: false
+            referencedRelation: "gatherings"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "gathering_invite_messages_invitee_id_fkey"
+            columns: ["invitee_id"]
+            isOneToOne: false
+            referencedRelation: "gathering_invitees"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      gathering_invitees: {
+        Row: {
+          contact_id: string
+          created_at: string
+          dietary_overrides: string | null
+          gathering_id: string
+          id: string
+          invited_at: string | null
+          notes: string | null
+          plus_ones: number
+          responded_at: string | null
+          rsvp_token: string | null
+          rsvp_token_expires_at: string | null
+          status: string
+          updated_at: string
+        }
+        Insert: {
+          contact_id: string
+          created_at?: string
+          dietary_overrides?: string | null
+          gathering_id: string
+          id?: string
+          invited_at?: string | null
+          notes?: string | null
+          plus_ones?: number
+          responded_at?: string | null
+          rsvp_token?: string | null
+          rsvp_token_expires_at?: string | null
+          status?: string
+          updated_at?: string
+        }
+        Update: {
+          contact_id?: string
+          created_at?: string
+          dietary_overrides?: string | null
+          gathering_id?: string
+          id?: string
+          invited_at?: string | null
+          notes?: string | null
+          plus_ones?: number
+          responded_at?: string | null
+          rsvp_token?: string | null
+          rsvp_token_expires_at?: string | null
+          status?: string
+          updated_at?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "gathering_invitees_contact_id_fkey"
+            columns: ["contact_id"]
+            isOneToOne: false
+            referencedRelation: "contacts"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "gathering_invitees_gathering_id_fkey"
+            columns: ["gathering_id"]
+            isOneToOne: false
+            referencedRelation: "gatherings"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      gathering_proposed_slots: {
+        Row: {
+          availability_breakdown: Json
+          created_at: string
+          gathering_id: string
+          id: string
+          score: number | null
+          slot_end: string
+          slot_start: string
+        }
+        Insert: {
+          availability_breakdown?: Json
+          created_at?: string
+          gathering_id: string
+          id?: string
+          score?: number | null
+          slot_end: string
+          slot_start: string
+        }
+        Update: {
+          availability_breakdown?: Json
+          created_at?: string
+          gathering_id?: string
+          id?: string
+          score?: number | null
+          slot_end?: string
+          slot_start?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "gathering_proposed_slots_gathering_id_fkey"
+            columns: ["gathering_id"]
+            isOneToOne: false
+            referencedRelation: "gatherings"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      gatherings: {
+        Row: {
+          accessibility_required: string[]
+          capacity_max: number | null
+          capacity_min: number | null
+          created_at: string
+          deleted_at: string | null
+          description: string | null
+          dietary_summary: string | null
+          finalised_slot_end: string | null
+          finalised_slot_start: string | null
+          gathering_type: string
+          host_user_id: string
+          id: string
+          notes: string | null
+          silence_nudge_days: number
+          silence_presumed_declined_days: number
+          status: string
+          target_window_end: string | null
+          target_window_start: string | null
+          title: string
+          updated_at: string
+          venue_id: string | null
+        }
+        Insert: {
+          accessibility_required?: string[]
+          capacity_max?: number | null
+          capacity_min?: number | null
+          created_at?: string
+          deleted_at?: string | null
+          description?: string | null
+          dietary_summary?: string | null
+          finalised_slot_end?: string | null
+          finalised_slot_start?: string | null
+          gathering_type: string
+          host_user_id: string
+          id?: string
+          notes?: string | null
+          silence_nudge_days?: number
+          silence_presumed_declined_days?: number
+          status?: string
+          target_window_end?: string | null
+          target_window_start?: string | null
+          title: string
+          updated_at?: string
+          venue_id?: string | null
+        }
+        Update: {
+          accessibility_required?: string[]
+          capacity_max?: number | null
+          capacity_min?: number | null
+          created_at?: string
+          deleted_at?: string | null
+          description?: string | null
+          dietary_summary?: string | null
+          finalised_slot_end?: string | null
+          finalised_slot_start?: string | null
+          gathering_type?: string
+          host_user_id?: string
+          id?: string
+          notes?: string | null
+          silence_nudge_days?: number
+          silence_presumed_declined_days?: number
+          status?: string
+          target_window_end?: string | null
+          target_window_start?: string | null
+          title?: string
+          updated_at?: string
+          venue_id?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "gatherings_venue_id_fkey"
+            columns: ["venue_id"]
+            isOneToOne: false
+            referencedRelation: "venues"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      global_feature_switches: {
+        Row: {
+          created_at: string
+          enabled: boolean
+          environment: string
+          feature_key: string
+          id: string
+          updated_at: string
+          updated_by: string | null
+        }
+        Insert: {
+          created_at?: string
+          enabled?: boolean
+          environment: string
+          feature_key: string
+          id?: string
+          updated_at?: string
+          updated_by?: string | null
+        }
+        Update: {
+          created_at?: string
+          enabled?: boolean
+          environment?: string
+          feature_key?: string
+          id?: string
+          updated_at?: string
+          updated_by?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "global_feature_switches_updated_by_fkey"
+            columns: ["updated_by"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      mcp_tool_call_log: {
+        Row: {
+          api_key_prefix: string | null
+          id: string
+          ip: string
+          method: string
+          status_code: number | null
+          tool: string
+          ts: string
+        }
+        Insert: {
+          api_key_prefix?: string | null
+          id?: string
+          ip: string
+          method: string
+          status_code?: number | null
+          tool: string
+          ts?: string
+        }
+        Update: {
+          api_key_prefix?: string | null
+          id?: string
+          ip?: string
+          method?: string
+          status_code?: number | null
+          tool?: string
+          ts?: string
+        }
+        Relationships: []
+      }
+      moderation_logs: {
+        Row: {
+          action: string
+          actor_user_id: string
+          created_at: string
+          id: string
+          metadata: Json
+          prev_hash: string | null
+          reason: string | null
+          row_hash: string
+          seq: number
+          target_item_id: string | null
+          target_profile_id: string | null
+        }
+        Insert: {
+          action: string
+          actor_user_id: string
+          created_at?: string
+          id?: string
+          metadata?: Json
+          prev_hash?: string | null
+          reason?: string | null
+          row_hash: string
+          seq: number
+          target_item_id?: string | null
+          target_profile_id?: string | null
+        }
+        Update: {
+          action?: string
+          actor_user_id?: string
+          created_at?: string
+          id?: string
+          metadata?: Json
+          prev_hash?: string | null
+          reason?: string | null
+          row_hash?: string
+          seq?: number
+          target_item_id?: string | null
+          target_profile_id?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "moderation_logs_target_item_id_fkey"
+            columns: ["target_item_id"]
+            isOneToOne: false
+            referencedRelation: "profile_items"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "moderation_logs_target_profile_id_fkey"
+            columns: ["target_profile_id"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      oauth_access_tokens: {
+        Row: {
+          client_id: string
+          expires_at: string
+          issued_at: string
+          jti: string
+          revoked_at: string | null
+          scope: string
+          user_id: string
+        }
+        Insert: {
+          client_id: string
+          expires_at: string
+          issued_at?: string
+          jti?: string
+          revoked_at?: string | null
+          scope: string
+          user_id: string
+        }
+        Update: {
+          client_id?: string
+          expires_at?: string
+          issued_at?: string
+          jti?: string
+          revoked_at?: string | null
+          scope?: string
+          user_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "oauth_access_tokens_client_id_fkey"
+            columns: ["client_id"]
+            isOneToOne: false
+            referencedRelation: "oauth_clients"
+            referencedColumns: ["client_id"]
+          },
+        ]
+      }
+      oauth_authorization_codes: {
+        Row: {
+          client_id: string
+          code: string
+          code_challenge: string
+          code_challenge_method: string
+          created_at: string
+          expires_at: string
+          redirect_uri: string
+          scope: string
+          used_at: string | null
+          user_id: string
+        }
+        Insert: {
+          client_id: string
+          code: string
+          code_challenge: string
+          code_challenge_method: string
+          created_at?: string
+          expires_at: string
+          redirect_uri: string
+          scope: string
+          used_at?: string | null
+          user_id: string
+        }
+        Update: {
+          client_id?: string
+          code?: string
+          code_challenge?: string
+          code_challenge_method?: string
+          created_at?: string
+          expires_at?: string
+          redirect_uri?: string
+          scope?: string
+          used_at?: string | null
+          user_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "oauth_authorization_codes_client_id_fkey"
+            columns: ["client_id"]
+            isOneToOne: false
+            referencedRelation: "oauth_clients"
+            referencedColumns: ["client_id"]
+          },
+        ]
+      }
+      oauth_clients: {
+        Row: {
+          application_type: string
+          client_id: string
+          client_name: string
+          client_secret_hash: string | null
+          created_at: string
+          grant_types: string[]
+          id: string
+          is_first_party: boolean
+          redirect_uris: string[]
+          response_types: string[]
+          revoked_at: string | null
+          scopes: string
+          token_endpoint_auth_method: string
+          updated_at: string
+        }
+        Insert: {
+          application_type?: string
+          client_id: string
+          client_name: string
+          client_secret_hash?: string | null
+          created_at?: string
+          grant_types?: string[]
+          id?: string
+          is_first_party?: boolean
+          redirect_uris: string[]
+          response_types?: string[]
+          revoked_at?: string | null
+          scopes?: string
+          token_endpoint_auth_method?: string
+          updated_at?: string
+        }
+        Update: {
+          application_type?: string
+          client_id?: string
+          client_name?: string
+          client_secret_hash?: string | null
+          created_at?: string
+          grant_types?: string[]
+          id?: string
+          is_first_party?: boolean
+          redirect_uris?: string[]
+          response_types?: string[]
+          revoked_at?: string | null
+          scopes?: string
+          token_endpoint_auth_method?: string
+          updated_at?: string
+        }
+        Relationships: []
+      }
+      oauth_connect_state: {
+        Row: {
+          created_at: string
+          expires_at: string
+          provider: string
+          state: string
+          user_id: string
+        }
+        Insert: {
+          created_at?: string
+          expires_at?: string
+          provider: string
+          state: string
+          user_id: string
+        }
+        Update: {
+          created_at?: string
+          expires_at?: string
+          provider?: string
+          state?: string
+          user_id?: string
+        }
+        Relationships: []
+      }
+      oauth_connections: {
+        Row: {
+          access_token_expires_at: string | null
+          access_token_secret_id: string | null
+          created_at: string
+          deleted_at: string | null
+          display_name: string | null
+          id: string
+          last_used_at: string | null
+          owner_user_id: string
+          provider: string
+          provider_account_id: string
+          refresh_token_secret_id: string
+          scope_granted: string
+          status: string
+          updated_at: string
+        }
+        Insert: {
+          access_token_expires_at?: string | null
+          access_token_secret_id?: string | null
+          created_at?: string
+          deleted_at?: string | null
+          display_name?: string | null
+          id?: string
+          last_used_at?: string | null
+          owner_user_id: string
+          provider: string
+          provider_account_id: string
+          refresh_token_secret_id: string
+          scope_granted: string
+          status?: string
+          updated_at?: string
+        }
+        Update: {
+          access_token_expires_at?: string | null
+          access_token_secret_id?: string | null
+          created_at?: string
+          deleted_at?: string | null
+          display_name?: string | null
+          id?: string
+          last_used_at?: string | null
+          owner_user_id?: string
+          provider?: string
+          provider_account_id?: string
+          refresh_token_secret_id?: string
+          scope_granted?: string
+          status?: string
+          updated_at?: string
+        }
+        Relationships: []
+      }
+      oauth_consents: {
+        Row: {
+          client_id: string
+          granted_at: string
+          id: string
+          revoked_at: string | null
+          scopes: string
+          user_id: string
+        }
+        Insert: {
+          client_id: string
+          granted_at?: string
+          id?: string
+          revoked_at?: string | null
+          scopes: string
+          user_id: string
+        }
+        Update: {
+          client_id?: string
+          granted_at?: string
+          id?: string
+          revoked_at?: string | null
+          scopes?: string
+          user_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "oauth_consents_client_id_fkey"
+            columns: ["client_id"]
+            isOneToOne: false
+            referencedRelation: "oauth_clients"
+            referencedColumns: ["client_id"]
+          },
+        ]
+      }
+      oauth_refresh_tokens: {
+        Row: {
+          client_id: string
+          expires_at: string
+          family_id: string
+          issued_at: string
+          scope: string
+          token_hash: string
+          used_at: string | null
+          user_id: string
+        }
+        Insert: {
+          client_id: string
+          expires_at: string
+          family_id: string
+          issued_at?: string
+          scope: string
+          token_hash: string
+          used_at?: string | null
+          user_id: string
+        }
+        Update: {
+          client_id?: string
+          expires_at?: string
+          family_id?: string
+          issued_at?: string
+          scope?: string
+          token_hash?: string
+          used_at?: string | null
+          user_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "oauth_refresh_tokens_client_id_fkey"
+            columns: ["client_id"]
+            isOneToOne: false
+            referencedRelation: "oauth_clients"
+            referencedColumns: ["client_id"]
+          },
+        ]
+      }
+      oauth_scopes_granted: {
+        Row: {
+          granted_at: string
+          id: string
+          oauth_connection_id: string
+          revoked_at: string | null
+          scope: string
+        }
+        Insert: {
+          granted_at?: string
+          id?: string
+          oauth_connection_id: string
+          revoked_at?: string | null
+          scope: string
+        }
+        Update: {
+          granted_at?: string
+          id?: string
+          oauth_connection_id?: string
+          revoked_at?: string | null
+          scope?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "oauth_scopes_granted_oauth_connection_id_fkey"
+            columns: ["oauth_connection_id"]
+            isOneToOne: false
+            referencedRelation: "oauth_connections"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      profile_conversation_starters: {
+        Row: {
+          answer: string
+          created_at: string | null
+          id: string
+          profile_id: string
+          prompt_id: string
+          sort_order: number | null
+          updated_at: string | null
+        }
+        Insert: {
+          answer: string
+          created_at?: string | null
+          id?: string
+          profile_id: string
+          prompt_id: string
+          sort_order?: number | null
+          updated_at?: string | null
+        }
+        Update: {
+          answer?: string
+          created_at?: string | null
+          id?: string
+          profile_id?: string
+          prompt_id?: string
+          sort_order?: number | null
+          updated_at?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "profile_conversation_starters_profile_id_fkey"
+            columns: ["profile_id"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "profile_conversation_starters_prompt_id_fkey"
+            columns: ["prompt_id"]
+            isOneToOne: false
+            referencedRelation: "conversation_starter_prompts"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      profile_files: {
+        Row: {
+          created_at: string | null
+          file_name: string
+          id: string
+          mime_type: string
+          profile_id: string
+          size_bytes: number
+          sort_order: number | null
+          storage_path: string
+          visibility: Database["public"]["Enums"]["visibility_level"] | null
+        }
+        Insert: {
+          created_at?: string | null
+          file_name: string
+          id?: string
+          mime_type: string
+          profile_id: string
+          size_bytes: number
+          sort_order?: number | null
+          storage_path: string
+          visibility?: Database["public"]["Enums"]["visibility_level"] | null
+        }
+        Update: {
+          created_at?: string | null
+          file_name?: string
+          id?: string
+          mime_type?: string
+          profile_id?: string
+          size_bytes?: number
+          sort_order?: number | null
+          storage_path?: string
+          visibility?: Database["public"]["Enums"]["visibility_level"] | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "profile_files_profile_id_fkey"
+            columns: ["profile_id"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      profile_items: {
+        Row: {
+          category: Database["public"]["Enums"]["item_category"]
+          created_at: string | null
+          description: string | null
+          id: string
+          profile_id: string
+          sort_order: number | null
+          title: string
+          url: string | null
+          visibility: Database["public"]["Enums"]["visibility_level"] | null
+        }
+        Insert: {
+          category: Database["public"]["Enums"]["item_category"]
+          created_at?: string | null
+          description?: string | null
+          id?: string
+          profile_id: string
+          sort_order?: number | null
+          title: string
+          url?: string | null
+          visibility?: Database["public"]["Enums"]["visibility_level"] | null
+        }
+        Update: {
+          category?: Database["public"]["Enums"]["item_category"]
+          created_at?: string | null
+          description?: string | null
+          id?: string
+          profile_id?: string
+          sort_order?: number | null
+          title?: string
+          url?: string | null
+          visibility?: Database["public"]["Enums"]["visibility_level"] | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "profile_items_profile_id_fkey"
+            columns: ["profile_id"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      profile_manual_of_me: {
+        Row: {
+          boundaries: string | null
+          communication_style: string | null
+          created_at: string | null
+          drains_me: string | null
+          energises_me: string | null
+          good_to_know: string | null
+          profile_id: string
+          updated_at: string | null
+          working_preferences: string | null
+        }
+        Insert: {
+          boundaries?: string | null
+          communication_style?: string | null
+          created_at?: string | null
+          drains_me?: string | null
+          energises_me?: string | null
+          good_to_know?: string | null
+          profile_id: string
+          updated_at?: string | null
+          working_preferences?: string | null
+        }
+        Update: {
+          boundaries?: string | null
+          communication_style?: string | null
+          created_at?: string | null
+          drains_me?: string | null
+          energises_me?: string | null
+          good_to_know?: string | null
+          profile_id?: string
+          updated_at?: string | null
+          working_preferences?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "profile_manual_of_me_profile_id_fkey"
+            columns: ["profile_id"]
+            isOneToOne: true
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      profiles: {
+        Row: {
+          access_tier: Database["public"]["Enums"]["access_tier"]
+          age_checked_at: string | null
+          age_declared_18_at: string | null
+          age_provider: string | null
+          age_provider_ref: string | null
+          age_range: string | null
+          age_status: Database["public"]["Enums"]["age_status"]
+          avatar_url: string | null
+          beta_approved_at: string | null
+          beta_requested_at: string | null
+          bio_short: string | null
+          city: string | null
+          completion_score: number | null
+          country: string | null
+          created_at: string | null
+          dashboard_widget_state: Json
+          delivery_country_code: string | null
+          discoverable_by_phone: boolean
+          discoverable_by_postcode: boolean
+          display_name: string
+          headline: string | null
+          homepage_example_order: number | null
+          id: string
+          is_admin: boolean
+          is_homepage_example: boolean
+          is_published: boolean | null
+          is_suspended: boolean
+          onboarding_complete: boolean | null
+          phone_search_hash: string | null
+          postcode_prefix: string | null
+          postcode_search_hash: string | null
+          recipient_attributes: Json
+          region: string | null
+          section_visibility: Json
+          share_availability_with_contacts: boolean
+          slug: string
+          suspended_at: string | null
+          suspension_reason: string | null
+          updated_at: string | null
+          user_id: string
+          user_status: Database["public"]["Enums"]["user_status"]
+        }
+        Insert: {
+          access_tier?: Database["public"]["Enums"]["access_tier"]
+          age_checked_at?: string | null
+          age_declared_18_at?: string | null
+          age_provider?: string | null
+          age_provider_ref?: string | null
+          age_range?: string | null
+          age_status?: Database["public"]["Enums"]["age_status"]
+          avatar_url?: string | null
+          beta_approved_at?: string | null
+          beta_requested_at?: string | null
+          bio_short?: string | null
+          city?: string | null
+          completion_score?: number | null
+          country?: string | null
+          created_at?: string | null
+          dashboard_widget_state?: Json
+          delivery_country_code?: string | null
+          discoverable_by_phone?: boolean
+          discoverable_by_postcode?: boolean
+          display_name: string
+          headline?: string | null
+          homepage_example_order?: number | null
+          id?: string
+          is_admin?: boolean
+          is_homepage_example?: boolean
+          is_published?: boolean | null
+          is_suspended?: boolean
+          onboarding_complete?: boolean | null
+          phone_search_hash?: string | null
+          postcode_prefix?: string | null
+          postcode_search_hash?: string | null
+          recipient_attributes?: Json
+          region?: string | null
+          section_visibility?: Json
+          share_availability_with_contacts?: boolean
+          slug: string
+          suspended_at?: string | null
+          suspension_reason?: string | null
+          updated_at?: string | null
+          user_id: string
+          user_status?: Database["public"]["Enums"]["user_status"]
+        }
+        Update: {
+          access_tier?: Database["public"]["Enums"]["access_tier"]
+          age_checked_at?: string | null
+          age_declared_18_at?: string | null
+          age_provider?: string | null
+          age_provider_ref?: string | null
+          age_range?: string | null
+          age_status?: Database["public"]["Enums"]["age_status"]
+          avatar_url?: string | null
+          beta_approved_at?: string | null
+          beta_requested_at?: string | null
+          bio_short?: string | null
+          city?: string | null
+          completion_score?: number | null
+          country?: string | null
+          created_at?: string | null
+          dashboard_widget_state?: Json
+          delivery_country_code?: string | null
+          discoverable_by_phone?: boolean
+          discoverable_by_postcode?: boolean
+          display_name?: string
+          headline?: string | null
+          homepage_example_order?: number | null
+          id?: string
+          is_admin?: boolean
+          is_homepage_example?: boolean
+          is_published?: boolean | null
+          is_suspended?: boolean
+          onboarding_complete?: boolean | null
+          phone_search_hash?: string | null
+          postcode_prefix?: string | null
+          postcode_search_hash?: string | null
+          recipient_attributes?: Json
+          region?: string | null
+          section_visibility?: Json
+          share_availability_with_contacts?: boolean
+          slug?: string
+          suspended_at?: string | null
+          suspension_reason?: string | null
+          updated_at?: string | null
+          user_id?: string
+          user_status?: Database["public"]["Enums"]["user_status"]
+        }
+        Relationships: []
+      }
+      rate_limits: {
+        Row: {
+          bucket: string
+          hits: number
+          reset_at: string
+        }
+        Insert: {
+          bucket: string
+          hits?: number
+          reset_at: string
+        }
+        Update: {
+          bucket?: string
+          hits?: number
+          reset_at?: string
+        }
+        Relationships: []
+      }
+      recommendation_events: {
+        Row: {
+          created_at: string
+          event_id: string
+          event_type: string
+          merchant_id: string | null
+          metadata: Json
+          recipient_id: string | null
+          recommendation_id: string
+          session_id: string | null
+          source: string
+          user_id: string | null
+        }
+        Insert: {
+          created_at?: string
+          event_id?: string
+          event_type: string
+          merchant_id?: string | null
+          metadata?: Json
+          recipient_id?: string | null
+          recommendation_id: string
+          session_id?: string | null
+          source?: string
+          user_id?: string | null
+        }
+        Update: {
+          created_at?: string
+          event_id?: string
+          event_type?: string
+          merchant_id?: string | null
+          metadata?: Json
+          recipient_id?: string | null
+          recommendation_id?: string
+          session_id?: string | null
+          source?: string
+          user_id?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "recommendation_events_recipient_id_fkey"
+            columns: ["recipient_id"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      recommender_catalogue: {
+        Row: {
+          buyer_countries: string[] | null
+          catalogue_id: string
+          concept_category: string
+          concept_keywords: string[]
+          created_at: string
+          description: string | null
+          image_url: string | null
+          is_active: boolean
+          merchant_id: string
+          price_currency: string | null
+          price_max_minor: number | null
+          price_min_minor: number | null
+          rationale_fragment: string | null
+          raw_url: string
+          title: string
+          updated_at: string
+          weight: number
+        }
+        Insert: {
+          buyer_countries?: string[] | null
+          catalogue_id?: string
+          concept_category: string
+          concept_keywords?: string[]
+          created_at?: string
+          description?: string | null
+          image_url?: string | null
+          is_active?: boolean
+          merchant_id: string
+          price_currency?: string | null
+          price_max_minor?: number | null
+          price_min_minor?: number | null
+          rationale_fragment?: string | null
+          raw_url: string
+          title: string
+          updated_at?: string
+          weight?: number
+        }
+        Update: {
+          buyer_countries?: string[] | null
+          catalogue_id?: string
+          concept_category?: string
+          concept_keywords?: string[]
+          created_at?: string
+          description?: string | null
+          image_url?: string | null
+          is_active?: boolean
+          merchant_id?: string
+          price_currency?: string | null
+          price_max_minor?: number | null
+          price_min_minor?: number | null
+          rationale_fragment?: string | null
+          raw_url?: string
+          title?: string
+          updated_at?: string
+          weight?: number
+        }
+        Relationships: []
+      }
+      reports: {
+        Row: {
+          created_at: string
+          id: string
+          note: string | null
+          profile_id: string
+          profile_item_id: string | null
+          reason: Database["public"]["Enums"]["report_reason"]
+          reporter_user_id: string | null
+          resolved_at: string | null
+          resolved_by: string | null
+          status: Database["public"]["Enums"]["report_status"]
+        }
+        Insert: {
+          created_at?: string
+          id?: string
+          note?: string | null
+          profile_id: string
+          profile_item_id?: string | null
+          reason: Database["public"]["Enums"]["report_reason"]
+          reporter_user_id?: string | null
+          resolved_at?: string | null
+          resolved_by?: string | null
+          status?: Database["public"]["Enums"]["report_status"]
+        }
+        Update: {
+          created_at?: string
+          id?: string
+          note?: string | null
+          profile_id?: string
+          profile_item_id?: string | null
+          reason?: Database["public"]["Enums"]["report_reason"]
+          reporter_user_id?: string | null
+          resolved_at?: string | null
+          resolved_by?: string | null
+          status?: Database["public"]["Enums"]["report_status"]
+        }
+        Relationships: [
+          {
+            foreignKeyName: "reports_profile_id_fkey"
+            columns: ["profile_id"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "reports_profile_item_id_fkey"
+            columns: ["profile_item_id"]
+            isOneToOne: false
+            referencedRelation: "profile_items"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      school_affiliations: {
+        Row: {
+          affiliation_type: string
+          created_at: string | null
+          description: string | null
+          id: string
+          profile_id: string
+          relationship:
+            | Database["public"]["Enums"]["school_relationship"]
+            | null
+          school_location: string | null
+          school_name: string
+          show_on_profile: boolean
+        }
+        Insert: {
+          affiliation_type?: string
+          created_at?: string | null
+          description?: string | null
+          id?: string
+          profile_id: string
+          relationship?:
+            | Database["public"]["Enums"]["school_relationship"]
+            | null
+          school_location?: string | null
+          school_name: string
+          show_on_profile?: boolean
+        }
+        Update: {
+          affiliation_type?: string
+          created_at?: string | null
+          description?: string | null
+          id?: string
+          profile_id?: string
+          relationship?:
+            | Database["public"]["Enums"]["school_relationship"]
+            | null
+          school_location?: string | null
+          school_name?: string
+          show_on_profile?: boolean
+        }
+        Relationships: [
+          {
+            foreignKeyName: "school_affiliations_profile_id_fkey"
+            columns: ["profile_id"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      tribe_members: {
+        Row: {
+          contact_id: string
+          created_at: string
+          id: string
+          tribe_id: string
+        }
+        Insert: {
+          contact_id: string
+          created_at?: string
+          id?: string
+          tribe_id: string
+        }
+        Update: {
+          contact_id?: string
+          created_at?: string
+          id?: string
+          tribe_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "tribe_members_contact_id_fkey"
+            columns: ["contact_id"]
+            isOneToOne: false
+            referencedRelation: "contacts"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "tribe_members_tribe_id_fkey"
+            columns: ["tribe_id"]
+            isOneToOne: false
+            referencedRelation: "tribes"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      tribes: {
+        Row: {
+          color_hex: string | null
+          created_at: string
+          deleted_at: string | null
+          description: string | null
+          id: string
+          name: string
+          owner_user_id: string
+          updated_at: string
+        }
+        Insert: {
+          color_hex?: string | null
+          created_at?: string
+          deleted_at?: string | null
+          description?: string | null
+          id?: string
+          name: string
+          owner_user_id: string
+          updated_at?: string
+        }
+        Update: {
+          color_hex?: string | null
+          created_at?: string
+          deleted_at?: string | null
+          description?: string | null
+          id?: string
+          name?: string
+          owner_user_id?: string
+          updated_at?: string
+        }
+        Relationships: []
+      }
+      venue_ratings: {
+        Row: {
+          created_at: string
+          id: string
+          note: string | null
+          rating: number
+          updated_at: string
+          user_id: string
+          venue_id: string
+        }
+        Insert: {
+          created_at?: string
+          id?: string
+          note?: string | null
+          rating: number
+          updated_at?: string
+          user_id: string
+          venue_id: string
+        }
+        Update: {
+          created_at?: string
+          id?: string
+          note?: string | null
+          rating?: number
+          updated_at?: string
+          user_id?: string
+          venue_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "venue_ratings_venue_id_fkey"
+            columns: ["venue_id"]
+            isOneToOne: false
+            referencedRelation: "venues"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      venue_visits: {
+        Row: {
+          created_at: string
+          gathering_id: string
+          id: string
+          venue_id: string
+          visited_at: string
+        }
+        Insert: {
+          created_at?: string
+          gathering_id: string
+          id?: string
+          venue_id: string
+          visited_at: string
+        }
+        Update: {
+          created_at?: string
+          gathering_id?: string
+          id?: string
+          venue_id?: string
+          visited_at?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "venue_visits_gathering_fk"
+            columns: ["gathering_id"]
+            isOneToOne: false
+            referencedRelation: "gatherings"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "venue_visits_venue_id_fkey"
+            columns: ["venue_id"]
+            isOneToOne: false
+            referencedRelation: "venues"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      venues: {
+        Row: {
+          accessibility_flags: string[]
+          address_line1: string | null
+          address_line2: string | null
+          capacity_estimate: number | null
+          city: string | null
+          country: string
+          created_at: string
+          cuisine: string | null
+          dietary_flags: string[]
+          external_rating: number | null
+          google_place_id: string | null
+          id: string
+          lat: number | null
+          lng: number | null
+          name: string
+          opening_hours: Json | null
+          phone: string | null
+          postcode: string | null
+          price_tier: number | null
+          region: string | null
+          updated_at: string
+          venue_type: string
+          website_url: string | null
+        }
+        Insert: {
+          accessibility_flags?: string[]
+          address_line1?: string | null
+          address_line2?: string | null
+          capacity_estimate?: number | null
+          city?: string | null
+          country?: string
+          created_at?: string
+          cuisine?: string | null
+          dietary_flags?: string[]
+          external_rating?: number | null
+          google_place_id?: string | null
+          id?: string
+          lat?: number | null
+          lng?: number | null
+          name: string
+          opening_hours?: Json | null
+          phone?: string | null
+          postcode?: string | null
+          price_tier?: number | null
+          region?: string | null
+          updated_at?: string
+          venue_type: string
+          website_url?: string | null
+        }
+        Update: {
+          accessibility_flags?: string[]
+          address_line1?: string | null
+          address_line2?: string | null
+          capacity_estimate?: number | null
+          city?: string | null
+          country?: string
+          created_at?: string
+          cuisine?: string | null
+          dietary_flags?: string[]
+          external_rating?: number | null
+          google_place_id?: string | null
+          id?: string
+          lat?: number | null
+          lng?: number | null
+          name?: string
+          opening_hours?: Json | null
+          phone?: string | null
+          postcode?: string | null
+          price_tier?: number | null
+          region?: string | null
+          updated_at?: string
+          venue_type?: string
+          website_url?: string | null
+        }
+        Relationships: []
+      }
+    }
+    Views: {
+      mcp_per_ip_recent_count: {
+        Row: {
+          first_seen: string | null
+          ip: string | null
+          last_seen: string | null
+          request_count: number | null
+        }
+        Relationships: []
+      }
+      relationship_signals: {
+        Row: {
+          contact_id: string | null
+          gathering_type_diversity: number | null
+          gathering_types_seen: string[] | null
+          last_attended_at: string | null
+          last_invited_at: string | null
+          total_accepted: number | null
+          total_attended: number | null
+          total_declined: number | null
+          total_invites: number | null
+          total_no_shows: number | null
+          total_silent: number | null
+          user_id: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "gathering_invitees_contact_id_fkey"
+            columns: ["contact_id"]
+            isOneToOne: false
+            referencedRelation: "contacts"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+    }
+    Functions: {
+      admin_filter_profile_ids: {
+        Args: {
+          p_admin?: boolean
+          p_cap?: number
+          p_early?: boolean
+          p_search?: string
+          p_stage?: string
+          p_suspended?: boolean
+        }
+        Returns: string[]
+      }
+      admin_list_users: {
+        Args: {
+          p_admin?: boolean
+          p_early?: boolean
+          p_limit?: number
+          p_offset?: number
+          p_search?: string
+          p_stage?: string
+          p_suspended?: boolean
+        }
+        Returns: Json
+      }
+      affiliate_clicks_purge_expired: {
+        Args: { cutoff: string }
+        Returns: number
+      }
+      convene_vault_read_secret: {
+        Args: { p_secret_id: string }
+        Returns: string
+      }
+      convene_vault_revoke_secret: {
+        Args: { p_secret_id: string }
+        Returns: undefined
+      }
+      convene_vault_store_secret: {
+        Args: { p_description: string; p_secret: string }
+        Returns: string
+      }
+      e2e_fix_auth_tokens: { Args: { uid: string }; Returns: undefined }
+      gatherings_purge_expired: { Args: { cutoff: string }; Returns: number }
+      get_metrics_for_window: {
+        Args: { p_end_at: string; p_start_at: string }
+        Returns: Json
+      }
+      moderation_log_row_hash: {
+        Args: {
+          p_action: string
+          p_actor_user_id: string
+          p_created_at: string
+          p_id: string
+          p_metadata: Json
+          p_prev_hash: string
+          p_reason: string
+          p_seq: number
+          p_target_item_id: string
+          p_target_profile_id: string
+        }
+        Returns: string
+      }
+      oauth_connect_state_purge_expired: { Args: never; Returns: number }
+      rate_limit_hit: {
+        Args: { p_bucket: string; p_limit: number; p_window_seconds: number }
+        Returns: {
+          limited: boolean
+          retry_after: number
+        }[]
+      }
+      record_erasure_obligation: {
+        Args: {
+          p_notes?: string
+          p_processors: string[]
+          p_subject_email: string
+          p_subject_user_id: string
+        }
+        Returns: string
+      }
+      refresh_relationship_signals: { Args: never; Returns: undefined }
+      search_by_contact_hash: {
+        Args: { p_hash: string; p_kind: string }
+        Returns: {
+          id: string
+          slug: string
+        }[]
+      }
+      security_invariants_report: {
+        Args: never
+        Returns: {
+          detail: string
+          invariant: string
+          object_name: string
+        }[]
+      }
+      tribe_only_visible_tribes: {
+        Args: { p_profile_user_id: string }
+        Returns: {
+          tribe_id: string
+        }[]
+      }
+      verify_moderation_log_chain: {
+        Args: never
+        Returns: {
+          detail: string
+          first_bad_seq: number
+          ok: boolean
+          rows_checked: number
+        }[]
+      }
+    }
+    Enums: {
+      access_stage: "waitlist" | "beta" | "live"
+      access_tier: "beta" | "prod"
+      age_status: "none" | "pending" | "passed" | "failed" | "manual_review"
+      beta_access_status: "none" | "requested" | "approved"
+      item_category:
+        | "gift_ideas"
+        | "gifts_to_avoid"
+        | "likes"
+        | "dislikes"
+        | "helpful_to_know"
+        | "boundaries"
+        | "favourite_books"
+        | "favourite_media"
+        | "causes"
+        | "quotes"
+        | "proud_of"
+        | "life_hacks"
+        | "questions"
+        | "billboard"
+        | "current_problems"
+        | "dietary"
+        | "mobility"
+        | "transport"
+        | "availability_pattern"
+        | "favourite_venues"
+        | "allergies"
+        | "favourite_tv"
+        | "favourite_places"
+        | "favourite_music"
+        | "plays"
+      link_type: "retailer" | "wishlist" | "article" | "general"
+      report_reason:
+        | "spam"
+        | "harassment"
+        | "impersonation"
+        | "inappropriate"
+        | "other"
+      report_status: "pending" | "reviewed" | "actioned" | "dismissed"
+      school_relationship: "parent" | "student" | "alumni" | "staff" | "other"
+      user_status: "not_applied" | "waitlist" | "live"
+      visibility_level:
+        | "public"
+        | "members_only"
+        | "private"
+        | "draft"
+        | "tribe_only"
+    }
+    CompositeTypes: {
+      [_ in never]: never
+    }
+  }
+}
+
+type DatabaseWithoutInternals = Omit<Database, "__InternalSupabase">
+
+type DefaultSchema = DatabaseWithoutInternals[Extract<keyof Database, "public">]
+
+export type Tables<
+  DefaultSchemaTableNameOrOptions extends
+    | keyof (DefaultSchema["Tables"] & DefaultSchema["Views"])
+    | { schema: keyof DatabaseWithoutInternals },
+  TableName extends DefaultSchemaTableNameOrOptions extends {
+    schema: keyof DatabaseWithoutInternals
+  }
+    ? keyof (DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"] &
+        DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Views"])
+    : never = never,
+> = DefaultSchemaTableNameOrOptions extends {
+  schema: keyof DatabaseWithoutInternals
+}
+  ? (DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"] &
+      DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Views"])[TableName] extends {
+      Row: infer R
+    }
+    ? R
+    : never
+  : DefaultSchemaTableNameOrOptions extends keyof (DefaultSchema["Tables"] &
+        DefaultSchema["Views"])
+    ? (DefaultSchema["Tables"] &
+        DefaultSchema["Views"])[DefaultSchemaTableNameOrOptions] extends {
+        Row: infer R
+      }
+      ? R
+      : never
+    : never
+
+export type TablesInsert<
+  DefaultSchemaTableNameOrOptions extends
+    | keyof DefaultSchema["Tables"]
+    | { schema: keyof DatabaseWithoutInternals },
+  TableName extends DefaultSchemaTableNameOrOptions extends {
+    schema: keyof DatabaseWithoutInternals
+  }
+    ? keyof DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"]
+    : never = never,
+> = DefaultSchemaTableNameOrOptions extends {
+  schema: keyof DatabaseWithoutInternals
+}
+  ? DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"][TableName] extends {
+      Insert: infer I
+    }
+    ? I
+    : never
+  : DefaultSchemaTableNameOrOptions extends keyof DefaultSchema["Tables"]
+    ? DefaultSchema["Tables"][DefaultSchemaTableNameOrOptions] extends {
+        Insert: infer I
+      }
+      ? I
+      : never
+    : never
+
+export type TablesUpdate<
+  DefaultSchemaTableNameOrOptions extends
+    | keyof DefaultSchema["Tables"]
+    | { schema: keyof DatabaseWithoutInternals },
+  TableName extends DefaultSchemaTableNameOrOptions extends {
+    schema: keyof DatabaseWithoutInternals
+  }
+    ? keyof DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"]
+    : never = never,
+> = DefaultSchemaTableNameOrOptions extends {
+  schema: keyof DatabaseWithoutInternals
+}
+  ? DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"][TableName] extends {
+      Update: infer U
+    }
+    ? U
+    : never
+  : DefaultSchemaTableNameOrOptions extends keyof DefaultSchema["Tables"]
+    ? DefaultSchema["Tables"][DefaultSchemaTableNameOrOptions] extends {
+        Update: infer U
+      }
+      ? U
+      : never
+    : never
+
+export type Enums<
+  DefaultSchemaEnumNameOrOptions extends
+    | keyof DefaultSchema["Enums"]
+    | { schema: keyof DatabaseWithoutInternals },
+  EnumName extends DefaultSchemaEnumNameOrOptions extends {
+    schema: keyof DatabaseWithoutInternals
+  }
+    ? keyof DatabaseWithoutInternals[DefaultSchemaEnumNameOrOptions["schema"]]["Enums"]
+    : never = never,
+> = DefaultSchemaEnumNameOrOptions extends {
+  schema: keyof DatabaseWithoutInternals
+}
+  ? DatabaseWithoutInternals[DefaultSchemaEnumNameOrOptions["schema"]]["Enums"][EnumName]
+  : DefaultSchemaEnumNameOrOptions extends keyof DefaultSchema["Enums"]
+    ? DefaultSchema["Enums"][DefaultSchemaEnumNameOrOptions]
+    : never
+
+export type CompositeTypes<
+  PublicCompositeTypeNameOrOptions extends
+    | keyof DefaultSchema["CompositeTypes"]
+    | { schema: keyof DatabaseWithoutInternals },
+  CompositeTypeName extends PublicCompositeTypeNameOrOptions extends {
+    schema: keyof DatabaseWithoutInternals
+  }
+    ? keyof DatabaseWithoutInternals[PublicCompositeTypeNameOrOptions["schema"]]["CompositeTypes"]
+    : never = never,
+> = PublicCompositeTypeNameOrOptions extends {
+  schema: keyof DatabaseWithoutInternals
+}
+  ? DatabaseWithoutInternals[PublicCompositeTypeNameOrOptions["schema"]]["CompositeTypes"][CompositeTypeName]
+  : PublicCompositeTypeNameOrOptions extends keyof DefaultSchema["CompositeTypes"]
+    ? DefaultSchema["CompositeTypes"][PublicCompositeTypeNameOrOptions]
+    : never
+
+export const Constants = {
+  public: {
+    Enums: {
+      access_stage: ["waitlist", "beta", "live"],
+      access_tier: ["beta", "prod"],
+      age_status: ["none", "pending", "passed", "failed", "manual_review"],
+      beta_access_status: ["none", "requested", "approved"],
+      item_category: [
+        "gift_ideas",
+        "gifts_to_avoid",
+        "likes",
+        "dislikes",
+        "helpful_to_know",
+        "boundaries",
+        "favourite_books",
+        "favourite_media",
+        "causes",
+        "quotes",
+        "proud_of",
+        "life_hacks",
+        "questions",
+        "billboard",
+        "current_problems",
+        "dietary",
+        "mobility",
+        "transport",
+        "availability_pattern",
+        "favourite_venues",
+        "allergies",
+        "favourite_tv",
+        "favourite_places",
+        "favourite_music",
+        "plays",
+      ],
+      link_type: ["retailer", "wishlist", "article", "general"],
+      report_reason: [
+        "spam",
+        "harassment",
+        "impersonation",
+        "inappropriate",
+        "other",
+      ],
+      report_status: ["pending", "reviewed", "actioned", "dismissed"],
+      school_relationship: ["parent", "student", "alumni", "staff", "other"],
+      user_status: ["not_applied", "waitlist", "live"],
+      visibility_level: [
+        "public",
+        "members_only",
+        "private",
+        "draft",
+        "tribe_only",
+      ],
+    },
+  },
+} as const
+

--- a/src/types/database/index.ts
+++ b/src/types/database/index.ts
@@ -1,0 +1,60 @@
+/**
+ * KAN-414 F6 — the generated `Database` schema type.
+ *
+ * WHY THREE FILES
+ * ---------------
+ * `dev.ts`, `staging.ts` and `prod.ts` are the schemas of the three Supabase
+ * projects, generated verbatim and committed unmodified. They are NOT
+ * interchangeable: the environments have measured, intentional drift (KAN-420
+ * R5), so no single file is a truthful description of all three.
+ *
+ *   staging -> prod   prod is MISSING: discoverable_by_phone,
+ *                     discoverable_by_postcode, phone_search_hash,
+ *                     postcode_search_hash (KAN-153); the `draft` label on
+ *                     visibility_level (KAN-143); and the functions
+ *                     search_by_contact_hash + e2e_fix_auth_tokens.
+ *   dev -> staging    dev is MISSING gathering_invite_messages.claimed_at
+ *                     (BUGS-62 — promotion ran backwards past dev).
+ *
+ * Those files carry no hand-written header on purpose. They must stay
+ * byte-identical to `supabase gen types` output so a regeneration diff is
+ * signal, not noise — a header would show up in every regeneration and train
+ * a reader to skim the diff.
+ *
+ * WHY `dev` IS THE ONE THE APP COMPILES AGAINST
+ * ----------------------------------------------
+ * It is the superset, and it is where code is written. The alternatives are
+ * both worse:
+ *
+ *   * Typing against `prod` would fail the build on code that legitimately
+ *     exists and is exercised on dev and staging (the KAN-153 discoverability
+ *     path). A type that will not compile working code gets deleted.
+ *   * Typing against an intersection would leave real columns untyped, which
+ *     is the status quo this ticket exists to end.
+ *
+ * The cost is explicit and must not be forgotten: **this type asserts that
+ * prod has columns it does not have.** `phone_search_hash`,
+ * `postcode_search_hash`, `discoverable_by_phone`, `discoverable_by_postcode`
+ * and the `draft` visibility label typecheck everywhere and are absent on
+ * production. TypeScript will not catch that; only the drift gate will, which
+ * is why `scripts/check-schema-type-parity.py` is a blocking control and not
+ * a report. Closing the gap is F7's job (SEC-107).
+ *
+ * Import from here, never from `dev.ts` directly — the indirection is what
+ * lets F7 change the canonical target in one line once parity lands.
+ */
+
+export type { Database, Json } from './dev';
+
+/**
+ * The Supabase project each committed schema was generated from. Used by the
+ * drift gate and by anything that needs to name an environment's schema
+ * without hardcoding a ref in two places.
+ */
+export const SCHEMA_PROJECT_REFS = {
+  dev: 'ilprytcrnqyrsbsrfujj',
+  staging: 'uobmlkzrjkptwhttzmmi',
+  prod: 'llzkgprqewuwkiwclowi',
+} as const;
+
+export type SchemaEnv = keyof typeof SCHEMA_PROJECT_REFS;

--- a/src/types/database/prod.ts
+++ b/src/types/database/prod.ts
@@ -1,0 +1,2304 @@
+export type Json =
+  | string
+  | number
+  | boolean
+  | null
+  | { [key: string]: Json | undefined }
+  | Json[]
+
+export type Database = {
+  // Allows to automatically instantiate createClient with right options
+  // instead of createClient<Database, { PostgrestVersion: 'XX' }>(URL, KEY)
+  __InternalSupabase: {
+    PostgrestVersion: "14.4"
+  }
+  public: {
+    Tables: {
+      affiliate_clicks: {
+        Row: {
+          buyer_country: string | null
+          click_id: string
+          commission_amount: number | null
+          commission_currency: string | null
+          commission_gbp: number | null
+          converted_at: string | null
+          created_at: string
+          merchant_id: string | null
+          monetised_url: string
+          provider: string
+          provider_subid: string | null
+          raw_url: string
+          recipient_country: string | null
+          recipient_id: string | null
+          recommendation_id: string | null
+          session_id: string | null
+          source: string
+          user_id: string | null
+        }
+        Insert: {
+          buyer_country?: string | null
+          click_id?: string
+          commission_amount?: number | null
+          commission_currency?: string | null
+          commission_gbp?: number | null
+          converted_at?: string | null
+          created_at?: string
+          merchant_id?: string | null
+          monetised_url: string
+          provider: string
+          provider_subid?: string | null
+          raw_url: string
+          recipient_country?: string | null
+          recipient_id?: string | null
+          recommendation_id?: string | null
+          session_id?: string | null
+          source?: string
+          user_id?: string | null
+        }
+        Update: {
+          buyer_country?: string | null
+          click_id?: string
+          commission_amount?: number | null
+          commission_currency?: string | null
+          commission_gbp?: number | null
+          converted_at?: string | null
+          created_at?: string
+          merchant_id?: string | null
+          monetised_url?: string
+          provider?: string
+          provider_subid?: string | null
+          raw_url?: string
+          recipient_country?: string | null
+          recipient_id?: string | null
+          recommendation_id?: string | null
+          session_id?: string | null
+          source?: string
+          user_id?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "affiliate_clicks_recipient_id_fkey"
+            columns: ["recipient_id"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      affiliate_merchant_eligibility: {
+        Row: {
+          affiliate_network: string
+          affiliate_program_id: string | null
+          commission_rate_pct: number | null
+          country_code: string
+          created_at: string
+          is_active: boolean
+          merchant_display_name: string
+          merchant_id: string
+          notes: string | null
+          updated_at: string
+        }
+        Insert: {
+          affiliate_network: string
+          affiliate_program_id?: string | null
+          commission_rate_pct?: number | null
+          country_code: string
+          created_at?: string
+          is_active?: boolean
+          merchant_display_name: string
+          merchant_id: string
+          notes?: string | null
+          updated_at?: string
+        }
+        Update: {
+          affiliate_network?: string
+          affiliate_program_id?: string | null
+          commission_rate_pct?: number | null
+          country_code?: string
+          created_at?: string
+          is_active?: boolean
+          merchant_display_name?: string
+          merchant_id?: string
+          notes?: string | null
+          updated_at?: string
+        }
+        Relationships: []
+      }
+      api_keys: {
+        Row: {
+          created_at: string | null
+          id: string
+          key_hash: string
+          key_prefix: string
+          last_used_at: string | null
+          name: string
+          revoked_at: string | null
+          user_id: string
+        }
+        Insert: {
+          created_at?: string | null
+          id?: string
+          key_hash: string
+          key_prefix: string
+          last_used_at?: string | null
+          name?: string
+          revoked_at?: string | null
+          user_id: string
+        }
+        Update: {
+          created_at?: string | null
+          id?: string
+          key_hash?: string
+          key_prefix?: string
+          last_used_at?: string | null
+          name?: string
+          revoked_at?: string | null
+          user_id?: string
+        }
+        Relationships: []
+      }
+      consent_log: {
+        Row: {
+          created_at: string
+          event_type: string
+          id: string
+          metadata: Json
+          subject_id: string | null
+          subject_kind: string | null
+          user_id: string
+        }
+        Insert: {
+          created_at?: string
+          event_type: string
+          id?: string
+          metadata?: Json
+          subject_id?: string | null
+          subject_kind?: string | null
+          user_id: string
+        }
+        Update: {
+          created_at?: string
+          event_type?: string
+          id?: string
+          metadata?: Json
+          subject_id?: string | null
+          subject_kind?: string | null
+          user_id?: string
+        }
+        Relationships: []
+      }
+      contact_methods: {
+        Row: {
+          contact_id: string
+          created_at: string
+          id: string
+          is_primary: boolean
+          kind: string
+          updated_at: string
+          value: string
+          verified_at: string | null
+        }
+        Insert: {
+          contact_id: string
+          created_at?: string
+          id?: string
+          is_primary?: boolean
+          kind: string
+          updated_at?: string
+          value: string
+          verified_at?: string | null
+        }
+        Update: {
+          contact_id?: string
+          created_at?: string
+          id?: string
+          is_primary?: boolean
+          kind?: string
+          updated_at?: string
+          value?: string
+          verified_at?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "contact_methods_contact_id_fkey"
+            columns: ["contact_id"]
+            isOneToOne: false
+            referencedRelation: "contacts"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      contacts: {
+        Row: {
+          avatar_url: string | null
+          city: string | null
+          country: string | null
+          created_at: string
+          deleted_at: string | null
+          display_name: string
+          external_id: string | null
+          id: string
+          linked_profile_id: string | null
+          notes: string | null
+          owner_user_id: string
+          source: string
+          updated_at: string
+        }
+        Insert: {
+          avatar_url?: string | null
+          city?: string | null
+          country?: string | null
+          created_at?: string
+          deleted_at?: string | null
+          display_name: string
+          external_id?: string | null
+          id?: string
+          linked_profile_id?: string | null
+          notes?: string | null
+          owner_user_id: string
+          source?: string
+          updated_at?: string
+        }
+        Update: {
+          avatar_url?: string | null
+          city?: string | null
+          country?: string | null
+          created_at?: string
+          deleted_at?: string | null
+          display_name?: string
+          external_id?: string | null
+          id?: string
+          linked_profile_id?: string | null
+          notes?: string | null
+          owner_user_id?: string
+          source?: string
+          updated_at?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "contacts_linked_profile_id_fkey"
+            columns: ["linked_profile_id"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      content_moderation_flags: {
+        Row: {
+          content_snippet: string
+          created_at: string
+          field: string
+          flags: string[]
+          id: string
+          profile_id: string | null
+          severity: string
+          source: string
+        }
+        Insert: {
+          content_snippet: string
+          created_at?: string
+          field: string
+          flags: string[]
+          id?: string
+          profile_id?: string | null
+          severity: string
+          source: string
+        }
+        Update: {
+          content_snippet?: string
+          created_at?: string
+          field?: string
+          flags?: string[]
+          id?: string
+          profile_id?: string | null
+          severity?: string
+          source?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "content_moderation_flags_profile_id_fkey"
+            columns: ["profile_id"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      conversation_starter_prompts: {
+        Row: {
+          category: string | null
+          created_at: string | null
+          id: string
+          is_active: boolean | null
+          prompt: string
+          sort_order: number | null
+        }
+        Insert: {
+          category?: string | null
+          created_at?: string | null
+          id?: string
+          is_active?: boolean | null
+          prompt: string
+          sort_order?: number | null
+        }
+        Update: {
+          category?: string | null
+          created_at?: string | null
+          id?: string
+          is_active?: boolean | null
+          prompt?: string
+          sort_order?: number | null
+        }
+        Relationships: []
+      }
+      erasure_obligations: {
+        Row: {
+          completed_at: string | null
+          created_at: string
+          id: string
+          notes: string | null
+          processors: string[]
+          status: string
+          subject_email: string | null
+          subject_user_id: string
+        }
+        Insert: {
+          completed_at?: string | null
+          created_at?: string
+          id?: string
+          notes?: string | null
+          processors?: string[]
+          status?: string
+          subject_email?: string | null
+          subject_user_id: string
+        }
+        Update: {
+          completed_at?: string | null
+          created_at?: string
+          id?: string
+          notes?: string | null
+          processors?: string[]
+          status?: string
+          subject_email?: string | null
+          subject_user_id?: string
+        }
+        Relationships: []
+      }
+      external_links: {
+        Row: {
+          created_at: string | null
+          description: string | null
+          id: string
+          link_type: Database["public"]["Enums"]["link_type"] | null
+          profile_id: string
+          sort_order: number | null
+          title: string
+          url: string
+        }
+        Insert: {
+          created_at?: string | null
+          description?: string | null
+          id?: string
+          link_type?: Database["public"]["Enums"]["link_type"] | null
+          profile_id: string
+          sort_order?: number | null
+          title: string
+          url: string
+        }
+        Update: {
+          created_at?: string | null
+          description?: string | null
+          id?: string
+          link_type?: Database["public"]["Enums"]["link_type"] | null
+          profile_id?: string
+          sort_order?: number | null
+          title?: string
+          url?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "external_links_profile_id_fkey"
+            columns: ["profile_id"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      feature_entitlements: {
+        Row: {
+          enabled: boolean
+          feature_key: string
+          granted_at: string
+          granted_by: string | null
+          id: string
+          metadata: Json | null
+          profile_id: string
+          updated_at: string
+        }
+        Insert: {
+          enabled?: boolean
+          feature_key: string
+          granted_at?: string
+          granted_by?: string | null
+          id?: string
+          metadata?: Json | null
+          profile_id: string
+          updated_at?: string
+        }
+        Update: {
+          enabled?: boolean
+          feature_key?: string
+          granted_at?: string
+          granted_by?: string | null
+          id?: string
+          metadata?: Json | null
+          profile_id?: string
+          updated_at?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "feature_entitlements_granted_by_fkey"
+            columns: ["granted_by"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "feature_entitlements_profile_id_fkey"
+            columns: ["profile_id"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      gathering_events_log: {
+        Row: {
+          actor_user_id: string | null
+          created_at: string
+          event_type: string
+          gathering_id: string
+          id: string
+          metadata: Json
+          subject_id: string | null
+          subject_kind: string | null
+        }
+        Insert: {
+          actor_user_id?: string | null
+          created_at?: string
+          event_type: string
+          gathering_id: string
+          id?: string
+          metadata?: Json
+          subject_id?: string | null
+          subject_kind?: string | null
+        }
+        Update: {
+          actor_user_id?: string | null
+          created_at?: string
+          event_type?: string
+          gathering_id?: string
+          id?: string
+          metadata?: Json
+          subject_id?: string | null
+          subject_kind?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "gathering_events_log_gathering_id_fkey"
+            columns: ["gathering_id"]
+            isOneToOne: false
+            referencedRelation: "gatherings"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      gathering_invite_messages: {
+        Row: {
+          bounce_reason: string | null
+          channel: string
+          claimed_at: string | null
+          created_at: string
+          delivery_status: string
+          external_message_id: string | null
+          gathering_id: string
+          id: string
+          invitee_id: string
+          sent_at: string | null
+          template_name: string
+        }
+        Insert: {
+          bounce_reason?: string | null
+          channel: string
+          claimed_at?: string | null
+          created_at?: string
+          delivery_status?: string
+          external_message_id?: string | null
+          gathering_id: string
+          id?: string
+          invitee_id: string
+          sent_at?: string | null
+          template_name: string
+        }
+        Update: {
+          bounce_reason?: string | null
+          channel?: string
+          claimed_at?: string | null
+          created_at?: string
+          delivery_status?: string
+          external_message_id?: string | null
+          gathering_id?: string
+          id?: string
+          invitee_id?: string
+          sent_at?: string | null
+          template_name?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "gathering_invite_messages_gathering_id_fkey"
+            columns: ["gathering_id"]
+            isOneToOne: false
+            referencedRelation: "gatherings"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "gathering_invite_messages_invitee_id_fkey"
+            columns: ["invitee_id"]
+            isOneToOne: false
+            referencedRelation: "gathering_invitees"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      gathering_invitees: {
+        Row: {
+          contact_id: string
+          created_at: string
+          dietary_overrides: string | null
+          gathering_id: string
+          id: string
+          invited_at: string | null
+          notes: string | null
+          plus_ones: number
+          responded_at: string | null
+          rsvp_token: string | null
+          rsvp_token_expires_at: string | null
+          status: string
+          updated_at: string
+        }
+        Insert: {
+          contact_id: string
+          created_at?: string
+          dietary_overrides?: string | null
+          gathering_id: string
+          id?: string
+          invited_at?: string | null
+          notes?: string | null
+          plus_ones?: number
+          responded_at?: string | null
+          rsvp_token?: string | null
+          rsvp_token_expires_at?: string | null
+          status?: string
+          updated_at?: string
+        }
+        Update: {
+          contact_id?: string
+          created_at?: string
+          dietary_overrides?: string | null
+          gathering_id?: string
+          id?: string
+          invited_at?: string | null
+          notes?: string | null
+          plus_ones?: number
+          responded_at?: string | null
+          rsvp_token?: string | null
+          rsvp_token_expires_at?: string | null
+          status?: string
+          updated_at?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "gathering_invitees_contact_id_fkey"
+            columns: ["contact_id"]
+            isOneToOne: false
+            referencedRelation: "contacts"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "gathering_invitees_gathering_id_fkey"
+            columns: ["gathering_id"]
+            isOneToOne: false
+            referencedRelation: "gatherings"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      gathering_proposed_slots: {
+        Row: {
+          availability_breakdown: Json
+          created_at: string
+          gathering_id: string
+          id: string
+          score: number | null
+          slot_end: string
+          slot_start: string
+        }
+        Insert: {
+          availability_breakdown?: Json
+          created_at?: string
+          gathering_id: string
+          id?: string
+          score?: number | null
+          slot_end: string
+          slot_start: string
+        }
+        Update: {
+          availability_breakdown?: Json
+          created_at?: string
+          gathering_id?: string
+          id?: string
+          score?: number | null
+          slot_end?: string
+          slot_start?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "gathering_proposed_slots_gathering_id_fkey"
+            columns: ["gathering_id"]
+            isOneToOne: false
+            referencedRelation: "gatherings"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      gatherings: {
+        Row: {
+          accessibility_required: string[]
+          capacity_max: number | null
+          capacity_min: number | null
+          created_at: string
+          deleted_at: string | null
+          description: string | null
+          dietary_summary: string | null
+          finalised_slot_end: string | null
+          finalised_slot_start: string | null
+          gathering_type: string
+          host_user_id: string
+          id: string
+          notes: string | null
+          silence_nudge_days: number
+          silence_presumed_declined_days: number
+          status: string
+          target_window_end: string | null
+          target_window_start: string | null
+          title: string
+          updated_at: string
+          venue_id: string | null
+        }
+        Insert: {
+          accessibility_required?: string[]
+          capacity_max?: number | null
+          capacity_min?: number | null
+          created_at?: string
+          deleted_at?: string | null
+          description?: string | null
+          dietary_summary?: string | null
+          finalised_slot_end?: string | null
+          finalised_slot_start?: string | null
+          gathering_type: string
+          host_user_id: string
+          id?: string
+          notes?: string | null
+          silence_nudge_days?: number
+          silence_presumed_declined_days?: number
+          status?: string
+          target_window_end?: string | null
+          target_window_start?: string | null
+          title: string
+          updated_at?: string
+          venue_id?: string | null
+        }
+        Update: {
+          accessibility_required?: string[]
+          capacity_max?: number | null
+          capacity_min?: number | null
+          created_at?: string
+          deleted_at?: string | null
+          description?: string | null
+          dietary_summary?: string | null
+          finalised_slot_end?: string | null
+          finalised_slot_start?: string | null
+          gathering_type?: string
+          host_user_id?: string
+          id?: string
+          notes?: string | null
+          silence_nudge_days?: number
+          silence_presumed_declined_days?: number
+          status?: string
+          target_window_end?: string | null
+          target_window_start?: string | null
+          title?: string
+          updated_at?: string
+          venue_id?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "gatherings_venue_id_fkey"
+            columns: ["venue_id"]
+            isOneToOne: false
+            referencedRelation: "venues"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      global_feature_switches: {
+        Row: {
+          created_at: string
+          enabled: boolean
+          environment: string
+          feature_key: string
+          id: string
+          updated_at: string
+          updated_by: string | null
+        }
+        Insert: {
+          created_at?: string
+          enabled?: boolean
+          environment: string
+          feature_key: string
+          id?: string
+          updated_at?: string
+          updated_by?: string | null
+        }
+        Update: {
+          created_at?: string
+          enabled?: boolean
+          environment?: string
+          feature_key?: string
+          id?: string
+          updated_at?: string
+          updated_by?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "global_feature_switches_updated_by_fkey"
+            columns: ["updated_by"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      mcp_tool_call_log: {
+        Row: {
+          api_key_prefix: string | null
+          id: string
+          ip: string
+          method: string
+          status_code: number | null
+          tool: string
+          ts: string
+        }
+        Insert: {
+          api_key_prefix?: string | null
+          id?: string
+          ip: string
+          method: string
+          status_code?: number | null
+          tool: string
+          ts?: string
+        }
+        Update: {
+          api_key_prefix?: string | null
+          id?: string
+          ip?: string
+          method?: string
+          status_code?: number | null
+          tool?: string
+          ts?: string
+        }
+        Relationships: []
+      }
+      moderation_logs: {
+        Row: {
+          action: string
+          actor_user_id: string
+          created_at: string
+          id: string
+          metadata: Json
+          prev_hash: string | null
+          reason: string | null
+          row_hash: string
+          seq: number
+          target_item_id: string | null
+          target_profile_id: string | null
+        }
+        Insert: {
+          action: string
+          actor_user_id: string
+          created_at?: string
+          id?: string
+          metadata?: Json
+          prev_hash?: string | null
+          reason?: string | null
+          row_hash: string
+          seq: number
+          target_item_id?: string | null
+          target_profile_id?: string | null
+        }
+        Update: {
+          action?: string
+          actor_user_id?: string
+          created_at?: string
+          id?: string
+          metadata?: Json
+          prev_hash?: string | null
+          reason?: string | null
+          row_hash?: string
+          seq?: number
+          target_item_id?: string | null
+          target_profile_id?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "moderation_logs_target_item_id_fkey"
+            columns: ["target_item_id"]
+            isOneToOne: false
+            referencedRelation: "profile_items"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "moderation_logs_target_profile_id_fkey"
+            columns: ["target_profile_id"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      oauth_access_tokens: {
+        Row: {
+          client_id: string
+          expires_at: string
+          issued_at: string
+          jti: string
+          revoked_at: string | null
+          scope: string
+          user_id: string
+        }
+        Insert: {
+          client_id: string
+          expires_at: string
+          issued_at?: string
+          jti?: string
+          revoked_at?: string | null
+          scope: string
+          user_id: string
+        }
+        Update: {
+          client_id?: string
+          expires_at?: string
+          issued_at?: string
+          jti?: string
+          revoked_at?: string | null
+          scope?: string
+          user_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "oauth_access_tokens_client_id_fkey"
+            columns: ["client_id"]
+            isOneToOne: false
+            referencedRelation: "oauth_clients"
+            referencedColumns: ["client_id"]
+          },
+        ]
+      }
+      oauth_authorization_codes: {
+        Row: {
+          client_id: string
+          code: string
+          code_challenge: string
+          code_challenge_method: string
+          created_at: string
+          expires_at: string
+          redirect_uri: string
+          scope: string
+          used_at: string | null
+          user_id: string
+        }
+        Insert: {
+          client_id: string
+          code: string
+          code_challenge: string
+          code_challenge_method: string
+          created_at?: string
+          expires_at: string
+          redirect_uri: string
+          scope: string
+          used_at?: string | null
+          user_id: string
+        }
+        Update: {
+          client_id?: string
+          code?: string
+          code_challenge?: string
+          code_challenge_method?: string
+          created_at?: string
+          expires_at?: string
+          redirect_uri?: string
+          scope?: string
+          used_at?: string | null
+          user_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "oauth_authorization_codes_client_id_fkey"
+            columns: ["client_id"]
+            isOneToOne: false
+            referencedRelation: "oauth_clients"
+            referencedColumns: ["client_id"]
+          },
+        ]
+      }
+      oauth_clients: {
+        Row: {
+          application_type: string
+          client_id: string
+          client_name: string
+          client_secret_hash: string | null
+          created_at: string
+          grant_types: string[]
+          id: string
+          is_first_party: boolean
+          redirect_uris: string[]
+          response_types: string[]
+          revoked_at: string | null
+          scopes: string
+          token_endpoint_auth_method: string
+          updated_at: string
+        }
+        Insert: {
+          application_type?: string
+          client_id: string
+          client_name: string
+          client_secret_hash?: string | null
+          created_at?: string
+          grant_types?: string[]
+          id?: string
+          is_first_party?: boolean
+          redirect_uris: string[]
+          response_types?: string[]
+          revoked_at?: string | null
+          scopes?: string
+          token_endpoint_auth_method?: string
+          updated_at?: string
+        }
+        Update: {
+          application_type?: string
+          client_id?: string
+          client_name?: string
+          client_secret_hash?: string | null
+          created_at?: string
+          grant_types?: string[]
+          id?: string
+          is_first_party?: boolean
+          redirect_uris?: string[]
+          response_types?: string[]
+          revoked_at?: string | null
+          scopes?: string
+          token_endpoint_auth_method?: string
+          updated_at?: string
+        }
+        Relationships: []
+      }
+      oauth_connect_state: {
+        Row: {
+          created_at: string
+          expires_at: string
+          provider: string
+          state: string
+          user_id: string
+        }
+        Insert: {
+          created_at?: string
+          expires_at?: string
+          provider: string
+          state: string
+          user_id: string
+        }
+        Update: {
+          created_at?: string
+          expires_at?: string
+          provider?: string
+          state?: string
+          user_id?: string
+        }
+        Relationships: []
+      }
+      oauth_connections: {
+        Row: {
+          access_token_expires_at: string | null
+          access_token_secret_id: string | null
+          created_at: string
+          deleted_at: string | null
+          display_name: string | null
+          id: string
+          last_used_at: string | null
+          owner_user_id: string
+          provider: string
+          provider_account_id: string
+          refresh_token_secret_id: string
+          scope_granted: string
+          status: string
+          updated_at: string
+        }
+        Insert: {
+          access_token_expires_at?: string | null
+          access_token_secret_id?: string | null
+          created_at?: string
+          deleted_at?: string | null
+          display_name?: string | null
+          id?: string
+          last_used_at?: string | null
+          owner_user_id: string
+          provider: string
+          provider_account_id: string
+          refresh_token_secret_id: string
+          scope_granted: string
+          status?: string
+          updated_at?: string
+        }
+        Update: {
+          access_token_expires_at?: string | null
+          access_token_secret_id?: string | null
+          created_at?: string
+          deleted_at?: string | null
+          display_name?: string | null
+          id?: string
+          last_used_at?: string | null
+          owner_user_id?: string
+          provider?: string
+          provider_account_id?: string
+          refresh_token_secret_id?: string
+          scope_granted?: string
+          status?: string
+          updated_at?: string
+        }
+        Relationships: []
+      }
+      oauth_consents: {
+        Row: {
+          client_id: string
+          granted_at: string
+          id: string
+          revoked_at: string | null
+          scopes: string
+          user_id: string
+        }
+        Insert: {
+          client_id: string
+          granted_at?: string
+          id?: string
+          revoked_at?: string | null
+          scopes: string
+          user_id: string
+        }
+        Update: {
+          client_id?: string
+          granted_at?: string
+          id?: string
+          revoked_at?: string | null
+          scopes?: string
+          user_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "oauth_consents_client_id_fkey"
+            columns: ["client_id"]
+            isOneToOne: false
+            referencedRelation: "oauth_clients"
+            referencedColumns: ["client_id"]
+          },
+        ]
+      }
+      oauth_refresh_tokens: {
+        Row: {
+          client_id: string
+          expires_at: string
+          family_id: string
+          issued_at: string
+          scope: string
+          token_hash: string
+          used_at: string | null
+          user_id: string
+        }
+        Insert: {
+          client_id: string
+          expires_at: string
+          family_id: string
+          issued_at?: string
+          scope: string
+          token_hash: string
+          used_at?: string | null
+          user_id: string
+        }
+        Update: {
+          client_id?: string
+          expires_at?: string
+          family_id?: string
+          issued_at?: string
+          scope?: string
+          token_hash?: string
+          used_at?: string | null
+          user_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "oauth_refresh_tokens_client_id_fkey"
+            columns: ["client_id"]
+            isOneToOne: false
+            referencedRelation: "oauth_clients"
+            referencedColumns: ["client_id"]
+          },
+        ]
+      }
+      oauth_scopes_granted: {
+        Row: {
+          granted_at: string
+          id: string
+          oauth_connection_id: string
+          revoked_at: string | null
+          scope: string
+        }
+        Insert: {
+          granted_at?: string
+          id?: string
+          oauth_connection_id: string
+          revoked_at?: string | null
+          scope: string
+        }
+        Update: {
+          granted_at?: string
+          id?: string
+          oauth_connection_id?: string
+          revoked_at?: string | null
+          scope?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "oauth_scopes_granted_oauth_connection_id_fkey"
+            columns: ["oauth_connection_id"]
+            isOneToOne: false
+            referencedRelation: "oauth_connections"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      profile_conversation_starters: {
+        Row: {
+          answer: string
+          created_at: string | null
+          id: string
+          profile_id: string
+          prompt_id: string
+          sort_order: number | null
+          updated_at: string | null
+        }
+        Insert: {
+          answer: string
+          created_at?: string | null
+          id?: string
+          profile_id: string
+          prompt_id: string
+          sort_order?: number | null
+          updated_at?: string | null
+        }
+        Update: {
+          answer?: string
+          created_at?: string | null
+          id?: string
+          profile_id?: string
+          prompt_id?: string
+          sort_order?: number | null
+          updated_at?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "profile_conversation_starters_profile_id_fkey"
+            columns: ["profile_id"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "profile_conversation_starters_prompt_id_fkey"
+            columns: ["prompt_id"]
+            isOneToOne: false
+            referencedRelation: "conversation_starter_prompts"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      profile_files: {
+        Row: {
+          created_at: string | null
+          file_name: string
+          id: string
+          mime_type: string
+          profile_id: string
+          size_bytes: number
+          sort_order: number | null
+          storage_path: string
+          visibility: Database["public"]["Enums"]["visibility_level"] | null
+        }
+        Insert: {
+          created_at?: string | null
+          file_name: string
+          id?: string
+          mime_type: string
+          profile_id: string
+          size_bytes: number
+          sort_order?: number | null
+          storage_path: string
+          visibility?: Database["public"]["Enums"]["visibility_level"] | null
+        }
+        Update: {
+          created_at?: string | null
+          file_name?: string
+          id?: string
+          mime_type?: string
+          profile_id?: string
+          size_bytes?: number
+          sort_order?: number | null
+          storage_path?: string
+          visibility?: Database["public"]["Enums"]["visibility_level"] | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "profile_files_profile_id_fkey"
+            columns: ["profile_id"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      profile_items: {
+        Row: {
+          category: Database["public"]["Enums"]["item_category"]
+          created_at: string | null
+          description: string | null
+          id: string
+          profile_id: string
+          sort_order: number | null
+          title: string
+          url: string | null
+          visibility: Database["public"]["Enums"]["visibility_level"] | null
+        }
+        Insert: {
+          category: Database["public"]["Enums"]["item_category"]
+          created_at?: string | null
+          description?: string | null
+          id?: string
+          profile_id: string
+          sort_order?: number | null
+          title: string
+          url?: string | null
+          visibility?: Database["public"]["Enums"]["visibility_level"] | null
+        }
+        Update: {
+          category?: Database["public"]["Enums"]["item_category"]
+          created_at?: string | null
+          description?: string | null
+          id?: string
+          profile_id?: string
+          sort_order?: number | null
+          title?: string
+          url?: string | null
+          visibility?: Database["public"]["Enums"]["visibility_level"] | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "profile_items_profile_id_fkey"
+            columns: ["profile_id"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      profile_manual_of_me: {
+        Row: {
+          boundaries: string | null
+          communication_style: string | null
+          created_at: string | null
+          drains_me: string | null
+          energises_me: string | null
+          good_to_know: string | null
+          profile_id: string
+          updated_at: string | null
+          working_preferences: string | null
+        }
+        Insert: {
+          boundaries?: string | null
+          communication_style?: string | null
+          created_at?: string | null
+          drains_me?: string | null
+          energises_me?: string | null
+          good_to_know?: string | null
+          profile_id: string
+          updated_at?: string | null
+          working_preferences?: string | null
+        }
+        Update: {
+          boundaries?: string | null
+          communication_style?: string | null
+          created_at?: string | null
+          drains_me?: string | null
+          energises_me?: string | null
+          good_to_know?: string | null
+          profile_id?: string
+          updated_at?: string | null
+          working_preferences?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "profile_manual_of_me_profile_id_fkey"
+            columns: ["profile_id"]
+            isOneToOne: true
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      profiles: {
+        Row: {
+          access_tier: Database["public"]["Enums"]["access_tier"]
+          age_checked_at: string | null
+          age_declared_18_at: string | null
+          age_provider: string | null
+          age_provider_ref: string | null
+          age_range: string | null
+          age_status: Database["public"]["Enums"]["age_status"]
+          avatar_url: string | null
+          beta_approved_at: string | null
+          beta_requested_at: string | null
+          bio_short: string | null
+          city: string | null
+          completion_score: number | null
+          country: string | null
+          created_at: string | null
+          dashboard_widget_state: Json
+          delivery_country_code: string | null
+          display_name: string
+          headline: string | null
+          homepage_example_order: number | null
+          id: string
+          is_admin: boolean
+          is_homepage_example: boolean
+          is_published: boolean | null
+          is_suspended: boolean
+          onboarding_complete: boolean | null
+          postcode_prefix: string | null
+          recipient_attributes: Json
+          region: string | null
+          section_visibility: Json
+          share_availability_with_contacts: boolean
+          slug: string
+          suspended_at: string | null
+          suspension_reason: string | null
+          updated_at: string | null
+          user_id: string
+          user_status: Database["public"]["Enums"]["user_status"]
+        }
+        Insert: {
+          access_tier?: Database["public"]["Enums"]["access_tier"]
+          age_checked_at?: string | null
+          age_declared_18_at?: string | null
+          age_provider?: string | null
+          age_provider_ref?: string | null
+          age_range?: string | null
+          age_status?: Database["public"]["Enums"]["age_status"]
+          avatar_url?: string | null
+          beta_approved_at?: string | null
+          beta_requested_at?: string | null
+          bio_short?: string | null
+          city?: string | null
+          completion_score?: number | null
+          country?: string | null
+          created_at?: string | null
+          dashboard_widget_state?: Json
+          delivery_country_code?: string | null
+          display_name: string
+          headline?: string | null
+          homepage_example_order?: number | null
+          id?: string
+          is_admin?: boolean
+          is_homepage_example?: boolean
+          is_published?: boolean | null
+          is_suspended?: boolean
+          onboarding_complete?: boolean | null
+          postcode_prefix?: string | null
+          recipient_attributes?: Json
+          region?: string | null
+          section_visibility?: Json
+          share_availability_with_contacts?: boolean
+          slug: string
+          suspended_at?: string | null
+          suspension_reason?: string | null
+          updated_at?: string | null
+          user_id: string
+          user_status?: Database["public"]["Enums"]["user_status"]
+        }
+        Update: {
+          access_tier?: Database["public"]["Enums"]["access_tier"]
+          age_checked_at?: string | null
+          age_declared_18_at?: string | null
+          age_provider?: string | null
+          age_provider_ref?: string | null
+          age_range?: string | null
+          age_status?: Database["public"]["Enums"]["age_status"]
+          avatar_url?: string | null
+          beta_approved_at?: string | null
+          beta_requested_at?: string | null
+          bio_short?: string | null
+          city?: string | null
+          completion_score?: number | null
+          country?: string | null
+          created_at?: string | null
+          dashboard_widget_state?: Json
+          delivery_country_code?: string | null
+          display_name?: string
+          headline?: string | null
+          homepage_example_order?: number | null
+          id?: string
+          is_admin?: boolean
+          is_homepage_example?: boolean
+          is_published?: boolean | null
+          is_suspended?: boolean
+          onboarding_complete?: boolean | null
+          postcode_prefix?: string | null
+          recipient_attributes?: Json
+          region?: string | null
+          section_visibility?: Json
+          share_availability_with_contacts?: boolean
+          slug?: string
+          suspended_at?: string | null
+          suspension_reason?: string | null
+          updated_at?: string | null
+          user_id?: string
+          user_status?: Database["public"]["Enums"]["user_status"]
+        }
+        Relationships: []
+      }
+      rate_limits: {
+        Row: {
+          bucket: string
+          hits: number
+          reset_at: string
+        }
+        Insert: {
+          bucket: string
+          hits?: number
+          reset_at: string
+        }
+        Update: {
+          bucket?: string
+          hits?: number
+          reset_at?: string
+        }
+        Relationships: []
+      }
+      recommendation_events: {
+        Row: {
+          created_at: string
+          event_id: string
+          event_type: string
+          merchant_id: string | null
+          metadata: Json
+          recipient_id: string | null
+          recommendation_id: string
+          session_id: string | null
+          source: string
+          user_id: string | null
+        }
+        Insert: {
+          created_at?: string
+          event_id?: string
+          event_type: string
+          merchant_id?: string | null
+          metadata?: Json
+          recipient_id?: string | null
+          recommendation_id: string
+          session_id?: string | null
+          source?: string
+          user_id?: string | null
+        }
+        Update: {
+          created_at?: string
+          event_id?: string
+          event_type?: string
+          merchant_id?: string | null
+          metadata?: Json
+          recipient_id?: string | null
+          recommendation_id?: string
+          session_id?: string | null
+          source?: string
+          user_id?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "recommendation_events_recipient_id_fkey"
+            columns: ["recipient_id"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      recommender_catalogue: {
+        Row: {
+          buyer_countries: string[] | null
+          catalogue_id: string
+          concept_category: string
+          concept_keywords: string[]
+          created_at: string
+          description: string | null
+          image_url: string | null
+          is_active: boolean
+          merchant_id: string
+          price_currency: string | null
+          price_max_minor: number | null
+          price_min_minor: number | null
+          rationale_fragment: string | null
+          raw_url: string
+          title: string
+          updated_at: string
+          weight: number
+        }
+        Insert: {
+          buyer_countries?: string[] | null
+          catalogue_id?: string
+          concept_category: string
+          concept_keywords?: string[]
+          created_at?: string
+          description?: string | null
+          image_url?: string | null
+          is_active?: boolean
+          merchant_id: string
+          price_currency?: string | null
+          price_max_minor?: number | null
+          price_min_minor?: number | null
+          rationale_fragment?: string | null
+          raw_url: string
+          title: string
+          updated_at?: string
+          weight?: number
+        }
+        Update: {
+          buyer_countries?: string[] | null
+          catalogue_id?: string
+          concept_category?: string
+          concept_keywords?: string[]
+          created_at?: string
+          description?: string | null
+          image_url?: string | null
+          is_active?: boolean
+          merchant_id?: string
+          price_currency?: string | null
+          price_max_minor?: number | null
+          price_min_minor?: number | null
+          rationale_fragment?: string | null
+          raw_url?: string
+          title?: string
+          updated_at?: string
+          weight?: number
+        }
+        Relationships: []
+      }
+      reports: {
+        Row: {
+          created_at: string
+          id: string
+          note: string | null
+          profile_id: string
+          profile_item_id: string | null
+          reason: Database["public"]["Enums"]["report_reason"]
+          reporter_user_id: string | null
+          resolved_at: string | null
+          resolved_by: string | null
+          status: Database["public"]["Enums"]["report_status"]
+        }
+        Insert: {
+          created_at?: string
+          id?: string
+          note?: string | null
+          profile_id: string
+          profile_item_id?: string | null
+          reason: Database["public"]["Enums"]["report_reason"]
+          reporter_user_id?: string | null
+          resolved_at?: string | null
+          resolved_by?: string | null
+          status?: Database["public"]["Enums"]["report_status"]
+        }
+        Update: {
+          created_at?: string
+          id?: string
+          note?: string | null
+          profile_id?: string
+          profile_item_id?: string | null
+          reason?: Database["public"]["Enums"]["report_reason"]
+          reporter_user_id?: string | null
+          resolved_at?: string | null
+          resolved_by?: string | null
+          status?: Database["public"]["Enums"]["report_status"]
+        }
+        Relationships: [
+          {
+            foreignKeyName: "reports_profile_id_fkey"
+            columns: ["profile_id"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "reports_profile_item_id_fkey"
+            columns: ["profile_item_id"]
+            isOneToOne: false
+            referencedRelation: "profile_items"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      school_affiliations: {
+        Row: {
+          affiliation_type: string
+          created_at: string | null
+          description: string | null
+          id: string
+          profile_id: string
+          relationship:
+            | Database["public"]["Enums"]["school_relationship"]
+            | null
+          school_location: string | null
+          school_name: string
+          show_on_profile: boolean
+        }
+        Insert: {
+          affiliation_type?: string
+          created_at?: string | null
+          description?: string | null
+          id?: string
+          profile_id: string
+          relationship?:
+            | Database["public"]["Enums"]["school_relationship"]
+            | null
+          school_location?: string | null
+          school_name: string
+          show_on_profile?: boolean
+        }
+        Update: {
+          affiliation_type?: string
+          created_at?: string | null
+          description?: string | null
+          id?: string
+          profile_id?: string
+          relationship?:
+            | Database["public"]["Enums"]["school_relationship"]
+            | null
+          school_location?: string | null
+          school_name?: string
+          show_on_profile?: boolean
+        }
+        Relationships: [
+          {
+            foreignKeyName: "school_affiliations_profile_id_fkey"
+            columns: ["profile_id"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      tribe_members: {
+        Row: {
+          contact_id: string
+          created_at: string
+          id: string
+          tribe_id: string
+        }
+        Insert: {
+          contact_id: string
+          created_at?: string
+          id?: string
+          tribe_id: string
+        }
+        Update: {
+          contact_id?: string
+          created_at?: string
+          id?: string
+          tribe_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "tribe_members_contact_id_fkey"
+            columns: ["contact_id"]
+            isOneToOne: false
+            referencedRelation: "contacts"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "tribe_members_tribe_id_fkey"
+            columns: ["tribe_id"]
+            isOneToOne: false
+            referencedRelation: "tribes"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      tribes: {
+        Row: {
+          color_hex: string | null
+          created_at: string
+          deleted_at: string | null
+          description: string | null
+          id: string
+          name: string
+          owner_user_id: string
+          updated_at: string
+        }
+        Insert: {
+          color_hex?: string | null
+          created_at?: string
+          deleted_at?: string | null
+          description?: string | null
+          id?: string
+          name: string
+          owner_user_id: string
+          updated_at?: string
+        }
+        Update: {
+          color_hex?: string | null
+          created_at?: string
+          deleted_at?: string | null
+          description?: string | null
+          id?: string
+          name?: string
+          owner_user_id?: string
+          updated_at?: string
+        }
+        Relationships: []
+      }
+      venue_ratings: {
+        Row: {
+          created_at: string
+          id: string
+          note: string | null
+          rating: number
+          updated_at: string
+          user_id: string
+          venue_id: string
+        }
+        Insert: {
+          created_at?: string
+          id?: string
+          note?: string | null
+          rating: number
+          updated_at?: string
+          user_id: string
+          venue_id: string
+        }
+        Update: {
+          created_at?: string
+          id?: string
+          note?: string | null
+          rating?: number
+          updated_at?: string
+          user_id?: string
+          venue_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "venue_ratings_venue_id_fkey"
+            columns: ["venue_id"]
+            isOneToOne: false
+            referencedRelation: "venues"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      venue_visits: {
+        Row: {
+          created_at: string
+          gathering_id: string
+          id: string
+          venue_id: string
+          visited_at: string
+        }
+        Insert: {
+          created_at?: string
+          gathering_id: string
+          id?: string
+          venue_id: string
+          visited_at: string
+        }
+        Update: {
+          created_at?: string
+          gathering_id?: string
+          id?: string
+          venue_id?: string
+          visited_at?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "venue_visits_gathering_fk"
+            columns: ["gathering_id"]
+            isOneToOne: false
+            referencedRelation: "gatherings"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "venue_visits_venue_id_fkey"
+            columns: ["venue_id"]
+            isOneToOne: false
+            referencedRelation: "venues"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      venues: {
+        Row: {
+          accessibility_flags: string[]
+          address_line1: string | null
+          address_line2: string | null
+          capacity_estimate: number | null
+          city: string | null
+          country: string
+          created_at: string
+          cuisine: string | null
+          dietary_flags: string[]
+          external_rating: number | null
+          google_place_id: string | null
+          id: string
+          lat: number | null
+          lng: number | null
+          name: string
+          opening_hours: Json | null
+          phone: string | null
+          postcode: string | null
+          price_tier: number | null
+          region: string | null
+          updated_at: string
+          venue_type: string
+          website_url: string | null
+        }
+        Insert: {
+          accessibility_flags?: string[]
+          address_line1?: string | null
+          address_line2?: string | null
+          capacity_estimate?: number | null
+          city?: string | null
+          country?: string
+          created_at?: string
+          cuisine?: string | null
+          dietary_flags?: string[]
+          external_rating?: number | null
+          google_place_id?: string | null
+          id?: string
+          lat?: number | null
+          lng?: number | null
+          name: string
+          opening_hours?: Json | null
+          phone?: string | null
+          postcode?: string | null
+          price_tier?: number | null
+          region?: string | null
+          updated_at?: string
+          venue_type: string
+          website_url?: string | null
+        }
+        Update: {
+          accessibility_flags?: string[]
+          address_line1?: string | null
+          address_line2?: string | null
+          capacity_estimate?: number | null
+          city?: string | null
+          country?: string
+          created_at?: string
+          cuisine?: string | null
+          dietary_flags?: string[]
+          external_rating?: number | null
+          google_place_id?: string | null
+          id?: string
+          lat?: number | null
+          lng?: number | null
+          name?: string
+          opening_hours?: Json | null
+          phone?: string | null
+          postcode?: string | null
+          price_tier?: number | null
+          region?: string | null
+          updated_at?: string
+          venue_type?: string
+          website_url?: string | null
+        }
+        Relationships: []
+      }
+    }
+    Views: {
+      mcp_per_ip_recent_count: {
+        Row: {
+          first_seen: string | null
+          ip: string | null
+          last_seen: string | null
+          request_count: number | null
+        }
+        Relationships: []
+      }
+      relationship_signals: {
+        Row: {
+          contact_id: string | null
+          gathering_type_diversity: number | null
+          gathering_types_seen: string[] | null
+          last_attended_at: string | null
+          last_invited_at: string | null
+          total_accepted: number | null
+          total_attended: number | null
+          total_declined: number | null
+          total_invites: number | null
+          total_no_shows: number | null
+          total_silent: number | null
+          user_id: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "gathering_invitees_contact_id_fkey"
+            columns: ["contact_id"]
+            isOneToOne: false
+            referencedRelation: "contacts"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+    }
+    Functions: {
+      admin_filter_profile_ids: {
+        Args: {
+          p_admin?: boolean
+          p_cap?: number
+          p_early?: boolean
+          p_search?: string
+          p_stage?: string
+          p_suspended?: boolean
+        }
+        Returns: string[]
+      }
+      admin_list_users: {
+        Args: {
+          p_admin?: boolean
+          p_early?: boolean
+          p_limit?: number
+          p_offset?: number
+          p_search?: string
+          p_stage?: string
+          p_suspended?: boolean
+        }
+        Returns: Json
+      }
+      affiliate_clicks_purge_expired: {
+        Args: { cutoff: string }
+        Returns: number
+      }
+      convene_vault_read_secret: {
+        Args: { p_secret_id: string }
+        Returns: string
+      }
+      convene_vault_revoke_secret: {
+        Args: { p_secret_id: string }
+        Returns: undefined
+      }
+      convene_vault_store_secret: {
+        Args: { p_description: string; p_secret: string }
+        Returns: string
+      }
+      gatherings_purge_expired: { Args: { cutoff: string }; Returns: number }
+      get_metrics_for_window: {
+        Args: { p_end_at: string; p_start_at: string }
+        Returns: Json
+      }
+      moderation_log_row_hash: {
+        Args: {
+          p_action: string
+          p_actor_user_id: string
+          p_created_at: string
+          p_id: string
+          p_metadata: Json
+          p_prev_hash: string
+          p_reason: string
+          p_seq: number
+          p_target_item_id: string
+          p_target_profile_id: string
+        }
+        Returns: string
+      }
+      oauth_connect_state_purge_expired: { Args: never; Returns: number }
+      rate_limit_hit: {
+        Args: { p_bucket: string; p_limit: number; p_window_seconds: number }
+        Returns: {
+          limited: boolean
+          retry_after: number
+        }[]
+      }
+      record_erasure_obligation: {
+        Args: {
+          p_notes?: string
+          p_processors: string[]
+          p_subject_email: string
+          p_subject_user_id: string
+        }
+        Returns: string
+      }
+      refresh_relationship_signals: { Args: never; Returns: undefined }
+      security_invariants_report: {
+        Args: never
+        Returns: {
+          detail: string
+          invariant: string
+          object_name: string
+        }[]
+      }
+      tribe_only_visible_tribes: {
+        Args: { p_profile_user_id: string }
+        Returns: {
+          tribe_id: string
+        }[]
+      }
+      verify_moderation_log_chain: {
+        Args: never
+        Returns: {
+          detail: string
+          first_bad_seq: number
+          ok: boolean
+          rows_checked: number
+        }[]
+      }
+    }
+    Enums: {
+      access_stage: "waitlist" | "beta" | "live"
+      access_tier: "beta" | "prod"
+      age_status: "none" | "pending" | "passed" | "failed" | "manual_review"
+      beta_access_status: "none" | "requested" | "approved"
+      item_category:
+        | "gift_ideas"
+        | "gifts_to_avoid"
+        | "likes"
+        | "dislikes"
+        | "helpful_to_know"
+        | "boundaries"
+        | "favourite_books"
+        | "favourite_media"
+        | "causes"
+        | "quotes"
+        | "proud_of"
+        | "life_hacks"
+        | "questions"
+        | "billboard"
+        | "current_problems"
+        | "dietary"
+        | "mobility"
+        | "transport"
+        | "availability_pattern"
+        | "favourite_venues"
+        | "allergies"
+        | "favourite_tv"
+        | "favourite_places"
+        | "favourite_music"
+        | "plays"
+      link_type: "retailer" | "wishlist" | "article" | "general"
+      report_reason:
+        | "spam"
+        | "harassment"
+        | "impersonation"
+        | "inappropriate"
+        | "other"
+      report_status: "pending" | "reviewed" | "actioned" | "dismissed"
+      school_relationship: "parent" | "student" | "alumni" | "staff" | "other"
+      user_status: "not_applied" | "waitlist" | "live"
+      visibility_level: "public" | "members_only" | "private" | "tribe_only"
+    }
+    CompositeTypes: {
+      [_ in never]: never
+    }
+  }
+}
+
+type DatabaseWithoutInternals = Omit<Database, "__InternalSupabase">
+
+type DefaultSchema = DatabaseWithoutInternals[Extract<keyof Database, "public">]
+
+export type Tables<
+  DefaultSchemaTableNameOrOptions extends
+    | keyof (DefaultSchema["Tables"] & DefaultSchema["Views"])
+    | { schema: keyof DatabaseWithoutInternals },
+  TableName extends DefaultSchemaTableNameOrOptions extends {
+    schema: keyof DatabaseWithoutInternals
+  }
+    ? keyof (DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"] &
+        DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Views"])
+    : never = never,
+> = DefaultSchemaTableNameOrOptions extends {
+  schema: keyof DatabaseWithoutInternals
+}
+  ? (DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"] &
+      DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Views"])[TableName] extends {
+      Row: infer R
+    }
+    ? R
+    : never
+  : DefaultSchemaTableNameOrOptions extends keyof (DefaultSchema["Tables"] &
+        DefaultSchema["Views"])
+    ? (DefaultSchema["Tables"] &
+        DefaultSchema["Views"])[DefaultSchemaTableNameOrOptions] extends {
+        Row: infer R
+      }
+      ? R
+      : never
+    : never
+
+export type TablesInsert<
+  DefaultSchemaTableNameOrOptions extends
+    | keyof DefaultSchema["Tables"]
+    | { schema: keyof DatabaseWithoutInternals },
+  TableName extends DefaultSchemaTableNameOrOptions extends {
+    schema: keyof DatabaseWithoutInternals
+  }
+    ? keyof DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"]
+    : never = never,
+> = DefaultSchemaTableNameOrOptions extends {
+  schema: keyof DatabaseWithoutInternals
+}
+  ? DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"][TableName] extends {
+      Insert: infer I
+    }
+    ? I
+    : never
+  : DefaultSchemaTableNameOrOptions extends keyof DefaultSchema["Tables"]
+    ? DefaultSchema["Tables"][DefaultSchemaTableNameOrOptions] extends {
+        Insert: infer I
+      }
+      ? I
+      : never
+    : never
+
+export type TablesUpdate<
+  DefaultSchemaTableNameOrOptions extends
+    | keyof DefaultSchema["Tables"]
+    | { schema: keyof DatabaseWithoutInternals },
+  TableName extends DefaultSchemaTableNameOrOptions extends {
+    schema: keyof DatabaseWithoutInternals
+  }
+    ? keyof DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"]
+    : never = never,
+> = DefaultSchemaTableNameOrOptions extends {
+  schema: keyof DatabaseWithoutInternals
+}
+  ? DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"][TableName] extends {
+      Update: infer U
+    }
+    ? U
+    : never
+  : DefaultSchemaTableNameOrOptions extends keyof DefaultSchema["Tables"]
+    ? DefaultSchema["Tables"][DefaultSchemaTableNameOrOptions] extends {
+        Update: infer U
+      }
+      ? U
+      : never
+    : never
+
+export type Enums<
+  DefaultSchemaEnumNameOrOptions extends
+    | keyof DefaultSchema["Enums"]
+    | { schema: keyof DatabaseWithoutInternals },
+  EnumName extends DefaultSchemaEnumNameOrOptions extends {
+    schema: keyof DatabaseWithoutInternals
+  }
+    ? keyof DatabaseWithoutInternals[DefaultSchemaEnumNameOrOptions["schema"]]["Enums"]
+    : never = never,
+> = DefaultSchemaEnumNameOrOptions extends {
+  schema: keyof DatabaseWithoutInternals
+}
+  ? DatabaseWithoutInternals[DefaultSchemaEnumNameOrOptions["schema"]]["Enums"][EnumName]
+  : DefaultSchemaEnumNameOrOptions extends keyof DefaultSchema["Enums"]
+    ? DefaultSchema["Enums"][DefaultSchemaEnumNameOrOptions]
+    : never
+
+export type CompositeTypes<
+  PublicCompositeTypeNameOrOptions extends
+    | keyof DefaultSchema["CompositeTypes"]
+    | { schema: keyof DatabaseWithoutInternals },
+  CompositeTypeName extends PublicCompositeTypeNameOrOptions extends {
+    schema: keyof DatabaseWithoutInternals
+  }
+    ? keyof DatabaseWithoutInternals[PublicCompositeTypeNameOrOptions["schema"]]["CompositeTypes"]
+    : never = never,
+> = PublicCompositeTypeNameOrOptions extends {
+  schema: keyof DatabaseWithoutInternals
+}
+  ? DatabaseWithoutInternals[PublicCompositeTypeNameOrOptions["schema"]]["CompositeTypes"][CompositeTypeName]
+  : PublicCompositeTypeNameOrOptions extends keyof DefaultSchema["CompositeTypes"]
+    ? DefaultSchema["CompositeTypes"][PublicCompositeTypeNameOrOptions]
+    : never
+
+export const Constants = {
+  public: {
+    Enums: {
+      access_stage: ["waitlist", "beta", "live"],
+      access_tier: ["beta", "prod"],
+      age_status: ["none", "pending", "passed", "failed", "manual_review"],
+      beta_access_status: ["none", "requested", "approved"],
+      item_category: [
+        "gift_ideas",
+        "gifts_to_avoid",
+        "likes",
+        "dislikes",
+        "helpful_to_know",
+        "boundaries",
+        "favourite_books",
+        "favourite_media",
+        "causes",
+        "quotes",
+        "proud_of",
+        "life_hacks",
+        "questions",
+        "billboard",
+        "current_problems",
+        "dietary",
+        "mobility",
+        "transport",
+        "availability_pattern",
+        "favourite_venues",
+        "allergies",
+        "favourite_tv",
+        "favourite_places",
+        "favourite_music",
+        "plays",
+      ],
+      link_type: ["retailer", "wishlist", "article", "general"],
+      report_reason: [
+        "spam",
+        "harassment",
+        "impersonation",
+        "inappropriate",
+        "other",
+      ],
+      report_status: ["pending", "reviewed", "actioned", "dismissed"],
+      school_relationship: ["parent", "student", "alumni", "staff", "other"],
+      user_status: ["not_applied", "waitlist", "live"],
+      visibility_level: ["public", "members_only", "private", "tribe_only"],
+    },
+  },
+} as const
+

--- a/src/types/database/staging.ts
+++ b/src/types/database/staging.ts
@@ -1,0 +1,2335 @@
+export type Json =
+  | string
+  | number
+  | boolean
+  | null
+  | { [key: string]: Json | undefined }
+  | Json[]
+
+export type Database = {
+  // Allows to automatically instantiate createClient with right options
+  // instead of createClient<Database, { PostgrestVersion: 'XX' }>(URL, KEY)
+  __InternalSupabase: {
+    PostgrestVersion: "14.4"
+  }
+  public: {
+    Tables: {
+      affiliate_clicks: {
+        Row: {
+          buyer_country: string | null
+          click_id: string
+          commission_amount: number | null
+          commission_currency: string | null
+          commission_gbp: number | null
+          converted_at: string | null
+          created_at: string
+          merchant_id: string | null
+          monetised_url: string
+          provider: string
+          provider_subid: string | null
+          raw_url: string
+          recipient_country: string | null
+          recipient_id: string | null
+          recommendation_id: string | null
+          session_id: string | null
+          source: string
+          user_id: string | null
+        }
+        Insert: {
+          buyer_country?: string | null
+          click_id?: string
+          commission_amount?: number | null
+          commission_currency?: string | null
+          commission_gbp?: number | null
+          converted_at?: string | null
+          created_at?: string
+          merchant_id?: string | null
+          monetised_url: string
+          provider: string
+          provider_subid?: string | null
+          raw_url: string
+          recipient_country?: string | null
+          recipient_id?: string | null
+          recommendation_id?: string | null
+          session_id?: string | null
+          source?: string
+          user_id?: string | null
+        }
+        Update: {
+          buyer_country?: string | null
+          click_id?: string
+          commission_amount?: number | null
+          commission_currency?: string | null
+          commission_gbp?: number | null
+          converted_at?: string | null
+          created_at?: string
+          merchant_id?: string | null
+          monetised_url?: string
+          provider?: string
+          provider_subid?: string | null
+          raw_url?: string
+          recipient_country?: string | null
+          recipient_id?: string | null
+          recommendation_id?: string | null
+          session_id?: string | null
+          source?: string
+          user_id?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "affiliate_clicks_recipient_id_fkey"
+            columns: ["recipient_id"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      affiliate_merchant_eligibility: {
+        Row: {
+          affiliate_network: string
+          affiliate_program_id: string | null
+          commission_rate_pct: number | null
+          country_code: string
+          created_at: string
+          is_active: boolean
+          merchant_display_name: string
+          merchant_id: string
+          notes: string | null
+          updated_at: string
+        }
+        Insert: {
+          affiliate_network: string
+          affiliate_program_id?: string | null
+          commission_rate_pct?: number | null
+          country_code: string
+          created_at?: string
+          is_active?: boolean
+          merchant_display_name: string
+          merchant_id: string
+          notes?: string | null
+          updated_at?: string
+        }
+        Update: {
+          affiliate_network?: string
+          affiliate_program_id?: string | null
+          commission_rate_pct?: number | null
+          country_code?: string
+          created_at?: string
+          is_active?: boolean
+          merchant_display_name?: string
+          merchant_id?: string
+          notes?: string | null
+          updated_at?: string
+        }
+        Relationships: []
+      }
+      api_keys: {
+        Row: {
+          created_at: string | null
+          id: string
+          key_hash: string
+          key_prefix: string
+          last_used_at: string | null
+          name: string
+          revoked_at: string | null
+          user_id: string
+        }
+        Insert: {
+          created_at?: string | null
+          id?: string
+          key_hash: string
+          key_prefix: string
+          last_used_at?: string | null
+          name?: string
+          revoked_at?: string | null
+          user_id: string
+        }
+        Update: {
+          created_at?: string | null
+          id?: string
+          key_hash?: string
+          key_prefix?: string
+          last_used_at?: string | null
+          name?: string
+          revoked_at?: string | null
+          user_id?: string
+        }
+        Relationships: []
+      }
+      consent_log: {
+        Row: {
+          created_at: string
+          event_type: string
+          id: string
+          metadata: Json
+          subject_id: string | null
+          subject_kind: string | null
+          user_id: string
+        }
+        Insert: {
+          created_at?: string
+          event_type: string
+          id?: string
+          metadata?: Json
+          subject_id?: string | null
+          subject_kind?: string | null
+          user_id: string
+        }
+        Update: {
+          created_at?: string
+          event_type?: string
+          id?: string
+          metadata?: Json
+          subject_id?: string | null
+          subject_kind?: string | null
+          user_id?: string
+        }
+        Relationships: []
+      }
+      contact_methods: {
+        Row: {
+          contact_id: string
+          created_at: string
+          id: string
+          is_primary: boolean
+          kind: string
+          updated_at: string
+          value: string
+          verified_at: string | null
+        }
+        Insert: {
+          contact_id: string
+          created_at?: string
+          id?: string
+          is_primary?: boolean
+          kind: string
+          updated_at?: string
+          value: string
+          verified_at?: string | null
+        }
+        Update: {
+          contact_id?: string
+          created_at?: string
+          id?: string
+          is_primary?: boolean
+          kind?: string
+          updated_at?: string
+          value?: string
+          verified_at?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "contact_methods_contact_id_fkey"
+            columns: ["contact_id"]
+            isOneToOne: false
+            referencedRelation: "contacts"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      contacts: {
+        Row: {
+          avatar_url: string | null
+          city: string | null
+          country: string | null
+          created_at: string
+          deleted_at: string | null
+          display_name: string
+          external_id: string | null
+          id: string
+          linked_profile_id: string | null
+          notes: string | null
+          owner_user_id: string
+          source: string
+          updated_at: string
+        }
+        Insert: {
+          avatar_url?: string | null
+          city?: string | null
+          country?: string | null
+          created_at?: string
+          deleted_at?: string | null
+          display_name: string
+          external_id?: string | null
+          id?: string
+          linked_profile_id?: string | null
+          notes?: string | null
+          owner_user_id: string
+          source?: string
+          updated_at?: string
+        }
+        Update: {
+          avatar_url?: string | null
+          city?: string | null
+          country?: string | null
+          created_at?: string
+          deleted_at?: string | null
+          display_name?: string
+          external_id?: string | null
+          id?: string
+          linked_profile_id?: string | null
+          notes?: string | null
+          owner_user_id?: string
+          source?: string
+          updated_at?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "contacts_linked_profile_id_fkey"
+            columns: ["linked_profile_id"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      content_moderation_flags: {
+        Row: {
+          content_snippet: string
+          created_at: string
+          field: string
+          flags: string[]
+          id: string
+          profile_id: string | null
+          severity: string
+          source: string
+        }
+        Insert: {
+          content_snippet: string
+          created_at?: string
+          field: string
+          flags: string[]
+          id?: string
+          profile_id?: string | null
+          severity: string
+          source: string
+        }
+        Update: {
+          content_snippet?: string
+          created_at?: string
+          field?: string
+          flags?: string[]
+          id?: string
+          profile_id?: string | null
+          severity?: string
+          source?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "content_moderation_flags_profile_id_fkey"
+            columns: ["profile_id"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      conversation_starter_prompts: {
+        Row: {
+          category: string | null
+          created_at: string | null
+          id: string
+          is_active: boolean | null
+          prompt: string
+          sort_order: number | null
+        }
+        Insert: {
+          category?: string | null
+          created_at?: string | null
+          id?: string
+          is_active?: boolean | null
+          prompt: string
+          sort_order?: number | null
+        }
+        Update: {
+          category?: string | null
+          created_at?: string | null
+          id?: string
+          is_active?: boolean | null
+          prompt?: string
+          sort_order?: number | null
+        }
+        Relationships: []
+      }
+      erasure_obligations: {
+        Row: {
+          completed_at: string | null
+          created_at: string
+          id: string
+          notes: string | null
+          processors: string[]
+          status: string
+          subject_email: string | null
+          subject_user_id: string
+        }
+        Insert: {
+          completed_at?: string | null
+          created_at?: string
+          id?: string
+          notes?: string | null
+          processors?: string[]
+          status?: string
+          subject_email?: string | null
+          subject_user_id: string
+        }
+        Update: {
+          completed_at?: string | null
+          created_at?: string
+          id?: string
+          notes?: string | null
+          processors?: string[]
+          status?: string
+          subject_email?: string | null
+          subject_user_id?: string
+        }
+        Relationships: []
+      }
+      external_links: {
+        Row: {
+          created_at: string | null
+          description: string | null
+          id: string
+          link_type: Database["public"]["Enums"]["link_type"] | null
+          profile_id: string
+          sort_order: number | null
+          title: string
+          url: string
+        }
+        Insert: {
+          created_at?: string | null
+          description?: string | null
+          id?: string
+          link_type?: Database["public"]["Enums"]["link_type"] | null
+          profile_id: string
+          sort_order?: number | null
+          title: string
+          url: string
+        }
+        Update: {
+          created_at?: string | null
+          description?: string | null
+          id?: string
+          link_type?: Database["public"]["Enums"]["link_type"] | null
+          profile_id?: string
+          sort_order?: number | null
+          title?: string
+          url?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "external_links_profile_id_fkey"
+            columns: ["profile_id"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      feature_entitlements: {
+        Row: {
+          enabled: boolean
+          feature_key: string
+          granted_at: string
+          granted_by: string | null
+          id: string
+          metadata: Json | null
+          profile_id: string
+          updated_at: string
+        }
+        Insert: {
+          enabled?: boolean
+          feature_key: string
+          granted_at?: string
+          granted_by?: string | null
+          id?: string
+          metadata?: Json | null
+          profile_id: string
+          updated_at?: string
+        }
+        Update: {
+          enabled?: boolean
+          feature_key?: string
+          granted_at?: string
+          granted_by?: string | null
+          id?: string
+          metadata?: Json | null
+          profile_id?: string
+          updated_at?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "feature_entitlements_granted_by_fkey"
+            columns: ["granted_by"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "feature_entitlements_profile_id_fkey"
+            columns: ["profile_id"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      gathering_events_log: {
+        Row: {
+          actor_user_id: string | null
+          created_at: string
+          event_type: string
+          gathering_id: string
+          id: string
+          metadata: Json
+          subject_id: string | null
+          subject_kind: string | null
+        }
+        Insert: {
+          actor_user_id?: string | null
+          created_at?: string
+          event_type: string
+          gathering_id: string
+          id?: string
+          metadata?: Json
+          subject_id?: string | null
+          subject_kind?: string | null
+        }
+        Update: {
+          actor_user_id?: string | null
+          created_at?: string
+          event_type?: string
+          gathering_id?: string
+          id?: string
+          metadata?: Json
+          subject_id?: string | null
+          subject_kind?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "gathering_events_log_gathering_id_fkey"
+            columns: ["gathering_id"]
+            isOneToOne: false
+            referencedRelation: "gatherings"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      gathering_invite_messages: {
+        Row: {
+          bounce_reason: string | null
+          channel: string
+          claimed_at: string | null
+          created_at: string
+          delivery_status: string
+          external_message_id: string | null
+          gathering_id: string
+          id: string
+          invitee_id: string
+          sent_at: string | null
+          template_name: string
+        }
+        Insert: {
+          bounce_reason?: string | null
+          channel: string
+          claimed_at?: string | null
+          created_at?: string
+          delivery_status?: string
+          external_message_id?: string | null
+          gathering_id: string
+          id?: string
+          invitee_id: string
+          sent_at?: string | null
+          template_name: string
+        }
+        Update: {
+          bounce_reason?: string | null
+          channel?: string
+          claimed_at?: string | null
+          created_at?: string
+          delivery_status?: string
+          external_message_id?: string | null
+          gathering_id?: string
+          id?: string
+          invitee_id?: string
+          sent_at?: string | null
+          template_name?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "gathering_invite_messages_gathering_id_fkey"
+            columns: ["gathering_id"]
+            isOneToOne: false
+            referencedRelation: "gatherings"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "gathering_invite_messages_invitee_id_fkey"
+            columns: ["invitee_id"]
+            isOneToOne: false
+            referencedRelation: "gathering_invitees"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      gathering_invitees: {
+        Row: {
+          contact_id: string
+          created_at: string
+          dietary_overrides: string | null
+          gathering_id: string
+          id: string
+          invited_at: string | null
+          notes: string | null
+          plus_ones: number
+          responded_at: string | null
+          rsvp_token: string | null
+          rsvp_token_expires_at: string | null
+          status: string
+          updated_at: string
+        }
+        Insert: {
+          contact_id: string
+          created_at?: string
+          dietary_overrides?: string | null
+          gathering_id: string
+          id?: string
+          invited_at?: string | null
+          notes?: string | null
+          plus_ones?: number
+          responded_at?: string | null
+          rsvp_token?: string | null
+          rsvp_token_expires_at?: string | null
+          status?: string
+          updated_at?: string
+        }
+        Update: {
+          contact_id?: string
+          created_at?: string
+          dietary_overrides?: string | null
+          gathering_id?: string
+          id?: string
+          invited_at?: string | null
+          notes?: string | null
+          plus_ones?: number
+          responded_at?: string | null
+          rsvp_token?: string | null
+          rsvp_token_expires_at?: string | null
+          status?: string
+          updated_at?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "gathering_invitees_contact_id_fkey"
+            columns: ["contact_id"]
+            isOneToOne: false
+            referencedRelation: "contacts"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "gathering_invitees_gathering_id_fkey"
+            columns: ["gathering_id"]
+            isOneToOne: false
+            referencedRelation: "gatherings"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      gathering_proposed_slots: {
+        Row: {
+          availability_breakdown: Json
+          created_at: string
+          gathering_id: string
+          id: string
+          score: number | null
+          slot_end: string
+          slot_start: string
+        }
+        Insert: {
+          availability_breakdown?: Json
+          created_at?: string
+          gathering_id: string
+          id?: string
+          score?: number | null
+          slot_end: string
+          slot_start: string
+        }
+        Update: {
+          availability_breakdown?: Json
+          created_at?: string
+          gathering_id?: string
+          id?: string
+          score?: number | null
+          slot_end?: string
+          slot_start?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "gathering_proposed_slots_gathering_id_fkey"
+            columns: ["gathering_id"]
+            isOneToOne: false
+            referencedRelation: "gatherings"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      gatherings: {
+        Row: {
+          accessibility_required: string[]
+          capacity_max: number | null
+          capacity_min: number | null
+          created_at: string
+          deleted_at: string | null
+          description: string | null
+          dietary_summary: string | null
+          finalised_slot_end: string | null
+          finalised_slot_start: string | null
+          gathering_type: string
+          host_user_id: string
+          id: string
+          notes: string | null
+          silence_nudge_days: number
+          silence_presumed_declined_days: number
+          status: string
+          target_window_end: string | null
+          target_window_start: string | null
+          title: string
+          updated_at: string
+          venue_id: string | null
+        }
+        Insert: {
+          accessibility_required?: string[]
+          capacity_max?: number | null
+          capacity_min?: number | null
+          created_at?: string
+          deleted_at?: string | null
+          description?: string | null
+          dietary_summary?: string | null
+          finalised_slot_end?: string | null
+          finalised_slot_start?: string | null
+          gathering_type: string
+          host_user_id: string
+          id?: string
+          notes?: string | null
+          silence_nudge_days?: number
+          silence_presumed_declined_days?: number
+          status?: string
+          target_window_end?: string | null
+          target_window_start?: string | null
+          title: string
+          updated_at?: string
+          venue_id?: string | null
+        }
+        Update: {
+          accessibility_required?: string[]
+          capacity_max?: number | null
+          capacity_min?: number | null
+          created_at?: string
+          deleted_at?: string | null
+          description?: string | null
+          dietary_summary?: string | null
+          finalised_slot_end?: string | null
+          finalised_slot_start?: string | null
+          gathering_type?: string
+          host_user_id?: string
+          id?: string
+          notes?: string | null
+          silence_nudge_days?: number
+          silence_presumed_declined_days?: number
+          status?: string
+          target_window_end?: string | null
+          target_window_start?: string | null
+          title?: string
+          updated_at?: string
+          venue_id?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "gatherings_venue_id_fkey"
+            columns: ["venue_id"]
+            isOneToOne: false
+            referencedRelation: "venues"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      global_feature_switches: {
+        Row: {
+          created_at: string
+          enabled: boolean
+          environment: string
+          feature_key: string
+          id: string
+          updated_at: string
+          updated_by: string | null
+        }
+        Insert: {
+          created_at?: string
+          enabled?: boolean
+          environment: string
+          feature_key: string
+          id?: string
+          updated_at?: string
+          updated_by?: string | null
+        }
+        Update: {
+          created_at?: string
+          enabled?: boolean
+          environment?: string
+          feature_key?: string
+          id?: string
+          updated_at?: string
+          updated_by?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "global_feature_switches_updated_by_fkey"
+            columns: ["updated_by"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      mcp_tool_call_log: {
+        Row: {
+          api_key_prefix: string | null
+          id: string
+          ip: string
+          method: string
+          status_code: number | null
+          tool: string
+          ts: string
+        }
+        Insert: {
+          api_key_prefix?: string | null
+          id?: string
+          ip: string
+          method: string
+          status_code?: number | null
+          tool: string
+          ts?: string
+        }
+        Update: {
+          api_key_prefix?: string | null
+          id?: string
+          ip?: string
+          method?: string
+          status_code?: number | null
+          tool?: string
+          ts?: string
+        }
+        Relationships: []
+      }
+      moderation_logs: {
+        Row: {
+          action: string
+          actor_user_id: string
+          created_at: string
+          id: string
+          metadata: Json
+          prev_hash: string | null
+          reason: string | null
+          row_hash: string
+          seq: number
+          target_item_id: string | null
+          target_profile_id: string | null
+        }
+        Insert: {
+          action: string
+          actor_user_id: string
+          created_at?: string
+          id?: string
+          metadata?: Json
+          prev_hash?: string | null
+          reason?: string | null
+          row_hash: string
+          seq: number
+          target_item_id?: string | null
+          target_profile_id?: string | null
+        }
+        Update: {
+          action?: string
+          actor_user_id?: string
+          created_at?: string
+          id?: string
+          metadata?: Json
+          prev_hash?: string | null
+          reason?: string | null
+          row_hash?: string
+          seq?: number
+          target_item_id?: string | null
+          target_profile_id?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "moderation_logs_target_item_id_fkey"
+            columns: ["target_item_id"]
+            isOneToOne: false
+            referencedRelation: "profile_items"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "moderation_logs_target_profile_id_fkey"
+            columns: ["target_profile_id"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      oauth_access_tokens: {
+        Row: {
+          client_id: string
+          expires_at: string
+          issued_at: string
+          jti: string
+          revoked_at: string | null
+          scope: string
+          user_id: string
+        }
+        Insert: {
+          client_id: string
+          expires_at: string
+          issued_at?: string
+          jti?: string
+          revoked_at?: string | null
+          scope: string
+          user_id: string
+        }
+        Update: {
+          client_id?: string
+          expires_at?: string
+          issued_at?: string
+          jti?: string
+          revoked_at?: string | null
+          scope?: string
+          user_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "oauth_access_tokens_client_id_fkey"
+            columns: ["client_id"]
+            isOneToOne: false
+            referencedRelation: "oauth_clients"
+            referencedColumns: ["client_id"]
+          },
+        ]
+      }
+      oauth_authorization_codes: {
+        Row: {
+          client_id: string
+          code: string
+          code_challenge: string
+          code_challenge_method: string
+          created_at: string
+          expires_at: string
+          redirect_uri: string
+          scope: string
+          used_at: string | null
+          user_id: string
+        }
+        Insert: {
+          client_id: string
+          code: string
+          code_challenge: string
+          code_challenge_method: string
+          created_at?: string
+          expires_at: string
+          redirect_uri: string
+          scope: string
+          used_at?: string | null
+          user_id: string
+        }
+        Update: {
+          client_id?: string
+          code?: string
+          code_challenge?: string
+          code_challenge_method?: string
+          created_at?: string
+          expires_at?: string
+          redirect_uri?: string
+          scope?: string
+          used_at?: string | null
+          user_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "oauth_authorization_codes_client_id_fkey"
+            columns: ["client_id"]
+            isOneToOne: false
+            referencedRelation: "oauth_clients"
+            referencedColumns: ["client_id"]
+          },
+        ]
+      }
+      oauth_clients: {
+        Row: {
+          application_type: string
+          client_id: string
+          client_name: string
+          client_secret_hash: string | null
+          created_at: string
+          grant_types: string[]
+          id: string
+          is_first_party: boolean
+          redirect_uris: string[]
+          response_types: string[]
+          revoked_at: string | null
+          scopes: string
+          token_endpoint_auth_method: string
+          updated_at: string
+        }
+        Insert: {
+          application_type?: string
+          client_id: string
+          client_name: string
+          client_secret_hash?: string | null
+          created_at?: string
+          grant_types?: string[]
+          id?: string
+          is_first_party?: boolean
+          redirect_uris: string[]
+          response_types?: string[]
+          revoked_at?: string | null
+          scopes?: string
+          token_endpoint_auth_method?: string
+          updated_at?: string
+        }
+        Update: {
+          application_type?: string
+          client_id?: string
+          client_name?: string
+          client_secret_hash?: string | null
+          created_at?: string
+          grant_types?: string[]
+          id?: string
+          is_first_party?: boolean
+          redirect_uris?: string[]
+          response_types?: string[]
+          revoked_at?: string | null
+          scopes?: string
+          token_endpoint_auth_method?: string
+          updated_at?: string
+        }
+        Relationships: []
+      }
+      oauth_connect_state: {
+        Row: {
+          created_at: string
+          expires_at: string
+          provider: string
+          state: string
+          user_id: string
+        }
+        Insert: {
+          created_at?: string
+          expires_at?: string
+          provider: string
+          state: string
+          user_id: string
+        }
+        Update: {
+          created_at?: string
+          expires_at?: string
+          provider?: string
+          state?: string
+          user_id?: string
+        }
+        Relationships: []
+      }
+      oauth_connections: {
+        Row: {
+          access_token_expires_at: string | null
+          access_token_secret_id: string | null
+          created_at: string
+          deleted_at: string | null
+          display_name: string | null
+          id: string
+          last_used_at: string | null
+          owner_user_id: string
+          provider: string
+          provider_account_id: string
+          refresh_token_secret_id: string
+          scope_granted: string
+          status: string
+          updated_at: string
+        }
+        Insert: {
+          access_token_expires_at?: string | null
+          access_token_secret_id?: string | null
+          created_at?: string
+          deleted_at?: string | null
+          display_name?: string | null
+          id?: string
+          last_used_at?: string | null
+          owner_user_id: string
+          provider: string
+          provider_account_id: string
+          refresh_token_secret_id: string
+          scope_granted: string
+          status?: string
+          updated_at?: string
+        }
+        Update: {
+          access_token_expires_at?: string | null
+          access_token_secret_id?: string | null
+          created_at?: string
+          deleted_at?: string | null
+          display_name?: string | null
+          id?: string
+          last_used_at?: string | null
+          owner_user_id?: string
+          provider?: string
+          provider_account_id?: string
+          refresh_token_secret_id?: string
+          scope_granted?: string
+          status?: string
+          updated_at?: string
+        }
+        Relationships: []
+      }
+      oauth_consents: {
+        Row: {
+          client_id: string
+          granted_at: string
+          id: string
+          revoked_at: string | null
+          scopes: string
+          user_id: string
+        }
+        Insert: {
+          client_id: string
+          granted_at?: string
+          id?: string
+          revoked_at?: string | null
+          scopes: string
+          user_id: string
+        }
+        Update: {
+          client_id?: string
+          granted_at?: string
+          id?: string
+          revoked_at?: string | null
+          scopes?: string
+          user_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "oauth_consents_client_id_fkey"
+            columns: ["client_id"]
+            isOneToOne: false
+            referencedRelation: "oauth_clients"
+            referencedColumns: ["client_id"]
+          },
+        ]
+      }
+      oauth_refresh_tokens: {
+        Row: {
+          client_id: string
+          expires_at: string
+          family_id: string
+          issued_at: string
+          scope: string
+          token_hash: string
+          used_at: string | null
+          user_id: string
+        }
+        Insert: {
+          client_id: string
+          expires_at: string
+          family_id: string
+          issued_at?: string
+          scope: string
+          token_hash: string
+          used_at?: string | null
+          user_id: string
+        }
+        Update: {
+          client_id?: string
+          expires_at?: string
+          family_id?: string
+          issued_at?: string
+          scope?: string
+          token_hash?: string
+          used_at?: string | null
+          user_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "oauth_refresh_tokens_client_id_fkey"
+            columns: ["client_id"]
+            isOneToOne: false
+            referencedRelation: "oauth_clients"
+            referencedColumns: ["client_id"]
+          },
+        ]
+      }
+      oauth_scopes_granted: {
+        Row: {
+          granted_at: string
+          id: string
+          oauth_connection_id: string
+          revoked_at: string | null
+          scope: string
+        }
+        Insert: {
+          granted_at?: string
+          id?: string
+          oauth_connection_id: string
+          revoked_at?: string | null
+          scope: string
+        }
+        Update: {
+          granted_at?: string
+          id?: string
+          oauth_connection_id?: string
+          revoked_at?: string | null
+          scope?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "oauth_scopes_granted_oauth_connection_id_fkey"
+            columns: ["oauth_connection_id"]
+            isOneToOne: false
+            referencedRelation: "oauth_connections"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      profile_conversation_starters: {
+        Row: {
+          answer: string
+          created_at: string | null
+          id: string
+          profile_id: string
+          prompt_id: string
+          sort_order: number | null
+          updated_at: string | null
+        }
+        Insert: {
+          answer: string
+          created_at?: string | null
+          id?: string
+          profile_id: string
+          prompt_id: string
+          sort_order?: number | null
+          updated_at?: string | null
+        }
+        Update: {
+          answer?: string
+          created_at?: string | null
+          id?: string
+          profile_id?: string
+          prompt_id?: string
+          sort_order?: number | null
+          updated_at?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "profile_conversation_starters_profile_id_fkey"
+            columns: ["profile_id"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "profile_conversation_starters_prompt_id_fkey"
+            columns: ["prompt_id"]
+            isOneToOne: false
+            referencedRelation: "conversation_starter_prompts"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      profile_files: {
+        Row: {
+          created_at: string | null
+          file_name: string
+          id: string
+          mime_type: string
+          profile_id: string
+          size_bytes: number
+          sort_order: number | null
+          storage_path: string
+          visibility: Database["public"]["Enums"]["visibility_level"] | null
+        }
+        Insert: {
+          created_at?: string | null
+          file_name: string
+          id?: string
+          mime_type: string
+          profile_id: string
+          size_bytes: number
+          sort_order?: number | null
+          storage_path: string
+          visibility?: Database["public"]["Enums"]["visibility_level"] | null
+        }
+        Update: {
+          created_at?: string | null
+          file_name?: string
+          id?: string
+          mime_type?: string
+          profile_id?: string
+          size_bytes?: number
+          sort_order?: number | null
+          storage_path?: string
+          visibility?: Database["public"]["Enums"]["visibility_level"] | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "profile_files_profile_id_fkey"
+            columns: ["profile_id"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      profile_items: {
+        Row: {
+          category: Database["public"]["Enums"]["item_category"]
+          created_at: string | null
+          description: string | null
+          id: string
+          profile_id: string
+          sort_order: number | null
+          title: string
+          url: string | null
+          visibility: Database["public"]["Enums"]["visibility_level"] | null
+        }
+        Insert: {
+          category: Database["public"]["Enums"]["item_category"]
+          created_at?: string | null
+          description?: string | null
+          id?: string
+          profile_id: string
+          sort_order?: number | null
+          title: string
+          url?: string | null
+          visibility?: Database["public"]["Enums"]["visibility_level"] | null
+        }
+        Update: {
+          category?: Database["public"]["Enums"]["item_category"]
+          created_at?: string | null
+          description?: string | null
+          id?: string
+          profile_id?: string
+          sort_order?: number | null
+          title?: string
+          url?: string | null
+          visibility?: Database["public"]["Enums"]["visibility_level"] | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "profile_items_profile_id_fkey"
+            columns: ["profile_id"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      profile_manual_of_me: {
+        Row: {
+          boundaries: string | null
+          communication_style: string | null
+          created_at: string | null
+          drains_me: string | null
+          energises_me: string | null
+          good_to_know: string | null
+          profile_id: string
+          updated_at: string | null
+          working_preferences: string | null
+        }
+        Insert: {
+          boundaries?: string | null
+          communication_style?: string | null
+          created_at?: string | null
+          drains_me?: string | null
+          energises_me?: string | null
+          good_to_know?: string | null
+          profile_id: string
+          updated_at?: string | null
+          working_preferences?: string | null
+        }
+        Update: {
+          boundaries?: string | null
+          communication_style?: string | null
+          created_at?: string | null
+          drains_me?: string | null
+          energises_me?: string | null
+          good_to_know?: string | null
+          profile_id?: string
+          updated_at?: string | null
+          working_preferences?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "profile_manual_of_me_profile_id_fkey"
+            columns: ["profile_id"]
+            isOneToOne: true
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      profiles: {
+        Row: {
+          access_tier: Database["public"]["Enums"]["access_tier"]
+          age_checked_at: string | null
+          age_declared_18_at: string | null
+          age_provider: string | null
+          age_provider_ref: string | null
+          age_range: string | null
+          age_status: Database["public"]["Enums"]["age_status"]
+          avatar_url: string | null
+          beta_approved_at: string | null
+          beta_requested_at: string | null
+          bio_short: string | null
+          city: string | null
+          completion_score: number | null
+          country: string | null
+          created_at: string | null
+          dashboard_widget_state: Json
+          delivery_country_code: string | null
+          discoverable_by_phone: boolean
+          discoverable_by_postcode: boolean
+          display_name: string
+          headline: string | null
+          homepage_example_order: number | null
+          id: string
+          is_admin: boolean
+          is_homepage_example: boolean
+          is_published: boolean | null
+          is_suspended: boolean
+          onboarding_complete: boolean | null
+          phone_search_hash: string | null
+          postcode_prefix: string | null
+          postcode_search_hash: string | null
+          recipient_attributes: Json
+          region: string | null
+          section_visibility: Json
+          share_availability_with_contacts: boolean
+          slug: string
+          suspended_at: string | null
+          suspension_reason: string | null
+          updated_at: string | null
+          user_id: string
+          user_status: Database["public"]["Enums"]["user_status"]
+        }
+        Insert: {
+          access_tier?: Database["public"]["Enums"]["access_tier"]
+          age_checked_at?: string | null
+          age_declared_18_at?: string | null
+          age_provider?: string | null
+          age_provider_ref?: string | null
+          age_range?: string | null
+          age_status?: Database["public"]["Enums"]["age_status"]
+          avatar_url?: string | null
+          beta_approved_at?: string | null
+          beta_requested_at?: string | null
+          bio_short?: string | null
+          city?: string | null
+          completion_score?: number | null
+          country?: string | null
+          created_at?: string | null
+          dashboard_widget_state?: Json
+          delivery_country_code?: string | null
+          discoverable_by_phone?: boolean
+          discoverable_by_postcode?: boolean
+          display_name: string
+          headline?: string | null
+          homepage_example_order?: number | null
+          id?: string
+          is_admin?: boolean
+          is_homepage_example?: boolean
+          is_published?: boolean | null
+          is_suspended?: boolean
+          onboarding_complete?: boolean | null
+          phone_search_hash?: string | null
+          postcode_prefix?: string | null
+          postcode_search_hash?: string | null
+          recipient_attributes?: Json
+          region?: string | null
+          section_visibility?: Json
+          share_availability_with_contacts?: boolean
+          slug: string
+          suspended_at?: string | null
+          suspension_reason?: string | null
+          updated_at?: string | null
+          user_id: string
+          user_status?: Database["public"]["Enums"]["user_status"]
+        }
+        Update: {
+          access_tier?: Database["public"]["Enums"]["access_tier"]
+          age_checked_at?: string | null
+          age_declared_18_at?: string | null
+          age_provider?: string | null
+          age_provider_ref?: string | null
+          age_range?: string | null
+          age_status?: Database["public"]["Enums"]["age_status"]
+          avatar_url?: string | null
+          beta_approved_at?: string | null
+          beta_requested_at?: string | null
+          bio_short?: string | null
+          city?: string | null
+          completion_score?: number | null
+          country?: string | null
+          created_at?: string | null
+          dashboard_widget_state?: Json
+          delivery_country_code?: string | null
+          discoverable_by_phone?: boolean
+          discoverable_by_postcode?: boolean
+          display_name?: string
+          headline?: string | null
+          homepage_example_order?: number | null
+          id?: string
+          is_admin?: boolean
+          is_homepage_example?: boolean
+          is_published?: boolean | null
+          is_suspended?: boolean
+          onboarding_complete?: boolean | null
+          phone_search_hash?: string | null
+          postcode_prefix?: string | null
+          postcode_search_hash?: string | null
+          recipient_attributes?: Json
+          region?: string | null
+          section_visibility?: Json
+          share_availability_with_contacts?: boolean
+          slug?: string
+          suspended_at?: string | null
+          suspension_reason?: string | null
+          updated_at?: string | null
+          user_id?: string
+          user_status?: Database["public"]["Enums"]["user_status"]
+        }
+        Relationships: []
+      }
+      rate_limits: {
+        Row: {
+          bucket: string
+          hits: number
+          reset_at: string
+        }
+        Insert: {
+          bucket: string
+          hits?: number
+          reset_at: string
+        }
+        Update: {
+          bucket?: string
+          hits?: number
+          reset_at?: string
+        }
+        Relationships: []
+      }
+      recommendation_events: {
+        Row: {
+          created_at: string
+          event_id: string
+          event_type: string
+          merchant_id: string | null
+          metadata: Json
+          recipient_id: string | null
+          recommendation_id: string
+          session_id: string | null
+          source: string
+          user_id: string | null
+        }
+        Insert: {
+          created_at?: string
+          event_id?: string
+          event_type: string
+          merchant_id?: string | null
+          metadata?: Json
+          recipient_id?: string | null
+          recommendation_id: string
+          session_id?: string | null
+          source?: string
+          user_id?: string | null
+        }
+        Update: {
+          created_at?: string
+          event_id?: string
+          event_type?: string
+          merchant_id?: string | null
+          metadata?: Json
+          recipient_id?: string | null
+          recommendation_id?: string
+          session_id?: string | null
+          source?: string
+          user_id?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "recommendation_events_recipient_id_fkey"
+            columns: ["recipient_id"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      recommender_catalogue: {
+        Row: {
+          buyer_countries: string[] | null
+          catalogue_id: string
+          concept_category: string
+          concept_keywords: string[]
+          created_at: string
+          description: string | null
+          image_url: string | null
+          is_active: boolean
+          merchant_id: string
+          price_currency: string | null
+          price_max_minor: number | null
+          price_min_minor: number | null
+          rationale_fragment: string | null
+          raw_url: string
+          title: string
+          updated_at: string
+          weight: number
+        }
+        Insert: {
+          buyer_countries?: string[] | null
+          catalogue_id?: string
+          concept_category: string
+          concept_keywords?: string[]
+          created_at?: string
+          description?: string | null
+          image_url?: string | null
+          is_active?: boolean
+          merchant_id: string
+          price_currency?: string | null
+          price_max_minor?: number | null
+          price_min_minor?: number | null
+          rationale_fragment?: string | null
+          raw_url: string
+          title: string
+          updated_at?: string
+          weight?: number
+        }
+        Update: {
+          buyer_countries?: string[] | null
+          catalogue_id?: string
+          concept_category?: string
+          concept_keywords?: string[]
+          created_at?: string
+          description?: string | null
+          image_url?: string | null
+          is_active?: boolean
+          merchant_id?: string
+          price_currency?: string | null
+          price_max_minor?: number | null
+          price_min_minor?: number | null
+          rationale_fragment?: string | null
+          raw_url?: string
+          title?: string
+          updated_at?: string
+          weight?: number
+        }
+        Relationships: []
+      }
+      reports: {
+        Row: {
+          created_at: string
+          id: string
+          note: string | null
+          profile_id: string
+          profile_item_id: string | null
+          reason: Database["public"]["Enums"]["report_reason"]
+          reporter_user_id: string | null
+          resolved_at: string | null
+          resolved_by: string | null
+          status: Database["public"]["Enums"]["report_status"]
+        }
+        Insert: {
+          created_at?: string
+          id?: string
+          note?: string | null
+          profile_id: string
+          profile_item_id?: string | null
+          reason: Database["public"]["Enums"]["report_reason"]
+          reporter_user_id?: string | null
+          resolved_at?: string | null
+          resolved_by?: string | null
+          status?: Database["public"]["Enums"]["report_status"]
+        }
+        Update: {
+          created_at?: string
+          id?: string
+          note?: string | null
+          profile_id?: string
+          profile_item_id?: string | null
+          reason?: Database["public"]["Enums"]["report_reason"]
+          reporter_user_id?: string | null
+          resolved_at?: string | null
+          resolved_by?: string | null
+          status?: Database["public"]["Enums"]["report_status"]
+        }
+        Relationships: [
+          {
+            foreignKeyName: "reports_profile_id_fkey"
+            columns: ["profile_id"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "reports_profile_item_id_fkey"
+            columns: ["profile_item_id"]
+            isOneToOne: false
+            referencedRelation: "profile_items"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      school_affiliations: {
+        Row: {
+          affiliation_type: string
+          created_at: string | null
+          description: string | null
+          id: string
+          profile_id: string
+          relationship:
+            | Database["public"]["Enums"]["school_relationship"]
+            | null
+          school_location: string | null
+          school_name: string
+          show_on_profile: boolean
+        }
+        Insert: {
+          affiliation_type?: string
+          created_at?: string | null
+          description?: string | null
+          id?: string
+          profile_id: string
+          relationship?:
+            | Database["public"]["Enums"]["school_relationship"]
+            | null
+          school_location?: string | null
+          school_name: string
+          show_on_profile?: boolean
+        }
+        Update: {
+          affiliation_type?: string
+          created_at?: string | null
+          description?: string | null
+          id?: string
+          profile_id?: string
+          relationship?:
+            | Database["public"]["Enums"]["school_relationship"]
+            | null
+          school_location?: string | null
+          school_name?: string
+          show_on_profile?: boolean
+        }
+        Relationships: [
+          {
+            foreignKeyName: "school_affiliations_profile_id_fkey"
+            columns: ["profile_id"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      tribe_members: {
+        Row: {
+          contact_id: string
+          created_at: string
+          id: string
+          tribe_id: string
+        }
+        Insert: {
+          contact_id: string
+          created_at?: string
+          id?: string
+          tribe_id: string
+        }
+        Update: {
+          contact_id?: string
+          created_at?: string
+          id?: string
+          tribe_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "tribe_members_contact_id_fkey"
+            columns: ["contact_id"]
+            isOneToOne: false
+            referencedRelation: "contacts"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "tribe_members_tribe_id_fkey"
+            columns: ["tribe_id"]
+            isOneToOne: false
+            referencedRelation: "tribes"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      tribes: {
+        Row: {
+          color_hex: string | null
+          created_at: string
+          deleted_at: string | null
+          description: string | null
+          id: string
+          name: string
+          owner_user_id: string
+          updated_at: string
+        }
+        Insert: {
+          color_hex?: string | null
+          created_at?: string
+          deleted_at?: string | null
+          description?: string | null
+          id?: string
+          name: string
+          owner_user_id: string
+          updated_at?: string
+        }
+        Update: {
+          color_hex?: string | null
+          created_at?: string
+          deleted_at?: string | null
+          description?: string | null
+          id?: string
+          name?: string
+          owner_user_id?: string
+          updated_at?: string
+        }
+        Relationships: []
+      }
+      venue_ratings: {
+        Row: {
+          created_at: string
+          id: string
+          note: string | null
+          rating: number
+          updated_at: string
+          user_id: string
+          venue_id: string
+        }
+        Insert: {
+          created_at?: string
+          id?: string
+          note?: string | null
+          rating: number
+          updated_at?: string
+          user_id: string
+          venue_id: string
+        }
+        Update: {
+          created_at?: string
+          id?: string
+          note?: string | null
+          rating?: number
+          updated_at?: string
+          user_id?: string
+          venue_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "venue_ratings_venue_id_fkey"
+            columns: ["venue_id"]
+            isOneToOne: false
+            referencedRelation: "venues"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      venue_visits: {
+        Row: {
+          created_at: string
+          gathering_id: string
+          id: string
+          venue_id: string
+          visited_at: string
+        }
+        Insert: {
+          created_at?: string
+          gathering_id: string
+          id?: string
+          venue_id: string
+          visited_at: string
+        }
+        Update: {
+          created_at?: string
+          gathering_id?: string
+          id?: string
+          venue_id?: string
+          visited_at?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "venue_visits_gathering_fk"
+            columns: ["gathering_id"]
+            isOneToOne: false
+            referencedRelation: "gatherings"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "venue_visits_venue_id_fkey"
+            columns: ["venue_id"]
+            isOneToOne: false
+            referencedRelation: "venues"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      venues: {
+        Row: {
+          accessibility_flags: string[]
+          address_line1: string | null
+          address_line2: string | null
+          capacity_estimate: number | null
+          city: string | null
+          country: string
+          created_at: string
+          cuisine: string | null
+          dietary_flags: string[]
+          external_rating: number | null
+          google_place_id: string | null
+          id: string
+          lat: number | null
+          lng: number | null
+          name: string
+          opening_hours: Json | null
+          phone: string | null
+          postcode: string | null
+          price_tier: number | null
+          region: string | null
+          updated_at: string
+          venue_type: string
+          website_url: string | null
+        }
+        Insert: {
+          accessibility_flags?: string[]
+          address_line1?: string | null
+          address_line2?: string | null
+          capacity_estimate?: number | null
+          city?: string | null
+          country?: string
+          created_at?: string
+          cuisine?: string | null
+          dietary_flags?: string[]
+          external_rating?: number | null
+          google_place_id?: string | null
+          id?: string
+          lat?: number | null
+          lng?: number | null
+          name: string
+          opening_hours?: Json | null
+          phone?: string | null
+          postcode?: string | null
+          price_tier?: number | null
+          region?: string | null
+          updated_at?: string
+          venue_type: string
+          website_url?: string | null
+        }
+        Update: {
+          accessibility_flags?: string[]
+          address_line1?: string | null
+          address_line2?: string | null
+          capacity_estimate?: number | null
+          city?: string | null
+          country?: string
+          created_at?: string
+          cuisine?: string | null
+          dietary_flags?: string[]
+          external_rating?: number | null
+          google_place_id?: string | null
+          id?: string
+          lat?: number | null
+          lng?: number | null
+          name?: string
+          opening_hours?: Json | null
+          phone?: string | null
+          postcode?: string | null
+          price_tier?: number | null
+          region?: string | null
+          updated_at?: string
+          venue_type?: string
+          website_url?: string | null
+        }
+        Relationships: []
+      }
+    }
+    Views: {
+      mcp_per_ip_recent_count: {
+        Row: {
+          first_seen: string | null
+          ip: string | null
+          last_seen: string | null
+          request_count: number | null
+        }
+        Relationships: []
+      }
+      relationship_signals: {
+        Row: {
+          contact_id: string | null
+          gathering_type_diversity: number | null
+          gathering_types_seen: string[] | null
+          last_attended_at: string | null
+          last_invited_at: string | null
+          total_accepted: number | null
+          total_attended: number | null
+          total_declined: number | null
+          total_invites: number | null
+          total_no_shows: number | null
+          total_silent: number | null
+          user_id: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "gathering_invitees_contact_id_fkey"
+            columns: ["contact_id"]
+            isOneToOne: false
+            referencedRelation: "contacts"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+    }
+    Functions: {
+      admin_filter_profile_ids: {
+        Args: {
+          p_admin?: boolean
+          p_cap?: number
+          p_early?: boolean
+          p_search?: string
+          p_stage?: string
+          p_suspended?: boolean
+        }
+        Returns: string[]
+      }
+      admin_list_users: {
+        Args: {
+          p_admin?: boolean
+          p_early?: boolean
+          p_limit?: number
+          p_offset?: number
+          p_search?: string
+          p_stage?: string
+          p_suspended?: boolean
+        }
+        Returns: Json
+      }
+      affiliate_clicks_purge_expired: {
+        Args: { cutoff: string }
+        Returns: number
+      }
+      convene_vault_read_secret: {
+        Args: { p_secret_id: string }
+        Returns: string
+      }
+      convene_vault_revoke_secret: {
+        Args: { p_secret_id: string }
+        Returns: undefined
+      }
+      convene_vault_store_secret: {
+        Args: { p_description: string; p_secret: string }
+        Returns: string
+      }
+      e2e_fix_auth_tokens: { Args: { uid: string }; Returns: undefined }
+      gatherings_purge_expired: { Args: { cutoff: string }; Returns: number }
+      get_metrics_for_window: {
+        Args: { p_end_at: string; p_start_at: string }
+        Returns: Json
+      }
+      moderation_log_row_hash: {
+        Args: {
+          p_action: string
+          p_actor_user_id: string
+          p_created_at: string
+          p_id: string
+          p_metadata: Json
+          p_prev_hash: string
+          p_reason: string
+          p_seq: number
+          p_target_item_id: string
+          p_target_profile_id: string
+        }
+        Returns: string
+      }
+      oauth_connect_state_purge_expired: { Args: never; Returns: number }
+      rate_limit_hit: {
+        Args: { p_bucket: string; p_limit: number; p_window_seconds: number }
+        Returns: {
+          limited: boolean
+          retry_after: number
+        }[]
+      }
+      record_erasure_obligation: {
+        Args: {
+          p_notes?: string
+          p_processors: string[]
+          p_subject_email: string
+          p_subject_user_id: string
+        }
+        Returns: string
+      }
+      refresh_relationship_signals: { Args: never; Returns: undefined }
+      search_by_contact_hash: {
+        Args: { p_hash: string; p_kind: string }
+        Returns: {
+          id: string
+          slug: string
+        }[]
+      }
+      security_invariants_report: {
+        Args: never
+        Returns: {
+          detail: string
+          invariant: string
+          object_name: string
+        }[]
+      }
+      tribe_only_visible_tribes: {
+        Args: { p_profile_user_id: string }
+        Returns: {
+          tribe_id: string
+        }[]
+      }
+      verify_moderation_log_chain: {
+        Args: never
+        Returns: {
+          detail: string
+          first_bad_seq: number
+          ok: boolean
+          rows_checked: number
+        }[]
+      }
+    }
+    Enums: {
+      access_stage: "waitlist" | "beta" | "live"
+      access_tier: "beta" | "prod"
+      age_status: "none" | "pending" | "passed" | "failed" | "manual_review"
+      beta_access_status: "none" | "requested" | "approved"
+      item_category:
+        | "gift_ideas"
+        | "gifts_to_avoid"
+        | "likes"
+        | "dislikes"
+        | "helpful_to_know"
+        | "boundaries"
+        | "favourite_books"
+        | "favourite_media"
+        | "causes"
+        | "quotes"
+        | "proud_of"
+        | "life_hacks"
+        | "questions"
+        | "billboard"
+        | "current_problems"
+        | "dietary"
+        | "mobility"
+        | "transport"
+        | "availability_pattern"
+        | "favourite_venues"
+        | "allergies"
+        | "favourite_tv"
+        | "favourite_places"
+        | "favourite_music"
+        | "plays"
+      link_type: "retailer" | "wishlist" | "article" | "general"
+      report_reason:
+        | "spam"
+        | "harassment"
+        | "impersonation"
+        | "inappropriate"
+        | "other"
+      report_status: "pending" | "reviewed" | "actioned" | "dismissed"
+      school_relationship: "parent" | "student" | "alumni" | "staff" | "other"
+      user_status: "not_applied" | "waitlist" | "live"
+      visibility_level:
+        | "public"
+        | "members_only"
+        | "private"
+        | "draft"
+        | "tribe_only"
+    }
+    CompositeTypes: {
+      [_ in never]: never
+    }
+  }
+}
+
+type DatabaseWithoutInternals = Omit<Database, "__InternalSupabase">
+
+type DefaultSchema = DatabaseWithoutInternals[Extract<keyof Database, "public">]
+
+export type Tables<
+  DefaultSchemaTableNameOrOptions extends
+    | keyof (DefaultSchema["Tables"] & DefaultSchema["Views"])
+    | { schema: keyof DatabaseWithoutInternals },
+  TableName extends DefaultSchemaTableNameOrOptions extends {
+    schema: keyof DatabaseWithoutInternals
+  }
+    ? keyof (DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"] &
+        DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Views"])
+    : never = never,
+> = DefaultSchemaTableNameOrOptions extends {
+  schema: keyof DatabaseWithoutInternals
+}
+  ? (DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"] &
+      DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Views"])[TableName] extends {
+      Row: infer R
+    }
+    ? R
+    : never
+  : DefaultSchemaTableNameOrOptions extends keyof (DefaultSchema["Tables"] &
+        DefaultSchema["Views"])
+    ? (DefaultSchema["Tables"] &
+        DefaultSchema["Views"])[DefaultSchemaTableNameOrOptions] extends {
+        Row: infer R
+      }
+      ? R
+      : never
+    : never
+
+export type TablesInsert<
+  DefaultSchemaTableNameOrOptions extends
+    | keyof DefaultSchema["Tables"]
+    | { schema: keyof DatabaseWithoutInternals },
+  TableName extends DefaultSchemaTableNameOrOptions extends {
+    schema: keyof DatabaseWithoutInternals
+  }
+    ? keyof DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"]
+    : never = never,
+> = DefaultSchemaTableNameOrOptions extends {
+  schema: keyof DatabaseWithoutInternals
+}
+  ? DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"][TableName] extends {
+      Insert: infer I
+    }
+    ? I
+    : never
+  : DefaultSchemaTableNameOrOptions extends keyof DefaultSchema["Tables"]
+    ? DefaultSchema["Tables"][DefaultSchemaTableNameOrOptions] extends {
+        Insert: infer I
+      }
+      ? I
+      : never
+    : never
+
+export type TablesUpdate<
+  DefaultSchemaTableNameOrOptions extends
+    | keyof DefaultSchema["Tables"]
+    | { schema: keyof DatabaseWithoutInternals },
+  TableName extends DefaultSchemaTableNameOrOptions extends {
+    schema: keyof DatabaseWithoutInternals
+  }
+    ? keyof DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"]
+    : never = never,
+> = DefaultSchemaTableNameOrOptions extends {
+  schema: keyof DatabaseWithoutInternals
+}
+  ? DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"][TableName] extends {
+      Update: infer U
+    }
+    ? U
+    : never
+  : DefaultSchemaTableNameOrOptions extends keyof DefaultSchema["Tables"]
+    ? DefaultSchema["Tables"][DefaultSchemaTableNameOrOptions] extends {
+        Update: infer U
+      }
+      ? U
+      : never
+    : never
+
+export type Enums<
+  DefaultSchemaEnumNameOrOptions extends
+    | keyof DefaultSchema["Enums"]
+    | { schema: keyof DatabaseWithoutInternals },
+  EnumName extends DefaultSchemaEnumNameOrOptions extends {
+    schema: keyof DatabaseWithoutInternals
+  }
+    ? keyof DatabaseWithoutInternals[DefaultSchemaEnumNameOrOptions["schema"]]["Enums"]
+    : never = never,
+> = DefaultSchemaEnumNameOrOptions extends {
+  schema: keyof DatabaseWithoutInternals
+}
+  ? DatabaseWithoutInternals[DefaultSchemaEnumNameOrOptions["schema"]]["Enums"][EnumName]
+  : DefaultSchemaEnumNameOrOptions extends keyof DefaultSchema["Enums"]
+    ? DefaultSchema["Enums"][DefaultSchemaEnumNameOrOptions]
+    : never
+
+export type CompositeTypes<
+  PublicCompositeTypeNameOrOptions extends
+    | keyof DefaultSchema["CompositeTypes"]
+    | { schema: keyof DatabaseWithoutInternals },
+  CompositeTypeName extends PublicCompositeTypeNameOrOptions extends {
+    schema: keyof DatabaseWithoutInternals
+  }
+    ? keyof DatabaseWithoutInternals[PublicCompositeTypeNameOrOptions["schema"]]["CompositeTypes"]
+    : never = never,
+> = PublicCompositeTypeNameOrOptions extends {
+  schema: keyof DatabaseWithoutInternals
+}
+  ? DatabaseWithoutInternals[PublicCompositeTypeNameOrOptions["schema"]]["CompositeTypes"][CompositeTypeName]
+  : PublicCompositeTypeNameOrOptions extends keyof DefaultSchema["CompositeTypes"]
+    ? DefaultSchema["CompositeTypes"][PublicCompositeTypeNameOrOptions]
+    : never
+
+export const Constants = {
+  public: {
+    Enums: {
+      access_stage: ["waitlist", "beta", "live"],
+      access_tier: ["beta", "prod"],
+      age_status: ["none", "pending", "passed", "failed", "manual_review"],
+      beta_access_status: ["none", "requested", "approved"],
+      item_category: [
+        "gift_ideas",
+        "gifts_to_avoid",
+        "likes",
+        "dislikes",
+        "helpful_to_know",
+        "boundaries",
+        "favourite_books",
+        "favourite_media",
+        "causes",
+        "quotes",
+        "proud_of",
+        "life_hacks",
+        "questions",
+        "billboard",
+        "current_problems",
+        "dietary",
+        "mobility",
+        "transport",
+        "availability_pattern",
+        "favourite_venues",
+        "allergies",
+        "favourite_tv",
+        "favourite_places",
+        "favourite_music",
+        "plays",
+      ],
+      link_type: ["retailer", "wishlist", "article", "general"],
+      report_reason: [
+        "spam",
+        "harassment",
+        "impersonation",
+        "inappropriate",
+        "other",
+      ],
+      report_status: ["pending", "reviewed", "actioned", "dismissed"],
+      school_relationship: ["parent", "student", "alumni", "staff", "other"],
+      user_status: ["not_applied", "waitlist", "live"],
+      visibility_level: [
+        "public",
+        "members_only",
+        "private",
+        "draft",
+        "tribe_only",
+      ],
+    },
+  },
+} as const
+

--- a/supabase/schema-drift-baseline.json
+++ b/supabase/schema-drift-baseline.json
@@ -1,0 +1,61 @@
+{
+  "$comment": "KAN-414 F6 — the KNOWN, TICKETED schema drift between the three Supabase projects, as measured 2026-07-29. Enforced by scripts/check-schema-type-parity.py in pr-checks.yml (CTL-036). This list is SHRINK-ONLY: new drift fails the build, and so does an entry that has stopped drifting, because a baseline that may only grow is a suppression list rather than a ratchet. Closing these is F7's job.",
+  "measured_at": "2026-07-29",
+  "measured_against": {
+    "dev": "ilprytcrnqyrsbsrfujj",
+    "staging": "uobmlkzrjkptwhttzmmi",
+    "prod": "llzkgprqewuwkiwclowi"
+  },
+  "drift": {
+    "dev_vs_staging": {
+      "only_in_first": [],
+      "only_in_second": [
+        {
+          "line": "column:gathering_invite_messages.claimed_at",
+          "ticket": "BUGS-62",
+          "note": "DEV is behind, not ahead. The migration is in git and applied on staging and prod but never on dev — promotion ran backwards past its own first environment. Harmless to users; alarming as a process signal, which is why F7's monotonicity check exists."
+        }
+      ]
+    },
+    "staging_vs_prod": {
+      "only_in_first": [
+        {
+          "line": "column:profiles.discoverable_by_phone",
+          "ticket": "SEC-107",
+          "note": "KAN-153 never shipped to prod. INTENTIONAL — see SEC-80: phone/postcode discovery is a guarded no-op on production. Do not blind-apply."
+        },
+        {
+          "line": "column:profiles.discoverable_by_postcode",
+          "ticket": "SEC-107",
+          "note": "KAN-153, as above."
+        },
+        {
+          "line": "column:profiles.phone_search_hash",
+          "ticket": "SEC-107",
+          "note": "KAN-153, as above."
+        },
+        {
+          "line": "column:profiles.postcode_search_hash",
+          "ticket": "SEC-107",
+          "note": "KAN-153, as above."
+        },
+        {
+          "line": "enum-label:visibility_level.draft",
+          "ticket": "SEC-107",
+          "note": "KAN-143 never shipped to prod. This one is NOT harmless: src/app/dashboard/profile/visibility.ts uses 'draft' as its default and fail-closed value, and that label is not valid on the prod database — which beta.checklyra.com also shares."
+        },
+        {
+          "line": "function:search_by_contact_hash",
+          "ticket": "SEC-110",
+          "note": "ABSENT FROM PROD ENTIRELY — verified 2026-07-29 by pg_proc catalogue query across all schemas, correcting KAN-420 §1.2 which recorded it as present-but-erroring. Consequence: the phone-number membership oracle is reachable on dev and staging, and NOT on prod. SEC-110 Option A would therefore create it on production for the first time, so its enumeration-risk review is a pre-deployment control."
+        },
+        {
+          "line": "function:e2e_fix_auth_tokens",
+          "ticket": "SEC-107",
+          "note": "Test-support function for the auth.users NULL-token GoTrue-500 fix. Correctly absent from production; it should never be applied there."
+        }
+      ],
+      "only_in_second": []
+    }
+  }
+}

--- a/tests/scripts/check-schema-type-parity.test.js
+++ b/tests/scripts/check-schema-type-parity.test.js
@@ -1,0 +1,207 @@
+/**
+ * KAN-414 F6 — tests for scripts/check-schema-type-parity.py (CTL-036).
+ *
+ * The destructive cases mutate a COPY of the schema files in a temp dir and
+ * point the script at it, rather than editing the committed ones: several
+ * other suites read `src/types/`, and Jest runs test files in parallel.
+ */
+
+const { execFileSync } = require('node:child_process');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const ROOT = path.resolve(__dirname, '../..');
+const SCRIPT_REL = 'scripts/check-schema-type-parity.py';
+const SCRIPT = path.join(ROOT, SCRIPT_REL);
+
+function runAt(scriptPath, args = [], cwd = ROOT) {
+  try {
+    const stdout = execFileSync('python3', [scriptPath, ...args], {
+      encoding: 'utf-8',
+      cwd,
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    return { stdout, exitCode: 0 };
+  } catch (err) {
+    return { stdout: err.stdout ?? '', exitCode: err.status ?? 1 };
+  }
+}
+
+const run = (args = []) => runAt(SCRIPT, args);
+
+/**
+ * A disposable copy of everything the gate reads, so a mutation cannot touch
+ * the committed schemas or race another worker.
+ */
+function sandbox() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'schema-parity-'));
+  fs.mkdirSync(path.join(dir, 'src/types/database'), { recursive: true });
+  fs.mkdirSync(path.join(dir, 'scripts'), { recursive: true });
+  fs.mkdirSync(path.join(dir, 'supabase'), { recursive: true });
+  for (const env of ['dev', 'staging', 'prod']) {
+    fs.copyFileSync(
+      path.join(ROOT, `src/types/database/${env}.ts`),
+      path.join(dir, `src/types/database/${env}.ts`),
+    );
+  }
+  fs.copyFileSync(
+    path.join(ROOT, 'supabase/schema-drift-baseline.json'),
+    path.join(dir, 'supabase/schema-drift-baseline.json'),
+  );
+  // The script resolves its repo root from __file__, so copying it in is what
+  // repoints it at the sandbox.
+  fs.copyFileSync(SCRIPT, path.join(dir, SCRIPT_REL));
+  return { dir, script: path.join(dir, SCRIPT_REL) };
+}
+
+describe('check-schema-type-parity.py', () => {
+  test('self-test passes', () => {
+    const r = run(['--self-test']);
+    expect(r.stdout).toMatch(/self-test: \d+\/\d+ passed/);
+    expect(r.stdout).not.toMatch(/FAIL/);
+    expect(r.exitCode).toBe(0);
+  });
+
+  test('an enum losing a label is ONE fact, not sixteen lines', () => {
+    // The specific noise problem that makes a line-diff gate unreadable, and
+    // therefore ignorable. Pinned so nobody "simplifies" back to a line diff.
+    const r = run(['--self-test']);
+    expect(r.stdout).toMatch(/ok +enum label loss is exactly one fact despite reformatting/);
+  });
+
+  test('the committed schemas match the recorded baseline exactly', () => {
+    const r = run();
+    expect(r.exitCode).toBe(0);
+    expect(r.stdout).toMatch(/All drift is known, ticketed and unchanged\./);
+  });
+
+  test('every known drift is attributed to a ticket', () => {
+    const r = run();
+    // The summary groups by ticket; an "untracked" bucket would mean drift got
+    // into the baseline without an owner.
+    expect(r.stdout).toMatch(/Schema drift: \d+ differing declarations/);
+    expect(r.stdout).not.toMatch(/untracked/);
+    expect(r.stdout).toMatch(/SEC-107/);
+    expect(r.stdout).toMatch(/BUGS-62/);
+  });
+
+  test('--show works without a baseline, so a baseline can be bootstrapped', () => {
+    const { dir, script } = sandbox();
+    try {
+      fs.rmSync(path.join(dir, 'supabase/schema-drift-baseline.json'));
+      const r = runAt(script, ['--show'], dir);
+      expect(r.exitCode).toBe(0);
+      expect(() => JSON.parse(r.stdout)).not.toThrow();
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test('NEW, unrecorded drift fails with exit 1 and names the fact', () => {
+    const { dir, script } = sandbox();
+    try {
+      const prod = path.join(dir, 'src/types/database/prod.ts');
+      fs.writeFileSync(
+        prod,
+        fs.readFileSync(prod, 'utf-8').replace('          is_suspended: boolean\n', ''),
+      );
+      const r = runAt(script, [], dir);
+      expect(r.exitCode).toBe(1);
+      expect(r.stdout).toMatch(/NEW schema drift/);
+      expect(r.stdout).toMatch(/column:profiles\.is_suspended/);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test('drift that has been RESOLVED also fails — the baseline must shrink', () => {
+    // The rule that turns a suppression list into a ratchet. If this ever goes
+    // green, the baseline can permanently over-state the problem and nobody
+    // will notice the day it is actually fixed.
+    const { dir, script } = sandbox();
+    try {
+      const prod = path.join(dir, 'src/types/database/prod.ts');
+      fs.writeFileSync(
+        prod,
+        fs.readFileSync(prod, 'utf-8').replace(
+          '          is_suspended: boolean\n',
+          '          is_suspended: boolean\n          phone_search_hash: string | null\n',
+        ),
+      );
+      const r = runAt(script, [], dir);
+      expect(r.exitCode).toBe(1);
+      expect(r.stdout).toMatch(/no longer drifting/);
+      expect(r.stdout).toMatch(/phone_search_hash/);
+      expect(r.stdout).toMatch(/keeps shrinking/);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test('a MISSING schema file exits 2, not 0 and not 1', () => {
+    const { dir, script } = sandbox();
+    try {
+      fs.rmSync(path.join(dir, 'src/types/database/staging.ts'));
+      const r = runAt(script, [], dir);
+      expect(r.exitCode).toBe(2);
+      expect(r.exitCode).not.toBe(0);
+      expect(r.exitCode).not.toBe(1);
+      expect(r.stdout).toMatch(/Failing closed/);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test('a schema file that is not a generated schema exits 2', () => {
+    // "It parsed as a file" is not "it is the thing we must diff". An empty or
+    // wrong file yielding zero facts would otherwise read as perfect parity.
+    const { dir, script } = sandbox();
+    try {
+      fs.writeFileSync(path.join(dir, 'src/types/database/prod.ts'), '// oops\n');
+      const r = runAt(script, [], dir);
+      expect(r.exitCode).toBe(2);
+      expect(r.stdout).toMatch(/does not declare `export type Database`/);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test('an unparseable baseline exits 2', () => {
+    const { dir, script } = sandbox();
+    try {
+      fs.writeFileSync(path.join(dir, 'supabase/schema-drift-baseline.json'), '{ not json');
+      const r = runAt(script, [], dir);
+      expect(r.exitCode).toBe(2);
+      expect(r.stdout).toMatch(/not valid JSON/);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('the committed Database types', () => {
+  test('all three schemas exist and declare Database', () => {
+    for (const env of ['dev', 'staging', 'prod']) {
+      const p = path.join(ROOT, `src/types/database/${env}.ts`);
+      expect(fs.existsSync(p)).toBe(true);
+      expect(fs.readFileSync(p, 'utf-8')).toMatch(/export type Database/);
+    }
+  });
+
+  test('generated schemas carry no hand-written header', () => {
+    // They must stay byte-identical to the generator output so a regeneration
+    // diff is signal. A header would appear in every regeneration and teach a
+    // reviewer to skim.
+    for (const env of ['dev', 'staging', 'prod']) {
+      const src = fs.readFileSync(path.join(ROOT, `src/types/database/${env}.ts`), 'utf-8');
+      expect(src.startsWith('export type Json')).toBe(true);
+    }
+  });
+
+  test('the app imports the schema through the index, not a specific environment', () => {
+    // The indirection is what lets F7 change the canonical target in one line.
+    const index = fs.readFileSync(path.join(ROOT, 'src/types/database/index.ts'), 'utf-8');
+    expect(index).toMatch(/export type \{ Database, Json \} from '\.\/dev'/);
+  });
+});


### PR DESCRIPTION
## Summary

**"Step zero for anything touching data"** — 277 `.from()` sites and no generated schema type anywhere in the repo.

This generates and commits the schemas of all three Supabase projects. They are **not interchangeable**, and that is the finding: the environments have real, measured drift (KAN-420 R5), reproduced here independently by diffing the generated types.

```
staging -> prod   prod is MISSING: discoverable_by_phone, discoverable_by_postcode,
                  phone_search_hash, postcode_search_hash          (KAN-153)
                  the `draft` label on visibility_level             (KAN-143)
                  search_by_contact_hash, e2e_fix_auth_tokens       (functions)
dev -> staging    dev is MISSING gathering_invite_messages.claimed_at (BUGS-62)
```

## The trade, stated rather than hidden

The app compiles against **`dev`**, the superset — typing against prod would fail the build on code that legitimately runs on dev and staging.

The cost: **TypeScript now asserts production has columns it does not have.** `phone_search_hash`, the `draft` visibility label and the rest typecheck everywhere and are absent on prod. The type system therefore cannot be its own control here — which is exactly why the drift gate is **blocking**, not a report. Closing the gap is F7's job (SEC-107).

## Facts, not lines — 8 instead of 22

The generator wraps a 5-label union and inlines a 4-label one, so a **line** diff reports **sixteen** differences for the single fact *"prod is missing `draft`"*. The gate compares semantic facts (`column:`, `enum-label:`, `function:`) instead. Noise is how a gate earns the right to be ignored.

## The baseline is shrink-only, and that is the load-bearing rule

New drift fails. **A baseline entry that has STOPPED drifting also fails.** A list you may only add to is a suppression list; only one that must shrink when reality improves ever reaches zero.

## Mutation-proven

| Mutation | Result |
|---|---|
| Unrecorded column difference | exit 1, `NEW schema drift … column:profiles.is_suspended` |
| A baselined drift gets **fixed** | exit 1, *"no longer drifting … keeps shrinking"* |
| Schema file missing | **exit 2** |
| File present but not a generated schema | **exit 2** (`does not declare export type Database`) |
| Baseline unparseable | **exit 2** |

It deliberately does **not** regenerate from Supabase: that needs credentials CI doesn't have, and a step that skips when a secret is absent is the silent-skip pattern KAN-167 forbids.

## ⚠️ A security correction fell out of this

**`search_by_contact_hash` does not exist on production at all** — verified by `pg_proc` catalogue query across every schema. KAN-420 §1.2 records it as *present-but-erroring*, and SEC-110's risk statement says the phone-number membership oracle "remains directly callable via PostgREST". Both are true of **dev and staging** and **false of prod**.

Better news for production than recorded — but it moves the exposure to dev/staging, and it means SEC-110's Option A would **create** the function on prod for the first time, making its enumeration-risk review a pre-deployment control. Recorded on SEC-110 (comment 14174).

## Threading is deliberately NOT in this PR

Adding `<Database>` to the three factories produces **31 type errors across 10 files**. Measured, classified and sequenced in `docs/modularisation/KAN-414-F6-threading-fallout.md`.

- **24 of 31 are nullable columns consumed as non-null** — `is_published`, `visibility`, `created_at`, `sort_order`, `relationship`, `link_type`. `is_published` and `visibility` feed publication decisions, so code without a NULL branch takes whichever path truthiness lands on. That is the SEC-44/SEC-100 shape.
- 4 are loosely-typed update payloads — the BUGS-74 class `check-partial-write-safety.py` approximates statically.
- 3 are unsafe `Json` casts.

Split out because each is a judgement call ("is this genuinely never NULL, or has this code been quietly wrong?"), **two of the files are founder-gated** (`profile/page.tsx`, `profile/legacy/page.tsx`), and two more sit in the BUGS-74 write path. `as string` would make the errors vanish and the defects permanent.

## Jira Ticket

KAN-414 (F6)

## Checklist

- [x] Unit tests added/updated — 13 cases in `tests/scripts/check-schema-type-parity.test.js`, incl. all three fail-closed paths and the shrink-only rule
- [x] All existing tests pass — 2606 passed / 223 suites; the 2 failing suites are the pre-existing macOS-only ones, identical on clean `develop`
- [x] Lint passes — 0 errors
- [x] Type check passes — `tsc --noEmit` clean (threading, which is not clean, is deliberately excluded and documented)
- [x] Build succeeds — types are additive; no runtime code changed
- [x] Coverage has not decreased — net new tests only
- [x] No eslint-disable or ts-ignore without KAN-XX reference — none added
- [x] ARCHITECTURE.md updated if architectural changes were made — N/A: adds generated types + a CI gate, changes no architecture
- [x] Ops routine / Control-Room registry updated — **CTL-036 registered**; `check-control-registry.py` clean
- [x] Docs / system map updated — rationale in `src/types/database/index.ts`; fallout in `docs/modularisation/KAN-414-F6-threading-fallout.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)