### PR TITLE
fix(SEC-106): a deploy waiting for approval is not a failed deploy

### DIFF
--- a/.github/workflows/promote-to-production.yml
+++ b/.github/workflows/promote-to-production.yml
@@ -304,6 +304,24 @@ jobs:
             SEEN_RUN_ID="$RUN_ID"
             LAST_STATUS="$STATUS"
 
+            # SEC-106: the Production environment now requires a reviewer, so a
+            # deploy legitimately sits at 'waiting' until a human approves it.
+            # That is the control working, NOT a failure — but this loop was
+            # written when nothing could pause a production deploy, so it burned
+            # its budget, failed, and fired AUTO-ROLLBACK on a perfectly good
+            # promote (2026-07-31, run 30666194572: a spurious rollback alert
+            # emailed, and the rollback itself then failed on a Vercel 409).
+            #
+            # Exit 0 and stop waiting. main is already merged and correct; the
+            # deploy will run the moment it is approved, and deploy-production
+            # carries its own smoke tests. Blocking here adds nothing except a
+            # false failure and a misleading alert.
+            if [ "$STATUS" = "waiting" ]; then
+              echo "::notice::deploy-production run $RUN_ID is WAITING for environment approval (SEC-106 required reviewer). main is merged at ${EXPECTED_SHA:0:8}; the deploy runs on approval."
+              echo "::notice::Approve it at ${{ github.server_url }}/${{ github.repository }}/actions/runs/$RUN_ID — this promote is not failing and no rollback is warranted."
+              exit 0
+            fi
+
             if [ "$STATUS" = "completed" ]; then
               if [ "$CONCLUSION" = "success" ]; then
                 echo "::notice::deploy-production run $RUN_ID succeeded for SHA ${EXPECTED_SHA:0:8}"


### PR DESCRIPTION
## Summary

Adding the **Production required-reviewer** this morning broke `promote-to-production` in a way only a real promote reveals. Observed tonight, [run 30666194572](https://github.com/luisa-sys/lyra/actions/runs/30666194572):

| Job | Result |
|---|---|
| Merge beta → main | ✅ success |
| Wait for production deploy (SHA-matched) | ❌ **failed** — 600s budget, deploy was `waiting` for a human the whole time |
| Auto-rollback on failure | ⚠️ **fired** — emailed a rollback alert for a healthy promote, then itself failed on a Vercel 409 |

**Nothing was actually wrong.** `main` merged correctly, all four environments flat, prod serving fine, `guard` chain check green. The wait loop was written when nothing *could* pause a production deploy; SEC-106 made that possible and `waiting` fell straight through to the timeout branch.

## The fix

Treat `waiting` as what it is — the control working — and exit 0. `main` is already merged, the deploy runs the moment it's approved, and `deploy-production` carries its own smoke tests. Blocking there bought nothing and cost a false failure plus a misleading alert.

**The alert is the part that matters.** A rollback email that fires when nothing is wrong is worse than no alert, because the next real one gets ignored. Same shape as every finding this week: a control reporting the wrong thing erodes trust in the ones reporting correctly.

Also prints the approval URL in the run summary, so nobody is left guessing why a green-looking promote appears stuck.

## Not applied to `promote-staging-to-beta.yml`

Beta has no required reviewer today. If one is ever added, that workflow needs the identical change — noted rather than pre-emptively edited, since an unused branch is an untested one.

## Jira Ticket

SEC-106 (follow-on)

## Checklist

- [x] Unit tests added/updated — N/A: workflow control flow; the failure mode was observed on a live promote and is documented inline
- [x] All existing tests pass — no code changed
- [x] Lint passes — no JS/TS changed
- [x] Type check passes — no TS changed
- [x] Build succeeds — workflow only
- [x] Coverage has not decreased — no src changes
- [x] No eslint-disable or ts-ignore without KAN-XX reference — none added
- [x] ARCHITECTURE.md updated — N/A
- [x] Ops routine / Control-Room registry updated — N/A: no routine ownership change
- [x] Docs / system map updated — rationale recorded inline at the point of change, including why beta was left alone

🤖 Generated with [Claude Code](https://claude.com/claude-code)