### PR TITLE
feat(KAN-413): soak every staging deploy, and refuse to promote past a failed one

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -62,12 +62,49 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Resolve the Playwright version for the cache key
+        # Keyed on the exact installed version, not a floating one: browser
+        # binaries are version-locked, and a stale cache would produce
+        # "Executable doesn't exist" — the same failure the webkit note below
+        # describes, but harder to diagnose because the install step is green.
+        id: pw
+        run: |
+          set -euo pipefail
+          V=$(node -p "require('@playwright/test/package.json').version")
+          echo "version=$V" >> "$GITHUB_OUTPUT"
+          echo "Playwright $V"
+
+      - name: Cache Playwright browsers
+        # This step download hung for 19+ minutes on 2026-07-31 and again on
+        # 2026-07-30, both times tripping the job's 20-minute timeout and
+        # cancelling a run that was otherwise fine. Normal duration is ~54s, so
+        # this is upstream CDN variance, not our code — but two cancelled runs
+        # cost ~40 minutes of CI and, worse, read as a red check on a healthy PR.
+        # A cache hit removes the download from the critical path entirely.
+        id: pw-cache
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ steps.pw.outputs.version }}
+
       - name: Install Playwright browsers
         # chromium + webkit: playwright.config.ts defines a mobile-safari
         # (iPhone 14 / webkit) project alongside chromium. Without webkit
         # every mobile-safari test errors with "Executable doesn't exist"
         # and the job goes red even when chromium passes (KAN-180).
-        run: npx playwright install --with-deps chromium webkit
+        #
+        # On a cache hit only the OS-level deps are installed (fast, and not
+        # cacheable); the browser binaries come from the cache. `--with-deps` is
+        # kept in both paths because those system packages live outside
+        # ~/.cache/ms-playwright and are NOT restored by the cache.
+        run: |
+          set -euo pipefail
+          if [ "${{ steps.pw-cache.outputs.cache-hit }}" = "true" ]; then
+            echo "Browser binaries restored from cache; installing OS deps only."
+            npx playwright install-deps chromium webkit
+          else
+            npx playwright install --with-deps chromium webkit
+          fi
 
       - name: Build the app
         # Run the production build as its own step so its duration doesn't

--- a/.github/workflows/promote-staging-to-beta.yml
+++ b/.github/workflows/promote-staging-to-beta.yml
@@ -103,6 +103,69 @@ jobs:
           echo "::error::Could not verify staging CI for ${STAGING_SHA:0:8} after $MAX_ATTEMPTS attempts."
           exit 1
 
+      - name: Check the post-deploy soak passed for this SHA
+        # The staging CI check above proves the BUILD was good. It says nothing
+        # about whether the deployed app still works end to end — which is what
+        # staging is for. soak-journey.yml now fires automatically on every
+        # successful staging deploy, so by the time anyone promotes there is a
+        # soak result for this exact SHA to read.
+        #
+        # FAILS CLOSED, deliberately, in three directions:
+        #   * soak FAILED            -> refuse
+        #   * soak never ran for SHA -> refuse (not "assume fine")
+        #   * budget exhausted       -> refuse
+        # "No soak found" is the dangerous one. Treating absence as success is
+        # how a gate becomes decorative, and it is the exact SEC-79 shape this
+        # repo keeps re-learning. Someone who genuinely needs to promote without
+        # a soak can dispatch soak-journey manually and wait, or take the
+        # documented decision to bypass — but not silently.
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          STAGING_SHA="${{ steps.check.outputs.staging_sha }}"
+          echo "Looking for a soak result for ${STAGING_SHA:0:8}"
+
+          # The soak takes ~5-10 min and starts only after deploy-staging
+          # finishes, so allow a generous budget. 40 x 20s = ~13 min.
+          MAX_ATTEMPTS=40
+          ATTEMPT=0
+          while [ $ATTEMPT -lt $MAX_ATTEMPTS ]; do
+            ATTEMPT=$((ATTEMPT + 1))
+            INFO=$(gh run list \
+              --repo "${{ github.repository }}" \
+              --workflow soak-journey.yml \
+              --limit 20 \
+              --json status,conclusion,headSha,databaseId \
+              | python3 -c "
+          import json, sys
+          target = '$STAGING_SHA'
+          for r in json.load(sys.stdin):
+              if r['headSha'] == target:
+                  print(f\"{r['status']}|{r['conclusion'] or 'pending'}|{r['databaseId']}\")
+                  break
+          else:
+              print('NONE||')
+          ")
+            ST=$(echo "$INFO" | cut -d'|' -f1)
+            CC=$(echo "$INFO" | cut -d'|' -f2)
+            RID=$(echo "$INFO" | cut -d'|' -f3)
+            echo "Attempt $ATTEMPT/$MAX_ATTEMPTS: soak for ${STAGING_SHA:0:8} = $ST / $CC"
+
+            if [ "$ST" = "completed" ]; then
+              if [ "$CC" = "success" ]; then
+                echo "::notice::Post-deploy soak PASSED for ${STAGING_SHA:0:8} (run $RID). Safe to promote to beta."
+                exit 0
+              fi
+              echo "::error::Post-deploy soak did NOT pass for ${STAGING_SHA:0:8} — conclusion '$CC' (run $RID). Refusing to promote a build that failed its own staging soak. Fix the failure, or re-run the soak if it was infrastructure."
+              exit 1
+            fi
+            sleep 20
+          done
+
+          echo "::error::No completed soak found for staging HEAD ${STAGING_SHA:0:8} after $MAX_ATTEMPTS attempts. Refusing to promote: an unsoaked build is not a soaked one, and treating a missing result as a pass is how this gate would stop meaning anything. Dispatch soak-journey.yml against staging and re-run this promote."
+          exit 1
+
   merge-and-push:
     name: Merge staging → beta
     needs: verify-source

--- a/.github/workflows/soak-journey.yml
+++ b/.github/workflows/soak-journey.yml
@@ -31,6 +31,14 @@ on:
         description: 'DNS-only grey-cloud staging alias to run against (bypasses CF bot-mgmt)'
         required: false
         default: 'https://e2e-stage.checklyra.com'
+  # Fire automatically after every staging deploy, so a promote is always soaked
+  # against the build that actually landed rather than against whatever staging
+  # happened to be running when someone last remembered to press the button.
+  # promote-staging-to-beta.yml then REFUSES to promote until the soak for that
+  # exact SHA has passed — see its "post-deploy soak" gate.
+  workflow_run:
+    workflows: ["Deploy to Staging"]
+    types: [completed]
 
 permissions:
   contents: read
@@ -43,6 +51,9 @@ jobs:
   soak-journey:
     name: Playwright soak journey (staging via e2e-stage)
     runs-on: ubuntu-latest
+    # Don't soak a staging deploy that itself failed — there is nothing
+    # meaningful to test and a red soak would mask the real cause.
+    if: ${{ github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success' }}
     timeout-minutes: 20
     # Fixed soak-user email → concurrent runs would race on reset/create. Serialise.
     concurrency:


### PR DESCRIPTION
## Summary

Requested 2026-07-31: **run the soak automatically after any promotion to stage, and check the result before promoting on to beta and prod.**

## Two halves

**1. `soak-journey.yml` fires after every staging deploy** — a `workflow_run` trigger on "Deploy to Staging" completion, guarded so a *failed* deploy isn't soaked (nothing meaningful to test, and a red soak would mask the real cause).

A promote is now always soaked against **the build that actually landed**, rather than against whatever staging happened to be running when someone last pressed the button.

**2. `promote-staging-to-beta.yml` refuses to promote past a failed soak.** The gate sits in `verify-source` next to the existing staging-CI check — that one proves the *build* was good; it says nothing about whether the deployed app still works end to end, which is what staging is for. `merge-and-push` depends on `verify-source`, so **a failed soak blocks beta and therefore blocks production.**

### Fails closed in three directions

| Case | Result |
|---|---|
| soak **failed** | refuse |
| soak **never ran** for this SHA | refuse |
| wait budget exhausted | refuse |

The middle one is the dangerous one. **Treating "no soak found" as success is how a gate becomes decorative** — the SEC-79 shape this repo keeps re-learning. Budget is 40 × 20s (~13 min), since the soak only starts once `deploy-staging` finishes.

## Also: cache the Playwright browsers

The "Install Playwright browsers" step **hung for 19+ minutes today and again on 2026-07-30**, both times tripping the 20-minute job timeout and **cancelling an otherwise-healthy run**. Normal duration is ~54s — upstream CDN variance, not our code. But it cost ~40 minutes of CI and painted a red check on a green PR twice.

**A soak that can't finish can't gate anything**, so this belongs with the gate rather than in a tidy-up later.

Keyed on the **exact installed Playwright version** — browser binaries are version-locked, and a stale cache produces "Executable doesn't exist", the same failure the existing webkit note describes but harder to spot because the install step stays *green*. On a cache hit only the OS-level deps are installed: those live outside `~/.cache/ms-playwright` and are **not** restored by the cache, so `--with-deps` can't simply be dropped.

`check-action-pinning.sh` caught `actions/cache@v4` as a mutable ref (SEC-77 F-22) before it could merge — now SHA-pinned.

## Verification

Both workflows parse · `check-workflow-integrity`, `check-action-pinning` and all five Phase 0 gates exit 0 · 28/28 on the two guard suites.

## Jira Ticket

KAN-413 (staging soak) / SEC-98 (promotion controls)

## Checklist

- [x] Unit tests added/updated — N/A: workflow wiring; verified via the existing `check-action-pinning` / `check-workflow-integrity` suites (28/28), which caught a real defect here
- [x] All existing tests pass — no code changed
- [x] Lint passes — no JS/TS changed
- [x] Type check passes — no TS changed
- [x] Build succeeds — workflows only
- [x] Coverage has not decreased — no src changes
- [x] No eslint-disable or ts-ignore without KAN-XX reference — none added
- [x] ARCHITECTURE.md updated — N/A
- [x] Ops routine / Control-Room registry updated — the soak routine's trigger changes from schedule-only to schedule + post-deploy; rationale is in the workflow header
- [x] Docs / system map updated — documented inline in both workflows at the point of change

🤖 Generated with [Claude Code](https://claude.com/claude-code)