### PR TITLE
fix(waitlist): "approved" → "ready to go" (KAN-454)

### DIFF
--- a/src/app/waitlist/page.tsx
+++ b/src/app/waitlist/page.tsx
@@ -68,7 +68,7 @@ export default async function WaitlistPage({
 
         <p className="text-[var(--color-muted)] leading-relaxed">
           Thanks for trying the Lyra beta. Beta access is invite-only while we&rsquo;re polishing things.
-          We&rsquo;ll send an email when your account is approved.
+          We&rsquo;ll send an email when your account is ready to go.
         </p>
 
         {showCodeForm && (


### PR DESCRIPTION
**KAN-454** · pilot for the Claude Design → dev build loop (KAN-441 / KAN-456).

**What & why:** the waitlist confirmation ends "We'll send an email when your account is **approved**." Your recovered Document9 ("Lyra — to change", item 2) asked for "**ready to go**". One-word copy change on `src/app/waitlist/page.tsx:71`.

**Why this one:** smallest genuine change on the backlog, chosen deliberately as the pilot so the *design → PR → Jira* pipe (and the Claude Design card render) is proven end-to-end at near-zero risk.

**Tests:** no test asserts the old wording (`public-pages.spec.ts:86` only checks the "You're on the list" heading, unchanged). PR Quality Gate + CodeQL + E2E validate on CI.

**MCP coverage:** N/A — pure UI copy, no data-model/API change.
**Docs / system map:** N/A — copy-only.

Per the build loop this stays at DEV_IMPL: it does **not** merge or promote until founder design-approval, and won't close until it's live on all envs and the Claude Design baseline is re-synced.