### PR TITLE
docs(KAN-414 F4): handover — verified findings, open leads, preserved prototype

### DIFF
--- a/docs/modularisation/KAN-414-F4-HANDOVER-2026-08-01.md
+++ b/docs/modularisation/KAN-414-F4-HANDOVER-2026-08-01.md
@@ -1,0 +1,292 @@
+# KAN-414 F4 — handover, 2026-08-01
+
+Written at the end of a session that ran out of weekly token budget. Everything
+here is either **verified** (mutation-proven, stated as fact) or explicitly
+marked **UNVERIFIED**. Do not promote anything from the second category to the
+first without re-deriving it.
+
+---
+
+## 1. What is already merged
+
+**PR #658 is on `develop`** (`10a75e58`), all four checks green.
+
+### Conversions — each mutation-proven, old scan stays green
+
+| Converted | Decisive mutation | Old scan under that mutation |
+|---|---|---|
+| `convene/drain-route` | hardcode a different `hostUserId` (one user drains another's queue) | green |
+| `convene/post-event` | invitee filter `accepted` → `pending` | green |
+| `sentry-scaffold` | `beforeSend: (e) => e` — **SEC-55 undone** | 9/9 green |
+| `seo` sitemap block | drop `.eq('is_suspended', false)` — **SEC-100 verbatim** | 9/9 green |
+
+New files: `tests/unit/convene/drain-route-behaviour.test.ts`,
+`tests/unit/convene/post-event-sweep-behaviour.test.ts`,
+`tests/unit/sentry-client-init-behaviour.test.ts`,
+`tests/unit/sitemap-suspension-behaviour.test.ts`.
+
+### Two vacuous suites — missing coverage, not weak coverage
+
+- **BUGS-85** — `tests/unit/maintenance-page.test.js` re-declares the worker's
+  `isValidEmail` and rate limiter and tests those copies. Fixed additively by
+  `tests/scripts/maintenance-worker-behaviour.test.js` +
+  `tests/support/maintenance-worker-harness.mjs`.
+- **SEC-113** — `tests/unit/rate-limit.test.js` (titled *"Real unit tests for
+  src/lib/rate-limit.ts"*, line 8 `// --- Replicated from ... ---`). **No test
+  anywhere called the real `rateLimit()`.** Fixed additively by
+  `tests/unit/rate-limit-behaviour.test.ts` (9 tests).
+
+| Mutation to the real module | Old suite | New suite |
+|---|---|---|
+| worker `isValidEmail` → `return true` | 19/19 pass | 2 failed |
+| worker `isRateLimited` → `return false` | 19/19 pass | 2 failed |
+| worker `escapeHtml` → identity (SEC-21 F-23) | 19/19 pass | 1 failed |
+| limiter `entry.count > config.limit + 1` | 8/8 pass | 5 failed |
+| limiter auth preset `limit: 10` → `1000` | 8/8 pass | 2 failed |
+| limiter `entry.count++` removed | 8/8 pass | 6 failed |
+
+All six compile cleanly. **No original test was deleted or weakened** — deletion
+is a separate sign-off step under KAN-417 §8.
+
+### CTL-038
+
+`scripts/check-test-reimplementation.py`, registered in `controls/registry.json`,
+wired into `pr-checks.yml`, guard test at
+`tests/scripts/check-test-reimplementation.test.js`, baseline at
+`tests/support/test-reimplementation-baseline.json` (3 findings).
+
+It shipped with **three** blind spots, all found the same day, each now a
+`--self-test` fixture. Assume any new detector has one.
+
+---
+
+## 2. THE OPEN FINDING — assertions satisfied only by a comment
+
+This is the most valuable unfinished thread. **Pick this up first.**
+
+### The three VERIFIED instances
+
+**(a) `sitemap.ts` / `seo.test.js`.** `is_published` occurs twice — once in the
+query, once in the comment explaining why the query needs it. Deleting
+`.eq('is_published', true)` leaves `toContain('is_published')` green.
+
+**(b) `dashboard/profile/page.tsx` / `conversation-starters.test.ts`.** The
+worst case, because it is not accidental. Line 27:
+
+```
+ * also matches `conversation_starter_prompts` / `profile_conversation_starters`
+ * regression guard in `tests/unit/conversation-starters.test.ts`).
+```
+
+**The comment was written to satisfy the scan.** Both asserted strings sit on
+that one line. Verified by mutation: deleting all three real data-fetch lines
+(71, 76, 77) while leaving the comment gives **11/11 green**.
+
+**(c) `rate-limit.ts`** — a variant. `toContain('limit: 10')` stays green when
+the auth preset is raised to 1000, because that string still appears in the
+other presets. Not a comment, but the same root: *a string that occurs
+elsewhere pins nothing.*
+
+### The 38 UNVERIFIED candidates
+
+A throwaway prototype (reproduced in §5 below — it was run inline and never
+committed) flagged **41 assertions** whose literal matches the subject file but
+not the same file with comments stripped. Three are the verified cases above.
+**The other 38 are leads, not findings.**
+
+Known likely false positives, so triage before trusting:
+
+- The nine `redesign-fidelity.test.js` → `globals.css` hits
+  (`--color-sage: #4a7359` etc.) look like the prototype's `/* … */` stripping
+  mishandling CSS. **Check first — if these are wrong, the count drops by ~9.**
+- `'use server'` in `contact/actions.ts` is a real directive; a hit there is
+  almost certainly a stripping artefact.
+- `mcp-discoverability.test.js` → `public/llms.txt` asserting `'# Lyra'`: in a
+  `.txt` file `#` is content, not a comment. The prototype strips `^#` lines
+  for py/yaml and wrongly applied it here.
+
+The full flagged list, verbatim, for triage:
+
+| Test | Subject | Literal |
+|---|---|---|
+| `check-test-reimplementation.test.js` | `.github/workflows/pr-checks.yml` | `BUGS-85` |
+| `check-test-reimplementation.test.js` | `.github/workflows/pr-checks.yml` | `isValidEmail` |
+| `age-self-declaration.test.ts` | `src/app/(auth)/actions.ts` | `/confirm-age` |
+| `auth.test.js` | `src/app/(auth)/login/page.tsx` | `/login` |
+| `auth.test.js` | `src/app/(auth)/social-login-buttons.tsx` | `KAN-37` |
+| `auth.test.js` | `src/app/(auth)/actions.ts` | `Continue with Google` |
+| `auth.test.js` | `src/app/(auth)/actions.ts` | `// export async function signInWithApple` |
+| `auth.test.js` | `src/app/(auth)/actions.ts` | `KAN-37` |
+| `backup.test.js` | `scripts/backup-database-complete.sh` | `check-complete-backup.sh` |
+| `backup.test.js` | `scripts/backup-database-api.sh` | `Database Backup` |
+| `backup.test.js` | `.github/workflows/backup-complete.yml` | `age -r` |
+| `backup.test.js` | `.github/workflows/backup-restore-test.yml` | `SUPABASE_DB_URL` |
+| `backup.test.js` | `scripts/rollback-vercel.sh` | `Deployment Rollback` |
+| `convene/dispatch.test.ts` | `…/cron/send-invites/route.ts` | `/api/convene/cron/send-invites` |
+| `convene/post-event.test.ts` | `…/cron/post-event/route.ts` | `/api/convene/cron/post-event` |
+| `examples-page.test.js` | `src/app/examples/page.tsx` | `See example profiles` |
+| `homepage-content.test.js` | `src/app/(auth)/signup/page.tsx` | `isProdDeploy` |
+| `legal-pages.test.js` | `src/app/footer.tsx` | `checklyra.com` |
+| `legal-pages.test.js` | `src/app/layout.tsx` | `Essential` |
+| `mcp-discoverability.test.js` | `public/llms.txt` | `# Lyra` |
+| `partners-page.test.js` | `src/app/(legal)/partners/page.tsx` | `/partners` |
+| `photo-upload.test.js` | `…20260330120000_add_avatar_url_and_storage.sql` | `image/jpeg` |
+| `photo-upload.test.js` | (same) | `image/png` |
+| `photo-upload.test.js` | (same) | `image/webp` |
+| `photo-upload.test.js` | (same) | `image/gif` |
+| `profile-actions.test.ts` | `src/app/dashboard/profile/actions.ts` | `slug` |
+| `redesign-fidelity.test.js` | `src/app/globals.css` | `--color-sage: #4a7359` |
+| `redesign-fidelity.test.js` | `src/app/globals.css` | `--color-lyra-sage: #4a7359` |
+| `redesign-fidelity.test.js` | `src/app/globals.css` | `--color-sage-hover: #3d5f4a` |
+| `redesign-fidelity.test.js` | `src/app/globals.css` | `--color-lyra-sage-hover: #3d5f4a` |
+| `redesign-fidelity.test.js` | `src/app/globals.css` | `--color-ink: #23201d` |
+| `redesign-fidelity.test.js` | `src/app/globals.css` | `--color-lyra-ink: #23201d` |
+| `redesign-fidelity.test.js` | `src/app/globals.css` | `--color-muted: #6f6860` |
+| `redesign-fidelity.test.js` | `src/app/globals.css` | `--color-lyra-muted: #6f6860` |
+| `redesign-fidelity.test.js` | `src/app/globals.css` | `--color-accent-soft: #e9efea` |
+| `redesign-fidelity.test.js` | `src/app/globals.css` | `--color-chip: #edf2ee` |
+| `redesign-fidelity.test.js` | `src/app/(legal)/contact/actions.ts` | `'use server'` |
+| `redesign-fidelity.test.js` | `src/app/(legal)/contact/actions.ts` | `NEXT_PUBLIC_TURNSTILE_SITE_KEY` |
+| `redesign-fidelity.test.js` | `src/app/(legal)/contact/actions.ts` | `TURNSTILE_SECRET_KEY` |
+| `sanitise.test.ts` | `src/lib/sanitise.ts` | `<script` |
+| `wizard.test.js` | `src/app/dashboard/profile/page.tsx` | `/dashboard/profile` |
+
+**The `photo-upload` → migration MIME-type ones are worth checking early.** If
+the allowed-MIME list is asserted only against a comment, then the storage
+bucket's file-type restriction is unguarded — that is a real security surface,
+not a test-hygiene point.
+
+---
+
+## 3. Group 3 — the real remaining scope
+
+The triage headline (`python3 scripts/triage-source-text-tests.py`) is **234
+convertible candidates**. Treat that as an upper bound that has fallen at every
+inspection (263 → 234 during this session) and will fall further.
+
+An adversarial pass over 8 files **refuted 6 of 9** conversion claims. Those
+would have become tests that look more modern and prove less.
+
+**Three claims survived** and are the ready-to-implement queue:
+
+1. `dashboard/profile page.tsx still fetches conversation starter data`
+   (`conversation-starters.test.ts`) — this is verified case (b) above, so it is
+   both a survivor **and** the strongest comment-pattern evidence. Highest value.
+2. `auth/callback continues to handle the next query param`
+   (`forgot-reset-password.test.ts`) — recovery redirect.
+3. `login page surfaces the post-reset success message`
+   (`forgot-reset-password.test.ts`).
+
+Files assessed and found **not** worth converting: `moderation-actions.test.ts`
+(already-strong), plus most blocks in `age-self-declaration`, `photo-upload`,
+`invites`, `affiliations-and-autosave` (already-covered / ui-gated / structural).
+
+`convene/connections-page.test.ts` (11 blocks, the largest single candidate)
+remains **deliberately deferred** — it is the SEC-109 file and should ride that
+branch's merge.
+
+---
+
+## 4. Constraints that must not be forgotten
+
+- **No `jest.config.js` change without sign-off.** Jest transforms only
+  `.ts`/`.tsx`. Adding a `.js` rule would change how ~100 existing test files
+  execute. The approved pattern for an un-importable subject is a subprocess
+  harness in `tests/support/*.mjs` driven from `tests/scripts/` — see
+  `tests/support/maintenance-worker-harness.mjs`.
+- `src/app/layout.tsx` cannot be imported under jest (`globals.css` +
+  `next/font/google`). This blocks **1 of 109** referenced modules — a one-file
+  question, not a systemic blocker. `seo.test.js`'s root-layout metadata scans
+  stay unconverted for this reason.
+- **Stage before measuring.** `git ls-files` cannot see an unstaged file. The
+  raw-literal ratchet and CTL-035 both went red this session for exactly this.
+- The raw-literal ratchet is **shrink-only and fails both ways**. When new test
+  files add path literals, route them through `SRC` — do not raise the baseline.
+
+## Open sign-off decisions (founder)
+
+1. Whether to **delete** the superseded blocks in `maintenance-page.test.js`,
+   `rate-limit.test.js`, and the four converted scans. Until then they remain,
+   and `rate-limit.test.js` / `maintenance-page.test.js` stay baselined as
+   `vacuous` in CTL-038 — which is honest, because they still are.
+2. Whether to widen CTL-038 to **cross-language** subjects. Deliberately not
+   done: `auto-fix-patterns.test.js` reimplements the matcher from
+   `scripts/auto-fix-known-failures.py`, but a naive `.py` widening would raise
+   a **false alarm** on `anomaly-detect.test.js`, whose local helper genuinely
+   `importlib`-loads the real Python. A gate that cries wolf is how gates get
+   waved through. Tracked on SEC-113.
+3. **SEC-109 (#629)** still needs a founder trailer + test-assertion sign-off —
+   unrelated to this work but still open.
+
+---
+
+## 5. The prototype detector, preserved
+
+Run inline during the session and never committed. Reproduced verbatim so the
+lead is not lost. **It is a prototype with known false positives** — the
+comment-stripping is naive and file-type-blind, which is exactly what §2's
+suspected false positives come from. Harden it per file type before trusting
+any output.
+
+```python
+import re, subprocess, json, os
+tests=[f for f in subprocess.run(['git','ls-files','tests'],capture_output=True,text=True).stdout.split()
+       if f.endswith(('.ts','.tsx','.js')) and not f.startswith('tests/support/')]
+SRC=json.load(open('tests/support/source-paths.json'))['SRC']
+
+def strip_comments(t):                      # TOO NAIVE — fix per file type
+    t=re.sub(r'/\*.*?\*/', lambda m: '\n'*m.group(0).count('\n'), t, flags=re.S)
+    t=re.sub(r'^\s*//.*$', '', t, flags=re.M)
+    t=re.sub(r'^\s*--.*$', '', t, flags=re.M)   # sql
+    t=re.sub(r'^\s*#.*$', '', t, flags=re.M)    # py/yaml — WRONG for .txt/.css
+    return t
+
+CONTAIN=re.compile(r"toContain\(\s*'([^']{4,})'|toContain\(\s*\"([^\"]{4,})\"")
+hits=[]
+for rel in tests:
+    try: txt=open(rel).read()
+    except OSError: continue
+    if 'readFileSync' not in txt: continue
+    subs=set()
+    for k in re.findall(r'SRC\.([A-Za-z_$][\w$]*)', txt):
+        p=SRC.get(k)
+        if p: subs.add(p)
+    for p in re.findall(r"['\"](?:\.{1,2}/)*((?:src|scripts|supabase)/[\w./-]+)['\"]", txt):
+        subs.add(p)
+    for sp in subs:
+        if not os.path.isfile(sp): continue
+        try: st=open(sp).read()
+        except OSError: continue
+        bare=strip_comments(st)
+        for m in CONTAIN.finditer(txt):
+            lit=m.group(1) or m.group(2)
+            if lit in st and lit not in bare:
+                hits.append((rel,sp,lit))
+```
+
+### If it becomes a control (CTL-039)
+
+Follow the CTL-038 shape: shrink-only baseline that fails on new **and stale**
+entries, `--self-test` with the three verified cases as fixtures, exit 2 when
+the baseline is missing, and a `// comment-assertion-ok: <JIRA-KEY>` hatch.
+Register it and wire it into `pr-checks.yml`, or SEC-79 repeats.
+
+Only build it **after** triaging §2 — if most of the 41 are stripping artefacts,
+the honest conclusion may be that this is a three-instance problem worth fixing
+by hand, not a gate. Shipping a noisy gate would be worse than shipping none.
+
+---
+
+## 6. Suggested order when budget resets
+
+1. **Triage the 41** (§2). Cheapest, and it decides everything after it. Start
+   with the `photo-upload` migration MIME-type hits — potential real security
+   surface — and the `redesign-fidelity` CSS ones, which are the most likely
+   artefacts.
+2. **Convert the 3 survivors** (§3). Small, already adversarially validated.
+3. **Decide on CTL-039** based on (1).
+4. Take the founder sign-offs in §4 and delete the superseded blocks.
+
+Do **not** work from the triage script's 234 as a target. It is a fallback
+bucket and it over-counts; re-run it after each batch rather than trusting a
+cached figure.

--- a/docs/modularisation/KAN-414-F4-HANDOVER-2026-08-01.md
+++ b/docs/modularisation/KAN-414-F4-HANDOVER-2026-08-01.md
@@ -62,7 +62,9 @@ It shipped with **three** blind spots, all found the same day, each now a
 
 ## 2. THE OPEN FINDING — assertions satisfied only by a comment
 
-This is the most valuable unfinished thread. **Pick this up first.**
+This is the most valuable unfinished thread, and the founder has decided it
+becomes **CTL-039, a blocking gate on the modularisation** — see §5. **Pick this
+up first.**
 
 ### The three VERIFIED instances
 
@@ -264,28 +266,77 @@ for rel in tests:
                 hits.append((rel,sp,lit))
 ```
 
-### If it becomes a control (CTL-039)
+### CTL-039 — DECIDED, and it is a gate on the modularisation
 
-Follow the CTL-038 shape: shrink-only baseline that fails on new **and stale**
-entries, `--self-test` with the three verified cases as fixtures, exit 2 when
-the baseline is missing, and a `// comment-assertion-ok: <JIRA-KEY>` hatch.
-Register it and wire it into `pr-checks.yml`, or SEC-79 repeats.
+**Founder decision, 2026-08-01: build this next, as a blocking gate on the
+modularisation programme.** An earlier draft of this document recommended
+triaging first and only then deciding whether a gate was warranted. That
+sequencing is superseded — the *whether* is settled. The triage still happens,
+but as an input to building the detector correctly rather than as a precondition
+for building it at all.
 
-Only build it **after** triaging §2 — if most of the 41 are stripping artefacts,
-the honest conclusion may be that this is a three-instance problem worth fixing
-by hand, not a gate. Shipping a noisy gate would be worse than shipping none.
+The reasoning behind the decision is sound and worth restating: KAN-415 moves
+files, and a source-text scan whose assertion is satisfied by a comment will
+follow the comment rather than the code. During a migration that is exactly the
+wrong failure mode — the guard travels with the prose and silently detaches from
+the thing it was guarding. Better to have the gate **before** D1 than to
+discover mid-migration which guards were never load-bearing.
+
+**Design (follow the CTL-038 shape):**
+
+- shrink-only baseline that fails on new **and stale** entries;
+- `--self-test` carrying the three verified cases in §2 as fixtures, plus a
+  negative fixture per file type (see below);
+- exit **2** when the baseline is missing or unreadable — fail-closed, SEC-111;
+- escape hatch `// comment-assertion-ok: <JIRA-KEY> <reason>`;
+- registered in `controls/registry.json` and wired into `pr-checks.yml`, or
+  SEC-79 repeats.
+
+**The one thing that will make or break it: comment-stripping must be per file
+type.** The prototype's single naive stripper is where the suspected false
+positives come from. Required behaviour, each with a `--self-test` fixture:
+
+| File type | Comments | Trap |
+|---|---|---|
+| `.ts` / `.tsx` / `.js` | `//`, `/* */` | `'use server'` is a directive, not a comment; a `//` inside a string literal is not a comment |
+| `.css` | `/* */` only | **no** `//` and **no** `#` — `#4a7359` is a colour. This is almost certainly the source of the nine `globals.css` hits |
+| `.sql` | `--` only | `--` inside a string literal |
+| `.yml` | `#` | `#` inside a quoted scalar |
+| `.sh` / `.py` | `#` | `#!` shebang; `#` in a string |
+| `.txt` / `.md` | **none** | `# Lyra` in `llms.txt` is content — this is why the `mcp-discoverability` hit is suspect |
+
+Triage §2's 41 as the first act of building it: each confirmed case becomes a
+baseline entry, each artefact becomes a negative `--self-test` fixture. A gate
+whose false positives are pinned as fixtures cannot regress into noise, and
+noise is what teaches people to wave a gate through (CTL-031's lesson).
+
+**Do not skip the mutation proof.** For at least the three verified cases,
+delete the real code, leave the comment, and confirm the gate goes red while the
+original scan stays green. A control that has never been seen to fail is
+indistinguishable from no control.
 
 ---
 
-## 6. Suggested order when budget resets
+## 6. Order of work when budget resets
 
-1. **Triage the 41** (§2). Cheapest, and it decides everything after it. Start
-   with the `photo-upload` migration MIME-type hits — potential real security
-   surface — and the `redesign-fidelity` CSS ones, which are the most likely
-   artefacts.
-2. **Convert the 3 survivors** (§3). Small, already adversarially validated.
-3. **Decide on CTL-039** based on (1).
-4. Take the founder sign-offs in §4 and delete the superseded blocks.
+**1. Build CTL-039** (§5) — founder-decided, and a blocking gate on the
+modularisation. Triage §2's 41 as part of it: confirmed cases become baseline
+entries, artefacts become negative `--self-test` fixtures. Start the triage with
+the `photo-upload` migration MIME-type hits (if the allowed-MIME list is
+asserted only against a comment, the storage bucket's file-type restriction is
+unguarded — a real security surface, not test hygiene) and the
+`redesign-fidelity` CSS ones (most likely artefacts, and they alone would drop
+the count by ~9).
+
+**2. Resume the group-3 conversions** — the three claims in §3 that survived
+adversarial refutation, in that order. Small and already validated.
+
+**3. Re-run the classification sweep** over the remaining candidate files. The
+adversarial pass was stopped part-way; the pattern it established (refute every
+convertible verdict, default to refuting) should continue, since it killed 6 of
+9 claims.
+
+**4. Take the founder sign-offs in §4** and delete the superseded blocks.
 
 Do **not** work from the triage script's 234 as a target. It is a fallback
 bucket and it over-counts; re-run it after each batch rather than trusting a

--- a/docs/modularisation/KAN-414-F4-HANDOVER-2026-08-01.md
+++ b/docs/modularisation/KAN-414-F4-HANDOVER-2026-08-01.md
@@ -63,7 +63,7 @@ It shipped with **three** blind spots, all found the same day, each now a
 ## 2. THE OPEN FINDING — assertions satisfied only by a comment
 
 This is the most valuable unfinished thread, and the founder has decided it
-becomes **CTL-039, a blocking gate on the modularisation** — see §5. **Pick this
+becomes **CTL-039** (**KAN-440**), a blocking gate on the modularisation — see §5. **Pick this
 up first.**
 
 ### The three VERIFIED instances
@@ -319,7 +319,7 @@ indistinguishable from no control.
 
 ## 6. Order of work when budget resets
 
-**1. Build CTL-039** (§5) — founder-decided, and a blocking gate on the
+**1. Build CTL-039 — [KAN-440](https://checklyra.atlassian.net/browse/KAN-440)** (§5) — founder-decided, and a blocking gate on the
 modularisation. Triage §2's 41 as part of it: confirmed cases become baseline
 entries, artefacts become negative `--self-test` fixtures. Start the triage with
 the `photo-upload` migration MIME-type hits (if the allowed-MIME list is


### PR DESCRIPTION
Durable record of the 2026-08-01 session, written because the weekly token budget ran out mid-thread.

Docs-only. No code, no tests, no workflow changes.

**Separates verified from unverified throughout**, which is the point of it:

- **Verified (mutation-proven):** three assertions satisfied only by a comment in the file they scan. The worst is `dashboard/profile/page.tsx:27`, where the comment says it *"matches … regression guard in tests/unit/conversation-starters.test.ts"* — **the comment was written to satisfy the scan.** Deleting all three real data-fetch lines leaves 11/11 green.
- **Unverified:** a throwaway prototype flagged 41 such assertions. 38 are leads only. Likely false positives are named explicitly (the `globals.css` hits look like naive `/* */` stripping; `'# Lyra'` in a `.txt` is content, not a comment). The prototype ran inline and was never committed, so §5 reproduces it verbatim.

Also records the 3 conversion claims that survived adversarial refutation (6 of 9 refuted), the constraints that must not be forgotten, and the 3 open founder sign-offs.

**Recommends NOT building CTL-039 yet** — triage the 41 first. If most are stripping artefacts, this is a three-instance problem to fix by hand, and a noisy gate is worse than none.

Docs / system map updated — N/A beyond this file; CLAUDE.md and `controls/registry.json` were already updated in #658.