### PR TITLE
refactor(KAN-414 F4 group 1): route 378 test path literals through the manifest

### DIFF
--- a/scripts/gen-test-paths.mjs
+++ b/scripts/gen-test-paths.mjs
@@ -273,7 +273,15 @@ function writeBaseline() {
       'under-counts by exactly the file you are adding. Converting a file to the generated ' +
       'manifest lowers these counts; the guard fails if they rise, AND if they fall without ' +
       'this baseline being updated, so it cannot quietly over-state the remaining work. ' +
-      'tests/support/** is excluded — the manifest is where the literals are supposed to live.',
+      'tests/support/** is excluded — the manifest is where the literals are supposed to live. ' +
+      'THE FLOOR IS NOT ZERO. After the F4 Group 1 conversion the residual literals are all ' +
+      'paths that DO NOT EXIST: synthetic fixture paths written into sandbox trees ' +
+      "(src/app/alpha/a.ts, src/lib/__probe_new.ts, scripts/keep.sh) and deliberately " +
+      'asserted-absent paths (src/app/loading.tsx, the BUGS-66 guard). They are fixture ' +
+      'CONTENT, not references to real source, and the manifest only ever contains paths that ' +
+      'exist — that is its whole promise. Driving this count to 0 would mean inventing manifest ' +
+      'entries for files that are not there, which defeats the point. Expect this number to ' +
+      'move only when real source references are added or removed.',
     measured_at: new Date().toISOString().slice(0, 10),
     measured_on: 'develop',
     total_occurrences: total,

--- a/tests/scripts/check-action-pinning.test.js
+++ b/tests/scripts/check-action-pinning.test.js
@@ -2,9 +2,10 @@ const { execSync } = require('child_process');
 const fs = require('fs');
 const os = require('os');
 const path = require('path');
+const { SRC } = require('../support/source-paths.json');
 
 const REPO_ROOT = path.resolve(__dirname, '../../');
-const SCRIPT = path.resolve(REPO_ROOT, 'scripts/check-action-pinning.sh');
+const SCRIPT = path.resolve(REPO_ROOT, SRC.checkActionPinning);
 
 // Run the guard with a given working directory. Returns { status, output }.
 // status 0 == all actions pinned; non-zero == at least one un-pinned action.
@@ -50,7 +51,7 @@ function wf(steps) {
   );
 }
 
-describe('scripts/check-action-pinning.sh', () => {
+describe(SRC.checkActionPinning, () => {
   let source = '';
 
   beforeAll(() => {

--- a/tests/scripts/check-dependency-rules.test.js
+++ b/tests/scripts/check-dependency-rules.test.js
@@ -14,9 +14,10 @@ const { execSync } = require('child_process');
 const fs = require('fs');
 const os = require('os');
 const path = require('path');
+const { SRC } = require('../support/source-paths.json');
 
 const REPO_ROOT = path.resolve(__dirname, '../..');
-const SCRIPT = path.join(REPO_ROOT, 'scripts/check-dependency-rules.sh');
+const SCRIPT = path.join(REPO_ROOT, SRC.checkDependencyRules);
 const CONFIG = path.join(REPO_ROOT, '.dependency-cruiser.cjs');
 
 /**
@@ -152,11 +153,11 @@ describe('scripts/check-dependency-rules.sh (KAN-425)', () => {
     const { code, out } = run(
       makeTree({
         'src/lib/util.ts': 'export const util = 1;\n',
-        'src/app/[slug]/slug-utils.ts': 'export const slugUtil = 1;\n',
-        'src/app/[slug]/page.tsx':
+        [SRC.slugUtils]: 'export const slugUtil = 1;\n',
+        [SRC.slugPage]:
           "import { slugUtil } from './slug-utils';\nexport default () => slugUtil;\n",
-        'src/app/(auth)/auth-errors.ts': 'export const authError = 1;\n',
-        'src/app/(auth)/login/page.tsx':
+        [SRC.authErrors]: 'export const authError = 1;\n',
+        [SRC.loginPage]:
           "import { authError } from '../auth-errors';\nexport default () => authError;\n",
       })
     );

--- a/tests/scripts/check-doc-mirror-content.test.js
+++ b/tests/scripts/check-doc-mirror-content.test.js
@@ -2,6 +2,7 @@ const { execSync } = require('child_process');
 const fs = require('fs');
 const os = require('os');
 const path = require('path');
+const { SRC } = require('../support/source-paths.json');
 
 const SCRIPT = path.resolve(__dirname, '../../scripts/check-doc-mirror-content.sh');
 
@@ -46,7 +47,7 @@ function scaffold(rows, docs = {}) {
 // A substantial, valid doc: a heading plus well over MIN_NONBLANK content lines.
 const GOOD_DOC = ['# Title', '', 'Line one.', 'Line two.', 'Line three.', 'Line four.', 'Line five.', 'Line six.'].join('\n');
 
-describe('scripts/check-doc-mirror-content.sh', () => {
+describe(SRC.checkDocMirrorContent, () => {
   let source = '';
   beforeAll(() => { source = fs.readFileSync(SCRIPT, 'utf8'); });
 

--- a/tests/scripts/check-doc-mirror-manifest.test.js
+++ b/tests/scripts/check-doc-mirror-manifest.test.js
@@ -2,6 +2,7 @@ const { execSync } = require('child_process');
 const fs = require('fs');
 const os = require('os');
 const path = require('path');
+const { SRC } = require('../support/source-paths.json');
 
 const SCRIPT = path.resolve(__dirname, '../../scripts/check-doc-mirror-manifest.sh');
 const REPO_ROOT = path.resolve(__dirname, '../..');
@@ -31,7 +32,7 @@ function scaffold(manifestBody) {
 const BLOCK = (rows) =>
   ['# fixture', '', '<!-- doc-mirror-manifest:start -->', '| Repo path | x |', '|---|---|', ...rows, '<!-- doc-mirror-manifest:end -->', ''].join('\n');
 
-describe('scripts/check-doc-mirror-manifest.sh', () => {
+describe(SRC.checkDocMirrorManifest, () => {
   let source = '';
   beforeAll(() => { source = fs.readFileSync(SCRIPT, 'utf8'); });
 

--- a/tests/scripts/check-env-access.test.js
+++ b/tests/scripts/check-env-access.test.js
@@ -12,9 +12,10 @@ const { execFileSync } = require('node:child_process');
 const fs = require('node:fs');
 const os = require('node:os');
 const path = require('node:path');
+const { SRC } = require('../support/source-paths.json');
 
 const ROOT = path.resolve(__dirname, '../..');
-const SCRIPT_REL = 'scripts/check-env-access.py';
+const SCRIPT_REL = SRC.checkEnvAccess;
 const SCRIPT = path.join(ROOT, SCRIPT_REL);
 const BASELINE_REL = 'env-access-baseline.json';
 
@@ -93,7 +94,7 @@ describe('check-env-access.py — against the real tree', () => {
     // The resolver reading process.env is the point; baselining it would imply
     // it should eventually stop.
     const baseline = JSON.parse(fs.readFileSync(path.join(ROOT, BASELINE_REL), 'utf-8'));
-    expect(Object.keys(baseline.allowed)).not.toContain('src/lib/env.ts');
+    expect(Object.keys(baseline.allowed)).not.toContain(SRC.libEnv);
   });
 
   test('--show emits a valid baseline shape, so one can be regenerated', () => {
@@ -120,7 +121,7 @@ describe('check-env-access.py — the ratchet, in all four directions', () => {
   });
 
   test('a known-bad file reading MORE fails — may shrink, never grow', () => {
-    const rel = 'src/lib/turnstile.ts';
+    const rel = SRC.turnstile;
     const p = path.join(SANDBOX, rel);
     const original = fs.readFileSync(p, 'utf-8');
     try {
@@ -137,7 +138,7 @@ describe('check-env-access.py — the ratchet, in all four directions', () => {
   test('a MIGRATED file fails until its baseline entry is deleted', () => {
     // This is the direction that turns a suppression list into a ratchet. If it
     // ever goes green, the baseline can permanently over-state the problem.
-    const rel = 'src/lib/turnstile.ts';
+    const rel = SRC.turnstile;
     const p = path.join(SANDBOX, rel);
     const original = fs.readFileSync(p, 'utf-8');
     try {
@@ -152,7 +153,7 @@ describe('check-env-access.py — the ratchet, in all four directions', () => {
   });
 
   test('a stale baselined VARIABLE fails too, not just a stale file', () => {
-    const rel = 'src/lib/convene/invites/twilio.ts';
+    const rel = SRC.twilio;
     const p = path.join(SANDBOX, rel);
     const original = fs.readFileSync(p, 'utf-8');
     const baseline = JSON.parse(

--- a/tests/scripts/check-extraction-dod.test.js
+++ b/tests/scripts/check-extraction-dod.test.js
@@ -2,9 +2,10 @@ const { execSync } = require('child_process');
 const fs = require('fs');
 const os = require('os');
 const path = require('path');
+const { SRC } = require('../support/source-paths.json');
 
 const REPO_ROOT = path.resolve(__dirname, '../../');
-const SCRIPT = path.resolve(REPO_ROOT, 'scripts/check-extraction-dod.sh');
+const SCRIPT = path.resolve(REPO_ROOT, SRC.checkExtractionDod);
 
 // A PR body that answers every attestation. Individual tests override it.
 const FULL_BODY = [
@@ -34,7 +35,7 @@ function makeRepo({ estate = {}, extra = {} } = {}) {
 
   // --- baseline estate on develop, all pointing at the pre-move path ---
   write('src/lib/age/gate.ts', 'export const gate = 1;\n');
-  write('.github/CODEOWNERS', '* @luisa\n/src/lib/age/gate.ts @luisa\n');
+  write(SRC.codeowners, '* @luisa\n/src/lib/age/gate.ts @luisa\n');
   write('scripts/some-guard.sh', '#!/usr/bin/env bash\ngrep -q x src/lib/age/gate.ts\n');
   write('docs/ARCHITECTURE.md', 'The age gate lives at `src/lib/age/gate.ts`.\n');
   write(
@@ -79,7 +80,7 @@ function runMove({
 
   // Default: every artefact is updated to the new path (the passing case).
   const updated = {
-    '.github/CODEOWNERS': `* @luisa\n/${to} @luisa\n`,
+    [SRC.codeowners]: `* @luisa\n/${to} @luisa\n`,
     'scripts/some-guard.sh': `#!/usr/bin/env bash\ngrep -q x ${to}\n`,
     'docs/ARCHITECTURE.md': `The age gate lives at \`${to}\`.\n`,
     'docs/DOC_SOURCE_OF_TRUTH.md': `<!-- doc-mirror-manifest:start -->\n| \`${to}\` | wiki |\n<!-- doc-mirror-manifest:end -->\n`,
@@ -115,7 +116,7 @@ function runMove({
   return { status, output };
 }
 
-describe('scripts/check-extraction-dod.sh', () => {
+describe(SRC.checkExtractionDod, () => {
   let source = '';
   beforeAll(() => {
     source = fs.readFileSync(SCRIPT, 'utf8');
@@ -165,7 +166,7 @@ describe('scripts/check-extraction-dod.sh', () => {
   // ------------------------------------------------------------ violations
   it('fails, naming file and line, when a stale reference remains in .github/', () => {
     const { status, output } = runMove({
-      estate: { '.github/CODEOWNERS': '* @luisa\n/src/lib/age/gate.ts @luisa\n' },
+      estate: { [SRC.codeowners]: '* @luisa\n/src/lib/age/gate.ts @luisa\n' },
     });
     expect(status).toBe(1);
     expect(output).toMatch(/\[stale-refs\] stale reference to moved path 'src\/lib\/age\/gate\.ts'/);
@@ -281,7 +282,7 @@ describe('scripts/check-extraction-dod.sh', () => {
   it('suppresses exactly the named check and nothing else', () => {
     const { status, output } = runMove({
       estate: {
-        '.github/CODEOWNERS': '* @luisa\n/src/lib/age/gate.ts @luisa\n',
+        [SRC.codeowners]: '* @luisa\n/src/lib/age/gate.ts @luisa\n',
         'modules.json': JSON.stringify({ modules: { age: { paths: ['src/lib/age/gate.ts'] } } }, null, 2),
       },
       commitMessage: 'refactor: extract age module\n\nEXTRACTION-DOD-OK: KAN-428 stale-refs\n',
@@ -332,7 +333,7 @@ describe('scripts/check-extraction-dod.sh — routine-prompt coupling', () => {
     git('config user.name tester');
     git('config commit.gpgsign false');
     write('src/components/Card.tsx', 'export const Card = () => null;\n');
-    write('.github/CODEOWNERS', '* @luisa\n');
+    write(SRC.codeowners, '* @luisa\n');
     write('scripts/keep.sh', '#!/usr/bin/env bash\ntrue\n');
     write('docs/ARCHITECTURE.md', 'docs\n');
     write('docs/DOC_SOURCE_OF_TRUTH.md', '<!-- doc-mirror-manifest:start -->\n<!-- doc-mirror-manifest:end -->\n');

--- a/tests/scripts/check-fix-only-promote.test.js
+++ b/tests/scripts/check-fix-only-promote.test.js
@@ -2,9 +2,10 @@ const { execSync } = require('child_process');
 const fs = require('fs');
 const os = require('os');
 const path = require('path');
+const { SRC } = require('../support/source-paths.json');
 
 const REPO_ROOT = path.resolve(__dirname, '../../');
-const SCRIPT = path.resolve(REPO_ROOT, 'scripts/check-fix-only-promote.sh');
+const SCRIPT = path.resolve(REPO_ROOT, SRC.checkFixOnlyPromote);
 
 // Build a throwaway git repo with a `main` branch and a `beta` branch whose
 // commits (ahead of main) are the supplied subjects, then run the guard over
@@ -58,7 +59,7 @@ function runOverHistory(mode, betaCommits) {
   }
 }
 
-describe('scripts/check-fix-only-promote.sh', () => {
+describe(SRC.checkFixOnlyPromote, () => {
   let source = '';
 
   beforeAll(() => {

--- a/tests/scripts/check-guard-path-drift.test.js
+++ b/tests/scripts/check-guard-path-drift.test.js
@@ -26,9 +26,10 @@ const { execFileSync } = require('node:child_process');
 const fs = require('node:fs');
 const os = require('node:os');
 const path = require('node:path');
+const { SRC } = require('../support/source-paths.json');
 
 const ROOT = path.resolve(__dirname, '../..');
-const SCRIPT_REL = 'scripts/check-guard-path-drift.py';
+const SCRIPT_REL = SRC.checkGuardPathDrift;
 const SCRIPT = path.join(ROOT, SCRIPT_REL);
 
 let SANDBOX = null;
@@ -123,7 +124,7 @@ describe('check-guard-path-drift.py — drift detection (sandboxed)', () => {
 
   // §7.9 case 2.
   test('a moved file that disarms a control fails with exit 1 and names it', () => {
-    const from = path.join(SANDBOX, 'src/lib/supabase-service.ts');
+    const from = path.join(SANDBOX, SRC.supabaseService);
     const toDir = path.join(SANDBOX, 'src/modules/platform/data');
     fs.mkdirSync(toDir, { recursive: true });
     execFileSync('git', ['mv', from, path.join(toDir, 'supabase-service.ts')], { cwd: SANDBOX });
@@ -155,7 +156,7 @@ describe('check-guard-path-drift.py — drift detection (sandboxed)', () => {
     const dir = path.join(SANDBOX, 'src/untracked-probe');
     fs.mkdirSync(dir, { recursive: true });
     fs.writeFileSync(path.join(dir, 'thing.ts'), 'export {};\n');
-    sandboxWrite('.github/signup-surface.paths', (s) => `${s}\nsrc/untracked-probe/**\n`);
+    sandboxWrite(SRC.signupSurface, (s) => `${s}\nsrc/untracked-probe/**\n`);
 
     const r = runSandbox();
     expect(r.exitCode).toBe(1);
@@ -164,7 +165,7 @@ describe('check-guard-path-drift.py — drift detection (sandboxed)', () => {
 
   // §7.9 case 15.
   test('an escape-hatch marker without a Jira key does NOT suppress', () => {
-    sandboxWrite('.github/signup-surface.paths', (s) =>
+    sandboxWrite(SRC.signupSurface, (s) =>
       `${s}\nsrc/nope/a/**   # guard-path-ok: no key here\n`);
     const r = runSandbox();
     expect(r.exitCode).toBe(1);
@@ -173,7 +174,7 @@ describe('check-guard-path-drift.py — drift detection (sandboxed)', () => {
 
   // §7.9 case 14.
   test('a valid hatch suppresses exactly its own pattern, not its neighbour', () => {
-    sandboxWrite('.github/signup-surface.paths', (s) =>
+    sandboxWrite(SRC.signupSurface, (s) =>
       `${s}\nsrc/nope/b/**   # guard-path-ok: KAN-414 fixture\nsrc/nope/c/**\n`);
     const r = runSandbox();
     expect(r.exitCode).toBe(1);
@@ -230,7 +231,7 @@ describe('check-guard-path-drift.py — fail-closed (§7.9 cases 12–13, NOT op
       execFileSync('git', ['clone', '--local', '--quiet', ROOT, sb], { stdio: 'ignore' });
       const script = path.join(sb, SCRIPT_REL);
       fs.copyFileSync(SCRIPT, script);
-      fs.writeFileSync(path.join(sb, '.github/signup-surface.paths'), '# all commented out\n');
+      fs.writeFileSync(path.join(sb, SRC.signupSurface), '# all commented out\n');
 
       const r = runAt(script, [], sb);
       expect(r.exitCode).toBe(2);

--- a/tests/scripts/check-routine-ownership.test.js
+++ b/tests/scripts/check-routine-ownership.test.js
@@ -2,6 +2,7 @@ const { execSync } = require('child_process');
 const fs = require('fs');
 const os = require('os');
 const path = require('path');
+const { SRC } = require('../support/source-paths.json');
 
 // The guard under test resolves the repo root from its own location
 // ($SCRIPT_DIR/..), so to exercise the failure paths deterministically we
@@ -15,13 +16,13 @@ const REAL_SCRIPT = path.resolve(
 // The four target files and a minimal body that carries EVERY required marker.
 // Keep these in sync with check-marker() calls in the script.
 const GOOD_FILES = {
-  '.github/workflows/weekly-report.yml': [
+  [SRC.weeklyReport]: [
     'name: Weekly Status Report',
     '# Section 1 reads the liveness owner:',
     'gh run list --workflow=health-check.yml -L 1',
     'echo "_Source of record: **Daily Security routine** (docs/DAILY_SECURITY_CHECK.md)._"',
   ].join('\n'),
-  '.github/workflows/security-audit.yml': [
+  [SRC.securityAudit]: [
     'name: Weekly Security Audit',
     '# KAN-361 — Belt-and-braces only. Authoritative sweep = the',
     '# Daily Security routine (docs/DAILY_SECURITY_CHECK.md).',
@@ -41,7 +42,7 @@ const GOOD_FILES = {
     '# Staging Soak',
     '## The release contract — what good looks like on staging',
   ].join('\n'),
-  '.github/signup-surface.paths': [
+  [SRC.signupSurface]: [
     '# Lyra sign-up / account-creation surface',
     'src/app/(auth)/signup/**',
   ].join('\n'),
@@ -73,7 +74,7 @@ function run(scriptPath) {
   }
 }
 
-describe('scripts/check-routine-ownership.sh', () => {
+describe(SRC.checkRoutineOwnership, () => {
   let source = '';
   beforeAll(() => {
     source = fs.readFileSync(REAL_SCRIPT, 'utf8');
@@ -120,22 +121,22 @@ describe('scripts/check-routine-ownership.sh', () => {
   const MARKER_REMOVALS = [
     {
       name: 'weekly-report drops the health-check.yml liveness read',
-      file: '.github/workflows/weekly-report.yml',
+      file: SRC.weeklyReport,
       strip: /gh run list --workflow=health-check\.yml -L 1/,
     },
     {
       name: 'security-audit loses its belt-and-braces demotion header',
-      file: '.github/workflows/security-audit.yml',
+      file: SRC.securityAudit,
       strip: /Belt-and-braces only\. Authoritative sweep = the/,
     },
     {
       name: 'security-audit stops citing the Daily Security routine',
-      file: '.github/workflows/security-audit.yml',
+      file: SRC.securityAudit,
       strip: /Daily Security routine \(docs\/DAILY_SECURITY_CHECK\.md\)\./,
     },
     {
       name: 'weekly-report Section 5 drops the Daily-Security source-of-record cite',
-      file: '.github/workflows/weekly-report.yml',
+      file: SRC.weeklyReport,
       strip: /Source of record: \*\*Daily Security routine\*\*/,
     },
     {
@@ -165,7 +166,7 @@ describe('scripts/check-routine-ownership.sh', () => {
     },
     {
       name: 'signup-surface manifest drops the sign-up form path (KAN-413)',
-      file: '.github/signup-surface.paths',
+      file: SRC.signupSurface,
       strip: /src\/app\/\(auth\)\/signup\/\*\*/,
     },
   ];

--- a/tests/scripts/check-schema-type-parity.test.js
+++ b/tests/scripts/check-schema-type-parity.test.js
@@ -10,9 +10,10 @@ const { execFileSync } = require('node:child_process');
 const fs = require('node:fs');
 const os = require('node:os');
 const path = require('node:path');
+const { SRC } = require('../support/source-paths.json');
 
 const ROOT = path.resolve(__dirname, '../..');
-const SCRIPT_REL = 'scripts/check-schema-type-parity.py';
+const SCRIPT_REL = SRC.checkSchemaTypeParity;
 const SCRIPT = path.join(ROOT, SCRIPT_REL);
 
 function runAt(scriptPath, args = [], cwd = ROOT) {
@@ -36,7 +37,7 @@ const run = (args = []) => runAt(SCRIPT, args);
  */
 function sandbox() {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'schema-parity-'));
-  fs.mkdirSync(path.join(dir, 'src/types/database'), { recursive: true });
+  fs.mkdirSync(path.join(dir, SRC.database), { recursive: true });
   fs.mkdirSync(path.join(dir, 'scripts'), { recursive: true });
   fs.mkdirSync(path.join(dir, 'supabase'), { recursive: true });
   for (const env of ['dev', 'staging', 'prod']) {
@@ -46,8 +47,8 @@ function sandbox() {
     );
   }
   fs.copyFileSync(
-    path.join(ROOT, 'supabase/schema-drift-baseline.json'),
-    path.join(dir, 'supabase/schema-drift-baseline.json'),
+    path.join(ROOT, SRC.schemaDriftBaseline),
+    path.join(dir, SRC.schemaDriftBaseline),
   );
   // The script resolves its repo root from __file__, so copying it in is what
   // repoints it at the sandbox.
@@ -89,7 +90,7 @@ describe('check-schema-type-parity.py', () => {
   test('--show works without a baseline, so a baseline can be bootstrapped', () => {
     const { dir, script } = sandbox();
     try {
-      fs.rmSync(path.join(dir, 'supabase/schema-drift-baseline.json'));
+      fs.rmSync(path.join(dir, SRC.schemaDriftBaseline));
       const r = runAt(script, ['--show'], dir);
       expect(r.exitCode).toBe(0);
       expect(() => JSON.parse(r.stdout)).not.toThrow();
@@ -101,7 +102,7 @@ describe('check-schema-type-parity.py', () => {
   test('NEW, unrecorded drift fails with exit 1 and names the fact', () => {
     const { dir, script } = sandbox();
     try {
-      const prod = path.join(dir, 'src/types/database/prod.ts');
+      const prod = path.join(dir, SRC.prod);
       fs.writeFileSync(
         prod,
         fs.readFileSync(prod, 'utf-8').replace('          is_suspended: boolean\n', ''),
@@ -121,7 +122,7 @@ describe('check-schema-type-parity.py', () => {
     // will notice the day it is actually fixed.
     const { dir, script } = sandbox();
     try {
-      const prod = path.join(dir, 'src/types/database/prod.ts');
+      const prod = path.join(dir, SRC.prod);
       fs.writeFileSync(
         prod,
         fs.readFileSync(prod, 'utf-8').replace(
@@ -142,7 +143,7 @@ describe('check-schema-type-parity.py', () => {
   test('a MISSING schema file exits 2, not 0 and not 1', () => {
     const { dir, script } = sandbox();
     try {
-      fs.rmSync(path.join(dir, 'src/types/database/staging.ts'));
+      fs.rmSync(path.join(dir, SRC.staging));
       const r = runAt(script, [], dir);
       expect(r.exitCode).toBe(2);
       expect(r.exitCode).not.toBe(0);
@@ -158,7 +159,7 @@ describe('check-schema-type-parity.py', () => {
     // wrong file yielding zero facts would otherwise read as perfect parity.
     const { dir, script } = sandbox();
     try {
-      fs.writeFileSync(path.join(dir, 'src/types/database/prod.ts'), '// oops\n');
+      fs.writeFileSync(path.join(dir, SRC.prod), '// oops\n');
       const r = runAt(script, [], dir);
       expect(r.exitCode).toBe(2);
       expect(r.stdout).toMatch(/does not declare `export type Database`/);
@@ -170,7 +171,7 @@ describe('check-schema-type-parity.py', () => {
   test('an unparseable baseline exits 2', () => {
     const { dir, script } = sandbox();
     try {
-      fs.writeFileSync(path.join(dir, 'supabase/schema-drift-baseline.json'), '{ not json');
+      fs.writeFileSync(path.join(dir, SRC.schemaDriftBaseline), '{ not json');
       const r = runAt(script, [], dir);
       expect(r.exitCode).toBe(2);
       expect(r.stdout).toMatch(/not valid JSON/);
@@ -201,7 +202,7 @@ describe('the committed Database types', () => {
 
   test('the app imports the schema through the index, not a specific environment', () => {
     // The indirection is what lets F7 change the canonical target in one line.
-    const index = fs.readFileSync(path.join(ROOT, 'src/types/database/index.ts'), 'utf-8');
+    const index = fs.readFileSync(path.join(ROOT, SRC.index), 'utf-8');
     expect(index).toMatch(/export type \{ Database, Json \} from '\.\/dev'/);
   });
 });

--- a/tests/scripts/check-ui-copy-ownership.test.js
+++ b/tests/scripts/check-ui-copy-ownership.test.js
@@ -2,9 +2,10 @@ const { execSync } = require('child_process');
 const fs = require('fs');
 const os = require('os');
 const path = require('path');
+const { SRC } = require('../support/source-paths.json');
 
 const REPO_ROOT = path.resolve(__dirname, '../../');
-const SCRIPT = path.resolve(REPO_ROOT, 'scripts/check-ui-copy-ownership.sh');
+const SCRIPT = path.resolve(REPO_ROOT, SRC.checkUiCopyOwnership);
 
 // Build a throwaway git repo with a `develop` branch and a `feature` branch
 // whose commits (ahead of develop) create/modify the supplied files with the
@@ -56,7 +57,7 @@ function runOverCommits(commits, { baseRef = 'develop' } = {}) {
   }
 }
 
-describe('scripts/check-ui-copy-ownership.sh', () => {
+describe(SRC.checkUiCopyOwnership, () => {
   let source = '';
   beforeAll(() => {
     source = fs.readFileSync(SCRIPT, 'utf8');
@@ -89,7 +90,7 @@ describe('scripts/check-ui-copy-ownership.sh', () => {
 
   it('FAILS a src/app page (.tsx) change with no trailer', () => {
     const { status, output } = runOverCommits([
-      { files: ['src/app/dashboard/page.tsx'], message: 'change the dashboard' },
+      { files: [SRC.dashboardPage], message: 'change the dashboard' },
     ]);
     expect(status).not.toBe(0);
     expect(output).toMatch(/no approval trailer/);
@@ -99,7 +100,7 @@ describe('scripts/check-ui-copy-ownership.sh', () => {
   it('PASSES the same .tsx change when a UI-Change-Approved trailer is present', () => {
     const { status, output } = runOverCommits([
       {
-        files: ['src/app/dashboard/page.tsx'],
+        files: [SRC.dashboardPage],
         message: 'feat: new dashboard hero\n\nUI-Change-Approved: KAN-410',
       },
     ]);
@@ -111,7 +112,7 @@ describe('scripts/check-ui-copy-ownership.sh', () => {
   it('PASSES the same .tsx change with a UI-Bugfix-Only trailer (carve-out)', () => {
     const { status, output } = runOverCommits([
       {
-        files: ['src/app/dashboard/page.tsx'],
+        files: [SRC.dashboardPage],
         message: 'fix: correct a typo in the heading\n\nUI-Bugfix-Only: BUGS-70',
       },
     ]);
@@ -129,7 +130,7 @@ describe('scripts/check-ui-copy-ownership.sh', () => {
 
   it('PASSES an admin-console change (carve-out) with no trailer', () => {
     const { status, output } = runOverCommits([
-      { files: ['src/app/admin/features/page.tsx'], message: 'admin: tweak' },
+      { files: [SRC.featuresPage], message: 'admin: tweak' },
     ]);
     expect(status).toBe(0);
     expect(output).toMatch(/no founder-owned UI\/copy paths changed/);
@@ -144,7 +145,7 @@ describe('scripts/check-ui-copy-ownership.sh', () => {
 
   it('FAILS a named copy module change (src/lib/invite-text.ts) with no trailer', () => {
     const { status, output } = runOverCommits([
-      { files: ['src/lib/invite-text.ts'], message: 'reword the invite copy' },
+      { files: [SRC.inviteText], message: 'reword the invite copy' },
     ]);
     expect(status).not.toBe(0);
     expect(output).toMatch(/invite-text\.ts/);
@@ -152,14 +153,14 @@ describe('scripts/check-ui-copy-ownership.sh', () => {
 
   it('PASSES a non-copy src/lib logic change with no trailer', () => {
     const { status } = runOverCommits([
-      { files: ['src/lib/dashboard/resolve-widgets.ts'], message: 'logic: gate a widget' },
+      { files: [SRC.resolveWidgets], message: 'logic: gate a widget' },
     ]);
     expect(status).toBe(0);
   });
 
   it('FAILS a globals.css / design-token change with no trailer', () => {
     const { status, output } = runOverCommits([
-      { files: ['src/app/globals.css'], message: 'restyle tokens' },
+      { files: [SRC.globals], message: 'restyle tokens' },
     ]);
     expect(status).not.toBe(0);
     expect(output).toMatch(/globals\.css/);
@@ -168,7 +169,7 @@ describe('scripts/check-ui-copy-ownership.sh', () => {
   it('requires a JIRA key on the trailer (bare trailer does not satisfy)', () => {
     const { status } = runOverCommits([
       {
-        files: ['src/app/page.tsx'],
+        files: [SRC.appPage],
         message: 'change home\n\nUI-Change-Approved: yes please',
       },
     ]);
@@ -177,7 +178,7 @@ describe('scripts/check-ui-copy-ownership.sh', () => {
 
   it('WARNS and passes (fail-open) when the base ref cannot be resolved', () => {
     const { status, output } = runOverCommits(
-      [{ files: ['src/app/page.tsx'], message: 'change home' }],
+      [{ files: [SRC.appPage], message: 'change home' }],
       { baseRef: 'origin/does-not-exist-xyz' },
     );
     expect(status).toBe(0);

--- a/tests/scripts/check-workflow-integrity.test.js
+++ b/tests/scripts/check-workflow-integrity.test.js
@@ -2,9 +2,10 @@ const { execSync } = require('child_process');
 const fs = require('fs');
 const os = require('os');
 const path = require('path');
+const { SRC } = require('../support/source-paths.json');
 
 const REPO_ROOT = path.resolve(__dirname, '../../');
-const SCRIPT = path.resolve(REPO_ROOT, 'scripts/check-workflow-integrity.sh');
+const SCRIPT = path.resolve(REPO_ROOT, SRC.checkWorkflowIntegrity);
 
 // Run the integrity script with a given working directory. Returns
 // { status, output }. status 0 == clean; non-zero == integrity problem(s).
@@ -35,7 +36,7 @@ function runWithWorkflow(name, contents) {
   }
 }
 
-describe('scripts/check-workflow-integrity.sh', () => {
+describe(SRC.checkWorkflowIntegrity, () => {
   let source = '';
 
   beforeAll(() => {

--- a/tests/scripts/daily-security-check.test.js
+++ b/tests/scripts/daily-security-check.test.js
@@ -1,10 +1,11 @@
 const { execSync } = require('child_process');
 const fs = require('fs');
 const path = require('path');
+const { SRC } = require('../support/source-paths.json');
 
 const SCRIPT = path.resolve(__dirname, '../../scripts/daily-security-check.sh');
 
-describe('scripts/daily-security-check.sh', () => {
+describe(SRC.dailySecurityCheck, () => {
   let source = '';
 
   beforeAll(() => {

--- a/tests/scripts/doc-sync-healthcheck.test.js
+++ b/tests/scripts/doc-sync-healthcheck.test.js
@@ -1,6 +1,7 @@
 const { execSync } = require('child_process');
 const fs = require('fs');
 const path = require('path');
+const { SRC } = require('../support/source-paths.json');
 
 const SCRIPT = path.resolve(__dirname, '../../scripts/doc-sync-healthcheck.sh');
 
@@ -14,7 +15,7 @@ function run(args) {
   }
 }
 
-describe('scripts/doc-sync-healthcheck.sh', () => {
+describe(SRC.docSyncHealthcheck, () => {
   let source = '';
   beforeAll(() => { source = fs.readFileSync(SCRIPT, 'utf8'); });
 

--- a/tests/scripts/guard-fail-closed.test.js
+++ b/tests/scripts/guard-fail-closed.test.js
@@ -2,6 +2,7 @@ const { execSync } = require('child_process');
 const fs = require('fs');
 const os = require('os');
 const path = require('path');
+const { SRC } = require('../support/source-paths.json');
 
 const REPO_ROOT = path.resolve(__dirname, '../../');
 
@@ -47,7 +48,7 @@ function runIn(dir, script, { pathPrefix } = {}) {
 // "run from the wrong directory, or src/ moved" failure.
 function makeTreeWithoutSrc() {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'failclosed-'));
-  fs.mkdirSync(path.join(dir, '.github/workflows'), { recursive: true });
+  fs.mkdirSync(path.join(dir, SRC.workflows), { recursive: true });
   fs.writeFileSync(path.join(dir, '.github/workflows/a.yml'), 'on: push\njobs: {}\n');
   return dir;
 }

--- a/tests/scripts/routine-watchdog.test.js
+++ b/tests/scripts/routine-watchdog.test.js
@@ -1,6 +1,7 @@
 const { execSync } = require('child_process');
 const fs = require('fs');
 const path = require('path');
+const { SRC } = require('../support/source-paths.json');
 
 const SCRIPT = path.resolve(__dirname, '../../scripts/routine-watchdog.sh');
 
@@ -24,7 +25,7 @@ function run(args, now = SAT_NOON) {
   }
 }
 
-describe('scripts/routine-watchdog.sh', () => {
+describe(SRC.routineWatchdog, () => {
   let source = '';
   beforeAll(() => { source = fs.readFileSync(SCRIPT, 'utf8'); });
 

--- a/tests/scripts/security-alert-email.test.js
+++ b/tests/scripts/security-alert-email.test.js
@@ -1,10 +1,11 @@
 const { execSync } = require('child_process');
 const fs = require('fs');
 const path = require('path');
+const { SRC } = require('../support/source-paths.json');
 
 const SCRIPT = path.resolve(__dirname, '../../scripts/security-alert-email.sh');
 
-describe('scripts/security-alert-email.sh', () => {
+describe(SRC.securityAlertEmail, () => {
   let source = '';
 
   beforeAll(() => {

--- a/tests/scripts/weekly-health-regression.test.js
+++ b/tests/scripts/weekly-health-regression.test.js
@@ -2,10 +2,11 @@ const { execSync, spawnSync } = require('child_process');
 const fs = require('fs');
 const os = require('os');
 const path = require('path');
+const { SRC } = require('../support/source-paths.json');
 
 const SCRIPT = path.resolve(__dirname, '../../scripts/weekly-health-regression.sh');
 
-describe('scripts/weekly-health-regression.sh', () => {
+describe(SRC.weeklyHealthRegression, () => {
   let source = '';
   beforeAll(() => { source = fs.readFileSync(SCRIPT, 'utf8'); });
 

--- a/tests/support/raw-path-literal-baseline.json
+++ b/tests/support/raw-path-literal-baseline.json
@@ -1,7 +1,7 @@
 {
-  "$comment": "KAN-414 F4 / KAN-417 §3 — the SHRINK-ONLY ratchet on raw repo-path literals in tests/. Regenerate with `npm run gen:test-paths -- --write-baseline` AFTER staging your changes: `git ls-files` cannot see an unstaged file, so measuring first under-counts by exactly the file you are adding. Converting a file to the generated manifest lowers these counts; the guard fails if they rise, AND if they fall without this baseline being updated, so it cannot quietly over-state the remaining work. tests/support/** is excluded — the manifest is where the literals are supposed to live.",
+  "$comment": "KAN-414 F4 / KAN-417 §3 — the SHRINK-ONLY ratchet on raw repo-path literals in tests/. Regenerate with `npm run gen:test-paths -- --write-baseline` AFTER staging your changes: `git ls-files` cannot see an unstaged file, so measuring first under-counts by exactly the file you are adding. Converting a file to the generated manifest lowers these counts; the guard fails if they rise, AND if they fall without this baseline being updated, so it cannot quietly over-state the remaining work. tests/support/** is excluded — the manifest is where the literals are supposed to live. THE FLOOR IS NOT ZERO. After the F4 Group 1 conversion the residual literals are all paths that DO NOT EXIST: synthetic fixture paths written into sandbox trees (src/app/alpha/a.ts, src/lib/__probe_new.ts, scripts/keep.sh) and deliberately asserted-absent paths (src/app/loading.tsx, the BUGS-66 guard). They are fixture CONTENT, not references to real source, and the manifest only ever contains paths that exist — that is its whole promise. Driving this count to 0 would mean inventing manifest entries for files that are not there, which defeats the point. Expect this number to move only when real source references are added or removed.",
   "measured_at": "2026-07-31",
   "measured_on": "develop",
-  "total_occurrences": 350,
-  "files_with_raw_literals": 85
+  "total_occurrences": 40,
+  "files_with_raw_literals": 10
 }

--- a/tests/support/raw-path-literal-baseline.json
+++ b/tests/support/raw-path-literal-baseline.json
@@ -1,7 +1,7 @@
 {
   "$comment": "KAN-414 F4 / KAN-417 §3 — the SHRINK-ONLY ratchet on raw repo-path literals in tests/. Regenerate with `npm run gen:test-paths -- --write-baseline` AFTER staging your changes: `git ls-files` cannot see an unstaged file, so measuring first under-counts by exactly the file you are adding. Converting a file to the generated manifest lowers these counts; the guard fails if they rise, AND if they fall without this baseline being updated, so it cannot quietly over-state the remaining work. tests/support/** is excluded — the manifest is where the literals are supposed to live.",
-  "measured_at": "2026-07-30",
+  "measured_at": "2026-07-31",
   "measured_on": "develop",
-  "total_occurrences": 418,
-  "files_with_raw_literals": 96
+  "total_occurrences": 350,
+  "files_with_raw_literals": 85
 }

--- a/tests/unit/affiliations-and-autosave.test.ts
+++ b/tests/unit/affiliations-and-autosave.test.ts
@@ -30,6 +30,7 @@
 
 import { readFileSync, existsSync } from 'node:fs';
 import { resolve } from 'node:path';
+import { SRC } from '../support/source-paths';
 
 const ROOT = resolve(__dirname, '../..');
 
@@ -329,7 +330,7 @@ describe('KAN-404: addSchoolAffiliation postcode requirement', () => {
 describe('KAN-220: surface-area regression guards', () => {
   test('migration file exists with the affiliation_type CHECK constraint', () => {
     const src = readFileSync(
-      resolve(ROOT, 'supabase/migrations/20260517010000_affiliation_type.sql'),
+      resolve(ROOT, SRC.migrations20260517010000AffiliationType),
       'utf-8',
     );
     expect(src).toMatch(/add column affiliation_type/i);
@@ -340,7 +341,7 @@ describe('KAN-220: surface-area regression guards', () => {
   });
 
   test('affiliation-fields module exists and exports the right surface', () => {
-    const path = resolve(ROOT, 'src/app/dashboard/profile/affiliation-fields.ts');
+    const path = resolve(ROOT, SRC.affiliationFields);
     expect(existsSync(path)).toBe(true);
     const src = readFileSync(path, 'utf-8');
     expect(src).toMatch(/export const ALLOWED_AFFILIATION_TYPES/);
@@ -351,7 +352,7 @@ describe('KAN-220: surface-area regression guards', () => {
 
   test('actions.ts addSchoolAffiliation accepts affiliation_type', () => {
     const src = readFileSync(
-      resolve(ROOT, 'src/app/dashboard/profile/actions.ts'),
+      resolve(ROOT, SRC.profileActions),
       'utf-8',
     );
     expect(src).toMatch(/affiliation_type\?:\s*string/);
@@ -360,7 +361,7 @@ describe('KAN-220: surface-area regression guards', () => {
 
   test('WizardSchool type declares affiliation_type', () => {
     const src = readFileSync(
-      resolve(ROOT, 'src/app/dashboard/profile/steps/types.tsx'),
+      resolve(ROOT, SRC.types),
       'utf-8',
     );
     // Type now carries affiliation_type — KAN-220 schools/orgs/communities split
@@ -383,7 +384,7 @@ describe('KAN-220: surface-area regression guards', () => {
 
   test('edit-profile-form orchestrator imports all four new sections + uses ItemsStep for lists', () => {
     const src = readFileSync(
-      resolve(ROOT, 'src/app/dashboard/profile/edit-profile-form.tsx'),
+      resolve(ROOT, SRC.editProfileForm),
       'utf-8',
     );
     expect(src).toMatch(/BasicInfoSection/);
@@ -413,7 +414,7 @@ describe('KAN-220: surface-area regression guards', () => {
   });
 
   test('legacy wizard route exists at /dashboard/profile/legacy', () => {
-    const p = resolve(ROOT, 'src/app/dashboard/profile/legacy/page.tsx');
+    const p = resolve(ROOT, SRC.legacyPage);
     expect(existsSync(p)).toBe(true);
     const src = readFileSync(p, 'utf-8');
     expect(src).toMatch(/ProfileWizard/);
@@ -422,7 +423,7 @@ describe('KAN-220: surface-area regression guards', () => {
 
   test('main /dashboard/profile route renders EditProfileForm (new single-page editor)', () => {
     const src = readFileSync(
-      resolve(ROOT, 'src/app/dashboard/profile/page.tsx'),
+      resolve(ROOT, SRC.profilePage),
       'utf-8',
     );
     expect(src).toMatch(/EditProfileForm/);
@@ -435,7 +436,7 @@ describe('KAN-220: surface-area regression guards', () => {
     // module, which broke that test by hiding the strings — reverted.
     // This sibling assertion documents the intent.
     const src = readFileSync(
-      resolve(ROOT, 'src/app/dashboard/profile/page.tsx'),
+      resolve(ROOT, SRC.profilePage),
       'utf-8',
     );
     expect(src).toMatch(/conversation_starter_prompts/);
@@ -444,7 +445,7 @@ describe('KAN-220: surface-area regression guards', () => {
 
   test('legacy /dashboard/profile/legacy page also fetches the full dataset', () => {
     const src = readFileSync(
-      resolve(ROOT, 'src/app/dashboard/profile/legacy/page.tsx'),
+      resolve(ROOT, SRC.legacyPage),
       'utf-8',
     );
     expect(src).toMatch(/conversation_starter_prompts/);
@@ -454,7 +455,7 @@ describe('KAN-220: surface-area regression guards', () => {
 
   test('public profile [slug]/page.tsx groups Schools / Orgs / Communities', () => {
     const src = readFileSync(
-      resolve(ROOT, 'src/app/[slug]/page.tsx'),
+      resolve(ROOT, SRC.slugPage),
       'utf-8',
     );
     // The render groups by affiliation_type — checking distinctive strings
@@ -465,7 +466,7 @@ describe('KAN-220: surface-area regression guards', () => {
 
   test('legacy wizard.tsx left untouched (preserves profile-sections.test.js assertions)', () => {
     const src = readFileSync(
-      resolve(ROOT, 'src/app/dashboard/profile/wizard.tsx'),
+      resolve(ROOT, SRC.wizard),
       'utf-8',
     );
     // These strings are still expected by tests/unit/profile-sections.test.js

--- a/tests/unit/age-self-declaration.test.ts
+++ b/tests/unit/age-self-declaration.test.ts
@@ -13,6 +13,7 @@
  */
 import fs from 'fs';
 import path from 'path';
+import { SRC } from '../support/source-paths';
 import {
   isAgeDeclared,
   AGE_DECLARATION_FIELD,
@@ -48,7 +49,7 @@ describe('constants are shared, not restated', () => {
 
 describe('the declaration gates BOTH sign-up paths', () => {
   const form = fs.readFileSync(
-    path.join(root, 'src/app/(auth)/signup/signup-form.tsx'),
+    path.join(root, SRC.signupForm),
     'utf8',
   );
 
@@ -65,7 +66,7 @@ describe('the declaration gates BOTH sign-up paths', () => {
 });
 
 describe('server-side enforcement (not just the UI)', () => {
-  const actions = fs.readFileSync(path.join(root, 'src/app/(auth)/actions.ts'), 'utf8');
+  const actions = fs.readFileSync(path.join(root, SRC.actions), 'utf8');
 
   it('signUp re-checks the declaration and refuses without it', () => {
     // Client state is an affordance; a hand-crafted POST must still be refused.
@@ -91,7 +92,7 @@ describe('server-side enforcement (not just the UI)', () => {
 
 describe('recording + backstop at the shared chokepoint', () => {
   const chokepoint = fs.readFileSync(
-    path.join(root, 'src/lib/auth/post-login-redirect.ts'),
+    path.join(root, SRC.postLoginRedirect),
     'utf8',
   );
 
@@ -110,7 +111,7 @@ describe('the declaration is not user-writable', () => {
     // It is written by the service role only. If it ever became user-settable
     // the record would be worthless as evidence.
     const fields = fs.readFileSync(
-      path.join(root, 'src/app/dashboard/profile/profile-fields.ts'),
+      path.join(root, SRC.profileFields),
       'utf8',
     );
     expect(fields).not.toContain('age_declared_18_at');
@@ -124,7 +125,7 @@ describe('the declaration is not user-writable', () => {
 describe('the provider age gate is re-introduced as an opt-in switch (KAN-408)', () => {
   it('both publish paths consult the (switch-gated) provider age check', () => {
     const actions = fs.readFileSync(
-      path.join(root, 'src/app/dashboard/profile/actions.ts'),
+      path.join(root, SRC.profileActions),
       'utf8',
     );
     expect((actions.match(/isProviderAgeCheckActive\(\)/g) || []).length).toBeGreaterThanOrEqual(2);
@@ -135,6 +136,6 @@ describe('the provider age gate is re-introduced as an opt-in switch (KAN-408)',
     // gate.ts was the AGE_VERIFICATION_REQUIRED env-var gate — it stays deleted.
     expect(fs.existsSync(path.join(root, 'src/lib/age/gate.ts'))).toBe(false);
     // provider-gate.ts is the new switch-keyed gate.
-    expect(fs.existsSync(path.join(root, 'src/lib/age/provider-gate.ts'))).toBe(true);
+    expect(fs.existsSync(path.join(root, SRC.providerGate))).toBe(true);
   });
 });

--- a/tests/unit/auth-confirm-route.test.ts
+++ b/tests/unit/auth-confirm-route.test.ts
@@ -38,6 +38,7 @@ jest.mock('@/lib/auth/post-login-redirect', () => ({
 }));
 
 import { GET } from '@/app/auth/confirm/route';
+import { SRC } from '../support/source-paths';
 
 const ORIGIN = 'https://dev.checklyra.com';
 
@@ -127,7 +128,7 @@ describe('GET /auth/confirm (BUGS-50 token-hash flow)', () => {
 
 describe('BUGS-50: auth-route surface guards', () => {
   test('/auth/confirm route exists and uses verifyOtp (not the PKCE code exchange)', () => {
-    const p = resolve(ROOT, 'src/app/auth/confirm/route.ts');
+    const p = resolve(ROOT, SRC.confirmRoute);
     expect(existsSync(p)).toBe(true);
     const src = readFileSync(p, 'utf-8');
     expect(src).toMatch(/verifyOtp/);
@@ -137,7 +138,7 @@ describe('BUGS-50: auth-route surface guards', () => {
   });
 
   test('/auth/callback is still the OAuth code-exchange route (regression guard)', () => {
-    const src = readFileSync(resolve(ROOT, 'src/app/auth/callback/route.ts'), 'utf-8');
+    const src = readFileSync(resolve(ROOT, SRC.authCallbackRoute), 'utf-8');
     expect(src).toMatch(/exchangeCodeForSession/);
     expect(src).toMatch(/searchParams\.get\(['"]next['"]\)/);
   });

--- a/tests/unit/auth.test.js
+++ b/tests/unit/auth.test.js
@@ -6,28 +6,29 @@
 
 const fs = require('fs');
 const path = require('path');
+const { SRC } = require('../support/source-paths.json');
 
 const root = path.join(__dirname, '../..');
 
 describe('Auth pages', () => {
   test('signup page file exists', () => {
-    expect(fs.existsSync(path.join(root, 'src/app/(auth)/signup/page.tsx'))).toBe(true);
+    expect(fs.existsSync(path.join(root, SRC.signupPage))).toBe(true);
   });
 
   test('login page file exists', () => {
-    expect(fs.existsSync(path.join(root, 'src/app/(auth)/login/page.tsx'))).toBe(true);
+    expect(fs.existsSync(path.join(root, SRC.loginPage))).toBe(true);
   });
 
   test('auth callback route exists', () => {
-    expect(fs.existsSync(path.join(root, 'src/app/auth/callback/route.ts'))).toBe(true);
+    expect(fs.existsSync(path.join(root, SRC.authCallbackRoute))).toBe(true);
   });
 
   test('dashboard page exists', () => {
-    expect(fs.existsSync(path.join(root, 'src/app/dashboard/page.tsx'))).toBe(true);
+    expect(fs.existsSync(path.join(root, SRC.dashboardPage))).toBe(true);
   });
 
   test('middleware exists and handles auth routes', () => {
-    const middlewarePath = path.join(root, 'src/middleware.ts');
+    const middlewarePath = path.join(root, SRC.middleware);
     expect(fs.existsSync(middlewarePath)).toBe(true);
     const content = fs.readFileSync(middlewarePath, 'utf8');
     expect(content).toContain('/dashboard');
@@ -36,7 +37,7 @@ describe('Auth pages', () => {
   });
 
   test('server actions file exists with signUp, signIn, signOut', () => {
-    const actionsPath = path.join(root, 'src/app/(auth)/actions.ts');
+    const actionsPath = path.join(root, SRC.actions);
     expect(fs.existsSync(actionsPath)).toBe(true);
     const content = fs.readFileSync(actionsPath, 'utf8');
     expect(content).toContain('export async function signUp');
@@ -47,7 +48,7 @@ describe('Auth pages', () => {
 
 describe('KAN-130: Apple Sign-In commented out', () => {
   test('social-login-buttons does not import signInWithApple as active import', () => {
-    const filePath = path.join(root, 'src/app/(auth)/social-login-buttons.tsx');
+    const filePath = path.join(root, SRC.socialLoginButtons);
     const content = fs.readFileSync(filePath, 'utf8');
     // signInWithApple should only appear inside a comment, not as an active import
     const lines = content.split('\n');
@@ -62,7 +63,7 @@ describe('KAN-130: Apple Sign-In commented out', () => {
   });
 
   test('social-login-buttons still exports SocialLoginButtons with Google', () => {
-    const filePath = path.join(root, 'src/app/(auth)/social-login-buttons.tsx');
+    const filePath = path.join(root, SRC.socialLoginButtons);
     const content = fs.readFileSync(filePath, 'utf8');
     expect(content).toContain('export function SocialLoginButtons');
     expect(content).toContain('signInWithGoogle');
@@ -70,7 +71,7 @@ describe('KAN-130: Apple Sign-In commented out', () => {
   });
 
   test('actions.ts has signInWithApple commented out with KAN-37 reference', () => {
-    const actionsPath = path.join(root, 'src/app/(auth)/actions.ts');
+    const actionsPath = path.join(root, SRC.actions);
     const content = fs.readFileSync(actionsPath, 'utf8');
     // signInWithApple should be commented out
     expect(content).not.toMatch(/^export async function signInWithApple/m);
@@ -81,7 +82,7 @@ describe('KAN-130: Apple Sign-In commented out', () => {
   });
 
   test('Google signInWithGoogle is still exported and active', () => {
-    const actionsPath = path.join(root, 'src/app/(auth)/actions.ts');
+    const actionsPath = path.join(root, SRC.actions);
     const content = fs.readFileSync(actionsPath, 'utf8');
     expect(content).toMatch(/^export async function signInWithGoogle/m);
   });

--- a/tests/unit/auto-save-flush.test.ts
+++ b/tests/unit/auto-save-flush.test.ts
@@ -22,9 +22,10 @@
 import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { runSave } from '@/app/dashboard/profile/sections/auto-save-core';
+import { SRC } from '../support/source-paths';
 
 const ROOT = resolve(__dirname, '../..');
-const SECTIONS = resolve(ROOT, 'src/app/dashboard/profile/sections');
+const SECTIONS = resolve(ROOT, SRC.profileSections);
 
 // ─────────── 1. runSave behaviour ───────────
 
@@ -119,7 +120,7 @@ describe('KAN-404: SectionSaveBar + free-text sections render a visible Save', (
 });
 
 describe('KAN-404: Continue button gated behind showContinue', () => {
-  const STEPS = resolve(ROOT, 'src/app/dashboard/profile/steps');
+  const STEPS = resolve(ROOT, SRC.steps);
 
   test.each(['items-step.tsx', 'links-step.tsx', 'conversation-starters-step.tsx', 'files-step.tsx'])(
     '%s only renders the Continue button when showContinue is not false',
@@ -135,7 +136,7 @@ describe('KAN-404: Continue button gated behind showContinue', () => {
 
   test('single-page editor passes showContinue={false} to the list steps', () => {
     const src = readFileSync(
-      resolve(ROOT, 'src/app/dashboard/profile/edit-profile-form.tsx'),
+      resolve(ROOT, SRC.editProfileForm),
       'utf-8',
     );
     const count = (src.match(/showContinue=\{false\}/g) || []).length;
@@ -144,7 +145,7 @@ describe('KAN-404: Continue button gated behind showContinue', () => {
 
   test('legacy wizard.tsx does NOT pass showContinue (keeps the default true)', () => {
     const src = readFileSync(
-      resolve(ROOT, 'src/app/dashboard/profile/wizard.tsx'),
+      resolve(ROOT, SRC.wizard),
       'utf-8',
     );
     expect(src).not.toMatch(/showContinue/);

--- a/tests/unit/backup.test.js
+++ b/tests/unit/backup.test.js
@@ -5,33 +5,34 @@
 
 const fs = require('fs');
 const path = require('path');
+const { SRC } = require('../support/source-paths.json');
 
 const root = path.join(__dirname, '../..');
 
 describe('Backup & Rollback', () => {
   test('rollback script exists and is executable', () => {
-    const scriptPath = path.join(root, 'scripts/rollback-vercel.sh');
+    const scriptPath = path.join(root, SRC.rollbackVercel);
     expect(fs.existsSync(scriptPath)).toBe(true);
     const stats = fs.statSync(scriptPath);
     expect(stats.mode & 0o111).toBeTruthy(); // executable
   });
 
   test('backup script exists and is executable', () => {
-    const scriptPath = path.join(root, 'scripts/backup-database.sh');
+    const scriptPath = path.join(root, SRC.scriptsBackupDatabase);
     expect(fs.existsSync(scriptPath)).toBe(true);
     const stats = fs.statSync(scriptPath);
     expect(stats.mode & 0o111).toBeTruthy();
   });
 
   test('restore script exists and is executable', () => {
-    const scriptPath = path.join(root, 'scripts/restore-database.sh');
+    const scriptPath = path.join(root, SRC.restoreDatabase);
     expect(fs.existsSync(scriptPath)).toBe(true);
     const stats = fs.statSync(scriptPath);
     expect(stats.mode & 0o111).toBeTruthy();
   });
 
   test('backup workflow exists for GitHub Actions', () => {
-    const workflowPath = path.join(root, '.github/workflows/backup-database.yml');
+    const workflowPath = path.join(root, SRC.backupDatabase);
     expect(fs.existsSync(workflowPath)).toBe(true);
     const content = fs.readFileSync(workflowPath, 'utf8');
     expect(content).toContain('schedule');
@@ -60,22 +61,22 @@ describe('SEC-23 — DR/backup coverage hardening', () => {
   const executable = (p) => Boolean(fs.statSync(path.join(root, p)).mode & 0o111);
 
   test('complete backup script exists, is executable, and captures auth+storage', () => {
-    expect(exists('scripts/backup-database-complete.sh')).toBe(true);
-    expect(executable('scripts/backup-database-complete.sh')).toBe(true);
-    const s = read('scripts/backup-database-complete.sh');
+    expect(exists(SRC.backupDatabaseComplete)).toBe(true);
+    expect(executable(SRC.backupDatabaseComplete)).toBe(true);
+    const s = read(SRC.backupDatabaseComplete);
     // The whole point: it must NOT be public-only like backup-database.sh.
     expect(s).toMatch(/SCHEMAS=\(public auth storage\)/);
     expect(s).toContain('pg_dumpall --roles-only');
   });
 
   test('complete-backup integrity validator exists and is executable', () => {
-    expect(exists('scripts/check-complete-backup.sh')).toBe(true);
-    expect(executable('scripts/check-complete-backup.sh')).toBe(true);
+    expect(exists(SRC.checkCompleteBackup)).toBe(true);
+    expect(executable(SRC.checkCompleteBackup)).toBe(true);
   });
 
   test('complete backup workflow: daily cadence documented, encrypts, write-only WORM cred, dispatchable', () => {
-    expect(exists('.github/workflows/backup-complete.yml')).toBe(true);
-    const w = read('.github/workflows/backup-complete.yml');
+    expect(exists(SRC.backupComplete)).toBe(true);
+    const w = read(SRC.backupComplete);
     // Daily cadence is documented; the schedule ships commented until the backup
     // is commissioned (SEC-23) so prod never goes nightly-red before secrets exist.
     expect(w).toMatch(/cron:\s*'0 1 \* \* \*'/);
@@ -86,7 +87,7 @@ describe('SEC-23 — DR/backup coverage hardening', () => {
   });
 
   test('restore drill actually restores (no silent-skip) and asserts round-trip', () => {
-    const w = read('.github/workflows/backup-restore-test.yml');
+    const w = read(SRC.backupRestoreTest);
     expect(w).toContain('image: postgres:17'); // clean-room restore target
     expect(w).toMatch(/Restore the backup/);
     expect(w).toMatch(/row count|round-trip/i);
@@ -95,13 +96,13 @@ describe('SEC-23 — DR/backup coverage hardening', () => {
   });
 
   test('REST fallback enumerates tables dynamically (not a hardcoded short list)', () => {
-    const s = read('scripts/backup-database-api.sh');
+    const s = read(SRC.backupDatabaseApi);
     expect(s).not.toMatch(/TABLES=\("profiles" "profile_items"/);
     expect(s).toMatch(/PostgREST|paths/);
   });
 
   test('restore script resets the whole public schema, not a hardcoded table list', () => {
-    const s = read('scripts/restore-database.sh');
+    const s = read(SRC.restoreDatabase);
     expect(s).toContain('DROP SCHEMA IF EXISTS public CASCADE');
   });
 

--- a/tests/unit/bugs74-manual-of-me-field-coverage.test.ts
+++ b/tests/unit/bugs74-manual-of-me-field-coverage.test.ts
@@ -17,6 +17,7 @@
 import { readFileSync, existsSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { MANUAL_OF_ME_FIELDS } from '@/app/dashboard/profile/manual-of-me-fields';
+import { SRC } from '../support/source-paths';
 
 /** Pull the `.select(...)` argument attached to the profile_manual_of_me query. */
 function manualOfMeSelectArg(source: string, file: string): string {
@@ -51,13 +52,13 @@ function assertCoversEveryField(selectArg: string, file: string): void {
 }
 
 const LOADERS = [
-  { label: 'profile editor', path: 'src/app/dashboard/profile/page.tsx' },
-  { label: 'public profile', path: 'src/app/[slug]/page.tsx' },
+  { label: 'profile editor', path: SRC.profilePage },
+  { label: 'public profile', path: SRC.slugPage },
   // BUGS-74 follow-up: the legacy step-by-step editor carried the identical
   // four-column select and was missed by the original fix. It is the live
   // rollback path, so leaving it drifted meant a rollback would resume the
   // data loss. Every loader belongs in this list, not just the default one.
-  { label: 'legacy profile editor', path: 'src/app/dashboard/profile/legacy/page.tsx' },
+  { label: 'legacy profile editor', path: SRC.legacyPage },
 ];
 
 describe('BUGS-74 — profile_manual_of_me loaders cover the full allowlist', () => {

--- a/tests/unit/consented-analytics.test.ts
+++ b/tests/unit/consented-analytics.test.ts
@@ -9,6 +9,7 @@
 
 import fs from 'fs';
 import path from 'path';
+import { SRC } from '../support/source-paths';
 import {
   analyticsAllowed,
   getConsentSnapshot,
@@ -54,7 +55,7 @@ describe('SEC-72 analytics consent gate', () => {
     test('gate reads the same localStorage key the banner writes', () => {
       expect(CONSENT_STORAGE_KEY).toBe('lyra-cookie-consent');
       const banner = fs.readFileSync(
-        path.join(root, 'src/app/cookie-consent.tsx'),
+        path.join(root, SRC.cookieConsent),
         'utf8',
       );
       expect(banner).toContain(CONSENT_STORAGE_KEY);
@@ -63,7 +64,7 @@ describe('SEC-72 analytics consent gate', () => {
 
   describe('layout wiring', () => {
     const layout = fs.readFileSync(
-      path.join(root, 'src/app/layout.tsx'),
+      path.join(root, SRC.layout),
       'utf8',
     );
 
@@ -82,7 +83,7 @@ describe('SEC-72 analytics consent gate', () => {
 
     test('the gate component owns the Vercel analytics imports', () => {
       const gate = fs.readFileSync(
-        path.join(root, 'src/app/consented-analytics.tsx'),
+        path.join(root, SRC.consentedAnalytics),
         'utf8',
       );
       expect(gate).toContain('@vercel/analytics/react');

--- a/tests/unit/convene/connections-page.test.ts
+++ b/tests/unit/convene/connections-page.test.ts
@@ -8,12 +8,13 @@
 
 import fs from 'fs';
 import path from 'path';
+import { SRC } from '../../support/source-paths';
 
 const ROOT = path.join(__dirname, '..', '..', '..');
 
 describe('Convene connections page (KAN-206)', () => {
-  const pagePath = path.join(ROOT, 'src/app/dashboard/convene/connections/page.tsx');
-  const clientPath = path.join(ROOT, 'src/app/dashboard/convene/connections/connections-client.tsx');
+  const pagePath = path.join(ROOT, SRC.connectionsPage);
+  const clientPath = path.join(ROOT, SRC.connectionsClient);
 
   test('page file exists', () => {
     expect(fs.existsSync(pagePath)).toBe(true);
@@ -57,7 +58,7 @@ describe('Convene connections page (KAN-206)', () => {
 });
 
 describe('Convene token-health cron route (KAN-206)', () => {
-  const routePath = path.join(ROOT, 'src/app/api/convene/cron/token-health/route.ts');
+  const routePath = path.join(ROOT, SRC.tokenHealthRoute);
 
   test('route file exists', () => {
     expect(fs.existsSync(routePath)).toBe(true);

--- a/tests/unit/convene/contacts-ui.test.ts
+++ b/tests/unit/convene/contacts-ui.test.ts
@@ -7,9 +7,10 @@
 
 import fs from 'fs';
 import path from 'path';
+import { SRC } from '../../support/source-paths';
 
 const ROOT = path.join(__dirname, '..', '..', '..');
-const base = 'src/app/dashboard/convene/contacts';
+const base = SRC.contacts;
 const pagePath = path.join(ROOT, base, 'page.tsx');
 const clientPath = path.join(ROOT, base, 'contacts-client.tsx');
 const actionsPath = path.join(ROOT, base, 'actions.ts');

--- a/tests/unit/convene/convene-nav.test.ts
+++ b/tests/unit/convene/convene-nav.test.ts
@@ -7,11 +7,12 @@
 
 import fs from 'fs';
 import path from 'path';
+import { SRC } from '../../support/source-paths';
 
 const ROOT = path.join(__dirname, '..', '..', '..');
-const dashboardPath = path.join(ROOT, 'src/app/dashboard/page.tsx');
-const profileFormPath = path.join(ROOT, 'src/app/dashboard/profile/edit-profile-form.tsx');
-const profilePagePath = path.join(ROOT, 'src/app/dashboard/profile/page.tsx');
+const dashboardPath = path.join(ROOT, SRC.dashboardPage);
+const profileFormPath = path.join(ROOT, SRC.editProfileForm);
+const profilePagePath = path.join(ROOT, SRC.profilePage);
 
 describe('Convene nav entry points (KAN-303)', () => {
   describe('dashboard page', () => {
@@ -31,7 +32,7 @@ describe('Convene nav entry points (KAN-303)', () => {
       expect(src).toMatch(/conveneEntitled:\s*conveneEnabled/);
     });
     test('the widget resolver only emits the convene widget when entitled (KAN-349)', () => {
-      const resolverSrc = fs.readFileSync(path.join(ROOT, 'src/lib/dashboard/resolve-widgets.ts'), 'utf8');
+      const resolverSrc = fs.readFileSync(path.join(ROOT, SRC.resolveWidgets), 'utf8');
       expect(resolverSrc).toMatch(/if \(input\.conveneEntitled\)[\s\S]{0,80}'convene'/);
     });
   });

--- a/tests/unit/convene/cron-auth.test.ts
+++ b/tests/unit/convene/cron-auth.test.ts
@@ -12,6 +12,7 @@
 import fs from 'fs';
 import path from 'path';
 import { timingSafeStrEqual } from '@/lib/convene/cron-auth';
+import { SRC } from '../../support/source-paths';
 
 const ROOT = path.join(__dirname, '..', '..', '..');
 
@@ -48,9 +49,9 @@ describe('timingSafeStrEqual', () => {
 
 describe('cron routes use the constant-time helper', () => {
   const routes = [
-    'src/app/api/convene/cron/send-invites/route.ts',
-    'src/app/api/convene/cron/post-event/route.ts',
-    'src/app/api/convene/cron/token-health/route.ts',
+    SRC.sendInvitesRoute,
+    SRC.postEventRoute,
+    SRC.tokenHealthRoute,
   ];
 
   test.each(routes)('%s imports and calls timingSafeStrEqual', (rel) => {

--- a/tests/unit/convene/dispatch-atomic-claim.test.ts
+++ b/tests/unit/convene/dispatch-atomic-claim.test.ts
@@ -17,6 +17,7 @@
 import fs from 'fs';
 import path from 'path';
 import { _internal } from '@/lib/convene/invites/dispatch';
+import { SRC } from '../../support/source-paths';
 
 const { claimQueuedRows, releaseClaim } = _internal as unknown as {
   claimQueuedRows: (
@@ -164,7 +165,7 @@ describe('claimQueuedRows — atomic claim (BUGS-62)', () => {
 // ─── static guards: the wiring that must move with the 'sending' state ──────
 
 describe('dispatch.ts claim wiring (BUGS-62)', () => {
-  const src = fs.readFileSync(path.join(ROOT, 'src/lib/convene/invites/dispatch.ts'), 'utf8');
+  const src = fs.readFileSync(path.join(ROOT, SRC.dispatch), 'utf8');
 
   test('claim UPDATE is guarded by delivery_status=queued', () => {
     expect(src).toMatch(/delivery_status:\s*'sending'/);
@@ -196,7 +197,7 @@ describe('dispatch.ts claim wiring (BUGS-62)', () => {
 describe('schema + re-queue guards move with the state (BUGS-62)', () => {
   test('migration widens the delivery_status CHECK to include sending + adds claimed_at', () => {
     const mig = fs.readFileSync(
-      path.join(ROOT, 'supabase/migrations/20260706153000_bugs62_convene_invite_atomic_claim.sql'),
+      path.join(ROOT, SRC.migrations20260706153000Bugs62ConveneInviteAtomicClaim),
       'utf8'
     );
     expect(mig).toMatch(/'queued',\s*'sending',\s*'sent'/);
@@ -205,7 +206,7 @@ describe('schema + re-queue guards move with the state (BUGS-62)', () => {
 
   test('web re-queue treats sending as an already-live message', () => {
     const actions = fs.readFileSync(
-      path.join(ROOT, 'src/app/dashboard/convene/gatherings/[id]/actions.ts'),
+      path.join(ROOT, SRC.idActions),
       'utf8'
     );
     expect(actions).toMatch(/\['queued',\s*'sending',\s*'sent'/);

--- a/tests/unit/convene/dispatch.test.ts
+++ b/tests/unit/convene/dispatch.test.ts
@@ -15,6 +15,7 @@ import path from 'path';
 const ROOT = path.join(__dirname, '..', '..', '..');
 
 import { _internal } from '@/lib/convene/invites/dispatch';
+import { SRC } from '../../support/source-paths';
 const { buildSendInputs } = _internal;
 
 describe('buildSendInputs (KAN-209)', () => {
@@ -81,7 +82,7 @@ describe('buildSendInputs (KAN-209)', () => {
 // ─── cron route shape ──────────────────────────────────────────────────
 
 describe('send-invites cron route (KAN-209)', () => {
-  const routePath = path.join(ROOT, 'src/app/api/convene/cron/send-invites/route.ts');
+  const routePath = path.join(ROOT, SRC.sendInvitesRoute);
 
   test('route file exists', () => {
     expect(fs.existsSync(routePath)).toBe(true);

--- a/tests/unit/convene/drain-route.test.ts
+++ b/tests/unit/convene/drain-route.test.ts
@@ -7,12 +7,13 @@
 
 import fs from 'fs';
 import path from 'path';
+import { SRC } from '../../support/source-paths';
 
 const ROOT = path.join(__dirname, '..', '..', '..');
 
 describe('admin drain-queue route (KAN-209)', () => {
-  const routePath = path.join(ROOT, 'src/app/api/convene/admin/drain-queue/route.ts');
-  const authPath = path.join(ROOT, 'src/lib/convene/auth-bearer.ts');
+  const routePath = path.join(ROOT, SRC.route);
+  const authPath = path.join(ROOT, SRC.authBearer);
 
   test('route file exists', () => {
     expect(fs.existsSync(routePath)).toBe(true);
@@ -85,7 +86,7 @@ describe('admin drain-queue route (KAN-209)', () => {
 });
 
 describe('dispatchQueuedInvites — hostUserId filter (KAN-209)', () => {
-  const dispatchPath = path.join(ROOT, 'src/lib/convene/invites/dispatch.ts');
+  const dispatchPath = path.join(ROOT, SRC.dispatch);
 
   test('accepts optional hostUserId option', () => {
     const src = fs.readFileSync(dispatchPath, 'utf8');

--- a/tests/unit/convene/gathering-ui.test.ts
+++ b/tests/unit/convene/gathering-ui.test.ts
@@ -6,14 +6,15 @@
 
 import fs from 'fs';
 import path from 'path';
+import { SRC } from '../../support/source-paths';
 
 const ROOT = path.join(__dirname, '..', '..', '..');
 
 describe('Convene gatherings UI (KAN-236)', () => {
-  const listPath = path.join(ROOT, 'src/app/dashboard/convene/gatherings/page.tsx');
-  const detailPath = path.join(ROOT, 'src/app/dashboard/convene/gatherings/[id]/page.tsx');
-  const actionsPath = path.join(ROOT, 'src/app/dashboard/convene/gatherings/[id]/actions.ts');
-  const clientPath = path.join(ROOT, 'src/app/dashboard/convene/gatherings/[id]/gathering-actions.tsx');
+  const listPath = path.join(ROOT, SRC.gatheringsPage);
+  const detailPath = path.join(ROOT, SRC.idPage);
+  const actionsPath = path.join(ROOT, SRC.idActions);
+  const clientPath = path.join(ROOT, SRC.gatheringActions);
 
   test('all four files exist', () => {
     expect(fs.existsSync(listPath)).toBe(true);

--- a/tests/unit/convene/invites-ui.test.ts
+++ b/tests/unit/convene/invites-ui.test.ts
@@ -4,9 +4,10 @@
 
 import fs from 'fs';
 import path from 'path';
+import { SRC } from '../../support/source-paths';
 
 const ROOT = path.join(__dirname, '..', '..', '..');
-const base = 'src/app/dashboard/convene/gatherings/[id]';
+const base = SRC.id;
 const actionsPath = path.join(ROOT, base, 'actions.ts');
 const islandPath = path.join(ROOT, base, 'invite-actions.tsx');
 const pagePath = path.join(ROOT, base, 'page.tsx');

--- a/tests/unit/convene/invites.test.ts
+++ b/tests/unit/convene/invites.test.ts
@@ -13,6 +13,7 @@ const ROOT = path.join(__dirname, '..', '..', '..');
 // ─── ICS builder ────────────────────────────────────────────────────────
 
 import { buildICS } from '@/lib/convene/invites/ics';
+import { SRC } from '../../support/source-paths';
 
 describe('buildICS (KAN-209)', () => {
   const base = {
@@ -180,9 +181,9 @@ describe('generateRsvpToken (KAN-209)', () => {
 // ─── /r/[token] page + form ────────────────────────────────────────────
 
 describe('RSVP UI pages (KAN-209)', () => {
-  const pagePath = path.join(ROOT, 'src/app/r/[token]/page.tsx');
-  const formPath = path.join(ROOT, 'src/app/r/[token]/rsvp-form.tsx');
-  const actionsPath = path.join(ROOT, 'src/app/r/[token]/actions.ts');
+  const pagePath = path.join(ROOT, SRC.tokenPage);
+  const formPath = path.join(ROOT, SRC.rsvpForm);
+  const actionsPath = path.join(ROOT, SRC.tokenActions);
 
   test('all three files exist', () => {
     expect(fs.existsSync(pagePath)).toBe(true);

--- a/tests/unit/convene/microsoft-calendar.test.ts
+++ b/tests/unit/convene/microsoft-calendar.test.ts
@@ -8,11 +8,12 @@
 
 import fs from 'fs';
 import path from 'path';
+import { SRC } from '../../support/source-paths';
 
 const ROOT = path.join(__dirname, '..', '..', '..');
 
 describe('microsoft/oauth.ts (KAN-211 P7)', () => {
-  const src = fs.readFileSync(path.join(ROOT, 'src/lib/convene/microsoft/oauth.ts'), 'utf8');
+  const src = fs.readFileSync(path.join(ROOT, SRC.oauth), 'utf8');
 
   test('declares the documented Microsoft Graph scopes', () => {
     expect(src).toMatch(/offline_access/);
@@ -49,7 +50,7 @@ describe('microsoft/oauth.ts (KAN-211 P7)', () => {
 });
 
 describe('microsoft.ts calendar adapter (KAN-211 P7)', () => {
-  const src = fs.readFileSync(path.join(ROOT, 'src/lib/convene/calendar/microsoft.ts'), 'utf8');
+  const src = fs.readFileSync(path.join(ROOT, SRC.microsoft), 'utf8');
 
   test('exports microsoftCalendarAdapter implementing CalendarAdapter', () => {
     expect(src).toMatch(/export const microsoftCalendarAdapter:\s*CalendarAdapter/);
@@ -87,7 +88,7 @@ describe('microsoft.ts calendar adapter (KAN-211 P7)', () => {
 
 describe('Microsoft OAuth routes (KAN-211 P7)', () => {
   test('/api/convene/oauth/microsoft/initiate route exists + gated by Convene flag', () => {
-    const p = path.join(ROOT, 'src/app/api/convene/oauth/microsoft/initiate/route.ts');
+    const p = path.join(ROOT, SRC.initiateRoute);
     expect(fs.existsSync(p)).toBe(true);
     const src = fs.readFileSync(p, 'utf8');
     expect(src).toMatch(/isConveneEnabled\(\)/);
@@ -96,7 +97,7 @@ describe('Microsoft OAuth routes (KAN-211 P7)', () => {
   });
 
   test('/api/convene/oauth/microsoft/callback exists + validates state.provider', () => {
-    const p = path.join(ROOT, 'src/app/api/convene/oauth/microsoft/callback/route.ts');
+    const p = path.join(ROOT, SRC.microsoftCallbackRoute);
     expect(fs.existsSync(p)).toBe(true);
     const src = fs.readFileSync(p, 'utf8');
     expect(src).toMatch(/stateRow\.provider !== ['"]microsoft['"]/);
@@ -107,7 +108,7 @@ describe('Microsoft OAuth routes (KAN-211 P7)', () => {
 
   test('callback consumes the state row (single-use)', () => {
     const src = fs.readFileSync(
-      path.join(ROOT, 'src/app/api/convene/oauth/microsoft/callback/route.ts'),
+      path.join(ROOT, SRC.microsoftCallbackRoute),
       'utf8'
     );
     expect(src).toMatch(/\.delete\(\)\.eq\(['"]state['"]/);
@@ -115,7 +116,7 @@ describe('Microsoft OAuth routes (KAN-211 P7)', () => {
 
   test('callback rejects when offline_access scope missing (no refresh_token)', () => {
     const src = fs.readFileSync(
-      path.join(ROOT, 'src/app/api/convene/oauth/microsoft/callback/route.ts'),
+      path.join(ROOT, SRC.microsoftCallbackRoute),
       'utf8'
     );
     expect(src).toMatch(/no_refresh_token/);
@@ -124,7 +125,7 @@ describe('Microsoft OAuth routes (KAN-211 P7)', () => {
 });
 
 describe('oauth-connections provider dispatch (KAN-211 P7)', () => {
-  const src = fs.readFileSync(path.join(ROOT, 'src/lib/convene/oauth-connections.ts'), 'utf8');
+  const src = fs.readFileSync(path.join(ROOT, SRC.oauthConnections), 'utf8');
 
   test('imports both refresh functions under aliases', () => {
     expect(src).toMatch(/refreshAccessToken as refreshGoogleAccessToken/);
@@ -141,7 +142,7 @@ describe('oauth-connections provider dispatch (KAN-211 P7)', () => {
 });
 
 describe('conveneEnv microsoft entries (KAN-211 P7)', () => {
-  const src = fs.readFileSync(path.join(ROOT, 'src/lib/convene/env.ts'), 'utf8');
+  const src = fs.readFileSync(path.join(ROOT, SRC.env), 'utf8');
   test('declares MICROSOFT_CALENDAR_CLIENT_ID/SECRET/REDIRECT_URI', () => {
     expect(src).toMatch(/MICROSOFT_CALENDAR_CLIENT_ID/);
     expect(src).toMatch(/MICROSOFT_CALENDAR_CLIENT_SECRET/);

--- a/tests/unit/convene/oauth-callback-error-masking.test.ts
+++ b/tests/unit/convene/oauth-callback-error-masking.test.ts
@@ -11,12 +11,13 @@
 
 import fs from 'fs';
 import path from 'path';
+import { SRC } from '../../support/source-paths';
 
 const ROOT = path.join(__dirname, '..', '..', '..');
 
 const callbacks = [
-  'src/app/api/convene/oauth/google/callback/route.ts',
-  'src/app/api/convene/oauth/microsoft/callback/route.ts',
+  SRC.callbackRoute,
+  SRC.microsoftCallbackRoute,
 ];
 
 describe.each(callbacks)('%s error masking', (rel) => {

--- a/tests/unit/convene/organise-ui.test.ts
+++ b/tests/unit/convene/organise-ui.test.ts
@@ -4,9 +4,10 @@
 
 import fs from 'fs';
 import path from 'path';
+import { SRC } from '../../support/source-paths';
 
 const ROOT = path.join(__dirname, '..', '..', '..');
-const base = 'src/app/dashboard/convene/organise';
+const base = SRC.organise;
 const pagePath = path.join(ROOT, base, 'page.tsx');
 const wizardPath = path.join(ROOT, base, 'organise-wizard.tsx');
 const actionsPath = path.join(ROOT, base, 'actions.ts');

--- a/tests/unit/convene/post-event.test.ts
+++ b/tests/unit/convene/post-event.test.ts
@@ -8,11 +8,12 @@
 
 import fs from 'fs';
 import path from 'path';
+import { SRC } from '../../support/source-paths';
 
 const ROOT = path.join(__dirname, '..', '..', '..');
 
 describe('post-event sweep library (KAN-212 P8)', () => {
-  const src = fs.readFileSync(path.join(ROOT, 'src/lib/convene/post-event.ts'), 'utf8');
+  const src = fs.readFileSync(path.join(ROOT, SRC.postEvent), 'utf8');
 
   test('exports runPostEventSweep + PostEventSummary type', () => {
     expect(src).toMatch(/export async function runPostEventSweep/);
@@ -59,7 +60,7 @@ describe('post-event sweep library (KAN-212 P8)', () => {
 });
 
 describe('post-event cron route (KAN-212 P8)', () => {
-  const p = path.join(ROOT, 'src/app/api/convene/cron/post-event/route.ts');
+  const p = path.join(ROOT, SRC.postEventRoute);
   test('route file exists', () => {
     expect(fs.existsSync(p)).toBe(true);
   });

--- a/tests/unit/convene/twilio-send.test.ts
+++ b/tests/unit/convene/twilio-send.test.ts
@@ -6,6 +6,7 @@ import { renderSmsBody } from '@/lib/convene/invites/sms-templates';
 import { _internal as twilioInternal } from '@/lib/convene/invites/twilio';
 import fs from 'fs';
 import path from 'path';
+import { SRC } from '../../support/source-paths';
 
 const ROOT = path.join(__dirname, '..', '..', '..');
 
@@ -78,7 +79,7 @@ describe('Twilio allowlist gate (KAN-214)', () => {
 });
 
 describe('Twilio source structure (KAN-214)', () => {
-  const src = fs.readFileSync(path.join(ROOT, 'src/lib/convene/invites/twilio.ts'), 'utf8');
+  const src = fs.readFileSync(path.join(ROOT, SRC.twilio), 'utf8');
 
   test('uses HTTP Basic auth with TWILIO_ACCOUNT_SID + TWILIO_AUTH_TOKEN', () => {
     expect(src).toMatch(/TWILIO_ACCOUNT_SID/);
@@ -115,7 +116,7 @@ describe('Twilio source structure (KAN-214)', () => {
 });
 
 describe('dispatch.ts channel routing (KAN-214)', () => {
-  const src = fs.readFileSync(path.join(ROOT, 'src/lib/convene/invites/dispatch.ts'), 'utf8');
+  const src = fs.readFileSync(path.join(ROOT, SRC.dispatch), 'utf8');
 
   test('imports twilio + sms-templates', () => {
     expect(src).toMatch(/from\s+['"]\.\/twilio['"]/);

--- a/tests/unit/conversation-starters.test.ts
+++ b/tests/unit/conversation-starters.test.ts
@@ -16,13 +16,14 @@
 
 import { readFileSync, existsSync } from 'node:fs';
 import { resolve } from 'node:path';
+import { SRC } from '../support/source-paths';
 
 const ROOT = resolve(__dirname, '../..');
 
 describe('KAN-181 conversation starters — surface-area regression guards', () => {
   test('migration file exists and creates both tables', () => {
     const src = readFileSync(
-      resolve(ROOT, 'supabase/migrations/20260516200200_conversation_starters.sql'),
+      resolve(ROOT, SRC.migrations20260516200200ConversationStarters),
       'utf-8',
     );
     expect(src).toMatch(/create table.*conversation_starter_prompts/i);
@@ -31,7 +32,7 @@ describe('KAN-181 conversation starters — surface-area regression guards', () 
 
   test('migration seeds at least 8 prompts', () => {
     const src = readFileSync(
-      resolve(ROOT, 'supabase/migrations/20260516200200_conversation_starters.sql'),
+      resolve(ROOT, SRC.migrations20260516200200ConversationStarters),
       'utf-8',
     );
     const matches = src.match(/^\s*\(['"]/gm);
@@ -43,7 +44,7 @@ describe('KAN-181 conversation starters — surface-area regression guards', () 
 
   test('migration enforces the 5-answer cap via a BEFORE INSERT trigger', () => {
     const src = readFileSync(
-      resolve(ROOT, 'supabase/migrations/20260516200200_conversation_starters.sql'),
+      resolve(ROOT, SRC.migrations20260516200200ConversationStarters),
       'utf-8',
     );
     expect(src).toMatch(/limit \(5\) reached/i);
@@ -52,7 +53,7 @@ describe('KAN-181 conversation starters — surface-area regression guards', () 
 
   test('migration enforces 500-char answer limit via CHECK', () => {
     const src = readFileSync(
-      resolve(ROOT, 'supabase/migrations/20260516200200_conversation_starters.sql'),
+      resolve(ROOT, SRC.migrations20260516200200ConversationStarters),
       'utf-8',
     );
     expect(src).toMatch(/check \(length\(answer\) <= 500/i);
@@ -60,7 +61,7 @@ describe('KAN-181 conversation starters — surface-area regression guards', () 
 
   test('migration enforces unique (profile_id, prompt_id)', () => {
     const src = readFileSync(
-      resolve(ROOT, 'supabase/migrations/20260516200200_conversation_starters.sql'),
+      resolve(ROOT, SRC.migrations20260516200200ConversationStarters),
       'utf-8',
     );
     expect(src).toMatch(/unique\s*\(\s*profile_id\s*,\s*prompt_id\s*\)/i);
@@ -68,7 +69,7 @@ describe('KAN-181 conversation starters — surface-area regression guards', () 
 
   test('server-actions file exports the three CRUD functions', () => {
     const src = readFileSync(
-      resolve(ROOT, 'src/app/dashboard/profile/conversation-starters-actions.ts'),
+      resolve(ROOT, SRC.conversationStartersActions),
       'utf-8',
     );
     expect(src).toMatch(/export\s+async\s+function\s+addConversationStarter/);
@@ -78,7 +79,7 @@ describe('KAN-181 conversation starters — surface-area regression guards', () 
 
   test('server-actions file uses sanitiseText and a 500-char cap', () => {
     const src = readFileSync(
-      resolve(ROOT, 'src/app/dashboard/profile/conversation-starters-actions.ts'),
+      resolve(ROOT, SRC.conversationStartersActions),
       'utf-8',
     );
     expect(src).toMatch(/sanitiseText/);
@@ -87,7 +88,7 @@ describe('KAN-181 conversation starters — surface-area regression guards', () 
 
   test('server-actions file surfaces the answer cap as a clean error', () => {
     const src = readFileSync(
-      resolve(ROOT, 'src/app/dashboard/profile/conversation-starters-actions.ts'),
+      resolve(ROOT, SRC.conversationStartersActions),
       'utf-8',
     );
     // KAN-404 #14: the actions file now matches the trigger message with a
@@ -106,13 +107,13 @@ describe('KAN-181 conversation starters — surface-area regression guards', () 
 
   test('wizard step component exists', () => {
     expect(existsSync(
-      resolve(ROOT, 'src/app/dashboard/profile/steps/conversation-starters-step.tsx'),
+      resolve(ROOT, SRC.conversationStartersStep),
     )).toBe(true);
   });
 
   test('public profile page references the conversation starters table', () => {
     const src = readFileSync(
-      resolve(ROOT, 'src/app/[slug]/page.tsx'),
+      resolve(ROOT, SRC.slugPage),
       'utf-8',
     );
     expect(src).toMatch(/profile_conversation_starters/);
@@ -122,7 +123,7 @@ describe('KAN-181 conversation starters — surface-area regression guards', () 
 
   test('dashboard profile page fetches conversation starter data', () => {
     const src = readFileSync(
-      resolve(ROOT, 'src/app/dashboard/profile/page.tsx'),
+      resolve(ROOT, SRC.profilePage),
       'utf-8',
     );
     expect(src).toMatch(/conversation_starter_prompts/);

--- a/tests/unit/current-problems-category.test.ts
+++ b/tests/unit/current-problems-category.test.ts
@@ -20,13 +20,14 @@
 
 import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
+import { SRC } from '../support/source-paths';
 
 const ROOT = resolve(__dirname, '../..');
 
 describe('KAN-182 current_problems category — surface-area regression guards', () => {
   test('dashboard items-step has a categoryLabel for current_problems', () => {
     const src = readFileSync(
-      resolve(ROOT, 'src/app/dashboard/profile/steps/items-step.tsx'),
+      resolve(ROOT, SRC.itemsStep),
       'utf-8',
     );
     expect(src).toMatch(/current_problems\s*:\s*['"`][^'"`]+['"`]/);
@@ -34,7 +35,7 @@ describe('KAN-182 current_problems category — surface-area regression guards',
 
   test('dashboard wizard step 9 lists current_problems', () => {
     const src = readFileSync(
-      resolve(ROOT, 'src/app/dashboard/profile/wizard.tsx'),
+      resolve(ROOT, SRC.wizard),
       'utf-8',
     );
     // The categories prop on step 9's ItemsStep — match the array entry.
@@ -43,7 +44,7 @@ describe('KAN-182 current_problems category — surface-area regression guards',
 
   test('public profile [slug]/page.tsx renders current_problems with a warm heading', () => {
     const src = readFileSync(
-      resolve(ROOT, 'src/app/[slug]/page.tsx'),
+      resolve(ROOT, SRC.slugPage),
       'utf-8',
     );
     // KAN-265 redesign: rendered via an explicit <CardSection> (grouped items +
@@ -54,7 +55,7 @@ describe('KAN-182 current_problems category — surface-area regression guards',
 
   test('migration file exists and adds the enum value', () => {
     const src = readFileSync(
-      resolve(ROOT, 'supabase/migrations/20260516160000_add_current_problems_category.sql'),
+      resolve(ROOT, SRC.migrations20260516160000AddCurrentProblemsCategory),
       'utf-8',
     );
     expect(src).toMatch(/alter type item_category add value/i);

--- a/tests/unit/dependabot-target-branch.test.js
+++ b/tests/unit/dependabot-target-branch.test.js
@@ -1,13 +1,14 @@
 const fs = require('fs');
 const path = require('path');
 const yaml = require('js-yaml');
+const { SRC } = require('../support/source-paths.json');
 
 // BUGS-79: the github-actions ecosystem block had no target-branch, so it
 // fell back to the repo default (main) — putting every weekly bump in direct
 // conflict with SEC-98 (main-chain-guard.yml blocks any PR targeting main).
 // This test is the control: it fails the build if a future ecosystem block
 // omits target-branch, so the config cannot silently drift back.
-describe('.github/dependabot.yml', () => {
+describe(SRC.dependabot, () => {
   const configPath = path.join(__dirname, '..', '..', '.github', 'dependabot.yml');
   const config = yaml.load(fs.readFileSync(configPath, 'utf8'));
 

--- a/tests/unit/doc-dod.test.js
+++ b/tests/unit/doc-dod.test.js
@@ -8,6 +8,7 @@
  */
 const fs = require('fs');
 const path = require('path');
+const { SRC } = require('../support/source-paths.json');
 
 const root = path.join(__dirname, '../..');
 const read = (p) => fs.readFileSync(path.join(root, p), 'utf8');
@@ -27,7 +28,7 @@ describe('KAN-359: Documentation Definition-of-Done is documented', () => {
   });
 
   test('PR template has the docs/system-map DoD checklist item', () => {
-    const content = read('.github/PULL_REQUEST_TEMPLATE.md');
+    const content = read(SRC.pullRequestTemplate);
     expect(content).toMatch(/Docs \/ system map updated/);
     expect(content).toContain('KAN-359');
   });

--- a/tests/unit/examples-page.test.js
+++ b/tests/unit/examples-page.test.js
@@ -9,10 +9,11 @@
 
 const fs = require('fs');
 const path = require('path');
+const { SRC } = require('../support/source-paths.json');
 
 const root = path.join(__dirname, '../..');
-const examplesPath = path.join(root, 'src/app/examples/page.tsx');
-const homepagePath = path.join(root, 'src/app/page.tsx');
+const examplesPath = path.join(root, SRC.examplesPage);
+const homepagePath = path.join(root, SRC.appPage);
 
 describe('Example profiles gallery (/examples)', () => {
   let content;

--- a/tests/unit/feature-entitlements.test.ts
+++ b/tests/unit/feature-entitlements.test.ts
@@ -3,6 +3,7 @@
  */
 import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
+import { SRC } from '../support/source-paths';
 import {
   FEATURE_KEYS,
   FEATURE_CONFIG,
@@ -61,12 +62,12 @@ describe('media_uploads gate covers BOTH upload entrypoints (KAN-309)', () => {
   // file uploader AND the avatar uploader must check it, or an admin's revoke
   // is only partially effective.
   it('uploadProfileFile gates on media_uploads', () => {
-    const src = readFileSync(resolve(ROOT, 'src/app/dashboard/profile/files-actions.ts'), 'utf-8');
+    const src = readFileSync(resolve(ROOT, SRC.filesActions), 'utf-8');
     expect(src).toMatch(/getMyFeatureEntitlements/);
     expect(src).toMatch(/media_uploads/);
   });
   it('uploadAvatar gates on media_uploads', () => {
-    const src = readFileSync(resolve(ROOT, 'src/app/dashboard/profile/actions.ts'), 'utf-8');
+    const src = readFileSync(resolve(ROOT, SRC.profileActions), 'utf-8');
     // the gate must appear inside uploadAvatar, before the storage upload
     const fn = src.slice(src.indexOf('export async function uploadAvatar'));
     const gateIdx = fn.indexOf('features.media_uploads');

--- a/tests/unit/forgot-reset-password.test.ts
+++ b/tests/unit/forgot-reset-password.test.ts
@@ -17,6 +17,7 @@
 
 import { readFileSync, existsSync } from 'node:fs';
 import { resolve } from 'node:path';
+import { SRC } from '../support/source-paths';
 
 const ROOT = resolve(__dirname, '../..');
 
@@ -220,7 +221,7 @@ describe('KAN-225: updateRecoveryPassword', () => {
 
 describe('KAN-225: surface-area regression guards', () => {
   test('forgot-password page exists in the (auth) route group', () => {
-    const p = resolve(ROOT, 'src/app/(auth)/forgot-password/page.tsx');
+    const p = resolve(ROOT, SRC.page);
     expect(existsSync(p)).toBe(true);
     const src = readFileSync(p, 'utf-8');
     expect(src).toMatch(/requestPasswordReset/);
@@ -229,7 +230,7 @@ describe('KAN-225: surface-area regression guards', () => {
   });
 
   test('reset-password page exists and guards against missing session', () => {
-    const p = resolve(ROOT, 'src/app/(auth)/reset-password/page.tsx');
+    const p = resolve(ROOT, SRC.resetPasswordPage);
     expect(existsSync(p)).toBe(true);
     const src = readFileSync(p, 'utf-8');
     expect(src).toMatch(/updateRecoveryPassword/);
@@ -245,7 +246,7 @@ describe('KAN-225: surface-area regression guards', () => {
     // and /reset-password routes remain in place but unlinked, pending a
     // follow-up that removes the vestigial password-reset flow.
     const src = readFileSync(
-      resolve(ROOT, 'src/app/(auth)/login/page.tsx'),
+      resolve(ROOT, SRC.loginPage),
       'utf-8',
     );
     expect(src).not.toMatch(/name=["']password["']/);
@@ -255,7 +256,7 @@ describe('KAN-225: surface-area regression guards', () => {
 
   test('login page surfaces the post-reset success message', () => {
     const src = readFileSync(
-      resolve(ROOT, 'src/app/(auth)/login/page.tsx'),
+      resolve(ROOT, SRC.loginPage),
       'utf-8',
     );
     expect(src).toMatch(/params\.message/);
@@ -263,7 +264,7 @@ describe('KAN-225: surface-area regression guards', () => {
 
   test('auth/callback continues to handle the `next` query param (recovery redirect)', () => {
     const src = readFileSync(
-      resolve(ROOT, 'src/app/auth/callback/route.ts'),
+      resolve(ROOT, SRC.authCallbackRoute),
       'utf-8',
     );
     // The recovery flow piggybacks on the existing callback behaviour:
@@ -276,7 +277,7 @@ describe('KAN-225: surface-area regression guards', () => {
 
   test('actions.ts exports both recovery actions', () => {
     const src = readFileSync(
-      resolve(ROOT, 'src/app/(auth)/actions.ts'),
+      resolve(ROOT, SRC.actions),
       'utf-8',
     );
     expect(src).toMatch(/export async function requestPasswordReset/);
@@ -285,7 +286,7 @@ describe('KAN-225: surface-area regression guards', () => {
 
   test('actions.ts uses Supabase-side rate limiting (no custom token table)', () => {
     const src = readFileSync(
-      resolve(ROOT, 'src/app/(auth)/actions.ts'),
+      resolve(ROOT, SRC.actions),
       'utf-8',
     );
     // Critical: we lean on Supabase Auth for the email + token lifecycle.

--- a/tests/unit/gdpr-settings.test.js
+++ b/tests/unit/gdpr-settings.test.js
@@ -5,10 +5,11 @@
 
 const fs = require('fs');
 const path = require('path');
+const { SRC } = require('../support/source-paths.json');
 
 const root = path.join(__dirname, '../..');
-const actionsPath = path.join(root, 'src/app/dashboard/settings/actions.ts');
-const clientPath = path.join(root, 'src/app/dashboard/settings/settings-client.tsx');
+const actionsPath = path.join(root, SRC.settingsActions);
+const clientPath = path.join(root, SRC.settingsClient);
 
 describe('KAN-140: Data export action', () => {
   let content;

--- a/tests/unit/gdpr.test.js
+++ b/tests/unit/gdpr.test.js
@@ -5,20 +5,21 @@
 
 const fs = require('fs');
 const path = require('path');
+const { SRC } = require('../support/source-paths.json');
 
 const root = path.join(__dirname, '../..');
 
 describe('GDPR Compliance', () => {
   test('privacy policy page exists', () => {
-    expect(fs.existsSync(path.join(root, 'src/app/(legal)/privacy/page.tsx'))).toBe(true);
+    expect(fs.existsSync(path.join(root, SRC.privacyPage))).toBe(true);
   });
 
   test('terms of service page exists', () => {
-    expect(fs.existsSync(path.join(root, 'src/app/(legal)/terms/page.tsx'))).toBe(true);
+    expect(fs.existsSync(path.join(root, SRC.termsPage))).toBe(true);
   });
 
   test('privacy policy covers required GDPR sections', () => {
-    const content = fs.readFileSync(path.join(root, 'src/app/(legal)/privacy/page.tsx'), 'utf8');
+    const content = fs.readFileSync(path.join(root, SRC.privacyPage), 'utf8');
     expect(content).toContain('What data we collect');
     expect(content).toContain('Your rights');
     expect(content).toContain('Data retention');
@@ -27,21 +28,21 @@ describe('GDPR Compliance', () => {
   });
 
   test('cookie consent component exists', () => {
-    expect(fs.existsSync(path.join(root, 'src/app/cookie-consent.tsx'))).toBe(true);
-    const content = fs.readFileSync(path.join(root, 'src/app/cookie-consent.tsx'), 'utf8');
+    expect(fs.existsSync(path.join(root, SRC.cookieConsent))).toBe(true);
+    const content = fs.readFileSync(path.join(root, SRC.cookieConsent), 'utf8');
     expect(content).toContain('Essential only');
     expect(content).toContain('Accept all');
     expect(content).toContain('lyra-cookie-consent');
   });
 
   test('cookie consent is included in root layout', () => {
-    const content = fs.readFileSync(path.join(root, 'src/app/layout.tsx'), 'utf8');
+    const content = fs.readFileSync(path.join(root, SRC.layout), 'utf8');
     expect(content).toContain('CookieConsent');
   });
 
   test('account settings page exists with data export and deletion', () => {
-    expect(fs.existsSync(path.join(root, 'src/app/dashboard/settings/page.tsx'))).toBe(true);
-    const actions = fs.readFileSync(path.join(root, 'src/app/dashboard/settings/actions.ts'), 'utf8');
+    expect(fs.existsSync(path.join(root, SRC.settingsPage))).toBe(true);
+    const actions = fs.readFileSync(path.join(root, SRC.settingsActions), 'utf8');
     expect(actions).toContain('exportUserData');
     expect(actions).toContain('deleteAccount');
   });
@@ -51,7 +52,7 @@ describe('GDPR Compliance', () => {
     // client component so one 18+ tick could gate both the email and Google
     // paths. Same assertions, new file.
     const content = fs.readFileSync(
-      path.join(root, 'src/app/(auth)/signup/signup-form.tsx'),
+      path.join(root, SRC.signupForm),
       'utf8',
     );
     expect(content).toContain('consent');
@@ -63,7 +64,7 @@ describe('GDPR Compliance', () => {
     // KAN-407: Lyra is 18+. The tick must gate the Google button too — gating
     // only the email form would leave OAuth as an undeclared signup route.
     const content = fs.readFileSync(
-      path.join(root, 'src/app/(auth)/signup/signup-form.tsx'),
+      path.join(root, SRC.signupForm),
       'utf8',
     );
     expect(content).toContain('18 or over');
@@ -75,13 +76,13 @@ describe('GDPR Compliance', () => {
   test('site-wide footer includes privacy and terms links', () => {
     // KAN-272: the legal footer links moved off page.tsx into the shared
     // <Footer/> rendered in the root layout, so they appear on every page.
-    const content = fs.readFileSync(path.join(root, 'src/app/footer.tsx'), 'utf8');
+    const content = fs.readFileSync(path.join(root, SRC.footer), 'utf8');
     expect(content).toContain('/privacy');
     expect(content).toContain('/terms');
   });
 
   test('dashboard includes settings link', () => {
-    const content = fs.readFileSync(path.join(root, 'src/app/dashboard/page.tsx'), 'utf8');
+    const content = fs.readFileSync(path.join(root, SRC.dashboardPage), 'utf8');
     expect(content).toContain('/dashboard/settings');
   });
 });

--- a/tests/unit/global-enforcement.test.ts
+++ b/tests/unit/global-enforcement.test.ts
@@ -11,6 +11,7 @@ jest.mock('@/lib/features/global-switches-service', () => ({
 }));
 
 import { isPaidLinksAllowedForRecipient } from '@/lib/features/entitlements-service';
+import { SRC } from '../support/source-paths';
 
 describe('paid referrals — global switch enforcement (KAN-408)', () => {
   const OLD = process.env.PAID_LINKS_COMPLIANCE_READY;
@@ -39,22 +40,22 @@ describe('enforcement wiring is present at each gate (KAN-408)', () => {
   const read = (p: string) => readFileSync(resolve(__dirname, '../../', p), 'utf-8');
 
   it('age: BOTH web publish paths gate on the provider age check (global switch)', () => {
-    const actions = read('src/app/dashboard/profile/actions.ts');
+    const actions = read(SRC.profileActions);
     expect(
       (actions.match(/isProviderAgeCheckActive\(\)/g) || []).length,
     ).toBeGreaterThanOrEqual(2);
     // and the provider gate itself is keyed on the age_verification global switch
-    const gate = read('src/lib/age/provider-gate.ts');
+    const gate = read(SRC.providerGate);
     expect(gate).toMatch(/isFeatureGloballyEnabled\('age_verification'\)/);
   });
 
   it('paid: the recipient gate ANDs the global paid_gift_links switch', () => {
-    const svc = read('src/lib/features/entitlements-service.ts');
+    const svc = read(SRC.entitlementsService);
     expect(svc).toMatch(/isFeatureGloballyEnabled\('paid_gift_links'\)/);
   });
 
   it('mcp: API-key generation gates on the global mcp switch', () => {
-    const settings = read('src/app/dashboard/settings/actions.ts');
+    const settings = read(SRC.settingsActions);
     expect(settings).toMatch(/isFeatureGloballyEnabled\('mcp'\)/);
   });
 });

--- a/tests/unit/homepage-content.test.js
+++ b/tests/unit/homepage-content.test.js
@@ -13,11 +13,12 @@
 
 const fs = require('fs');
 const path = require('path');
+const { SRC } = require('../support/source-paths.json');
 
 const root = path.join(__dirname, '../..');
-const homepagePath = path.join(root, 'src/app/page.tsx');
-const marketingPath = path.join(root, 'src/app/_marketing/sections.tsx');
-const aboutPath = path.join(root, 'src/app/(legal)/about/page.tsx');
+const homepagePath = path.join(root, SRC.appPage);
+const marketingPath = path.join(root, SRC.sections);
+const aboutPath = path.join(root, SRC.aboutPage);
 
 describe('KAN-272: Minimal homepage (June-2026 redesign)', () => {
   let content;
@@ -182,7 +183,7 @@ describe('KAN-272: About page hosts the moved trio', () => {
 describe('KAN-273/287: Production waitlist front door', () => {
   let home;
   let signup;
-  const signupPath = path.join(root, 'src/app/(auth)/signup/page.tsx');
+  const signupPath = path.join(root, SRC.signupPage);
 
   beforeAll(() => {
     home = fs.readFileSync(homepagePath, 'utf8');

--- a/tests/unit/inline-item-edit.test.ts
+++ b/tests/unit/inline-item-edit.test.ts
@@ -10,9 +10,10 @@
 
 import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
+import { SRC } from '../support/source-paths';
 
 const ROOT = resolve(__dirname, '../..');
-const PROFILE = resolve(ROOT, 'src/app/dashboard/profile');
+const PROFILE = resolve(ROOT, SRC.profile);
 
 describe('KAN-404 (#12): ItemsStep inline edit', () => {
   const src = readFileSync(resolve(PROFILE, 'steps/items-step.tsx'), 'utf-8');

--- a/tests/unit/kan342-gift-visibility.test.ts
+++ b/tests/unit/kan342-gift-visibility.test.ts
@@ -11,30 +11,31 @@
  */
 import fs from 'fs';
 import path from 'path';
+import { SRC } from '../support/source-paths';
 
 const ROOT = path.join(__dirname, '..', '..');
 const read = (p: string) => fs.readFileSync(path.join(ROOT, p), 'utf8');
 
 describe('KAN-342 gift visibility is not gated by paid_gift_links', () => {
   it('the public profile renders the recommendations section with no paid_gift_links visibility gate', () => {
-    const page = read('src/app/[slug]/page.tsx');
+    const page = read(SRC.slugPage);
     expect(page).toMatch(/RecommendationsSection/);
     // Visibility must not reference the monetisation entitlement.
     expect(page).not.toMatch(/paid_gift_links/);
   });
 
   it('paid_gift_links is consumed only by the monetisation gate, not visibility', () => {
-    const svc = read('src/lib/features/entitlements-service.ts');
+    const svc = read(SRC.entitlementsService);
     expect(svc).toMatch(/isPaidLinksAllowedForRecipient/);
     // The v2 pipeline always runs; the entitlement only decides monetisation.
-    const pipeline = read('src/lib/recommender/v2/pipeline.ts');
+    const pipeline = read(SRC.pipeline);
     expect(pipeline).toMatch(/isPaidLinksAllowedForRecipient/);
     expect(pipeline).toMatch(/monetised/);
   });
 
   it('the dashboard add-gifts widget (W3) does not require an entitlement', () => {
     // W3 is emitted in published_activate purely on "has no gifts" — no entitlement gate.
-    const resolver = read('src/lib/dashboard/resolve-widgets.ts');
+    const resolver = read(SRC.resolveWidgets);
     expect(resolver).toMatch(/if \(!input\.hasGifts\) candidates\.push\('add_gifts'\)/);
     expect(resolver).not.toMatch(/paid_gift_links/);
   });

--- a/tests/unit/kan351-public-profile-data-integrity.test.ts
+++ b/tests/unit/kan351-public-profile-data-integrity.test.ts
@@ -18,9 +18,10 @@
  */
 import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
+import { SRC } from '../support/source-paths';
 
 const ROOT = resolve(__dirname, '../..');
-const PAGE = 'src/app/[slug]/page.tsx';
+const PAGE = SRC.slugPage;
 
 describe('KAN-351: public profile reads are batched and errors surfaced', () => {
   const src = readFileSync(resolve(ROOT, PAGE), 'utf8');

--- a/tests/unit/legal-pages.test.js
+++ b/tests/unit/legal-pages.test.js
@@ -5,11 +5,12 @@
 
 const fs = require('fs');
 const path = require('path');
+const { SRC } = require('../support/source-paths.json');
 
 const root = path.join(__dirname, '../..');
 
 describe('KAN-126: Privacy policy page', () => {
-  const filePath = path.join(root, 'src/app/(legal)/privacy/page.tsx');
+  const filePath = path.join(root, SRC.privacyPage);
   let content;
 
   beforeAll(() => {
@@ -71,7 +72,7 @@ describe('KAN-126: Privacy policy page', () => {
 });
 
 describe('KAN-126: Terms of service page', () => {
-  const filePath = path.join(root, 'src/app/(legal)/terms/page.tsx');
+  const filePath = path.join(root, SRC.termsPage);
   let content;
 
   beforeAll(() => {
@@ -125,7 +126,7 @@ describe('KAN-272: Site-wide footer links (moved from homepage to the shared Foo
   // <Footer/> rendered in the root layout, so they appear on EVERY page (the
   // Companies Act company line needs to be everywhere). Assert the shared
   // footer carries the legal routes.
-  const filePath = path.join(root, 'src/app/footer.tsx');
+  const filePath = path.join(root, SRC.footer);
   let content;
 
   beforeAll(() => {
@@ -154,13 +155,13 @@ describe('KAN-272: Site-wide footer links (moved from homepage to the shared Foo
   });
 
   test('footer is rendered in the root layout (so it is site-wide)', () => {
-    const layout = fs.readFileSync(path.join(root, 'src/app/layout.tsx'), 'utf8');
+    const layout = fs.readFileSync(path.join(root, SRC.layout), 'utf8');
     expect(layout).toContain('<Footer');
   });
 });
 
 describe('KAN-144: Cookie policy page', () => {
-  const filePath = path.join(root, 'src/app/(legal)/cookies/page.tsx');
+  const filePath = path.join(root, SRC.cookiesPage);
   let content;
 
   beforeAll(() => {

--- a/tests/unit/maintenance-page.test.js
+++ b/tests/unit/maintenance-page.test.js
@@ -5,6 +5,7 @@
  * Tests the validation and rate-limiting logic extracted from the Worker.
  * The actual Worker runs on Cloudflare, but we test the core logic here.
  */
+const { SRC } = require('../support/source-paths.json');
 
 // Extract validation logic from Worker for testing
 function isValidEmail(email) {
@@ -99,7 +100,7 @@ describe('KAN-129: Worker code file integrity', () => {
   const fs = require('fs');
   const path = require('path');
   const root = path.join(__dirname, '../..');
-  const workerPath = path.join(root, 'scripts/lyra-maintenance-worker.js');
+  const workerPath = path.join(root, SRC.lyraMaintenanceWorker);
 
   test('worker script file exists', () => {
     expect(fs.existsSync(workerPath)).toBe(true);

--- a/tests/unit/mcp-discoverability.test.js
+++ b/tests/unit/mcp-discoverability.test.js
@@ -5,12 +5,13 @@
 
 const fs = require('fs');
 const path = require('path');
+const { SRC } = require('../support/source-paths.json');
 
 const root = path.join(__dirname, '../..');
 
 describe('MCP Discoverability', () => {
   test('llms.txt exists in public directory', () => {
-    const llmsTxt = fs.readFileSync(path.join(root, 'public/llms.txt'), 'utf8');
+    const llmsTxt = fs.readFileSync(path.join(root, SRC.llms), 'utf8');
     expect(llmsTxt).toContain('# Lyra');
     expect(llmsTxt).toContain('MCP');
     expect(llmsTxt).toContain('lyra_search_profiles');
@@ -19,7 +20,7 @@ describe('MCP Discoverability', () => {
   });
 
   test('llms.txt follows spec format (H1, blockquote, sections)', () => {
-    const llmsTxt = fs.readFileSync(path.join(root, 'public/llms.txt'), 'utf8');
+    const llmsTxt = fs.readFileSync(path.join(root, SRC.llms), 'utf8');
     const lines = llmsTxt.split('\n');
     expect(lines[0]).toBe('# Lyra');
     expect(llmsTxt).toContain('> ');
@@ -27,7 +28,7 @@ describe('MCP Discoverability', () => {
   });
 
   test('.well-known/mcp.json exists with valid structure', () => {
-    const mcpJson = JSON.parse(fs.readFileSync(path.join(root, 'public/.well-known/mcp.json'), 'utf8'));
+    const mcpJson = JSON.parse(fs.readFileSync(path.join(root, SRC.mcp), 'utf8'));
     expect(mcpJson.name).toBe('Lyra');
     expect(mcpJson.mcp).toBeDefined();
     expect(mcpJson.mcp.transport).toBe('streamable-http');
@@ -36,7 +37,7 @@ describe('MCP Discoverability', () => {
   });
 
   test('public profile page includes JSON-LD structured data', () => {
-    const profilePage = fs.readFileSync(path.join(root, 'src/app/[slug]/page.tsx'), 'utf8');
+    const profilePage = fs.readFileSync(path.join(root, SRC.slugPage), 'utf8');
     expect(profilePage).toContain('application/ld+json');
     expect(profilePage).toContain('@context');
     expect(profilePage).toContain('schema.org');
@@ -44,7 +45,7 @@ describe('MCP Discoverability', () => {
   });
 
   test('landing page includes JSON-LD structured data', () => {
-    const homePage = fs.readFileSync(path.join(root, 'src/app/page.tsx'), 'utf8');
+    const homePage = fs.readFileSync(path.join(root, SRC.appPage), 'utf8');
     expect(homePage).toContain('application/ld+json');
     expect(homePage).toContain('WebSite');
     expect(homePage).toContain('checklyra.com');

--- a/tests/unit/moderation-actions.test.ts
+++ b/tests/unit/moderation-actions.test.ts
@@ -12,6 +12,7 @@
 
 import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
+import { SRC } from '../support/source-paths';
 
 const ROOT = resolve(__dirname, '../..');
 
@@ -360,7 +361,7 @@ describe('KAN-241: conversation starter moderation', () => {
 
 describe('KAN-241: surface-area regression guards', () => {
   test('moderation-policy module exists with checkModeration export', () => {
-    const src = readFileSync(resolve(ROOT, 'src/lib/moderation-policy.ts'), 'utf-8');
+    const src = readFileSync(resolve(ROOT, SRC.moderationPolicy), 'utf-8');
     expect(src).toMatch(/export function checkModeration/);
     expect(src).toMatch(/moderateContent/); // pulls from content-moderation
   });
@@ -370,7 +371,7 @@ describe('KAN-241: surface-area regression guards', () => {
   // row). The guards accept either entry point — the original intent
   // ("moderation is wired in this file") is preserved.
   test('actions.ts imports + calls moderation (checkModeration or moderateAndAudit)', () => {
-    const src = readFileSync(resolve(ROOT, 'src/app/dashboard/profile/actions.ts'), 'utf-8');
+    const src = readFileSync(resolve(ROOT, SRC.profileActions), 'utf-8');
     expect(src).toMatch(/import\s*\{\s*(?:checkModeration|moderateAndAudit)\s*\}\s*from\s*['"]@\/lib\/moderation-(?:policy|audit)['"]/);
     // Used in at least 4 places (updateProfileFields, addProfileItem,
     // addSchoolAffiliation, addExternalLink)
@@ -379,13 +380,13 @@ describe('KAN-241: surface-area regression guards', () => {
   });
 
   test('manual-of-me-actions.ts imports + calls moderation', () => {
-    const src = readFileSync(resolve(ROOT, 'src/app/dashboard/profile/manual-of-me-actions.ts'), 'utf-8');
+    const src = readFileSync(resolve(ROOT, SRC.manualOfMeActions), 'utf-8');
     expect(src).toMatch(/import\s*\{\s*(?:checkModeration|moderateAndAudit)\s*\}\s*from\s*['"]@\/lib\/moderation-(?:policy|audit)['"]/);
     expect(src).toMatch(/(?:checkModeration|moderateAndAudit)\(/);
   });
 
   test('conversation-starters-actions.ts imports + calls moderation in both add + update', () => {
-    const src = readFileSync(resolve(ROOT, 'src/app/dashboard/profile/conversation-starters-actions.ts'), 'utf-8');
+    const src = readFileSync(resolve(ROOT, SRC.conversationStartersActions), 'utf-8');
     expect(src).toMatch(/import\s*\{\s*(?:checkModeration|moderateAndAudit)\s*\}\s*from\s*['"]@\/lib\/moderation-(?:policy|audit)['"]/);
     // One call in add path, one in update path
     const callCount = (src.match(/(?:checkModeration|moderateAndAudit)\(/g) || []).length;
@@ -393,7 +394,7 @@ describe('KAN-241: surface-area regression guards', () => {
   });
 
   test('moderation-policy.ts is NOT a use-server file (BUGS-12 safe)', () => {
-    const src = readFileSync(resolve(ROOT, 'src/lib/moderation-policy.ts'), 'utf-8');
+    const src = readFileSync(resolve(ROOT, SRC.moderationPolicy), 'utf-8');
     expect(src).not.toMatch(/^['"]use server['"]/m);
   });
 });

--- a/tests/unit/oauth/consent-account-banner.test.ts
+++ b/tests/unit/oauth/consent-account-banner.test.ts
@@ -11,11 +11,12 @@
  */
 import fs from 'fs';
 import path from 'path';
+import { SRC } from '../../support/source-paths';
 
 const ROOT = path.join(__dirname, '..', '..', '..');
 
 describe('Account banner on /oauth/authorize page (KAN-88)', () => {
-  const src = fs.readFileSync(path.join(ROOT, 'src/app/oauth/authorize/page.tsx'), 'utf8');
+  const src = fs.readFileSync(path.join(ROOT, SRC.authorizePage), 'utf8');
 
   test("the prominent 'granting access as <email>' line exists", () => {
     expect(src).toMatch(/You will be granting access as/);
@@ -51,7 +52,7 @@ describe('Account banner on /oauth/authorize page (KAN-88)', () => {
 });
 
 describe('switchAccountAndContinue server action (KAN-88)', () => {
-  const src = fs.readFileSync(path.join(ROOT, 'src/app/oauth/authorize/actions.ts'), 'utf8');
+  const src = fs.readFileSync(path.join(ROOT, SRC.authorizeActions), 'utf8');
 
   test('is an exported async function (use-server safe)', () => {
     expect(src).toMatch(/export async function switchAccountAndContinue/);

--- a/tests/unit/oauth/dcr-anti-phishing.test.ts
+++ b/tests/unit/oauth/dcr-anti-phishing.test.ts
@@ -8,11 +8,12 @@
  */
 import fs from 'fs';
 import path from 'path';
+import { SRC } from '../../support/source-paths';
 
 const ROOT = path.join(__dirname, '..', '..', '..');
 
 describe('consent screen wires the trust surface (SEC-76 web-oauth-7)', () => {
-  const src = fs.readFileSync(path.join(ROOT, 'src/app/oauth/authorize/page.tsx'), 'utf8');
+  const src = fs.readFileSync(path.join(ROOT, SRC.authorizePage), 'utf8');
 
   test('imports clientTrust + redirectHost from the helper module', () => {
     expect(src).toMatch(
@@ -45,7 +46,7 @@ describe('consent screen wires the trust surface (SEC-76 web-oauth-7)', () => {
 });
 
 describe('oauth_clients repository treats DCR clients as unverified (SEC-76)', () => {
-  const src = fs.readFileSync(path.join(ROOT, 'src/lib/oauth/clients.ts'), 'utf8');
+  const src = fs.readFileSync(path.join(ROOT, SRC.clients), 'utf8');
 
   test('DCR insert explicitly sets is_first_party: false', () => {
     expect(src).toMatch(/is_first_party:\s*false/);
@@ -62,7 +63,7 @@ describe('oauth_clients repository treats DCR clients as unverified (SEC-76)', (
 
 describe('migration adds the is_first_party column (SEC-76)', () => {
   const mig = fs.readFileSync(
-    path.join(ROOT, 'supabase/migrations/20260707193000_sec76_oauth_clients_is_first_party.sql'),
+    path.join(ROOT, SRC.migrations20260707193000Sec76OauthClientsIsFirstParty),
     'utf8'
   );
 

--- a/tests/unit/oauth/revoke-route.test.ts
+++ b/tests/unit/oauth/revoke-route.test.ts
@@ -22,6 +22,7 @@ jest.mock('@/lib/oauth/access-tokens', () => ({
 }));
 
 import { POST } from '@/app/oauth/revoke/route';
+import { SRC } from '../../support/source-paths';
 
 function form(body: Record<string, string>): Request {
   return new Request('https://dev.checklyra.com/oauth/revoke', {
@@ -86,7 +87,7 @@ describe('POST /oauth/revoke (KAN-88 P6, RFC 7009)', () => {
 });
 
 describe('revoke route source structure (KAN-88 P6)', () => {
-  const src = fs.readFileSync(path.join(ROOT, 'src/app/oauth/revoke/route.ts'), 'utf8');
+  const src = fs.readFileSync(path.join(ROOT, SRC.revokeRoute), 'utf8');
 
   test('calls revokeFamily for refresh tokens (not just markUsed)', () => {
     expect(src).toMatch(/revokeFamily\(/);

--- a/tests/unit/partial-write-safety.test.ts
+++ b/tests/unit/partial-write-safety.test.ts
@@ -43,10 +43,11 @@ import { resolve, join } from 'node:path';
 
 import { MANUAL_OF_ME_FIELDS } from '@/app/dashboard/profile/manual-of-me-fields';
 import { ALLOWED_PROFILE_FIELDS } from '@/app/dashboard/profile/profile-fields';
+import { SRC } from '../support/source-paths';
 
 const REPO_ROOT = resolve(__dirname, '../..');
 const SRC_ROOT = join(REPO_ROOT, 'src');
-const MIGRATIONS_ROOT = join(REPO_ROOT, 'supabase/migrations');
+const MIGRATIONS_ROOT = join(REPO_ROOT, SRC.migrations);
 
 // ---------------------------------------------------------------------------
 // Registry — 1-1 "form-backed" tables whose allowlist IS the complete set of
@@ -259,9 +260,9 @@ describe('form-backed tables: every reader loads the full field set', () => {
     // them, coverage above is meaningless.
     expect(files).toEqual(
       expect.arrayContaining([
-        'src/app/dashboard/profile/page.tsx',
-        'src/app/[slug]/page.tsx',
-        'src/app/dashboard/profile/legacy/page.tsx',
+        SRC.profilePage,
+        SRC.slugPage,
+        SRC.legacyPage,
       ]),
     );
   });

--- a/tests/unit/partners-page.test.js
+++ b/tests/unit/partners-page.test.js
@@ -9,11 +9,12 @@
 
 const fs = require('fs');
 const path = require('path');
+const { SRC } = require('../support/source-paths.json');
 
 const root = path.join(__dirname, '../..');
 
 describe('KAN-184: Partners page', () => {
-  const filePath = path.join(root, 'src/app/(legal)/partners/page.tsx');
+  const filePath = path.join(root, SRC.partnersPage);
   let content;
 
   beforeAll(() => {
@@ -68,7 +69,7 @@ describe('KAN-184: Partners link in the site-wide footer', () => {
   // verification requirement is unchanged — Partners must stay reachable from
   // the footer alongside the legal links — so the assertion just moves to the
   // footer component.
-  const filePath = path.join(root, 'src/app/footer.tsx');
+  const filePath = path.join(root, SRC.footer);
   let content;
 
   beforeAll(() => {

--- a/tests/unit/phase3-ui-integration.test.ts
+++ b/tests/unit/phase3-ui-integration.test.ts
@@ -22,6 +22,7 @@
 
 import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
+import { SRC } from '../support/source-paths';
 
 const ROOT = resolve(__dirname, '../..');
 
@@ -192,7 +193,7 @@ describe('KAN-234: updateProfileItemVisibility writes NULL for inherit', () => {
 describe('KAN-234: surface-area regression guards', () => {
   test('items-step.tsx has the "Use section default" option (empty value)', () => {
     const src = readFileSync(
-      resolve(ROOT, 'src/app/dashboard/profile/steps/items-step.tsx'),
+      resolve(ROOT, SRC.itemsStep),
       'utf-8',
     );
     // The option's value is the empty string — distinctive label too.
@@ -203,7 +204,7 @@ describe('KAN-234: surface-area regression guards', () => {
 
   test('items-step.tsx handles null/undefined item.visibility in the per-item selector', () => {
     const src = readFileSync(
-      resolve(ROOT, 'src/app/dashboard/profile/steps/items-step.tsx'),
+      resolve(ROOT, SRC.itemsStep),
       'utf-8',
     );
     // The select value derives '' from a null/undefined item.visibility.
@@ -212,7 +213,7 @@ describe('KAN-234: surface-area regression guards', () => {
 
   test('WizardProfile and WizardItem types declare section_visibility / nullable visibility', () => {
     const src = readFileSync(
-      resolve(ROOT, 'src/app/dashboard/profile/steps/types.tsx'),
+      resolve(ROOT, SRC.types),
       'utf-8',
     );
     expect(src).toMatch(/section_visibility:\s*Record<string,\s*string>\s*\|\s*null/);
@@ -222,7 +223,7 @@ describe('KAN-234: surface-area regression guards', () => {
 
   test('KAN-266: redesigned editor drops per-section visibility selects (profile is simply public)', () => {
     const src = readFileSync(
-      resolve(ROOT, 'src/app/dashboard/profile/edit-profile-form.tsx'),
+      resolve(ROOT, SRC.editProfileForm),
       'utf-8',
     );
     // The June-2026 redesign removed the section-header visibility toggles.
@@ -240,7 +241,7 @@ describe('KAN-234: surface-area regression guards', () => {
 
   test('[slug]/page.tsx uses the hybrid filter (isItemVisibleUnderHybridModel)', () => {
     const src = readFileSync(
-      resolve(ROOT, 'src/app/[slug]/page.tsx'),
+      resolve(ROOT, SRC.slugPage),
       'utf-8',
     );
     expect(src).toMatch(/isItemVisibleUnderHybridModel/);
@@ -253,7 +254,7 @@ describe('KAN-234: surface-area regression guards', () => {
 
   test('[slug]/page.tsx removes the .in("visibility", [...]) query filter (hybrid model needs NULL rows too)', () => {
     const src = readFileSync(
-      resolve(ROOT, 'src/app/[slug]/page.tsx'),
+      resolve(ROOT, SRC.slugPage),
       'utf-8',
     );
     // The previous query had `.in('visibility', allowedVisibility)` — that

--- a/tests/unit/photo-upload.test.js
+++ b/tests/unit/photo-upload.test.js
@@ -5,11 +5,12 @@
 
 const fs = require('fs');
 const path = require('path');
+const { SRC } = require('../support/source-paths.json');
 
 const root = path.join(__dirname, '../..');
 
 describe('KAN-135: Upload action exists with validation', () => {
-  const actionsPath = path.join(root, 'src/app/dashboard/profile/actions.ts');
+  const actionsPath = path.join(root, SRC.profileActions);
   let content;
 
   beforeAll(() => {
@@ -49,7 +50,7 @@ describe('KAN-135: Upload action exists with validation', () => {
 });
 
 describe('KAN-135: WizardProfile includes avatar_url', () => {
-  const typesPath = path.join(root, 'src/app/dashboard/profile/steps/types.tsx');
+  const typesPath = path.join(root, SRC.types);
   let content;
 
   beforeAll(() => {
@@ -62,7 +63,7 @@ describe('KAN-135: WizardProfile includes avatar_url', () => {
 });
 
 describe('KAN-135: Identity step has photo upload UI', () => {
-  const identityPath = path.join(root, 'src/app/dashboard/profile/steps/identity-step.tsx');
+  const identityPath = path.join(root, SRC.identityStep);
   let content;
 
   beforeAll(() => {
@@ -95,7 +96,7 @@ describe('KAN-135: Identity step has photo upload UI', () => {
 });
 
 describe('KAN-135: Public profile shows avatar', () => {
-  const profilePath = path.join(root, 'src/app/[slug]/page.tsx');
+  const profilePath = path.join(root, SRC.slugPage);
   let content;
 
   beforeAll(() => {
@@ -113,7 +114,7 @@ describe('KAN-135: Public profile shows avatar', () => {
 });
 
 describe('KAN-135: Search page shows avatar in cards', () => {
-  const searchPath = path.join(root, 'src/app/search/page.tsx');
+  const searchPath = path.join(root, SRC.searchPage);
   let content;
 
   beforeAll(() => {
@@ -137,7 +138,7 @@ describe('KAN-135: Search page shows avatar in cards', () => {
 
 describe('KAN-135: Migration file exists', () => {
   test('migration SQL file is present', () => {
-    const migrationPath = path.join(root, 'supabase/migrations/20260330120000_add_avatar_url_and_storage.sql');
+    const migrationPath = path.join(root, SRC.migrations20260330120000AddAvatarUrlAndStorage);
     expect(fs.existsSync(migrationPath)).toBe(true);
     const content = fs.readFileSync(migrationPath, 'utf8');
     expect(content).toContain('avatar_url');

--- a/tests/unit/privacy-affiliate-disclosure.test.js
+++ b/tests/unit/privacy-affiliate-disclosure.test.js
@@ -10,11 +10,12 @@
 
 const fs = require('fs');
 const path = require('path');
+const { SRC } = require('../support/source-paths.json');
 
 const root = path.join(__dirname, '../..');
 
 describe('KAN-193: privacy policy — Affiliate partners section', () => {
-  const filePath = path.join(root, 'src/app/(legal)/privacy/page.tsx');
+  const filePath = path.join(root, SRC.privacyPage);
   let content;
 
   beforeAll(() => {
@@ -77,7 +78,7 @@ describe('KAN-193: privacy policy — Affiliate partners section', () => {
 });
 
 describe('KAN-193: cookie policy — Affiliate links section', () => {
-  const filePath = path.join(root, 'src/app/(legal)/cookies/page.tsx');
+  const filePath = path.join(root, SRC.cookiesPage);
   let content;
 
   beforeAll(() => {
@@ -151,8 +152,8 @@ describe('KAN-193: cookie audit doc', () => {
   });
 
   test('points at the public-facing pages for the human-readable disclosure', () => {
-    expect(content).toContain('src/app/(legal)/cookies/page.tsx');
-    expect(content).toContain('src/app/(legal)/privacy/page.tsx');
-    expect(content).toContain('src/app/(legal)/partners/page.tsx');
+    expect(content).toContain(SRC.cookiesPage);
+    expect(content).toContain(SRC.privacyPage);
+    expect(content).toContain(SRC.partnersPage);
   });
 });

--- a/tests/unit/privacy-complaints.test.js
+++ b/tests/unit/privacy-complaints.test.js
@@ -11,11 +11,12 @@
 
 const fs = require('fs');
 const path = require('path');
+const { SRC } = require('../support/source-paths.json');
 
 const root = path.join(__dirname, '../..');
-const privacyPath = path.join(root, 'src/app/(legal)/privacy/page.tsx');
-const complaintsPath = path.join(root, 'src/app/(legal)/complaints/page.tsx');
-const footerPath = path.join(root, 'src/app/footer.tsx');
+const privacyPath = path.join(root, SRC.privacyPage);
+const complaintsPath = path.join(root, SRC.complaintsPage);
+const footerPath = path.join(root, SRC.footer);
 
 describe('KAN-283: privacy notice — ICO registration reference', () => {
   let content;

--- a/tests/unit/privacy-places-disclosure.test.js
+++ b/tests/unit/privacy-places-disclosure.test.js
@@ -11,9 +11,10 @@
 
 const fs = require('fs');
 const path = require('path');
+const { SRC } = require('../support/source-paths.json');
 
 const root = path.join(__dirname, '../..');
-const filePath = path.join(root, 'src/app/(legal)/privacy/page.tsx');
+const filePath = path.join(root, SRC.privacyPage);
 
 describe('KAN-251/KAN-341: privacy policy — Google Places town/city disclosure', () => {
   let content;

--- a/tests/unit/privacy-subprocessors.test.js
+++ b/tests/unit/privacy-subprocessors.test.js
@@ -17,11 +17,12 @@
 
 const fs = require('fs');
 const path = require('path');
+const { SRC } = require('../support/source-paths.json');
 
 const root = path.join(__dirname, '../..');
 
 describe('SEC-73: privacy policy — sub-processor disclosure', () => {
-  const filePath = path.join(root, 'src/app/(legal)/privacy/page.tsx');
+  const filePath = path.join(root, SRC.privacyPage);
   let content;
 
   beforeAll(() => {
@@ -59,7 +60,7 @@ describe('SEC-73: privacy policy — sub-processor disclosure', () => {
 });
 
 describe('KAN-407: privacy policy — 18+ self-declaration (no biometric)', () => {
-  const filePath = path.join(root, 'src/app/(legal)/privacy/page.tsx');
+  const filePath = path.join(root, SRC.privacyPage);
   let content;
 
   beforeAll(() => {
@@ -111,7 +112,7 @@ describe('KAN-407: privacy policy — 18+ self-declaration (no biometric)', () =
 
 describe('SEC-73: policy stays in sync with the sub-processor register', () => {
   const registerPath = path.join(root, 'docs/compliance/SUBPROCESSORS.md');
-  const policyPath = path.join(root, 'src/app/(legal)/privacy/page.tsx');
+  const policyPath = path.join(root, SRC.privacyPage);
 
   test('register exists', () => {
     expect(fs.existsSync(registerPath)).toBe(true);

--- a/tests/unit/profile-actions.test.ts
+++ b/tests/unit/profile-actions.test.ts
@@ -20,6 +20,7 @@
 
 import * as fs from 'fs';
 import * as path from 'path';
+import { SRC } from '../support/source-paths';
 
 // Mock next/cache
 const mockRevalidatePath = jest.fn();
@@ -202,7 +203,7 @@ describe('ALLOWED_PROFILE_FIELDS — allowlist contents', () => {
 });
 
 describe('Regression guard — actions.ts must never reintroduce the property injection pattern', () => {
-  const actionsPath = path.join(__dirname, '../..', 'src/app/dashboard/profile/actions.ts');
+  const actionsPath = path.join(__dirname, '../..', SRC.profileActions);
   const source = fs.readFileSync(actionsPath, 'utf8');
 
   test('the deleted updateProfile function MUST NOT be re-added without an allowlist', () => {

--- a/tests/unit/profile-item-url.test.ts
+++ b/tests/unit/profile-item-url.test.ts
@@ -24,6 +24,7 @@
 
 import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
+import { SRC } from '../support/source-paths';
 
 // ───────────── Mocks ─────────────
 
@@ -211,7 +212,7 @@ describe('KAN-219: surface-area regression guards', () => {
 
   test('items-step.tsx renders a Link input with type="url"', () => {
     const src = readFileSync(
-      resolve(ROOT, 'src/app/dashboard/profile/steps/items-step.tsx'),
+      resolve(ROOT, SRC.itemsStep),
       'utf-8',
     );
     expect(src).toMatch(/Link \(optional\)/);
@@ -221,7 +222,7 @@ describe('KAN-219: surface-area regression guards', () => {
 
   test('items-step.tsx handleAdd passes the trimmed URL in onAdd payload', () => {
     const src = readFileSync(
-      resolve(ROOT, 'src/app/dashboard/profile/steps/items-step.tsx'),
+      resolve(ROOT, SRC.itemsStep),
       'utf-8',
     );
     expect(src).toMatch(/trimmedUrl/);
@@ -230,7 +231,7 @@ describe('KAN-219: surface-area regression guards', () => {
 
   test('items-step.tsx renders ↗ link on saved items when url is present', () => {
     const src = readFileSync(
-      resolve(ROOT, 'src/app/dashboard/profile/steps/items-step.tsx'),
+      resolve(ROOT, SRC.itemsStep),
       'utf-8',
     );
     expect(src).toMatch(/item\.url/);
@@ -239,7 +240,7 @@ describe('KAN-219: surface-area regression guards', () => {
 
   test('actions.ts addProfileItem accepts url param and uses sanitiseUrl', () => {
     const src = readFileSync(
-      resolve(ROOT, 'src/app/dashboard/profile/actions.ts'),
+      resolve(ROOT, SRC.profileActions),
       'utf-8',
     );
     // url is an optional param on the addProfileItem data type
@@ -252,7 +253,7 @@ describe('KAN-219: surface-area regression guards', () => {
 
   test('public profile [slug]/page.tsx renders item URLs as clickable links', () => {
     const src = readFileSync(
-      resolve(ROOT, 'src/app/[slug]/page.tsx'),
+      resolve(ROOT, SRC.slugPage),
       'utf-8',
     );
     // The ProfileItem interface declares the url column
@@ -265,7 +266,7 @@ describe('KAN-219: surface-area regression guards', () => {
 
   test('wizard.tsx uses the richer Python lyra-app prompts', () => {
     const src = readFileSync(
-      resolve(ROOT, 'src/app/dashboard/profile/wizard.tsx'),
+      resolve(ROOT, SRC.wizard),
       'utf-8',
     );
     // Replaces the terse one-liners with the Python predecessor's longer

--- a/tests/unit/profile-items-visibility-migration.test.js
+++ b/tests/unit/profile-items-visibility-migration.test.js
@@ -9,11 +9,12 @@
 
 const fs = require('fs');
 const path = require('path');
+const { SRC } = require('../support/source-paths.json');
 
 const root = path.join(__dirname, '../..');
 
 describe('KAN-143 — profile_items visibility migration', () => {
-  const migrationsDir = path.join(root, 'supabase/migrations');
+  const migrationsDir = path.join(root, SRC.migrations);
 
   function findVisibilityMigration() {
     const files = fs.readdirSync(migrationsDir);
@@ -73,7 +74,7 @@ describe('KAN-143 — profile_items visibility migration', () => {
 });
 
 describe('KAN-143 — public profile page filters by visibility', () => {
-  const pagePath = path.join(root, 'src/app/[slug]/page.tsx');
+  const pagePath = path.join(root, SRC.slugPage);
   const content = fs.readFileSync(pagePath, 'utf8');
 
   // KAN-234: filter helper switched to `isItemVisibleUnderHybridModel`
@@ -107,7 +108,7 @@ describe('KAN-143 — public profile page filters by visibility', () => {
 });
 
 describe('KAN-143 — items step UI exposes visibility selector', () => {
-  const stepPath = path.join(root, 'src/app/dashboard/profile/steps/items-step.tsx');
+  const stepPath = path.join(root, SRC.itemsStep);
   const content = fs.readFileSync(stepPath, 'utf8');
 
   test('renders a <select> for visibility on the add-item form', () => {
@@ -140,7 +141,7 @@ describe('KAN-143 — items step UI exposes visibility selector', () => {
 });
 
 describe('KAN-143 — actions.ts wiring', () => {
-  const actionsPath = path.join(root, 'src/app/dashboard/profile/actions.ts');
+  const actionsPath = path.join(root, SRC.profileActions);
   const content = fs.readFileSync(actionsPath, 'utf8');
 
   test('imports coerceVisibility from the sibling module (not inlined in the use-server file)', () => {

--- a/tests/unit/profile-rate-limit-wiring.test.ts
+++ b/tests/unit/profile-rate-limit-wiring.test.ts
@@ -11,6 +11,7 @@
 
 import { readFileSync } from 'fs';
 import { join } from 'path';
+import { SRC } from '../support/source-paths';
 
 function read(p: string): string {
   return readFileSync(join(__dirname, '..', '..', p), 'utf8');
@@ -30,8 +31,8 @@ function extractFn(src: string, name: string): string | null {
 }
 
 describe('KAN-231 rate-limit wiring regression guards', () => {
-  describe('src/app/dashboard/profile/actions.ts', () => {
-    const src = read('src/app/dashboard/profile/actions.ts');
+  describe(SRC.profileActions, () => {
+    const src = read(SRC.profileActions);
 
     test('imports checkProfileWriteRateLimit', () => {
       expect(src).toMatch(
@@ -53,8 +54,8 @@ describe('KAN-231 rate-limit wiring regression guards', () => {
     });
   });
 
-  describe('src/app/dashboard/profile/conversation-starters-actions.ts', () => {
-    const src = read('src/app/dashboard/profile/conversation-starters-actions.ts');
+  describe(SRC.conversationStartersActions, () => {
+    const src = read(SRC.conversationStartersActions);
 
     test('imports checkProfileWriteRateLimit', () => {
       expect(src).toMatch(/checkProfileWriteRateLimit/);
@@ -70,8 +71,8 @@ describe('KAN-231 rate-limit wiring regression guards', () => {
     );
   });
 
-  describe('src/app/dashboard/profile/manual-of-me-actions.ts', () => {
-    const src = read('src/app/dashboard/profile/manual-of-me-actions.ts');
+  describe(SRC.manualOfMeActions, () => {
+    const src = read(SRC.manualOfMeActions);
 
     test('updateManualOfMe wires the rate limit', () => {
       const fn = extractFn(src, 'updateManualOfMe');
@@ -80,8 +81,8 @@ describe('KAN-231 rate-limit wiring regression guards', () => {
     });
   });
 
-  describe('src/app/dashboard/profile/files-actions.ts', () => {
-    const src = read('src/app/dashboard/profile/files-actions.ts');
+  describe(SRC.filesActions, () => {
+    const src = read(SRC.filesActions);
 
     test('uploadProfileFile wires the rate limit', () => {
       const fn = extractFn(src, 'uploadProfileFile');
@@ -90,8 +91,8 @@ describe('KAN-231 rate-limit wiring regression guards', () => {
     });
   });
 
-  describe('src/app/dashboard/profile/delivery-country-actions.ts', () => {
-    const src = read('src/app/dashboard/profile/delivery-country-actions.ts');
+  describe(SRC.deliveryCountryActions, () => {
+    const src = read(SRC.deliveryCountryActions);
 
     test('updateDeliveryCountry wires the rate limit', () => {
       const fn = extractFn(src, 'updateDeliveryCountry');
@@ -102,7 +103,7 @@ describe('KAN-231 rate-limit wiring regression guards', () => {
 
   describe('placement: rate-limit runs BEFORE any DB write', () => {
     test('actions.ts: rl.allowed check precedes every .from(...) write', () => {
-      const src = read('src/app/dashboard/profile/actions.ts');
+      const src = read(SRC.profileActions);
       // For each function we wired, find the rate-limit check index and the
       // first .insert/.update/.delete after it. The rate-limit must come
       // first within the function body.

--- a/tests/unit/profile-sections.test.js
+++ b/tests/unit/profile-sections.test.js
@@ -5,6 +5,7 @@
 
 const fs = require('fs');
 const path = require('path');
+const { SRC } = require('../support/source-paths.json');
 
 const root = path.join(__dirname, '../..');
 
@@ -14,7 +15,7 @@ const NEW_CATEGORIES = [
 ];
 
 describe('KAN-137: Wizard supports new section categories', () => {
-  const wizardPath = path.join(root, 'src/app/dashboard/profile/wizard.tsx');
+  const wizardPath = path.join(root, SRC.wizard);
   let wizardContent;
 
   beforeAll(() => {
@@ -69,7 +70,7 @@ describe('KAN-137: Wizard supports new section categories', () => {
 });
 
 describe('KAN-137: ItemsStep has labels for all categories', () => {
-  const itemsStepPath = path.join(root, 'src/app/dashboard/profile/steps/items-step.tsx');
+  const itemsStepPath = path.join(root, SRC.itemsStep);
   let content;
 
   beforeAll(() => {
@@ -87,7 +88,7 @@ describe('KAN-137 / KAN-265: Public profile renders all categories (redesign)', 
   // left-rule on each heading, a favourites grid, a Q&A block). Every category is
   // still rendered — these guards prove each is referenced so a future refactor
   // can't silently drop one (which would make those items vanish from profiles).
-  const profilePath = path.join(root, 'src/app/[slug]/page.tsx');
+  const profilePath = path.join(root, SRC.slugPage);
   let content;
 
   beforeAll(() => {

--- a/tests/unit/public-profile-suspended-gating.test.ts
+++ b/tests/unit/public-profile-suspended-gating.test.ts
@@ -12,9 +12,10 @@
  */
 import fs from 'fs';
 import path from 'path';
+import { SRC } from '../support/source-paths';
 
 const root = path.join(__dirname, '../..');
-const pagePath = 'src/app/[slug]/page.tsx';
+const pagePath = SRC.slugPage;
 
 describe('SEC-44: public profile page filters suspended profiles', () => {
   const content = fs.readFileSync(path.join(root, pagePath), 'utf8');

--- a/tests/unit/public-profile.test.js
+++ b/tests/unit/public-profile.test.js
@@ -5,32 +5,33 @@
 
 const fs = require('fs');
 const path = require('path');
+const { SRC } = require('../support/source-paths.json');
 
 const root = path.join(__dirname, '../..');
 
 describe('Public Profile', () => {
   test('public profile page exists at [slug]', () => {
-    expect(fs.existsSync(path.join(root, 'src/app/[slug]/page.tsx'))).toBe(true);
+    expect(fs.existsSync(path.join(root, SRC.slugPage))).toBe(true);
   });
 
   test('custom 404 page exists for missing profiles', () => {
-    expect(fs.existsSync(path.join(root, 'src/app/[slug]/not-found.tsx'))).toBe(true);
+    expect(fs.existsSync(path.join(root, SRC.notFound))).toBe(true);
   });
 
   test('public profile page has dynamic metadata generation', () => {
-    const content = fs.readFileSync(path.join(root, 'src/app/[slug]/page.tsx'), 'utf8');
+    const content = fs.readFileSync(path.join(root, SRC.slugPage), 'utf8');
     expect(content).toContain('generateMetadata');
     expect(content).toContain('openGraph');
   });
 
   test('public profile page only shows published profiles', () => {
-    const content = fs.readFileSync(path.join(root, 'src/app/[slug]/page.tsx'), 'utf8');
+    const content = fs.readFileSync(path.join(root, SRC.slugPage), 'utf8');
     expect(content).toContain("is_published");
     expect(content).toContain("notFound");
   });
 
   test('public profile page displays all profile sections', () => {
-    const content = fs.readFileSync(path.join(root, 'src/app/[slug]/page.tsx'), 'utf8');
+    const content = fs.readFileSync(path.join(root, SRC.slugPage), 'utf8');
     expect(content).toContain('bio_short');
     expect(content).toContain('school_affiliations');
     expect(content).toContain('profile_items');
@@ -44,7 +45,7 @@ describe('Public Profile', () => {
   // intentionally removed so edit == published. Guard that no Files/media
   // rendering — nor any bucket URL access — reappears on the public page.
   test('public profile does not render a Files & media section (KAN-404)', () => {
-    const content = fs.readFileSync(path.join(root, 'src/app/[slug]/page.tsx'), 'utf8');
+    const content = fs.readFileSync(path.join(root, SRC.slugPage), 'utf8');
     expect(content).not.toContain('Files & media');
     expect(content).not.toContain('createSignedUrl');
     expect(content).not.toContain('object/public/profile-files');
@@ -54,7 +55,7 @@ describe('Public Profile', () => {
   // rendered on the public profile (FAV_DEFS had no 'plays' entry, so Play items
   // saved but never showed). Guard that the public favourites grid includes it.
   test("public profile renders the 'plays' favourites category (KAN-404)", () => {
-    const content = fs.readFileSync(path.join(root, 'src/app/[slug]/page.tsx'), 'utf8');
+    const content = fs.readFileSync(path.join(root, SRC.slugPage), 'utf8');
     expect(content).toContain("'plays'");
     expect(content).toContain('Favourite plays');
   });

--- a/tests/unit/pwa-manifest.test.ts
+++ b/tests/unit/pwa-manifest.test.ts
@@ -10,6 +10,7 @@
 
 import { readFileSync, existsSync, statSync } from 'node:fs';
 import { resolve } from 'node:path';
+import { SRC } from '../support/source-paths';
 
 const ROOT = resolve(__dirname, '../..');
 
@@ -19,12 +20,12 @@ function readJson(path: string): Record<string, unknown> {
 
 describe('KAN-69a — PWA manifest invariants', () => {
   test('public/manifest.webmanifest exists and is valid JSON', () => {
-    expect(existsSync(resolve(ROOT, 'public/manifest.webmanifest'))).toBe(true);
-    expect(() => readJson('public/manifest.webmanifest')).not.toThrow();
+    expect(existsSync(resolve(ROOT, SRC.manifest))).toBe(true);
+    expect(() => readJson(SRC.manifest)).not.toThrow();
   });
 
   test('manifest declares the required PWA fields', () => {
-    const m = readJson('public/manifest.webmanifest');
+    const m = readJson(SRC.manifest);
     expect(m.name).toBeDefined();
     expect(m.short_name).toBeDefined();
     expect(m.start_url).toBeDefined();
@@ -36,7 +37,7 @@ describe('KAN-69a — PWA manifest invariants', () => {
   });
 
   test('manifest includes BOTH 192x192 and 512x512 icons (Lighthouse PWA minimum)', () => {
-    const m = readJson('public/manifest.webmanifest');
+    const m = readJson(SRC.manifest);
     const icons = m.icons as Array<{ sizes: string; purpose?: string }>;
     const sizes = icons.map((i) => i.sizes);
     expect(sizes).toEqual(expect.arrayContaining(['192x192', '512x512']));
@@ -45,14 +46,14 @@ describe('KAN-69a — PWA manifest invariants', () => {
   test('manifest includes a maskable icon', () => {
     // Maskable icons let Android apply its adaptive-icon masks without
     // cropping the Lyra mark. Required for the "polish" Lighthouse score.
-    const m = readJson('public/manifest.webmanifest');
+    const m = readJson(SRC.manifest);
     const icons = m.icons as Array<{ purpose?: string }>;
     const maskable = icons.find((i) => i.purpose === 'maskable');
     expect(maskable).toBeDefined();
   });
 
   test('every icon file referenced in the manifest actually exists on disk', () => {
-    const m = readJson('public/manifest.webmanifest');
+    const m = readJson(SRC.manifest);
     const icons = m.icons as Array<{ src: string }>;
     for (const icon of icons) {
       const path = resolve(ROOT, 'public', icon.src.replace(/^\//, ''));
@@ -68,12 +69,12 @@ describe('KAN-69a — PWA manifest invariants', () => {
     // dashboard rather than the marketing homepage; the `source=pwa` is
     // a telemetry hook so we can measure how often the installed app
     // gets opened vs the web entry points.
-    const m = readJson('public/manifest.webmanifest');
+    const m = readJson(SRC.manifest);
     expect(m.start_url).toMatch(/^\/dashboard.*source=pwa/);
   });
 
   test('layout.tsx wires up the manifest, viewport, and install prompt', () => {
-    const src = readFileSync(resolve(ROOT, 'src/app/layout.tsx'), 'utf-8');
+    const src = readFileSync(resolve(ROOT, SRC.layout), 'utf-8');
     expect(src).toMatch(/manifest:\s*['"]\/manifest\.webmanifest['"]/);
     expect(src).toMatch(/export\s+const\s+viewport/);
     expect(src).toMatch(/InstallPrompt/);
@@ -84,7 +85,7 @@ describe('KAN-69a — PWA manifest invariants', () => {
   });
 
   test('install-prompt component exists and only renders client-side', () => {
-    const path = resolve(ROOT, 'src/app/install-prompt.tsx');
+    const path = resolve(ROOT, SRC.installPrompt);
     expect(existsSync(path)).toBe(true);
     const src = readFileSync(path, 'utf-8');
     expect(src).toMatch(/^['"]use client['"]/);

--- a/tests/unit/pwa-service-worker.test.ts
+++ b/tests/unit/pwa-service-worker.test.ts
@@ -9,11 +9,12 @@
 
 import fs from 'fs';
 import path from 'path';
+import { SRC } from '../support/source-paths';
 
 const ROOT = path.join(__dirname, '..', '..');
 
 describe('public/sw.js (KAN-213 P9)', () => {
-  const src = fs.readFileSync(path.join(ROOT, 'public/sw.js'), 'utf8');
+  const src = fs.readFileSync(path.join(ROOT, SRC.sw), 'utf8');
 
   test('exists + has a CACHE_VERSION constant for cache busting', () => {
     expect(src).toMatch(/CACHE_VERSION/);
@@ -66,7 +67,7 @@ describe('public/sw.js (KAN-213 P9)', () => {
 });
 
 describe('public/offline.html (KAN-213 P9)', () => {
-  const src = fs.readFileSync(path.join(ROOT, 'public/offline.html'), 'utf8');
+  const src = fs.readFileSync(path.join(ROOT, SRC.offline), 'utf8');
   test('exists', () => {
     expect(src).toBeTruthy();
   });
@@ -83,7 +84,7 @@ describe('public/offline.html (KAN-213 P9)', () => {
 });
 
 describe('manifest.webmanifest Convene shortcuts (KAN-213 P9)', () => {
-  const m = JSON.parse(fs.readFileSync(path.join(ROOT, 'public/manifest.webmanifest'), 'utf8'));
+  const m = JSON.parse(fs.readFileSync(path.join(ROOT, SRC.manifest), 'utf8'));
   test('has the Convene gatherings shortcut', () => {
     const urls = m.shortcuts.map((s: { url: string }) => s.url);
     expect(urls).toContain('/dashboard/convene/gatherings?source=pwa');
@@ -100,7 +101,7 @@ describe('manifest.webmanifest Convene shortcuts (KAN-213 P9)', () => {
 });
 
 describe('service-worker-register component (KAN-213 P9)', () => {
-  const src = fs.readFileSync(path.join(ROOT, 'src/app/service-worker-register.tsx'), 'utf8');
+  const src = fs.readFileSync(path.join(ROOT, SRC.serviceWorkerRegister), 'utf8');
   test("declares 'use client'", () => {
     expect(src).toMatch(/^['"]use client['"]/);
   });
@@ -116,7 +117,7 @@ describe('service-worker-register component (KAN-213 P9)', () => {
 });
 
 describe('layout wires the registration component (KAN-213 P9)', () => {
-  const src = fs.readFileSync(path.join(ROOT, 'src/app/layout.tsx'), 'utf8');
+  const src = fs.readFileSync(path.join(ROOT, SRC.layout), 'utf8');
   test('imports + renders ServiceWorkerRegister', () => {
     expect(src).toMatch(/import\s*\{\s*ServiceWorkerRegister\s*\}\s*from\s*['"]\.\/service-worker-register['"]/);
     expect(src).toMatch(/<ServiceWorkerRegister\s*\/>/);

--- a/tests/unit/recommendations-routes-security.test.ts
+++ b/tests/unit/recommendations-routes-security.test.ts
@@ -6,13 +6,14 @@
  */
 import fs from 'fs';
 import path from 'path';
+import { SRC } from '../support/source-paths';
 
 const root = path.join(__dirname, '../..');
 
 describe('SEC-19/F-13: recommendation routes filter suspended profiles', () => {
   for (const rel of [
-    'src/app/api/recommendations/[slug]/route.ts',
-    'src/app/api/recommendations/v2/[slug]/route.ts',
+    SRC.slugRoute,
+    SRC.v2SlugRoute,
   ]) {
     test(`${rel} filters is_suspended = false on the profile lookup`, () => {
       const content = fs.readFileSync(path.join(root, rel), 'utf8');

--- a/tests/unit/redesign-fidelity.test.js
+++ b/tests/unit/redesign-fidelity.test.js
@@ -12,6 +12,7 @@
 
 const fs = require('fs');
 const path = require('path');
+const { SRC } = require('../support/source-paths.json');
 
 const root = path.join(__dirname, '../..');
 const read = (p) => fs.readFileSync(path.join(root, p), 'utf8');
@@ -37,7 +38,7 @@ const WHITE = '#FFFFFF';
 describe('KAN-272 A: design tokens (mock-up palette, WCAG AA preserved)', () => {
   let css;
   beforeAll(() => {
-    css = read('src/app/globals.css');
+    css = read(SRC.globals);
   });
 
   test('sage is the mock-up green #4a7359', () => {
@@ -87,7 +88,7 @@ describe('KAN-272 A: design tokens (mock-up palette, WCAG AA preserved)', () => 
 describe('KAN-272 B: typography — single Inter face', () => {
   let layout;
   beforeAll(() => {
-    layout = read('src/app/layout.tsx');
+    layout = read(SRC.layout);
   });
 
   test('loads Inter and drops the DM faces', () => {
@@ -110,7 +111,7 @@ describe('KAN-272 B: typography — single Inter face', () => {
 describe('KAN-272 D: site-wide footer', () => {
   let footer;
   beforeAll(() => {
-    footer = read('src/app/footer.tsx');
+    footer = read(SRC.footer);
   });
 
   test('renders all nine footer links', () => {
@@ -137,19 +138,19 @@ describe('KAN-272 D: site-wide footer', () => {
   });
 
   test('is rendered once in the root layout (no double footer)', () => {
-    const layout = read('src/app/layout.tsx');
+    const layout = read(SRC.layout);
     expect(layout).toContain('<Footer');
   });
 });
 
 describe('KAN-272 E: six support pages', () => {
   const pages = {
-    about: { file: 'src/app/(legal)/about/page.tsx', h1: 'About Lyra' },
-    guidelines: { file: 'src/app/(legal)/guidelines/page.tsx', h1: 'Guidelines' },
-    safe: { file: 'src/app/(legal)/safe/page.tsx', h1: 'Keeping people safe' },
-    accessibility: { file: 'src/app/(legal)/accessibility/page.tsx', h1: 'Accessibility' },
-    help: { file: 'src/app/(legal)/help/page.tsx', h1: 'Help' },
-    contact: { file: 'src/app/(legal)/contact/page.tsx', h1: 'Contact' },
+    about: { file: SRC.aboutPage, h1: 'About Lyra' },
+    guidelines: { file: SRC.guidelinesPage, h1: 'Guidelines' },
+    safe: { file: SRC.safePage, h1: 'Keeping people safe' },
+    accessibility: { file: SRC.accessibilityPage, h1: 'Accessibility' },
+    help: { file: SRC.helpPage, h1: 'Help' },
+    contact: { file: SRC.contactPage, h1: 'Contact' },
   };
 
   for (const [name, { file, h1 }] of Object.entries(pages)) {
@@ -162,14 +163,14 @@ describe('KAN-272 E: six support pages', () => {
   }
 
   test('about page includes the 📖 / 🤝 / 🕊️ trio', () => {
-    const c = read('src/app/_marketing/sections.tsx');
+    const c = read(SRC.sections);
     expect(c).toContain('📖');
     expect(c).toContain('🤝');
     expect(c).toContain('🕊️');
   });
 
   test('help page mirrors the mock-up FAQ copy', () => {
-    const c = read('src/app/(legal)/help/page.tsx');
+    const c = read(SRC.helpPage);
     expect(c).toContain('Who can see my profile?');
     expect(c).toContain('Can I write about my friend, or a celebrity?');
   });
@@ -177,13 +178,13 @@ describe('KAN-272 E: six support pages', () => {
 
 describe('KAN-272 E: Contact form + Turnstile', () => {
   test('contact page reads the public site key from the helper', () => {
-    const c = read('src/app/(legal)/contact/page.tsx');
+    const c = read(SRC.contactPage);
     expect(c).toContain('turnstileSiteKey');
     expect(c).toContain('ContactForm');
   });
 
   test('contact action is a use-server module exporting an async submit handler', () => {
-    const a = read('src/app/(legal)/contact/actions.ts');
+    const a = read(SRC.contactActions);
     expect(a).toContain("'use server'");
     expect(a).toContain('export async function submitContact');
     // gotcha #18: a use-server file must export only async functions; the
@@ -193,13 +194,13 @@ describe('KAN-272 E: Contact form + Turnstile', () => {
   });
 
   test('contact action verifies Turnstile and relays by email', () => {
-    const a = read('src/app/(legal)/contact/actions.ts');
+    const a = read(SRC.contactActions);
     expect(a).toContain('verifyTurnstile');
     expect(a).toContain('api.resend.com/emails');
   });
 
   test('Turnstile keys are read from env, never hardcoded', () => {
-    const t = read('src/lib/turnstile.ts');
+    const t = read(SRC.turnstile);
     expect(t).toContain('NEXT_PUBLIC_TURNSTILE_SITE_KEY');
     expect(t).toContain('TURNSTILE_SECRET_KEY');
     // No literal Cloudflare test/real keys committed.
@@ -247,7 +248,7 @@ describe('KAN-272 E: Turnstile helper degrades gracefully', () => {
 
 describe('KAN-272 F: Terms is 18+', () => {
   test('terms requires 18 or over (not 13)', () => {
-    const c = read('src/app/(legal)/terms/page.tsx');
+    const c = read(SRC.termsPage);
     expect(c).toContain('18 or over');
     expect(c).not.toContain('at least 13 years old');
   });

--- a/tests/unit/retention/affiliate-clicks-retention.test.ts
+++ b/tests/unit/retention/affiliate-clicks-retention.test.ts
@@ -8,6 +8,7 @@
 
 import fs from 'fs';
 import path from 'path';
+import { SRC } from '../../support/source-paths';
 import {
   DEFAULT_AFFILIATE_CLICKS_RETENTION_MONTHS,
   affiliateClicksRetentionMonths,
@@ -66,7 +67,7 @@ describe('affiliateClicksCutoff — always strictly in the past', () => {
 
 describe('SQL purge function — safety rails (structural)', () => {
   const sql = fs.readFileSync(
-    path.join(ROOT, 'supabase/migrations/20260712033000_sec74_affiliate_clicks_retention_purge.sql'),
+    path.join(ROOT, SRC.migrations20260712033000Sec74AffiliateClicksRetentionPurge),
     'utf8',
   );
 
@@ -93,10 +94,10 @@ describe('SQL purge function — safety rails (structural)', () => {
 
 describe('retention cron route + flag (structural)', () => {
   const route = fs.readFileSync(
-    path.join(ROOT, 'src/app/api/retention/cron/sweep/route.ts'),
+    path.join(ROOT, SRC.sweepRoute),
     'utf8',
   );
-  const flag = fs.readFileSync(path.join(ROOT, 'src/lib/retention/flags.ts'), 'utf8');
+  const flag = fs.readFileSync(path.join(ROOT, SRC.flags), 'utf8');
 
   test('flag is disabled by default (opt-in via RETENTION_ENABLED=true)', () => {
     expect(flag).toMatch(/process\.env\.RETENTION_ENABLED === 'true'/);

--- a/tests/unit/retention/gatherings-retention.test.ts
+++ b/tests/unit/retention/gatherings-retention.test.ts
@@ -9,6 +9,7 @@
 
 import fs from 'fs';
 import path from 'path';
+import { SRC } from '../../support/source-paths';
 import {
   DEFAULT_GATHERINGS_RETENTION_MONTHS,
   gatheringsRetentionMonths,
@@ -67,7 +68,7 @@ describe('gatheringsCutoff — always strictly in the past', () => {
 
 describe('SQL purge function — safety rails (structural)', () => {
   const sql = fs.readFileSync(
-    path.join(ROOT, 'supabase/migrations/20260717033000_sec74_gatherings_retention_purge.sql'),
+    path.join(ROOT, SRC.migrations20260717033000Sec74GatheringsRetentionPurge),
     'utf8',
   );
 
@@ -98,7 +99,7 @@ describe('SQL purge function — safety rails (structural)', () => {
 });
 
 describe('retention sweep — gatherings job wired in (structural)', () => {
-  const sweep = fs.readFileSync(path.join(ROOT, 'src/lib/retention/sweep.ts'), 'utf8');
+  const sweep = fs.readFileSync(path.join(ROOT, SRC.sweep), 'utf8');
 
   test('the sweep orchestrator runs the gatherings retention job', () => {
     expect(sweep).toMatch(/runGatheringsRetention/);

--- a/tests/unit/route-config.test.ts
+++ b/tests/unit/route-config.test.ts
@@ -15,13 +15,14 @@
 
 import { readFileSync, existsSync } from 'node:fs';
 import { resolve } from 'node:path';
+import { SRC } from '../support/source-paths';
 
 const ROOT = resolve(__dirname, '../..');
 
 describe('BUGS-14 — route configuration regression guards', () => {
   test('src/app/[slug]/page.tsx exports dynamic = "force-dynamic"', () => {
     const src = readFileSync(
-      resolve(ROOT, 'src/app/[slug]/page.tsx'),
+      resolve(ROOT, SRC.slugPage),
       'utf-8',
     );
     // Look for the export. We accept any of the canonical forms so the
@@ -48,18 +49,18 @@ describe('BUGS-14 — route configuration regression guards', () => {
     // Any URL with no closer not-found.tsx (e.g. `/foo/bar/baz`) falls
     // back to this root one. The segment-level `[slug]/not-found.tsx`
     // is preferred for slug URLs by Next.js routing.
-    expect(existsSync(resolve(ROOT, 'src/app/not-found.tsx'))).toBe(true);
+    expect(existsSync(resolve(ROOT, SRC.appNotFound))).toBe(true);
   });
 
   test('src/app/[slug]/not-found.tsx still exists for slug-specific UX', () => {
     // Provides "This profile doesn't exist" copy. Next.js's
     // closest-ancestor matching prefers this over the root one for
     // /[slug] routes.
-    expect(existsSync(resolve(ROOT, 'src/app/[slug]/not-found.tsx'))).toBe(true);
+    expect(existsSync(resolve(ROOT, SRC.notFound))).toBe(true);
   });
 
   test('root not-found.tsx contains the canonical 404 + Go to Lyra UI', () => {
-    const src = readFileSync(resolve(ROOT, 'src/app/not-found.tsx'), 'utf-8');
+    const src = readFileSync(resolve(ROOT, SRC.appNotFound), 'utf-8');
     // The visible "404" heading is what the E2E test (and humans) check.
     // If a refactor moves the heading to something else we want the
     // test to fail rather than silently regress.

--- a/tests/unit/sar-export-completeness.test.js
+++ b/tests/unit/sar-export-completeness.test.js
@@ -11,9 +11,10 @@
 
 const fs = require('fs');
 const path = require('path');
+const { SRC } = require('../support/source-paths.json');
 
 const root = path.join(__dirname, '../..');
-const actionsPath = path.join(root, 'src/app/dashboard/settings/actions.ts');
+const actionsPath = path.join(root, SRC.settingsActions);
 
 describe('SEC-71: SAR export covers all user/profile-keyed personal data', () => {
   let content;

--- a/tests/unit/search-page.test.js
+++ b/tests/unit/search-page.test.js
@@ -5,11 +5,12 @@
 
 const fs = require('fs');
 const path = require('path');
+const { SRC } = require('../support/source-paths.json');
 
 const root = path.join(__dirname, '../..');
 
 describe('KAN-136: Search page exists and has correct structure', () => {
-  const searchPagePath = path.join(root, 'src/app/search/page.tsx');
+  const searchPagePath = path.join(root, SRC.searchPage);
   let content;
 
   beforeAll(() => {
@@ -67,7 +68,7 @@ describe('KAN-136: Search page exists and has correct structure', () => {
 });
 
 describe('KAN-136: ProfileCard component', () => {
-  const searchPagePath = path.join(root, 'src/app/search/page.tsx');
+  const searchPagePath = path.join(root, SRC.searchPage);
   let content;
 
   beforeAll(() => {
@@ -100,7 +101,7 @@ describe('KAN-136: ProfileCard component', () => {
 });
 
 describe('KAN-136: Homepage links to search', () => {
-  const homepagePath = path.join(root, 'src/app/page.tsx');
+  const homepagePath = path.join(root, SRC.appPage);
   let content;
 
   beforeAll(() => {

--- a/tests/unit/sec4-status-page.test.js
+++ b/tests/unit/sec4-status-page.test.js
@@ -7,11 +7,12 @@
  */
 const fs = require('fs');
 const path = require('path');
+const { SRC } = require('../support/source-paths.json');
 
 const root = path.join(__dirname, '../..');
-const PAGE = fs.readFileSync(path.join(root, 'src/app/status/page.tsx'), 'utf8');
-const MW = fs.readFileSync(path.join(root, 'src/middleware.ts'), 'utf8');
-const WORKER = fs.readFileSync(path.join(root, 'scripts/lyra-maintenance-worker.js'), 'utf8');
+const PAGE = fs.readFileSync(path.join(root, SRC.statusPage), 'utf8');
+const MW = fs.readFileSync(path.join(root, SRC.middleware), 'utf8');
+const WORKER = fs.readFileSync(path.join(root, SRC.lyraMaintenanceWorker), 'utf8');
 
 describe('SEC-4 status page', () => {
   test('does a live MCP health probe, not a faked status', () => {

--- a/tests/unit/sec43-admin-rpc-acl-guard.test.js
+++ b/tests/unit/sec43-admin-rpc-acl-guard.test.js
@@ -30,9 +30,10 @@
 
 const fs = require('fs');
 const path = require('path');
+const { SRC } = require('../support/source-paths.json');
 
 const repoRoot = path.join(__dirname, '../..');
-const migrationsDir = path.join(repoRoot, 'supabase/migrations');
+const migrationsDir = path.join(repoRoot, SRC.migrations);
 const docPath = path.join(repoRoot, 'docs/DAILY_SECURITY_CHECK.md');
 
 // The intended-ACL migration (BUGS-60). Its 14-digit timestamp prefix is the

--- a/tests/unit/sec45-profile-items-public-read-rls.test.js
+++ b/tests/unit/sec45-profile-items-public-read-rls.test.js
@@ -17,9 +17,10 @@
 
 const fs = require('fs');
 const path = require('path');
+const { SRC } = require('../support/source-paths.json');
 
 const root = path.join(__dirname, '../..');
-const migrationsDir = path.join(root, 'supabase/migrations');
+const migrationsDir = path.join(root, SRC.migrations);
 
 const OVERBROAD_POLICY = 'Anyone can read items from published non-suspended profiles';
 const ADHOC_DUPLICATE = 'Read public items from published profiles';

--- a/tests/unit/sec52-upload-preflight.test.ts
+++ b/tests/unit/sec52-upload-preflight.test.ts
@@ -19,6 +19,7 @@
 import { readFileSync } from 'fs';
 import { resolve } from 'path';
 import { preflightUpload } from '@/lib/file-magic-bytes';
+import { SRC } from '../support/source-paths';
 
 const ROOT = resolve(__dirname, '../..');
 
@@ -114,7 +115,7 @@ describe('SEC-52 preflightUpload', () => {
 describe('SEC-52 source guards — both upload paths enforce the shared preflight', () => {
   test('uploadAvatar runs preflightUpload before the profile-photos upload', () => {
     const src = readFileSync(
-      resolve(ROOT, 'src/app/dashboard/profile/actions.ts'),
+      resolve(ROOT, SRC.profileActions),
       'utf-8',
     );
     const fn = src.slice(src.indexOf('export async function uploadAvatar'));
@@ -128,7 +129,7 @@ describe('SEC-52 source guards — both upload paths enforce the shared prefligh
 
   test('uploadProfileFile runs preflightUpload before the profile-files upload', () => {
     const src = readFileSync(
-      resolve(ROOT, 'src/app/dashboard/profile/files-actions.ts'),
+      resolve(ROOT, SRC.filesActions),
       'utf-8',
     );
     const fn = src.slice(src.indexOf('export async function uploadProfileFile'));
@@ -142,7 +143,7 @@ describe('SEC-52 source guards — both upload paths enforce the shared prefligh
   test('preflightUpload always reaches the magic-byte validator', () => {
     // Guard the helper itself: it must call validateFileMagicBytes so a future
     // edit can't quietly drop the anti-spoofing check.
-    const src = readFileSync(resolve(ROOT, 'src/lib/file-magic-bytes.ts'), 'utf-8');
+    const src = readFileSync(resolve(ROOT, SRC.fileMagicBytes), 'utf-8');
     const fn = src.slice(src.indexOf('export async function preflightUpload'));
     expect(fn).toMatch(/validateFileMagicBytes\(/);
   });

--- a/tests/unit/sec82-recommendations-v1-cache.test.ts
+++ b/tests/unit/sec82-recommendations-v1-cache.test.ts
@@ -9,9 +9,10 @@
  */
 import fs from 'fs';
 import path from 'path';
+import { SRC } from '../support/source-paths';
 
 const root = path.join(__dirname, '../..');
-const v1 = path.join(root, 'src/app/api/recommendations/[slug]/route.ts');
+const v1 = path.join(root, SRC.slugRoute);
 
 describe('SEC-82: V1 recommendations cache policy', () => {
   let content: string;

--- a/tests/unit/section-visibility.test.ts
+++ b/tests/unit/section-visibility.test.ts
@@ -15,6 +15,7 @@
 
 import { readFileSync, existsSync } from 'node:fs';
 import { resolve } from 'node:path';
+import { SRC } from '../support/source-paths';
 
 const ROOT = resolve(__dirname, '../..');
 
@@ -349,7 +350,7 @@ describe('KAN-221: updateSectionVisibility server action', () => {
 describe('KAN-221: surface-area regression guards', () => {
   test('migration file exists and adds the JSONB column', () => {
     const src = readFileSync(
-      resolve(ROOT, 'supabase/migrations/20260517020000_section_visibility.sql'),
+      resolve(ROOT, SRC.migrations20260517020000SectionVisibility),
       'utf-8',
     );
     expect(src).toMatch(/add column section_visibility jsonb/i);
@@ -358,7 +359,7 @@ describe('KAN-221: surface-area regression guards', () => {
   });
 
   test('section-visibility.ts module exports the right surface', () => {
-    const p = resolve(ROOT, 'src/app/dashboard/profile/section-visibility.ts');
+    const p = resolve(ROOT, SRC.sectionVisibility);
     expect(existsSync(p)).toBe(true);
     const src = readFileSync(p, 'utf-8');
     expect(src).toMatch(/export const CONTROLLABLE_SECTION_KEYS/);
@@ -371,7 +372,7 @@ describe('KAN-221: surface-area regression guards', () => {
 
   test('actions.ts exports updateSectionVisibility and imports the helper', () => {
     const src = readFileSync(
-      resolve(ROOT, 'src/app/dashboard/profile/actions.ts'),
+      resolve(ROOT, SRC.profileActions),
       'utf-8',
     );
     expect(src).toMatch(/export async function updateSectionVisibility/);
@@ -381,7 +382,7 @@ describe('KAN-221: surface-area regression guards', () => {
 
   test('section-visibility helper module is NOT a "use server" file (BUGS-12 safe)', () => {
     const src = readFileSync(
-      resolve(ROOT, 'src/app/dashboard/profile/section-visibility.ts'),
+      resolve(ROOT, SRC.sectionVisibility),
       'utf-8',
     );
     expect(src).not.toMatch(/^['"]use server['"]/m);

--- a/tests/unit/seo.test.js
+++ b/tests/unit/seo.test.js
@@ -5,12 +5,13 @@
 
 const fs = require('fs');
 const path = require('path');
+const { SRC } = require('../support/source-paths.json');
 
 const root = path.join(__dirname, '../..');
 
 describe('SEO Optimisation', () => {
   test('robots.txt exists with correct directives', () => {
-    const robots = fs.readFileSync(path.join(root, 'public/robots.txt'), 'utf8');
+    const robots = fs.readFileSync(path.join(root, SRC.robots), 'utf8');
     expect(robots).toContain('User-agent: *');
     expect(robots).toContain('Allow: /');
     expect(robots).toContain('Disallow: /dashboard/');
@@ -19,7 +20,7 @@ describe('SEO Optimisation', () => {
   });
 
   test('dynamic sitemap.ts exists and queries published profiles', () => {
-    const sitemap = fs.readFileSync(path.join(root, 'src/app/sitemap.ts'), 'utf8');
+    const sitemap = fs.readFileSync(path.join(root, SRC.sitemap), 'utf8');
     expect(sitemap).toContain('is_published');
     expect(sitemap).toContain('env.siteUrl()');
     expect(sitemap).toContain('changeFrequency');
@@ -27,48 +28,48 @@ describe('SEO Optimisation', () => {
   });
 
   test('root layout has metadataBase and canonical URL', () => {
-    const layout = fs.readFileSync(path.join(root, 'src/app/layout.tsx'), 'utf8');
+    const layout = fs.readFileSync(path.join(root, SRC.layout), 'utf8');
     expect(layout).toContain('metadataBase');
     expect(layout).toContain('checklyra.com');
     expect(layout).toContain('canonical');
   });
 
   test('root layout has Twitter card metadata', () => {
-    const layout = fs.readFileSync(path.join(root, 'src/app/layout.tsx'), 'utf8');
+    const layout = fs.readFileSync(path.join(root, SRC.layout), 'utf8');
     expect(layout).toContain('twitter');
     expect(layout).toContain('card');
     expect(layout).toContain('summary');
   });
 
   test('root layout has Open Graph metadata with locale', () => {
-    const layout = fs.readFileSync(path.join(root, 'src/app/layout.tsx'), 'utf8');
+    const layout = fs.readFileSync(path.join(root, SRC.layout), 'utf8');
     expect(layout).toContain('openGraph');
     expect(layout).toContain('en_GB');
     expect(layout).toContain('siteName');
   });
 
   test('public profile page has Twitter cards and canonical URL', () => {
-    const profile = fs.readFileSync(path.join(root, 'src/app/[slug]/page.tsx'), 'utf8');
+    const profile = fs.readFileSync(path.join(root, SRC.slugPage), 'utf8');
     expect(profile).toContain('twitter');
     expect(profile).toContain('canonical');
     expect(profile).toContain('generateMetadata');
   });
 
   test('public profile page has JSON-LD structured data', () => {
-    const profile = fs.readFileSync(path.join(root, 'src/app/[slug]/page.tsx'), 'utf8');
+    const profile = fs.readFileSync(path.join(root, SRC.slugPage), 'utf8');
     expect(profile).toContain('application/ld+json');
     expect(profile).toContain('schema.org');
     expect(profile).toContain('Person');
   });
 
   test('landing page has JSON-LD structured data', () => {
-    const home = fs.readFileSync(path.join(root, 'src/app/page.tsx'), 'utf8');
+    const home = fs.readFileSync(path.join(root, SRC.appPage), 'utf8');
     expect(home).toContain('application/ld+json');
     expect(home).toContain('WebSite');
   });
 
   test('robots.txt blocks auth and dashboard pages from indexing', () => {
-    const robots = fs.readFileSync(path.join(root, 'public/robots.txt'), 'utf8');
+    const robots = fs.readFileSync(path.join(root, SRC.robots), 'utf8');
     expect(robots).toContain('Disallow: /login');
     expect(robots).toContain('Disallow: /signup');
     expect(robots).toContain('Disallow: /auth/');

--- a/tests/unit/share-versions.test.ts
+++ b/tests/unit/share-versions.test.ts
@@ -15,6 +15,7 @@ jest.mock('@/lib/beta-access/flow', () => ({ isProdFamily: () => mockIsProdFamil
 import { publicSignupUrl } from '@/lib/beta-access/invite-link';
 import fs from 'fs';
 import path from 'path';
+import { SRC } from '../support/source-paths';
 
 const ROOT = path.join(__dirname, '..', '..');
 const read = (p: string) => fs.readFileSync(path.join(ROOT, p), 'utf8');
@@ -37,7 +38,7 @@ describe('KAN-349 publicSignupUrl', () => {
 });
 
 describe('KAN-349 the existing beta share wording is preserved', () => {
-  const shareBeta = read('src/app/dashboard/share-beta.tsx');
+  const shareBeta = read(SRC.shareBeta);
   it('keeps the exact "Share beta access" default title + waitlist description', () => {
     expect(shareBeta).toContain("title = 'Share beta access'");
     expect(shareBeta).toMatch(/skips the waitlist and drops them straight into the beta/);
@@ -48,7 +49,7 @@ describe('KAN-349 the existing beta share wording is preserved', () => {
 });
 
 describe('KAN-349 W5 renders both versions', () => {
-  const widgets = read('src/app/dashboard/widgets/dashboard-widgets.tsx');
+  const widgets = read(SRC.dashboardWidgets);
   it('shows the beta widget when a betaLink exists, else the sign-up version', () => {
     expect(widgets).toMatch(/ctx\.betaLink \?[\s\S]{0,400}ShareBeta inviteLink=\{ctx\.betaLink\}/);
     expect(widgets).toMatch(/inviteLink=\{ctx\.signupUrl\}[\s\S]{0,200}title="Share Lyra"/);

--- a/tests/unit/wizard.test.js
+++ b/tests/unit/wizard.test.js
@@ -5,20 +5,21 @@
 
 const fs = require('fs');
 const path = require('path');
+const { SRC } = require('../support/source-paths.json');
 
 const root = path.join(__dirname, '../..');
 
 describe('Profile Wizard', () => {
   test('wizard page exists', () => {
-    expect(fs.existsSync(path.join(root, 'src/app/dashboard/profile/page.tsx'))).toBe(true);
+    expect(fs.existsSync(path.join(root, SRC.profilePage))).toBe(true);
   });
 
   test('wizard client component exists', () => {
-    expect(fs.existsSync(path.join(root, 'src/app/dashboard/profile/wizard.tsx'))).toBe(true);
+    expect(fs.existsSync(path.join(root, SRC.wizard))).toBe(true);
   });
 
   test('wizard has all 8 steps defined', () => {
-    const content = fs.readFileSync(path.join(root, 'src/app/dashboard/profile/wizard.tsx'), 'utf8');
+    const content = fs.readFileSync(path.join(root, SRC.wizard), 'utf8');
     expect(content).toContain("id: 'identity'");
     expect(content).toContain("id: 'school'");
     expect(content).toContain("id: 'bio'");
@@ -30,7 +31,7 @@ describe('Profile Wizard', () => {
   });
 
   test('profile actions file exists with all CRUD operations', () => {
-    const content = fs.readFileSync(path.join(root, 'src/app/dashboard/profile/actions.ts'), 'utf8');
+    const content = fs.readFileSync(path.join(root, SRC.profileActions), 'utf8');
     expect(content).toContain('export async function updateProfileFields');
     expect(content).toContain('export async function addProfileItem');
     expect(content).toContain('export async function removeProfileItem');
@@ -40,7 +41,7 @@ describe('Profile Wizard', () => {
   });
 
   test('dashboard links to profile wizard', () => {
-    const content = fs.readFileSync(path.join(root, 'src/app/dashboard/page.tsx'), 'utf8');
+    const content = fs.readFileSync(path.join(root, SRC.dashboardPage), 'utf8');
     expect(content).toContain('/dashboard/profile');
   });
 });


### PR DESCRIPTION
## Summary

**Group 1 of the F4 sign-off, complete.** 95 files, **378 of 418** raw repo-path literals now resolve through `tests/support/source-paths`. Ratchet **418/96 → 40/10**.

**Value-preserving by construction:** `SRC.x` *is* the literal string, so every assertion keeps its exact expected value — only the *source* of the path changes. That's the property the sign-off rests on, and it's verified rather than asserted.

## Proof: the suite is byte-identical before and after

```
before:  2667 total / 2649 passed / 18 failed
after:   2667 total / 2649 passed / 18 failed
```

Those 18 are the known macOS-only pair (`guard-fail-closed`, `check-extraction-dod`), identical on clean `develop`. Also: `tsc --noEmit` clean, `node --check` clean on every converted `.js`, lint 0 errors.

## The count check earned its place immediately

The first attempt **broke 3 suites and lost 57 tests**. An object-literal *key* can't be a bare member expression:

```js
{'src/x.ts': v}   ->   {SRC.x: v}     // SyntaxError: Unexpected token '.'
```

It now emits a computed key `{[SRC.x]: v}`, and distinguishes that from a ternary's true-branch — also followed by `:` but which must **not** be bracketed — by the preceding token (`{`/`,` = key, `?` = ternary).

I also added a `node --check` syntax gate to the process, so a parse error surfaces in a second rather than as a suite that "failed to run" behind a generic Babel message.

## ⚠️ The remaining 40 are not unfinished work

Every residual literal is a path that **does not exist**: synthetic fixture paths written into sandbox trees (`src/app/alpha/a.ts`, `src/lib/__probe_new.ts`, `scripts/keep.sh`) or deliberately asserted-absent paths (`src/app/loading.tsx` — the BUGS-66 guard). They are fixture **content**, not references to real source.

The manifest only ever contains paths that exist — that's its entire promise. Converting these would mean inventing entries for files that aren't there, and **driving the count to zero would make the manifest lie.**

The baseline's `$comment` now records this, because *"the ratchet says 40 and should say 0"* is exactly the kind of well-meant tidy-up that would quietly break the guarantee.

## What this unblocks

A module move now updates **one generated file** instead of ~95 tests. That was the prerequisite for per-module CI, honest per-module floors (F5's remainder), and KAN-429's verification estate — and it removes the standing pressure to weaken a test rather than fix a path when an extraction lands.

## Jira Ticket

KAN-414 (F4) / KAN-417 §8 **Group 1** — approved 2026-07-30. Groups 2 and 3 not touched.

## Checklist

- [x] Unit tests added/updated — N/A: no test added or removed; this re-points where a path string comes from. Total count identical before and after
- [x] All existing tests pass — 2649 passed, unchanged
- [x] Lint passes — 0 errors
- [x] Type check passes — `tsc --noEmit` clean
- [x] Build succeeds — tests only
- [x] Coverage has not decreased — no src changes
- [x] No eslint-disable or ts-ignore without KAN-XX reference — none added
- [x] ARCHITECTURE.md updated if architectural changes were made — N/A: test infrastructure
- [x] Ops routine / Control-Room registry updated — N/A: the ratchet is a jest guard, already registered under F4
- [x] Docs / system map updated — the residual-40 rationale is recorded in the baseline `$comment`, where the next reader will actually meet it

🤖 Generated with [Claude Code](https://claude.com/claude-code)