### PR TITLE
fix(help): honest "How do people find me?" answer (KAN-454)

### DIFF
--- a/src/app/(legal)/help/page.tsx
+++ b/src/app/(legal)/help/page.tsx
@@ -30,8 +30,7 @@ export default function HelpPage() {
 
         <h2>How do people find me?</h2>
         <p>
-          By name, school, or organisation. Your affiliations help
-          people find you <em>even when they&apos;re hidden</em> from your public page.
+          By name. Search by school or organisation isn&apos;t available yet.
         </p>
 
         <h2>How do people contact me?</h2>


### PR DESCRIPTION
**KAN-454 (second half)** · change #2 through the Claude Design → dev loop.

The Help page's "How do people find me?" answer is **factually wrong** on production: it claims name/school/organisation search and that affiliations help "even when they're hidden". There is no school/org search, and nothing reads a hidden affiliation (26-July recovery audit). Corrected to: **"By name. Search by school or organisation isn't available yet."**

Design card built in Claude Design first (before/after). No test asserts the old copy (grep-verified). Becomes fully accurate once KAN-450 (Find someone) ships.

MCP coverage: N/A — pure UI copy. Docs: N/A — copy-only.