### PR TITLE
feat(KAN-414 F8): env-access ratchet — freeze the 72 direct process.env reads, shrink-only

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -140,6 +140,29 @@ jobs:
         # counted. Artefacts whose syntax forbids comments (package.json)
         # declare theirs in the script's DECLARED_EXCEPTIONS.
         run: python3 scripts/check-guard-path-drift.py
+      - name: Env-access ratchet (KAN-414 F8)
+        # 49 distinct environment variables are read from 38 files under src/,
+        # and src/lib/env.ts — the module built to be the single resolver — sees
+        # almost none of them. A missing variable therefore surfaces as
+        # `undefined` deep inside a request instead of failing loudly at boot,
+        # and no module can state its own configuration surface.
+        #
+        # This does NOT migrate anything. It freezes the existing 72 references
+        # as a baseline and makes the set SHRINK-ONLY: a new file, or a new
+        # variable in an already-listed file, fails; and so does a listed file
+        # or variable that has STOPPED being read, because a baseline that only
+        # grows is a suppression list.
+        #
+        # The precedent is why this is a gate and not a refactor:
+        # src/lib/deploy-env.ts was created to be the single environment
+        # resolver, and all six of the derivations it was meant to replace are
+        # still inline. Creating the module is 10% of the work; retiring the
+        # call sites and preventing new ones is the other 90%, and only CI does
+        # the 90%.
+        #
+        # Fails closed (exit 2) if the baseline is missing or unparseable.
+        # Escape hatch: `// env-access-ok: <JIRA-KEY> <reason>`.
+        run: python3 scripts/check-env-access.py
       - name: macOS Finder-duplicate file check (KAN-357)
         # Reject any committed " <n>"-suffixed file/dir (e.g. "[slug] 2/" or
         # "profile-sections 2.cjs"). These Finder-copy duplicates shadow the

--- a/controls/registry.json
+++ b/controls/registry.json
@@ -626,6 +626,22 @@
       ],
       "escape_hatch": "guard-path-ok: <JIRA-KEY> <reason>",
       "added": "2026-07-29"
+    },
+    {
+      "id": "CTL-037",
+      "name": "Env-access ratchet",
+      "defect_class": "scattered-configuration",
+      "summary": "Freezes the set of DIRECT process.env reads under src/ (72 references across 37 files at 2026-07-29) in env-access-baseline.json and makes it shrink-only: a new file fails, a new variable in an already-listed file fails, and a listed file or variable that has STOPPED being read ALSO fails so the baseline cannot over-state the problem. src/lib/env.ts is exempt by design. Keyed on file plus variable-set rather than line number, so unrelated edits do not churn it. Exists because src/lib/deploy-env.ts proved that creating a canonical resolver is ~10% of the work - all six derivations it was meant to replace are still inline - and only CI retires call sites.",
+      "implementation": "scripts/check-env-access.py",
+      "kind": "ci-gate",
+      "wired_in": [
+        ".github/workflows/pr-checks.yml"
+      ],
+      "prevents": [
+        "KAN-414"
+      ],
+      "escape_hatch": "// env-access-ok: <JIRA-KEY> <reason>",
+      "added": "2026-07-29"
     }
   ]
 }

--- a/env-access-baseline.json
+++ b/env-access-baseline.json
@@ -1,0 +1,152 @@
+{
+  "$comment": "KAN-414 F8 \u2014 the frozen set of DIRECT `process.env` reads under src/, as measured 2026-07-29. Enforced by scripts/check-env-access.py in pr-checks.yml (CTL-037). SHRINK-ONLY: a new file, or a new variable in an already-listed file, fails the build; so does a listed file or variable that has stopped being read, because a baseline that only grows is a suppression list rather than a ratchet. Migrate a file by routing its configuration through src/lib/env.ts and deleting its entry here in the SAME PR. src/lib/env.ts itself is exempt by design \u2014 reading process.env is its job.",
+  "measured_at": "2026-07-29",
+  "allowed": {
+    "src/app/(auth)/signup/page.tsx": [
+      "LYRA_FORCE_WAITLIST"
+    ],
+    "src/app/(legal)/contact/actions.ts": [
+      "CONTACT_FROM_EMAIL",
+      "CONTACT_TO_EMAIL",
+      "RESEND_API_KEY"
+    ],
+    "src/app/api/convene/cron/post-event/route.ts": [
+      "CRON_SECRET"
+    ],
+    "src/app/api/convene/cron/send-invites/route.ts": [
+      "CRON_SECRET"
+    ],
+    "src/app/api/convene/cron/token-health/route.ts": [
+      "CRON_SECRET"
+    ],
+    "src/app/api/health/route.ts": [
+      "IS_BETA_DEPLOY",
+      "NEXT_PUBLIC_SITE_URL",
+      "VERCEL_ENV"
+    ],
+    "src/app/api/recommendations/v2/[slug]/route.ts": [
+      "SOVRN_API_KEY"
+    ],
+    "src/app/api/retention/cron/sweep/route.ts": [
+      "CRON_SECRET"
+    ],
+    "src/app/api/well-known/jwks/route.ts": [
+      "OAUTH_JWT_KID",
+      "OAUTH_JWT_KID_NEXT",
+      "OAUTH_JWT_PUBLIC_KEY_B64",
+      "OAUTH_JWT_PUBLIC_KEY_B64_NEXT"
+    ],
+    "src/app/dashboard/page.tsx": [
+      "NEXT_PUBLIC_SITE_URL"
+    ],
+    "src/app/dashboard/profile/steps/preview-step.tsx": [
+      "NEXT_PUBLIC_SITE_URL"
+    ],
+    "src/app/dashboard/settings/discoverability-helpers.ts": [
+      "CONTACT_SEARCH_HMAC_KEY",
+      "LYRA_SEARCH_PEPPER"
+    ],
+    "src/app/examples/page.tsx": [
+      "LYRA_FORCE_WAITLIST"
+    ],
+    "src/app/join/route.ts": [
+      "NODE_ENV"
+    ],
+    "src/app/layout.tsx": [
+      "IS_BETA_DEPLOY",
+      "VERCEL_ENV"
+    ],
+    "src/app/page.tsx": [
+      "LYRA_FORCE_WAITLIST"
+    ],
+    "src/app/service-worker-register.tsx": [
+      "NEXT_PUBLIC_VERCEL_ENV",
+      "NODE_ENV"
+    ],
+    "src/lib/affiliate/link-service.ts": [
+      "SOVRN_API_KEY"
+    ],
+    "src/lib/age/didit.ts": [
+      "DIDIT_API_BASE",
+      "DIDIT_API_KEY",
+      "DIDIT_WEBHOOK_SECRET",
+      "DIDIT_WORKFLOW_ID"
+    ],
+    "src/lib/beta-access/email.ts": [
+      "LYRA_BETA_FROM_EMAIL",
+      "LYRA_BETA_NOTIFY_EMAIL",
+      "RESEND_API_KEY"
+    ],
+    "src/lib/cf-access.ts": [
+      "CF_ACCESS_AUD",
+      "CF_ACCESS_TEAM_DOMAIN"
+    ],
+    "src/lib/convene/env.ts": [
+      "<dynamic>"
+    ],
+    "src/lib/convene/flags.ts": [
+      "CONVENE_ENABLED"
+    ],
+    "src/lib/convene/invites/dispatch.ts": [
+      "LYRA_SITE_URL"
+    ],
+    "src/lib/convene/invites/email.ts": [
+      "CONVENE_INVITE_ALLOWLIST",
+      "CONVENE_INVITE_FROM_EMAIL",
+      "RESEND_API_KEY"
+    ],
+    "src/lib/convene/invites/twilio.ts": [
+      "CONVENE_INVITE_SMS_ALLOWLIST",
+      "TWILIO_ACCOUNT_SID",
+      "TWILIO_AUTH_TOKEN",
+      "TWILIO_SMS_FROM",
+      "TWILIO_WHATSAPP_FROM"
+    ],
+    "src/lib/features/entitlements-service.ts": [
+      "PAID_LINKS_COMPLIANCE_READY"
+    ],
+    "src/lib/geo/places-city.ts": [
+      "GOOGLE_PLACES_API_KEY"
+    ],
+    "src/lib/invite-text.ts": [
+      "NEXT_PUBLIC_SITE_URL"
+    ],
+    "src/lib/oauth/config.ts": [
+      "LYRA_SITE_URL",
+      "NEXT_PUBLIC_SITE_URL",
+      "VERCEL_URL"
+    ],
+    "src/lib/oauth/jwt.ts": [
+      "OAUTH_JWT_KID",
+      "OAUTH_JWT_PRIVATE_KEY_B64",
+      "OAUTH_JWT_PUBLIC_KEY_B64",
+      "OAUTH_JWT_SIGNING_SECRET"
+    ],
+    "src/lib/recommender/v2/candidate-sourcing.ts": [
+      "ANTHROPIC_API_KEY",
+      "SOVRN_API_KEY"
+    ],
+    "src/lib/retention/affiliate-clicks.ts": [
+      "RETENTION_AFFILIATE_CLICKS_MONTHS"
+    ],
+    "src/lib/retention/flags.ts": [
+      "RETENTION_ENABLED"
+    ],
+    "src/lib/retention/gatherings.ts": [
+      "RETENTION_GATHERINGS_MONTHS"
+    ],
+    "src/lib/turnstile.ts": [
+      "NEXT_PUBLIC_TURNSTILE_SITE_KEY",
+      "TURNSTILE_SECRET_KEY"
+    ],
+    "src/middleware.ts": [
+      "ADMIN_HOST",
+      "ADMIN_HOST_ENFORCED",
+      "IS_BETA_DEPLOY",
+      "NEXT_PUBLIC_SITE_URL",
+      "NEXT_PUBLIC_SUPABASE_ANON_KEY",
+      "NEXT_PUBLIC_SUPABASE_URL",
+      "VERCEL_ENV"
+    ]
+  }
+}

--- a/scripts/check-env-access.py
+++ b/scripts/check-env-access.py
@@ -1,0 +1,274 @@
+#!/usr/bin/env python3
+"""KAN-414 F8 — the env-access ratchet.
+
+WHY THIS EXISTS
+---------------
+"Modules can be configured independently" is currently false. There are 49
+distinct environment variables read from 38 files under `src/`, and only a
+handful pass through `src/lib/env.ts`, the module built to be the single
+resolver. Every other call site re-reads `process.env` directly, so:
+
+  * a missing variable surfaces as `undefined` deep inside a request rather
+    than as a loud failure at boot;
+  * no module can state its own configuration surface, because its config is
+    scattered across whichever files happen to need it;
+  * a rename or a typo is invisible until the code path runs in production.
+
+The plan's own precedent is the reason this is a GATE and not a refactor:
+`src/lib/deploy-env.ts` was created to be the single environment resolver. It is
+pure, tested and self-documenting — and **all six of the derivations it was
+meant to replace are still inline.** Creating the canonical module is ~10% of
+the work. Retiring the call sites and preventing new ones is the other 90%, and
+only CI does the 90%.
+
+So this does not migrate anything. It freezes the existing 73 references as a
+baseline and makes the set shrink-only. Migration then happens file by file,
+and the gate guarantees the number only ever goes down.
+
+WHAT IT CHECKS
+--------------
+The baseline maps each file to the exact set of variables it reads.
+
+  * a file reading `process.env` that is NOT in the baseline    -> FAIL (new)
+  * a baselined file reading a variable not listed for it       -> FAIL (creep)
+  * a baselined file that no longer reads `process.env` at all  -> FAIL (it was
+    migrated — delete its entry, so the baseline keeps shrinking)
+  * a listed variable that is no longer read                    -> FAIL (same)
+
+Keyed on FILE plus variable-set, deliberately not on line number: line numbers
+churn on every unrelated edit, and a baseline that needs updating for reasons
+unconnected to its purpose is one people learn to update without reading.
+
+`process.env[expr]` — a dynamic read — is recorded as the pseudo-variable
+`<dynamic>`, because the actual name cannot be known statically and pretending
+otherwise would let an arbitrary read hide behind a computed key.
+
+SANCTIONED READERS
+------------------
+`src/lib/env.ts` is the canonical resolver and is exempt by design — it is
+where `process.env` is SUPPOSED to be read. Anything else needs a baseline
+entry or an escape hatch.
+
+ESCAPE HATCH
+------------
+    // env-access-ok: <JIRA-KEY> <reason>
+
+on the reading line or the line above. Requires a Jira key; suppresses exactly
+one line. Every active exception is printed on every run.
+
+FAIL-CLOSED
+-----------
+Exit 2 if the baseline is missing or unparseable, or if `git ls-files` yields
+nothing. A gate that cannot see the tree must not report it clean.
+
+USAGE
+    python3 scripts/check-env-access.py
+    python3 scripts/check-env-access.py --show      # current map, as JSON
+    python3 scripts/check-env-access.py --self-test
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[1]
+BASELINE = REPO / "env-access-baseline.json"
+
+# src/lib/env.ts is the resolver: reading process.env is its entire job.
+SANCTIONED = {"src/lib/env.ts"}
+
+DYNAMIC = "<dynamic>"
+
+EXIT_OK = 0
+EXIT_DRIFT = 1
+EXIT_FAIL_CLOSED = 2
+
+VAR_RE = re.compile(r"process\.env\.([A-Za-z_][A-Za-z_0-9]*)")
+DYN_RE = re.compile(r"process\.env\s*\[")
+HATCH_RE = re.compile(r"env-access-ok:\s*(?P<key>[A-Z]+-\d+)?\s*(?P<reason>.*)$")
+
+
+class Unparseable(Exception):
+    """Missing or malformed input — always exit 2, never 0."""
+
+
+def tracked_ts_files() -> list[str]:
+    try:
+        out = subprocess.run(
+            ["git", "-C", str(REPO), "ls-files", "src"],
+            capture_output=True, text=True, check=True,
+        ).stdout
+    except (subprocess.CalledProcessError, FileNotFoundError) as exc:
+        raise Unparseable(f"git ls-files failed: {exc}")
+    files = [f for f in out.split() if f.endswith((".ts", ".tsx"))]
+    if not files:
+        raise Unparseable("git ls-files src returned no TypeScript files — "
+                          "refusing to report a clean tree we cannot see")
+    return sorted(files)
+
+
+def scan() -> tuple[dict[str, list[str]], list[dict]]:
+    """Returns (file -> sorted var list, active exceptions)."""
+    found: dict[str, set[str]] = {}
+    exceptions: list[dict] = []
+
+    for rel in tracked_ts_files():
+        if rel in SANCTIONED:
+            continue
+        p = REPO / rel
+        try:
+            lines = p.read_text(encoding="utf-8").splitlines()
+        except OSError as exc:
+            raise Unparseable(f"cannot read {rel}: {exc}")
+
+        for i, line in enumerate(lines):
+            vars_here = set(VAR_RE.findall(line))
+            dyn_here = bool(DYN_RE.search(line))
+            if not vars_here and not dyn_here:
+                continue
+
+            # A hatch may sit on this line or the one above it.
+            context = line + "\n" + (lines[i - 1] if i > 0 else "")
+            if "env-access-ok" in context:
+                m = HATCH_RE.search(context)
+                key = m.group("key") if m else None
+                if key:
+                    exceptions.append({
+                        "file": rel, "line": i + 1, "key": key,
+                        "reason": (m.group("reason") or "").strip(),
+                        "vars": sorted(vars_here) + ([DYNAMIC] if dyn_here else []),
+                    })
+                    continue
+                # A hatch with no Jira key does not suppress. Fall through so
+                # the read is still counted against the baseline.
+
+            bucket = found.setdefault(rel, set())
+            bucket |= vars_here
+            if dyn_here:
+                bucket.add(DYNAMIC)
+
+    return {k: sorted(v) for k, v in sorted(found.items())}, exceptions
+
+
+def load_baseline() -> dict[str, list[str]]:
+    if not BASELINE.is_file():
+        raise Unparseable(f"baseline missing: {BASELINE.name}")
+    try:
+        data = json.loads(BASELINE.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        raise Unparseable(f"baseline is not valid JSON: {exc}")
+    if "allowed" not in data or not isinstance(data["allowed"], dict):
+        raise Unparseable("baseline has no `allowed` object")
+    return data["allowed"]
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--show", action="store_true")
+    ap.add_argument("--self-test", action="store_true")
+    args = ap.parse_args()
+
+    if args.self_test:
+        return self_test()
+
+    try:
+        found, exceptions = scan()
+    except Unparseable as exc:
+        print(f"::error::env-access cannot verify: {exc}")
+        print("::error::Failing closed (Workflow & Backup Integrity Policy).")
+        return EXIT_FAIL_CLOSED
+
+    if args.show:
+        print(json.dumps({"allowed": found}, indent=2))
+        return EXIT_OK
+
+    try:
+        allowed = load_baseline()
+    except Unparseable as exc:
+        print(f"::error::env-access cannot verify: {exc}")
+        print("::error::Failing closed (Workflow & Backup Integrity Policy).")
+        return EXIT_FAIL_CLOSED
+
+    problems = 0
+
+    for rel, vars_ in found.items():
+        if rel not in allowed:
+            problems += 1
+            print(f"::error file={rel}::env-access: NEW direct `process.env` read in a file "
+                  f"that is not baselined ({', '.join(vars_)}). Resolve configuration "
+                  f"through src/lib/env.ts instead. If this read genuinely belongs here, "
+                  f"add `// env-access-ok: <JIRA-KEY> <reason>`.")
+            continue
+        extra = sorted(set(vars_) - set(allowed[rel]))
+        if extra:
+            problems += 1
+            print(f"::error file={rel}::env-access: this file already reads env directly, "
+                  f"and now reads MORE ({', '.join(extra)}). A known-bad file may shrink, "
+                  f"never grow — route new configuration through src/lib/env.ts.")
+
+    for rel, vars_ in allowed.items():
+        if rel not in found:
+            problems += 1
+            print(f"::error file={rel}::env-access: baselined but no longer reads "
+                  f"`process.env` — it was migrated. Delete its entry from "
+                  f"{BASELINE.name} so the baseline keeps shrinking.")
+            continue
+        gone = sorted(set(vars_) - set(found[rel]))
+        if gone:
+            problems += 1
+            print(f"::error file={rel}::env-access: these baselined variables are no "
+                  f"longer read ({', '.join(gone)}) — remove them from {BASELINE.name}. "
+                  f"A baseline that only grows is a suppression list.")
+
+    if exceptions:
+        print(f"\nActive env-access-ok exceptions ({len(exceptions)}):")
+        for e in exceptions:
+            print(f"  - {e['file']}:{e['line']}  [{e['key']}] {e['reason']}")
+
+    total_refs = sum(len(v) for v in found.values())
+    print(f"\nDirect env reads: {total_refs} references across {len(found)} files "
+          f"(baseline: {sum(len(v) for v in allowed.values())} across {len(allowed)}).")
+
+    if problems:
+        print(f"::error::{problems} env-access problem(s). The set of direct "
+              f"`process.env` reads may only shrink (KAN-414 F8).")
+        return EXIT_DRIFT
+
+    print("Direct env reads match the baseline exactly — no new ones, none silently kept.")
+    return EXIT_OK
+
+
+def self_test() -> int:
+    cases: list[tuple[str, bool]] = []
+
+    cases.append(("static var found", VAR_RE.findall("const a = process.env.FOO_BAR") == ["FOO_BAR"]))
+    cases.append(("dynamic read detected", bool(DYN_RE.search("process.env[key]"))))
+    cases.append(("dynamic with space detected", bool(DYN_RE.search("process.env [k]"))))
+    cases.append(("NEXT_PUBLIC captured",
+                  VAR_RE.findall("process.env.NEXT_PUBLIC_SITE_URL") == ["NEXT_PUBLIC_SITE_URL"]))
+    cases.append(("two on one line",
+                  set(VAR_RE.findall("process.env.A || process.env.B")) == {"A", "B"}))
+    m = HATCH_RE.search("// env-access-ok: KAN-414 bootstrap only")
+    cases.append(("hatch key parsed", m is not None and m.group("key") == "KAN-414"))
+    m2 = HATCH_RE.search("// env-access-ok: no key")
+    cases.append(("hatch without key rejected", m2 is not None and m2.group("key") is None))
+    cases.append(("no false positive on comment text",
+                  VAR_RE.findall("// mentions process env but not the property") == []))
+
+    failed = [n for n, ok in cases if not ok]
+    for n, ok in cases:
+        print(f"  {'ok  ' if ok else 'FAIL'} {n}")
+    if failed:
+        print(f"::error::self-test: {len(failed)} failed: {', '.join(failed)}")
+        return EXIT_DRIFT
+    print(f"self-test: {len(cases)}/{len(cases)} passed")
+    return EXIT_OK
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/scripts/check-env-access.test.js
+++ b/tests/scripts/check-env-access.test.js
@@ -225,7 +225,12 @@ describe('check-env-access.py — fail-closed', () => {
       execFileSync('git', ['clone', '--local', '--quiet', ROOT, sb], { stdio: 'ignore' });
       const script = path.join(sb, SCRIPT_REL);
       fs.copyFileSync(SCRIPT, script);
-      // deliberately do NOT copy the baseline in
+      // Delete it EXPLICITLY. An earlier version relied on simply not copying
+      // it in, which passed only while the baseline was still untracked — once
+      // committed, `git clone` brings it along and the case silently inverted.
+      // CI caught it; the lesson is that "absent because I did not add it" and
+      // "absent because I removed it" are different assertions.
+      fs.rmSync(path.join(sb, BASELINE_REL), { force: true });
       const r = runAt(script, [], sb);
       expect(r.exitCode).toBe(2);
       expect(r.exitCode).not.toBe(0);

--- a/tests/scripts/check-env-access.test.js
+++ b/tests/scripts/check-env-access.test.js
@@ -1,0 +1,253 @@
+/**
+ * KAN-414 F8 — tests for scripts/check-env-access.py (CTL-037).
+ *
+ * The mutating cases run in a `git clone --local` of the repo, not the working
+ * tree: the gate reads every tracked file under src/, so editing src/ in place
+ * would race the many other suites that also read those files (Jest runs test
+ * files in parallel). A `finally` that restores a file does not help a suite
+ * that read it mid-flight.
+ */
+
+const { execFileSync } = require('node:child_process');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const ROOT = path.resolve(__dirname, '../..');
+const SCRIPT_REL = 'scripts/check-env-access.py';
+const SCRIPT = path.join(ROOT, SCRIPT_REL);
+const BASELINE_REL = 'env-access-baseline.json';
+
+function runAt(scriptPath, args = [], cwd = ROOT) {
+  try {
+    const stdout = execFileSync('python3', [scriptPath, ...args], {
+      encoding: 'utf-8', cwd, stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    return { stdout, exitCode: 0 };
+  } catch (err) {
+    return { stdout: err.stdout ?? '', exitCode: err.status ?? 1 };
+  }
+}
+
+const run = (args = []) => runAt(SCRIPT, args);
+
+let SANDBOX = null;
+let SANDBOX_SCRIPT = null;
+
+beforeAll(() => {
+  SANDBOX = fs.mkdtempSync(path.join(os.tmpdir(), 'env-access-'));
+  execFileSync('git', ['clone', '--local', '--quiet', ROOT, SANDBOX], { stdio: 'ignore' });
+  SANDBOX_SCRIPT = path.join(SANDBOX, SCRIPT_REL);
+  // Untracked in ROOT until committed, so copy both in explicitly.
+  fs.copyFileSync(SCRIPT, SANDBOX_SCRIPT);
+  fs.copyFileSync(path.join(ROOT, BASELINE_REL), path.join(SANDBOX, BASELINE_REL));
+}, 120000);
+
+afterAll(() => {
+  if (SANDBOX) fs.rmSync(SANDBOX, { recursive: true, force: true });
+});
+
+/** Add a tracked file in the sandbox (the gate only sees tracked files). */
+function addTracked(rel, contents) {
+  const p = path.join(SANDBOX, rel);
+  fs.mkdirSync(path.dirname(p), { recursive: true });
+  fs.writeFileSync(p, contents);
+  execFileSync('git', ['add', rel], { cwd: SANDBOX });
+  return p;
+}
+
+function removeTracked(rel) {
+  execFileSync('git', ['rm', '-q', '-f', rel], { cwd: SANDBOX });
+}
+
+describe('check-env-access.py — detection semantics', () => {
+  test('self-test passes', () => {
+    const r = run(['--self-test']);
+    expect(r.stdout).toMatch(/self-test: \d+\/\d+ passed/);
+    expect(r.stdout).not.toMatch(/FAIL/);
+    expect(r.exitCode).toBe(0);
+  });
+
+  test('a dynamic process.env[expr] read is captured, not silently missed', () => {
+    // A computed key would otherwise be a hole big enough to drive anything
+    // through: the variable name is unknowable statically.
+    const r = run(['--self-test']);
+    expect(r.stdout).toMatch(/ok +dynamic read detected/);
+    expect(r.stdout).toMatch(/ok +dynamic with space detected/);
+  });
+});
+
+describe('check-env-access.py — against the real tree', () => {
+  test('the committed baseline matches reality exactly', () => {
+    const r = run();
+    expect(r.exitCode).toBe(0);
+    expect(r.stdout).toMatch(/match the baseline exactly/);
+  });
+
+  test('reports how many direct reads remain, so progress is visible', () => {
+    const r = run();
+    expect(r.stdout).toMatch(/Direct env reads: \d+ references across \d+ files/);
+  });
+
+  test('src/lib/env.ts is exempt and therefore absent from the baseline', () => {
+    // The resolver reading process.env is the point; baselining it would imply
+    // it should eventually stop.
+    const baseline = JSON.parse(fs.readFileSync(path.join(ROOT, BASELINE_REL), 'utf-8'));
+    expect(Object.keys(baseline.allowed)).not.toContain('src/lib/env.ts');
+  });
+
+  test('--show emits a valid baseline shape, so one can be regenerated', () => {
+    const r = run(['--show']);
+    expect(r.exitCode).toBe(0);
+    const parsed = JSON.parse(r.stdout);
+    expect(parsed).toHaveProperty('allowed');
+    expect(Object.keys(parsed.allowed).length).toBeGreaterThan(0);
+  });
+});
+
+describe('check-env-access.py — the ratchet, in all four directions', () => {
+  test('a NEW file reading process.env fails and names the variable', () => {
+    addTracked('src/lib/__probe_new.ts', 'export const x = process.env.BRAND_NEW_VAR;\n');
+    try {
+      const r = runAt(SANDBOX_SCRIPT, [], SANDBOX);
+      expect(r.exitCode).toBe(1);
+      expect(r.stdout).toMatch(/NEW direct `process\.env` read/);
+      expect(r.stdout).toMatch(/BRAND_NEW_VAR/);
+      expect(r.stdout).toMatch(/src\/lib\/env\.ts instead/);
+    } finally {
+      removeTracked('src/lib/__probe_new.ts');
+    }
+  });
+
+  test('a known-bad file reading MORE fails — may shrink, never grow', () => {
+    const rel = 'src/lib/turnstile.ts';
+    const p = path.join(SANDBOX, rel);
+    const original = fs.readFileSync(p, 'utf-8');
+    try {
+      fs.writeFileSync(p, `${original}\nconst sneaky = process.env.SOME_NEW_THING;\n`);
+      const r = runAt(SANDBOX_SCRIPT, [], SANDBOX);
+      expect(r.exitCode).toBe(1);
+      expect(r.stdout).toMatch(/now reads MORE/);
+      expect(r.stdout).toMatch(/SOME_NEW_THING/);
+    } finally {
+      fs.writeFileSync(p, original);
+    }
+  });
+
+  test('a MIGRATED file fails until its baseline entry is deleted', () => {
+    // This is the direction that turns a suppression list into a ratchet. If it
+    // ever goes green, the baseline can permanently over-state the problem.
+    const rel = 'src/lib/turnstile.ts';
+    const p = path.join(SANDBOX, rel);
+    const original = fs.readFileSync(p, 'utf-8');
+    try {
+      fs.writeFileSync(p, original.replace(/process\.env\./g, 'env.'));
+      const r = runAt(SANDBOX_SCRIPT, [], SANDBOX);
+      expect(r.exitCode).toBe(1);
+      expect(r.stdout).toMatch(/no longer reads `process\.env` — it was migrated/);
+      expect(r.stdout).toMatch(/keeps shrinking/);
+    } finally {
+      fs.writeFileSync(p, original);
+    }
+  });
+
+  test('a stale baselined VARIABLE fails too, not just a stale file', () => {
+    const rel = 'src/lib/convene/invites/twilio.ts';
+    const p = path.join(SANDBOX, rel);
+    const original = fs.readFileSync(p, 'utf-8');
+    const baseline = JSON.parse(
+      fs.readFileSync(path.join(SANDBOX, BASELINE_REL), 'utf-8'),
+    );
+    const listed = baseline.allowed[rel];
+    expect(Array.isArray(listed) && listed.length > 1).toBe(true);
+    try {
+      // Drop exactly one of its variables, keep the rest.
+      fs.writeFileSync(p, original.replace(`process.env.${listed[0]}`, `env.${listed[0]}`));
+      const r = runAt(SANDBOX_SCRIPT, [], SANDBOX);
+      expect(r.exitCode).toBe(1);
+      expect(r.stdout).toMatch(/no longer read/);
+      expect(r.stdout).toMatch(new RegExp(listed[0]));
+    } finally {
+      fs.writeFileSync(p, original);
+    }
+  });
+});
+
+describe('check-env-access.py — escape hatch', () => {
+  test('a valid hatch suppresses the read', () => {
+    addTracked(
+      'src/lib/__probe_hatch.ts',
+      'export const x = process.env.BOOTSTRAP_ONLY; // env-access-ok: KAN-414 fixture\n',
+    );
+    try {
+      const r = runAt(SANDBOX_SCRIPT, [], SANDBOX);
+      expect(r.exitCode).toBe(0);
+      expect(r.stdout).toMatch(/Active env-access-ok exceptions \(1\)/);
+      expect(r.stdout).toMatch(/\[KAN-414\]/);
+    } finally {
+      removeTracked('src/lib/__probe_hatch.ts');
+    }
+  });
+
+  test('a hatch on the line ABOVE also works', () => {
+    addTracked(
+      'src/lib/__probe_hatch2.ts',
+      '// env-access-ok: KAN-414 fixture above\nexport const x = process.env.BOOTSTRAP_ONLY;\n',
+    );
+    try {
+      const r = runAt(SANDBOX_SCRIPT, [], SANDBOX);
+      expect(r.exitCode).toBe(0);
+      expect(r.stdout).toMatch(/Active env-access-ok exceptions/);
+    } finally {
+      removeTracked('src/lib/__probe_hatch2.ts');
+    }
+  });
+
+  test('a hatch WITHOUT a Jira key does NOT suppress', () => {
+    addTracked(
+      'src/lib/__probe_nokey.ts',
+      'export const x = process.env.UNKEYED; // env-access-ok: no key here\n',
+    );
+    try {
+      const r = runAt(SANDBOX_SCRIPT, [], SANDBOX);
+      expect(r.exitCode).toBe(1);
+      expect(r.stdout).toMatch(/UNKEYED/);
+    } finally {
+      removeTracked('src/lib/__probe_nokey.ts');
+    }
+  });
+});
+
+describe('check-env-access.py — fail-closed', () => {
+  test('a missing baseline exits 2, not 0 and not 1', () => {
+    const sb = fs.mkdtempSync(path.join(os.tmpdir(), 'env-access-fc-'));
+    try {
+      execFileSync('git', ['clone', '--local', '--quiet', ROOT, sb], { stdio: 'ignore' });
+      const script = path.join(sb, SCRIPT_REL);
+      fs.copyFileSync(SCRIPT, script);
+      // deliberately do NOT copy the baseline in
+      const r = runAt(script, [], sb);
+      expect(r.exitCode).toBe(2);
+      expect(r.exitCode).not.toBe(0);
+      expect(r.exitCode).not.toBe(1);
+      expect(r.stdout).toMatch(/Failing closed/);
+    } finally {
+      fs.rmSync(sb, { recursive: true, force: true });
+    }
+  }, 120000);
+
+  test('an unparseable baseline exits 2', () => {
+    const sb = fs.mkdtempSync(path.join(os.tmpdir(), 'env-access-bad-'));
+    try {
+      execFileSync('git', ['clone', '--local', '--quiet', ROOT, sb], { stdio: 'ignore' });
+      const script = path.join(sb, SCRIPT_REL);
+      fs.copyFileSync(SCRIPT, script);
+      fs.writeFileSync(path.join(sb, BASELINE_REL), '{ not json');
+      const r = runAt(script, [], sb);
+      expect(r.exitCode).toBe(2);
+      expect(r.stdout).toMatch(/not valid JSON/);
+    } finally {
+      fs.rmSync(sb, { recursive: true, force: true });
+    }
+  }, 120000);
+});


### PR DESCRIPTION
## Summary

**"Modules can be configured independently" is currently false.** 49 distinct environment variables are read from 38 files under `src/`, and `src/lib/env.ts` — the module built to be the single resolver — sees almost none of them. So a missing variable surfaces as `undefined` deep inside a request instead of failing loudly at boot, and no module can state its own configuration surface.

**This migrates nothing.** It freezes the existing **72 references across 37 files** as a baseline and makes the set shrink-only.

## Why a gate first, and not a refactor

The plan's own precedent settles it: `src/lib/deploy-env.ts` was created to be the single environment resolver. It is pure, tested and self-documenting — and **all six of the derivations it was meant to replace are still inline.**

Creating the canonical module is ~10% of the work. Retiring the call sites and preventing new ones is the other 90%, and only CI does the 90%.

## The ratchet fails in all four directions — each mutation-proven

| Mutation | Result |
|---|---|
| A **new** file reads `process.env` | exit 1, names the variable, points at `src/lib/env.ts` |
| A baselined file reads **more** | exit 1 — *"may shrink, never grow"* |
| A baselined file **no longer** reads env | exit 1 — *"it was migrated — delete its entry"* |
| A baselined **variable** no longer read | exit 1 — same |
| Baseline missing / unparseable | **exit 2** |
| `env-access-ok` hatch with no Jira key | does **not** suppress |

The last two directions are load-bearing. **A baseline you may only add to is a suppression list**; only one that must shrink when reality improves ever reaches zero.

## Two design details that matter

**Keyed on file + variable-set, not line number.** Line numbers churn on every unrelated edit, and a baseline that needs updating for reasons unconnected to its purpose is one people learn to update without reading.

**`process.env[expr]` is recorded as `<dynamic>`.** A computed key would otherwise be a hole big enough to drive anything through, since the name is unknowable statically.

`src/lib/env.ts` is exempt by design — reading `process.env` is its job, and baselining it would imply it should eventually stop.

## For whoever does the migration

**7 of the 38 files are `.tsx` under `src/app/`**, several founder-gated (`app/page.tsx`, `app/layout.tsx`, `dashboard/page.tsx`, `(auth)/signup/page.tsx`). Building this gate touches none of them, but retiring *their* call sites will need a `UI-Change-Approved` / `UI-Bugfix-Only` trailer. Worth knowing before someone scopes it as purely mechanical.

## F1 caught this PR

Referencing `scripts/check-env-access.py` from a workflow while the file was still untracked made the **guard-path-drift** gate go red until it was staged — `git ls-files` couldn't see it. Second time today F1 has caught its own author, which is the behaviour we wanted from it.

## Jira Ticket

KAN-414 (F8)

## Checklist

- [x] Unit tests added/updated — 15 cases in `tests/scripts/check-env-access.test.js`: all four ratchet directions, both hatch forms, the keyless hatch, and both fail-closed paths
- [x] All existing tests pass — 2622 passed / 224 suites; the 2 failing suites are the pre-existing macOS-only ones, identical on clean `develop`
- [x] Lint passes — 0 errors
- [x] Type check passes — `tsc --noEmit` clean
- [x] Build succeeds — no runtime code changed; the gate is CI-only
- [x] Coverage has not decreased — net new tests only
- [x] No eslint-disable or ts-ignore without KAN-XX reference — none added
- [x] ARCHITECTURE.md updated if architectural changes were made — N/A: adds a CI gate, changes no architecture
- [x] Ops routine / Control-Room registry updated — **CTL-037 registered**; `check-control-registry.py` clean
- [x] Docs / system map updated — rationale is the script's header; the baseline carries its own `$comment` explaining the shrink-only rule

🤖 Generated with [Claude Code](https://claude.com/claude-code)