### PR TITLE
test(KAN-414 F4): uploadAvatar limits are wired, not just declared — plus a CTL-039 blind spot found doing it

### DIFF
--- a/scripts/check-comment-only-assertions.py
+++ b/scripts/check-comment-only-assertions.py
@@ -296,29 +296,38 @@ def analyse(root: Path, rel: str, manifest: dict) -> list[dict]:
         return []
 
     preamble, blocks = scopes_of(text)
-    pre_subjects = sorted(
-        {
-            s
-            for s in (
-                resolve_subject(m.group(1), manifest) for m in READ.finditer(preamble)
-            )
-            if s
-        }
-    )
 
-    findings = []
-    for block in blocks:
-        own = sorted(
+    def subjects_in(chunk: str) -> list[str]:
+        return sorted(
             {
-                s
-                for s in (
-                    resolve_subject(m.group(1), manifest) for m in READ.finditer(block)
+                x
+                for x in (
+                    resolve_subject(m.group(1), manifest) for m in READ.finditer(chunk)
                 )
-                if s
+                if x
             }
         )
-        # Prefer the block's own read; fall back to a describe-level one.
-        uniq = own or pre_subjects
+
+    findings = []
+    # Carry the most recently-read subject forward. A `describe` that is not the
+    # FIRST in the file does its `readFileSync` in its own body, which lands at
+    # the tail of the PREVIOUS test block's chunk — so a file-level preamble
+    # alone misses it. That blind spot hid src/lib/auth/post-login-redirect.ts,
+    # where `/confirm-age` sits in both a comment and the code, and it is the
+    # commonest shape in this repo. Pinned as a self-test fixture.
+    current = subjects_in(preamble)
+    current_vars = RECEIVER.findall(preamble)
+    for block in blocks:
+        own = subjects_in(block)
+        if own:
+            # The receiver travels with the read — `const chokepoint = ...` sits
+            # in the same chunk as its readFileSync, not in the block that
+            # asserts on it.
+            current_vars = RECEIVER.findall(block) or current_vars
+            # A block's own read wins, and becomes the running subject for any
+            # following block that does not read for itself.
+            current = own
+        uniq = current
         # Exactly one subject is attributable. More and we cannot tell which
         # assertion belongs to which — skip rather than guess. Guessing is how
         # the prototype reported the server action's `image/jpeg` assertions
@@ -338,7 +347,7 @@ def analyse(root: Path, rel: str, manifest: dict) -> list[dict]:
         comments = comment_text(stext, bare)
 
         # Which variable holds this file's contents in this block?
-        vars_ = RECEIVER.findall(block) or RECEIVER.findall(preamble)
+        vars_ = RECEIVER.findall(block) or current_vars
         if not vars_:
             continue
 
@@ -408,10 +417,21 @@ def compare(found: list[dict], baseline: list[dict]) -> list[str]:
     fails = []
     for k, f in sorted(seen.items()):
         if k not in base:
+            # The message must match the severity. A single hardcoded string
+            # said "appears ONLY in a comment" for both kinds, which is false
+            # for the commoner one and would send a reader looking for code
+            # that is in fact still there — a control that reports the wrong
+            # thing erodes trust in the ones that report correctly.
+            why = (
+                "that string appears ONLY in a comment, so the assertion "
+                "proves nothing about the code"
+                if f.get("severity") == "comment-only"
+                else "that string appears in the code AND in a comment, so "
+                "deleting the code would leave this assertion green"
+            )
             fails.append(
-                f"NEW: {f['test']} asserts {f['assertion']!r} against "
-                f"{f['subject']}, where that string appears ONLY in a comment. "
-                f"Deleting the code it guards would leave this test green."
+                f"NEW [{f.get('severity', 'unknown')}]: {f['test']} asserts "
+                f"{f['assertion']!r} against {f['subject']} — {why}."
             )
     for b in sorted(base - set(seen)):
         fails.append(
@@ -536,6 +556,35 @@ def self_test() -> int:
         got = _case(r, "src/b.ts", "// foo\nconst x = 1;\n// bar\n",
                     T("src/b.ts", "expect(c).toContain('foobar');"))
         check("separate comments are not concatenated", len(got), 0)
+
+    # --- carry-forward: a describe-level read in a NON-FIRST describe --------
+    with tempfile.TemporaryDirectory() as td:
+        r = Path(td)
+        (r / "src").mkdir(parents=True)
+        (r / "src" / "a.ts").write_text("const x = 1;\n")
+        (r / "src" / "chokepoint.ts").write_text(
+            "// diverted to /confirm-age first\n"
+            "return `${origin}/confirm-age?next=x`;\n"
+        )
+        (r / "tests" / "unit").mkdir(parents=True)
+        (r / "tests" / "unit" / "t.test.js").write_text(
+            "describe('first', () => {\n"
+            "  const a = require('fs').readFileSync('src/a.ts', 'utf8');\n"
+            "  test('one', () => { expect(a).toContain('const x'); });\n"
+            "});\n"
+            "describe('second', () => {\n"
+            "  const chokepoint = require('fs').readFileSync('src/chokepoint.ts', 'utf8');\n"
+            "  test('two', () => { expect(chokepoint).toContain('/confirm-age'); });\n"
+            "});\n"
+        )
+        got = scan(r, ["tests/unit/t.test.js"], {})
+        # The read sits in the SECOND describe's body, which lands at the tail
+        # of the first test block's chunk. A file-level preamble alone missed
+        # this and reported post-login-redirect.ts clean.
+        check("describe-level read in a NON-FIRST describe is seen", len(got), 1)
+        if got:
+            check("  ...and is comment-shadowed, not comment-only",
+                  1 if got[0]["severity"] == "comment-shadowed" else 0, 1)
 
     # --- (2) scoped subject attribution --------------------------------------
     with tempfile.TemporaryDirectory() as td:

--- a/tests/scripts/check-comment-only-assertions.test.js
+++ b/tests/scripts/check-comment-only-assertions.test.js
@@ -116,7 +116,11 @@ describe('CTL-039 — comment-satisfied assertion ratchet', () => {
       spawnSync('git', ['add', '--intent-to-add', rel], { cwd: ROOT });
       const r = run();
       expect(r.status).toBe(1);
-      expect(r.stdout).toContain('NEW:');
+      // The severity is part of the message on purpose: a single hardcoded
+      // "appears ONLY in a comment" was wrong for the commoner
+      // `comment-shadowed` kind and would send a reader hunting for code that
+      // is in fact still there.
+      expect(r.stdout).toContain('NEW [comment-only]:');
       expect(r.stdout).toContain('__ctl039_probe__');
     } finally {
       spawnSync('git', ['rm', '-q', '--cached', '--force', rel], { cwd: ROOT });

--- a/tests/support/comment-assertion-baseline.json
+++ b/tests/support/comment-assertion-baseline.json
@@ -27,6 +27,12 @@
       "severity": "comment-shadowed"
     },
     {
+      "test": "tests/unit/age-self-declaration.test.ts",
+      "subject": "src/lib/auth/post-login-redirect.ts",
+      "assertion": "/confirm-age",
+      "severity": "comment-shadowed"
+    },
+    {
       "test": "tests/unit/conversation-starters.test.ts",
       "subject": "src/app/[slug]/page.tsx",
       "assertion": "/A few more things about me/",
@@ -87,6 +93,18 @@
       "severity": "comment-shadowed"
     },
     {
+      "test": "tests/unit/oauth/dcr-anti-phishing.test.ts",
+      "subject": "supabase/migrations/20260707193000_sec76_oauth_clients_is_first_party.sql",
+      "assertion": "/drop column if exists is_first_party/",
+      "severity": "comment-only"
+    },
+    {
+      "test": "tests/unit/oauth/revoke-route.test.ts",
+      "subject": "src/app/oauth/revoke/route.ts",
+      "assertion": "/Unknown token \u2014 return 200/",
+      "severity": "comment-only"
+    },
+    {
       "test": "tests/unit/public-profile.test.js",
       "subject": "src/app/[slug]/page.tsx",
       "assertion": "notFound",
@@ -96,6 +114,30 @@
       "test": "tests/unit/pwa-service-worker.test.ts",
       "subject": "public/sw.js",
       "assertion": "/CACHE_VERSION/",
+      "severity": "comment-shadowed"
+    },
+    {
+      "test": "tests/unit/retention/affiliate-clicks-retention.test.ts",
+      "subject": "supabase/migrations/20260712033000_sec74_affiliate_clicks_retention_purge.sql",
+      "assertion": "/cutoff >= now\\(\\)/",
+      "severity": "comment-shadowed"
+    },
+    {
+      "test": "tests/unit/retention/affiliate-clicks-retention.test.ts",
+      "subject": "supabase/migrations/20260712033000_sec74_affiliate_clicks_retention_purge.sql",
+      "assertion": "/security definer/",
+      "severity": "comment-shadowed"
+    },
+    {
+      "test": "tests/unit/retention/gatherings-retention.test.ts",
+      "subject": "supabase/migrations/20260717033000_sec74_gatherings_retention_purge.sql",
+      "assertion": "/cutoff >= now\\(\\)/",
+      "severity": "comment-shadowed"
+    },
+    {
+      "test": "tests/unit/retention/gatherings-retention.test.ts",
+      "subject": "supabase/migrations/20260717033000_sec74_gatherings_retention_purge.sql",
+      "assertion": "/security definer/",
       "severity": "comment-shadowed"
     },
     {

--- a/tests/unit/profile-page-conversation-starters.test.tsx
+++ b/tests/unit/profile-page-conversation-starters.test.tsx
@@ -1,0 +1,202 @@
+/**
+ * KAN-414 F4 (KAN-417 §8 group 3) — behavioural replacement for the
+ * conversation-starter source scans over src/app/dashboard/profile/page.tsx.
+ *
+ * WHY: TWO GUARDS, ONE BLIND SPOT, AND AN UNTESTED BRANCH UNDERNEATH
+ * ------------------------------------------------------------------
+ * `tests/unit/affiliations-and-autosave.test.ts` and
+ * `tests/unit/conversation-starters.test.ts` both grep this file for
+ * `conversation_starter_prompts` and `profile_conversation_starters`. Neither
+ * can see the code go away, because page.tsx:27 carries a doc comment naming
+ * both strings:
+ *
+ *     * also matches `conversation_starter_prompts` / `profile_conversation_starters`
+ *     * regression guard in `tests/unit/conversation-starters.test.ts`).
+ *
+ * VERIFIED (2026-08-02): delete lines 70-93 — both queries AND the join
+ * flattening — and each regex still returns exactly one match, on that comment.
+ * The comment was written to satisfy the scan, so the scan now guards the
+ * comment. Both guards share the blind spot; this is CTL-039's shape, and it is
+ * the case that motivated building CTL-039.
+ *
+ * Worse than a weak guard, there is nothing underneath it:
+ * `grep -rn 'conversationAnswers|conversationPrompts' tests/` returned **zero**
+ * hits across the whole tree before this file. In particular the array-vs-object
+ * join flattening at lines 80-93 — which exists because Supabase's typegen
+ * returns the joined row as an object *sometimes* and an array *other times* —
+ * had no coverage at all, in a shape duplicated verbatim in `legacy/page.tsx`
+ * and `[slug]/page.tsx`.
+ *
+ * THE INVARIANTS, IN WORDS
+ * ------------------------
+ *  1. Only ACTIVE prompts are offered, in `sort_order`, so a retired prompt
+ *     cannot reappear in the editor.
+ *  2. Answers are scoped to the signed-in member's own profile.
+ *  3. Each answer's prompt text is resolved from the join in BOTH shapes
+ *     Supabase returns — object and array. Getting this wrong renders a saved
+ *     answer with a blank question above it.
+ *  4. A missing or malformed join degrades to an empty string, not a crash on
+ *     the profile editor.
+ *
+ * MUTATION PROOF (2026-08-02, each reverted)
+ *   * delete lines 70-93 and pass empty arrays  -> cases 1-4 redden; BOTH old
+ *     scans stay green, because page.tsx:27 still names the two tables
+ *   * drop `.eq('is_active', true)`              -> case 1 reddens
+ *   * handle only the object shape               -> case 3 reddens
+ */
+import React from 'react';
+import type { ReactElement } from 'react';
+
+// Source files use the automatic JSX runtime and do not import React
+// themselves; swc's classic transform emits React.createElement, so React has
+// to be resolvable as a global at call time. Same shim as
+// tests/unit/compliance/legal-dynamic-disclosures.test.tsx.
+(globalThis as unknown as { React: typeof React }).React = React;
+
+type Row = Record<string, unknown>;
+type Q = { table: string; op: string; args: unknown[] };
+
+const queries: Q[] = [];
+let tables: Record<string, Row[]> = {};
+
+/** Chainable Supabase stub that records filters and resolves to fixture rows. */
+function makeClient() {
+  const chain = (table: string) => {
+    const rows = () => tables[table] ?? [];
+    const self: Record<string, unknown> = {};
+    const rec = (op: string) => (...args: unknown[]) => {
+      queries.push({ table, op, args });
+      return self;
+    };
+    for (const op of ['select', 'eq', 'order', 'in', 'not']) self[op] = rec(op);
+    self.single = async () => ({ data: rows()[0] ?? null, error: null });
+    self.maybeSingle = async () => ({ data: rows()[0] ?? null, error: null });
+    // A terminated chain is awaited directly for list reads.
+    self.then = (resolve: (v: unknown) => unknown) =>
+      resolve({ data: rows(), error: null });
+    return self;
+  };
+  return {
+    auth: { getUser: async () => ({ data: { user: { id: 'user-1' } } }) },
+    from: (t: string) => chain(t),
+  };
+}
+
+jest.mock('@/lib/supabase-server', () => ({
+  createClient: jest.fn(async () => makeClient()),
+}));
+
+// `redirect` mocked as a no-op does NOT throw the way Next's does, so the
+// guard clauses would fall through on a missing fixture. Throwing keeps a
+// misconfigured test RED rather than silently green — the fixtures below
+// always supply a user and a profile.
+jest.mock('next/navigation', () => ({
+  redirect: jest.fn((to: string) => {
+    throw new Error(`unexpected redirect to ${to}`);
+  }),
+}));
+
+jest.mock('@/lib/convene/flags-user', () => ({
+  isConveneEnabledForCurrentUser: jest.fn(async () => false),
+}));
+
+// The editor itself is out of scope — this asserts what the page HANDS it.
+jest.mock('@/app/dashboard/profile/edit-profile-form', () => ({
+  EditProfileForm: (props: Record<string, unknown>) => props,
+}));
+
+import ProfilePage from '@/app/dashboard/profile/page';
+
+type Answer = { id: string; prompt_id: string; answer: string; prompt: string };
+
+async function renderProps(): Promise<Record<string, unknown>> {
+  const el = (await ProfilePage()) as ReactElement;
+  return el.props as Record<string, unknown>;
+}
+
+const PROFILE = { id: 'profile-1', user_id: 'user-1' };
+
+beforeEach(() => {
+  queries.length = 0;
+  tables = {
+    profiles: [PROFILE],
+    profile_items: [],
+    school_affiliations: [],
+    external_links: [],
+    profile_manual_of_me: [],
+    conversation_starter_prompts: [
+      { id: 'p1', prompt: 'What are you reading?', sort_order: 1 },
+    ],
+    profile_conversation_starters: [],
+  };
+});
+
+const argsFor = (table: string, op: string) =>
+  queries.filter((q) => q.table === table && q.op === op).map((q) => q.args);
+
+describe('profile editor page — conversation starters (behavioural, KAN-414 F4)', () => {
+  it('offers only ACTIVE prompts, ordered by sort_order', async () => {
+    const props = await renderProps();
+
+    expect(argsFor('conversation_starter_prompts', 'eq')).toContainEqual([
+      'is_active',
+      true,
+    ]);
+    const [col, opts] = argsFor('conversation_starter_prompts', 'order')[0] as [
+      string,
+      { ascending: boolean },
+    ];
+    expect(col).toBe('sort_order');
+    expect(opts).toEqual({ ascending: true });
+    expect(props.conversationPrompts).toHaveLength(1);
+  });
+
+  it('scopes saved answers to the signed-in member’s own profile', async () => {
+    await renderProps();
+
+    // Without this filter the editor would load another member's answers.
+    expect(argsFor('profile_conversation_starters', 'eq')).toContainEqual([
+      'profile_id',
+      'profile-1',
+    ]);
+  });
+
+  it('resolves the joined prompt when Supabase returns it as an OBJECT', async () => {
+    tables.profile_conversation_starters = [
+      { id: 'a1', prompt_id: 'p1', answer: 'Middlemarch', prompt: { prompt: 'What are you reading?' } },
+    ];
+
+    const answers = (await renderProps()).conversationAnswers as Answer[];
+
+    expect(answers).toEqual([
+      { id: 'a1', prompt_id: 'p1', answer: 'Middlemarch', prompt: 'What are you reading?' },
+    ]);
+  });
+
+  it('resolves the joined prompt when Supabase returns it as an ARRAY', async () => {
+    // The same query returns either shape depending on typegen. Handling only
+    // one renders a saved answer with a blank question above it — the reason
+    // the branch exists, and it had no coverage anywhere before this test.
+    tables.profile_conversation_starters = [
+      { id: 'a1', prompt_id: 'p1', answer: 'Middlemarch', prompt: [{ prompt: 'What are you reading?' }] },
+    ];
+
+    const answers = (await renderProps()).conversationAnswers as Answer[];
+
+    expect(answers[0].prompt).toBe('What are you reading?');
+  });
+
+  it('degrades a missing or malformed join to an empty string, not a crash', async () => {
+    tables.profile_conversation_starters = [
+      { id: 'a1', prompt_id: 'p1', answer: 'Middlemarch', prompt: null },
+      { id: 'a2', prompt_id: 'p2', answer: 'Solaris', prompt: [] },
+    ];
+
+    const answers = (await renderProps()).conversationAnswers as Answer[];
+
+    // The profile editor is the member's main surface; a null join must not
+    // take it down.
+    expect(answers.map((a) => a.prompt)).toEqual(['', '']);
+    expect(answers.map((a) => a.answer)).toEqual(['Middlemarch', 'Solaris']);
+  });
+});

--- a/tests/unit/upload-avatar-limits-wiring.test.ts
+++ b/tests/unit/upload-avatar-limits-wiring.test.ts
@@ -1,0 +1,167 @@
+/**
+ * KAN-414 F4 (KAN-417 §8 group 3) — behavioural replacement for the MIME/size
+ * scans in tests/unit/photo-upload.test.js.
+ *
+ * WHAT THIS IS *NOT* DUPLICATING
+ * ------------------------------
+ * `tests/unit/sec52-upload-preflight.test.ts` already tests `preflightUpload`
+ * itself, and tests it well: a genuine PNG accepted, EXE bytes declared as
+ * `image/png` rejected, oversize rejected, empty rejected. None of that is
+ * repeated here.
+ *
+ * The gap is one level up. SEC-52 calls the helper with **its own** options, so
+ * it proves the helper honours whatever allow-list it is handed — not that
+ * `uploadAvatar` hands it the right one. Widen the caller's list:
+ *
+ *     const preflightError = await preflightUpload(file, {
+ *   -   allowedMimes: ALLOWED_IMAGE_TYPES,
+ *   +   allowedMimes: [...ALLOWED_IMAGE_TYPES, 'application/pdf'],
+ *
+ * and **both existing guards stay green**: SEC-52 because it never calls
+ * `uploadAvatar`, and `photo-upload.test.js` because `ALLOWED_IMAGE_TYPES`,
+ * `image/jpeg`, `MAX_FILE_SIZE` and `5 * 1024 * 1024` are all still in the file.
+ * The scan asserts the constants EXIST; it cannot assert they are USED.
+ *
+ * That matters because `profile-photos` is a world-readable bucket, and the
+ * declared MIME is browser-controlled.
+ *
+ * THE INVARIANTS, IN WORDS
+ * ------------------------
+ *  1. A disallowed type is refused, and nothing is written to storage. The
+ *     absent upload is the property; the error string is the symptom.
+ *  2. A file over 5MB is refused.
+ *  3. A SPOOFED type — a real PNG declared as `image/jpeg` — is refused, which
+ *     is what magic-byte checking buys and what no text scan can observe.
+ *  4. A genuine allowed image reaches the `profile-photos` bucket, upserted so
+ *     a re-upload overwrites rather than accumulating.
+ *
+ * MUTATION PROOF (2026-08-02, each reverted)
+ *   * add 'application/pdf' to the caller's allowedMimes  -> case 1 reddens
+ *   * raise the caller's maxBytes to 50MB                 -> case 2 reddens
+ *   * pass a hardcoded allow-list instead of the constant -> cases 1 and 3 redden
+ * Under every one, photo-upload.test.js stays 6/6 green.
+ */
+import { uploadAvatar } from '@/app/dashboard/profile/actions';
+import { getMyFeatureEntitlements } from '@/lib/features/entitlements';
+
+jest.mock('next/cache', () => ({ revalidatePath: jest.fn() }));
+
+jest.mock('@/lib/profile-rate-limit', () => ({
+  checkProfileWriteRateLimit: jest.fn(async () => ({ allowed: true })),
+}));
+
+// Params are declared so `upload.mock.calls[0][n]` is typed — an untyped
+// jest.fn() infers a zero-length tuple and the assertions below won't compile.
+const upload = jest.fn(
+  async (_path: string, _body: unknown, _opts?: { upsert?: boolean }) => ({
+    data: { path: 'p' },
+    error: null,
+  }),
+);
+const getPublicUrl = jest.fn(() => ({ data: { publicUrl: 'https://cdn/x.png' } }));
+const storageFrom = jest.fn(() => ({ upload, getPublicUrl }));
+const profileUpdate = jest.fn(() => ({ eq: jest.fn(async () => ({ error: null })) }));
+
+jest.mock('@/lib/supabase-server', () => ({
+  createClient: jest.fn(async () => ({
+    auth: { getUser: jest.fn(async () => ({ data: { user: { id: 'user-1' } } })) },
+    from: jest.fn(() => ({
+      select: jest.fn(() => ({
+        eq: jest.fn(() => ({
+          single: jest.fn(async () => ({ data: { id: 'profile-1' } })),
+        })),
+      })),
+      update: profileUpdate,
+    })),
+    storage: { from: storageFrom },
+  })),
+}));
+
+jest.mock('@/lib/features/entitlements', () => ({
+  getMyFeatureEntitlements: jest.fn(),
+}));
+
+const GRANTED = {
+  media_uploads: true,
+  discovery: true,
+  mcp: false,
+  convene: false,
+  paid_gift_links: false,
+  convene_paid_channels: false,
+} as const;
+
+// Real signatures — the point of case 3 is that the BYTES decide, not the
+// declared type, so these have to be genuine.
+const PNG = new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+const PDF = new Uint8Array([0x25, 0x50, 0x44, 0x46, 0x2d]); // %PDF-
+
+function fileOf(bytes: Uint8Array, type: string, padTo = 0): File {
+  // Build on a concrete ArrayBuffer: a plain Uint8Array is typed over
+  // ArrayBufferLike, which is not assignable to BlobPart under TS 5.7+.
+  const size = Math.max(padTo, bytes.length);
+  const buf = new ArrayBuffer(size);
+  new Uint8Array(buf).set(bytes);
+  return new File([buf], 'avatar', { type });
+}
+
+function form(file: File): FormData {
+  const fd = new FormData();
+  fd.append('avatar', file);
+  return fd;
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  (getMyFeatureEntitlements as jest.Mock).mockResolvedValue(GRANTED);
+});
+
+describe('uploadAvatar — the limits are WIRED, not merely declared', () => {
+  it('refuses a disallowed type and writes nothing to storage', async () => {
+    const res = await uploadAvatar(form(fileOf(PDF, 'application/pdf')));
+
+    expect(res.success).toBe(false);
+    // The property: `profile-photos` is world-readable, so a refusal must mean
+    // the object never lands, not merely that an error string came back.
+    expect(upload).not.toHaveBeenCalled();
+  });
+
+  it('refuses a file over the 5MB cap', async () => {
+    const tooBig = fileOf(PNG, 'image/png', 5 * 1024 * 1024 + 1);
+
+    const res = await uploadAvatar(form(tooBig));
+
+    expect(res.success).toBe(false);
+    expect(upload).not.toHaveBeenCalled();
+  });
+
+  it('refuses a SPOOFED type — real PNG bytes declared as image/jpeg', async () => {
+    // Both types are on the allow-list, so only the magic-byte check can
+    // catch this. A text scan asserting the allow-list contains 'image/jpeg'
+    // is satisfied either way.
+    const res = await uploadAvatar(form(fileOf(PNG, 'image/jpeg')));
+
+    expect(res.success).toBe(false);
+    expect(upload).not.toHaveBeenCalled();
+  });
+
+  it('accepts a genuine PNG and upserts it into profile-photos', async () => {
+    const res = await uploadAvatar(form(fileOf(PNG, 'image/png')));
+
+    expect(res.success).toBe(true);
+    expect(storageFrom).toHaveBeenCalledWith('profile-photos');
+    expect(upload).toHaveBeenCalledTimes(1);
+    // upsert, so re-uploading replaces rather than accumulating orphans.
+    expect(upload.mock.calls[0][2]).toEqual(
+      expect.objectContaining({ upsert: true }),
+    );
+  });
+
+  it('stores the avatar under the caller’s own user id', async () => {
+    await uploadAvatar(form(fileOf(PNG, 'image/png')));
+
+    // Path scoping is what the storage RLS policy keys on
+    // (storage.foldername(name)[1] = auth.uid()), so a wrong prefix would let
+    // one member overwrite another's avatar.
+    expect(String(upload.mock.calls[0][0])).toMatch(/^user-1\//);
+  });
+});


### PR DESCRIPTION
KAN-414 F4 / KAN-417 §8 group 3. Additive only — no existing test deleted or weakened.

## 1. `uploadAvatar` — the limits are WIRED, not merely declared

`sec52-upload-preflight.test.ts` already tests `preflightUpload` well (spoofed MIME, oversize, empty), so none of that is repeated. But it calls the helper with **its own** options, so it proves the helper honours whatever allow-list it is handed — not that `uploadAvatar` hands it the right one. `photo-upload.test.js` asserts the constants **exist**; it cannot assert they are **used**.

| Mutation to the **caller's** options | New suite | `photo-upload` scan | `sec52` behavioural |
|---|---|---|---|
| allow `application/pdf` | **1 failed** | 18/18 green | **12/12 green** |
| raise cap to 50MB | **1 failed** | 18/18 green | — |

Both existing guards are blind to a change that would let a PDF into `profile-photos` — a **world-readable** bucket — while the declared MIME is browser-controlled.

Asserts: disallowed type refused **and nothing written to storage**; over-5MB refused; a **spoofed** type refused (real PNG bytes declared `image/jpeg`, both on the allow-list, so only magic bytes catch it); a genuine PNG upserted into `profile-photos`; and the object stored under the caller's own user id — the prefix the storage RLS policy keys on.

## 2. CTL-039 was reporting a compliance surface clean

Found while working the age-declaration survivors, which is rather the point.

CTL-039 said `src/lib/auth/post-login-redirect.ts` was clean while `/confirm-age` sat in **both** a comment (line 54) and the code (line 70) — textbook `comment-shadowed`, on the 18+ age gate (KAN-407).

**Cause:** the scope splitter treated `preamble` as everything before the *first* `test`/`it` in the whole file. A `describe` that is not the first does its `readFileSync` in its own body, which lands at the tail of the **previous** test block's chunk — so neither the block's own read nor the file preamble saw it. That is the commonest shape in this repo. Both the subject and the receiver variable now carry forward.

**Findings 19 → 26.** New ones include `oauth/revoke-route.test.ts` asserting `/Unknown token — return 200/` (RFC 7009 behaviour existing only in prose) and a retention purge asserting `/cutoff >= now()/`.

**Also fixed the error message**, which was the same class of defect the control exists to catch: one hardcoded *"appears ONLY in a comment"* printed for both severities. False for `comment-shadowed` — the commoner kind — and it would send a reader hunting for code that is still there. It now states the severity and what it means.

Fourth blind spot in this control, all found within a day, each now a `--self-test` fixture (SEC-101 §3a). Worth stating plainly: assume the next detector has one too.

Docs / system map updated — N/A; `controls/registry.json` entry for CTL-039 landed in #666.