### PR TITLE
feat(KAN-414 F5): a real coverage floor, replacing four zeroes

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -15,13 +15,40 @@ const config = {
   collectCoverageFrom: [
     'src/**/*.{ts,tsx}',
     '!src/**/*.d.ts',
+    // KAN-414 F6: generated Supabase schemas. 6,971 lines of pure type
+    // declarations that erase at build time, so they contain nothing
+    // executable to cover — including them would dilute every percentage
+    // below by roughly a third and make the floor meaningless.
+    '!src/types/database/*.ts',
   ],
+  // KAN-414 F5 — a real floor, replacing four zeroes.
+  //
+  // A threshold of 0 cannot detect anything: coverage could fall to nothing and
+  // CI would stay green, which is the same class of defect as a test floor
+  // recorded years below reality (KAN-435) or a guard that passes vacuously
+  // (SEC-111). Measured 2026-07-29 on `develop` via
+  //   npx jest --testPathPatterns='tests/(unit|scripts)' --coverage
+  // giving statements 47.65% / branches 39.08% / functions 34.09% /
+  // lines 48.89%.
+  //
+  // Set ~2-3 points below measured, deliberately. Tight enough that deleting a
+  // meaningful body of tests goes red; loose enough that ordinary churn does
+  // not, because a floor that fails on unrelated work is one people raise the
+  // ceiling on rather than investigate.
+  //
+  // This is a RATCHET: when coverage rises, raise these. It may not be lowered
+  // to make a red build pass — that is the Test Integrity Policy, and lowering
+  // it is indistinguishable from deleting the tests it was protecting.
+  //
+  // Per-module thresholds are F5's remaining scope and depend on F4's test
+  // decoupling: today a source-text test for module A can live in a file named
+  // after module B, so a per-path threshold would measure the wrong thing.
   coverageThreshold: {
     global: {
-      branches: 0,
-      functions: 0,
-      lines: 0,
-      statements: 0,
+      branches: 37,
+      functions: 32,
+      lines: 46,
+      statements: 45,
     },
   },
 };


### PR DESCRIPTION
## Summary

`coverageThreshold` was `{branches: 0, functions: 0, lines: 0, statements: 0}`.

**A threshold of zero cannot detect anything.** Coverage could fall to nothing and CI would stay green. That is the same class of defect as a test floor recorded years below reality (KAN-435) or a guard that passes vacuously (SEC-111): a control that exists, reports success, and is not operating.

## Measured, then set below

```
statements 47.65% (3625/7606)   branches 39.08% (2219/5678)
functions  34.09% (480/1408)    lines    48.89% (3270/6688)
```

Floor: **statements 45 · branches 37 · functions 32 · lines 46** — about 2–3 points below measured. Tight enough that deleting a meaningful body of tests goes red; loose enough that ordinary churn does not, because *a floor that fails on unrelated work is one people raise the ceiling on rather than investigate.*

## Proven live, not assumed

Temporarily setting statements to 60 produced:

```
Jest: Coverage for statements (47.65%) does not meet "global" threshold (60%)
```

So the mechanism is real. A threshold that has never been seen to fail is indistinguishable from zero.

## Also excludes F6's generated schemas

`src/types/database/*.ts` is ~7,000 lines of pure type declarations that erase at build time — nothing executable to cover. Forward-looking until #638 lands; harmless before then.

## This is a ratchet

Raise it when coverage rises. **It may not be lowered to make a red build pass** — lowering it is indistinguishable from deleting the tests it was protecting (Test Integrity Policy).

⚠️ **Flagging for your awareness:** this edits `jest.config.js`, which the Test Integrity Policy lists as needing sign-off. It is strictly a *tightening* and F5 explicitly authorises it, so I've proceeded under your blanket approval — but say the word and I'll revert or adjust the numbers.

## What's deliberately not here

Per-module thresholds are F5's remaining scope and genuinely depend on **F4**: today a source-text test for module A can live in a file named after module B, so a per-path threshold would measure the wrong thing.

## Jira Ticket

KAN-414 (F5)

## Checklist

- [x] Unit tests added/updated — N/A: this *is* a test-infrastructure threshold; verified by mutation at two values (45 passes, 60 fails)
- [x] All existing tests pass — 2635 passed; the 18 failures are the pre-existing macOS-only pair, identical on clean `develop`
- [x] Lint passes — no JS/TS source changed
- [x] Type check passes — no TS changed
- [x] Build succeeds — jest config only, not part of the build
- [x] Coverage has not decreased — unchanged; this measures it rather than altering it
- [x] No eslint-disable or ts-ignore without KAN-XX reference — none added
- [x] ARCHITECTURE.md updated if architectural changes were made — N/A
- [x] Ops routine / Control-Room registry updated — N/A: a jest threshold, not a registered control
- [x] Docs / system map updated — the rationale, the measurement and the ratchet rule are documented inline in `jest.config.js`

🤖 Generated with [Claude Code](https://claude.com/claude-code)