### PR TITLE
test(KAN-414 F4): conversation-starter actions + service-worker auth bypass

### DIFF
--- a/tests/unit/auth-callback-route-behaviour.test.ts
+++ b/tests/unit/auth-callback-route-behaviour.test.ts
@@ -1,0 +1,135 @@
+/**
+ * KAN-414 F4 (KAN-417 §8 group 3) — behavioural replacement for the
+ * `auth/callback continues to handle the next query param` scan in
+ * tests/unit/forgot-reset-password.test.ts.
+ *
+ * WHY: THE ROUTE HAD NO EXECUTING TEST AT ALL
+ * -------------------------------------------
+ * `src/app/auth/callback/route.ts` is the OAuth (PKCE) entry point — 32 lines
+ * that nothing imported before this file. Verified: `grep -rn "from
+ * '@/app/auth/callback" tests/` returned only the path manifest.
+ *
+ * The scan asserts two literals, `searchParams.get('next')` and
+ * `exchangeCodeForSession`, which prove the characters are present, not that
+ * the value flows anywhere.
+ *
+ * WHAT IS *NOT* CLAIMED HERE
+ * --------------------------
+ * The open-redirect defence is **already well covered** and is not repeated:
+ * `tests/unit/beta-access-flow.test.ts:95-99` drives `betaRedirectUrl` with
+ * `//evil.com`, `https://evil.com`, `@evil.com`, `/\evil.com` and `/\/evil.com`
+ * (SEC-07, SEC-19/F-12). This file asserts only that the route hands `next`
+ * to that guard rather than around it — the wiring, not the guard.
+ *
+ * THE INVARIANTS, IN WORDS
+ * ------------------------
+ *  1. `?next=` is read and passed through. The password-recovery flow depends
+ *     on it: `resetPasswordForEmail` sets `redirectTo=…?next=/reset-password`,
+ *     so a route that ignored `next` would silently land every recovering user
+ *     on the dashboard instead of the reset form — a broken flow that still
+ *     looks like a successful sign-in.
+ *  2. With no `next`, the default is `/dashboard`.
+ *  3. A FAILED code exchange must not redirect as though sign-in succeeded.
+ *  4. A request with no `code` at all does not attempt an exchange.
+ *
+ * MUTATION PROOF (2026-08-02, each reverted):
+ *
+ *   | mutation to the route                          | this suite | old scan |
+ *   |------------------------------------------------|------------|----------|
+ *   | hardcode `const next = '/dashboard'`           | 2 failed   | 1 failed |
+ *   | redirect onward even when the exchange errors   | 1 failed   | 17 PASS  |
+ *
+ * Row 1 the scan CATCHES — hardcoding removes the very literal it greps for.
+ * Recorded rather than glossed: my first draft of this comment claimed it
+ * stayed green, and it does not.
+ *
+ * Row 2 is the one that justifies this file, and it is the more dangerous of
+ * the two: a failed PKCE exchange that still routes onward sends an
+ * unauthenticated visitor into the app shell. The scan asserts
+ * `exchangeCodeForSession` appears; it says nothing about what happens when it
+ * fails. That plus the route having had NO executing test at all is the value
+ * here — not a claim that the scan is blind to everything.
+ */
+const exchangeCodeForSession = jest.fn(async () => ({ error: null as unknown }));
+
+jest.mock('@/lib/supabase-server', () => ({
+  createClient: jest.fn(async () => ({ auth: { exchangeCodeForSession } })),
+}));
+
+const resolvePostLoginRedirect = jest.fn(
+  async (_c: unknown, origin: string, next: string) => `${origin}${next}`,
+);
+
+jest.mock('@/lib/auth/post-login-redirect', () => ({
+  resolvePostLoginRedirect: (...a: unknown[]) =>
+    (resolvePostLoginRedirect as unknown as (...x: unknown[]) => unknown)(...a),
+}));
+
+import { GET } from '@/app/auth/callback/route';
+
+const ORIGIN = 'https://checklyra.com';
+
+function req(query: string) {
+  return new Request(`${ORIGIN}/auth/callback${query}`);
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  exchangeCodeForSession.mockResolvedValue({ error: null });
+});
+
+describe('auth/callback route (behavioural, KAN-414 F4)', () => {
+  it('passes ?next through to the post-login resolver', async () => {
+    // The recovery flow's whole shape: redirectTo carries ?next=/reset-password.
+    await GET(req('?code=abc&next=%2Freset-password'));
+
+    expect(resolvePostLoginRedirect).toHaveBeenCalledWith(
+      expect.anything(),
+      ORIGIN,
+      '/reset-password',
+    );
+  });
+
+  it('defaults to /dashboard when no next is supplied', async () => {
+    await GET(req('?code=abc'));
+
+    expect(resolvePostLoginRedirect).toHaveBeenCalledWith(
+      expect.anything(),
+      ORIGIN,
+      '/dashboard',
+    );
+  });
+
+  it('hands a hostile next to the resolver rather than around it', async () => {
+    // The rejection itself is betaRedirectUrl's job and is tested there
+    // (beta-access-flow.test.ts:95-99). What matters here is that the route
+    // does not bypass it — e.g. by redirecting to `next` directly.
+    const res = await GET(req('?code=abc&next=%2F%2Fevil.test'));
+
+    expect(resolvePostLoginRedirect).toHaveBeenCalledWith(
+      expect.anything(),
+      ORIGIN,
+      '//evil.test',
+    );
+    expect(res.headers.get('location') ?? '').not.toMatch(/^https?:\/\/evil\.test/);
+  });
+
+  it('does NOT redirect as signed-in when the code exchange fails', async () => {
+    exchangeCodeForSession.mockResolvedValue({ error: { message: 'bad code' } });
+
+    const res = await GET(req('?code=stale&next=%2Fdashboard'));
+
+    // A failed exchange that still routed onward would send an unauthenticated
+    // visitor into the app shell.
+    expect(resolvePostLoginRedirect).not.toHaveBeenCalled();
+    expect(res.headers.get('location') ?? '').toMatch(/error/i);
+  });
+
+  it('does not attempt an exchange when there is no code', async () => {
+    const res = await GET(req('?next=%2Fdashboard'));
+
+    expect(exchangeCodeForSession).not.toHaveBeenCalled();
+    expect(resolvePostLoginRedirect).not.toHaveBeenCalled();
+    expect(res.headers.get('location') ?? '').toMatch(/error/i);
+  });
+});

--- a/tests/unit/conversation-starters-actions-behaviour.test.ts
+++ b/tests/unit/conversation-starters-actions-behaviour.test.ts
@@ -1,0 +1,203 @@
+/**
+ * KAN-414 F4 (KAN-417 §8 group 3) — behavioural replacement for the
+ * server-action scans in tests/unit/conversation-starters.test.ts.
+ *
+ * WHAT THE SCANS ACTUALLY ASSERT
+ * ------------------------------
+ *   expect(src).toMatch(/sanitiseText/);
+ *   expect(src).toMatch(/500/);
+ *
+ * `500` is satisfied by an HTTP status, a timeout, a stray constant — and by
+ * the file's own doc comment at lines 18-19, which names both `sanitiseText`
+ * and "≤500 chars". CTL-039 flags both as `comment-shadowed`: delete the code
+ * and the prose keeps them green.
+ *
+ * THE SIBLING-DRIFT PROBLEM THE SCAN CANNOT SEE
+ * ---------------------------------------------
+ * `sanitiseText(...).slice(0, ANSWER_MAX)` appears TWICE — once in
+ * `addConversationStarter` (l.65) and once in `updateConversationStarter`
+ * (l.118). Remove it from ONE and the scan stays green, because the other
+ * occurrence still satisfies the regex.
+ *
+ * That is the single most repeated defect shape in this codebase. CLAUDE.md
+ * records eight tickets for a suspension guard added to one call site but not
+ * its siblings, and BUGS-74 is the same story on the profile write path. A
+ * whole-file substring match is structurally incapable of catching it.
+ *
+ * THE INVARIANTS, IN WORDS
+ * ------------------------
+ *  1. HTML is stripped before storage on BOTH paths. These answers render on
+ *     the public profile.
+ *  2. The 500-char cap applies on BOTH paths, mirroring the DB CHECK — an
+ *     un-capped path fails at the database with a raw 22001 instead of a clean
+ *     truncation.
+ *  3. An empty or whitespace-only answer is refused, and nothing is written.
+ *  4. An UPDATE is scoped to the caller's own profile. Without the second
+ *     `.eq('profile_id', …)` any member could edit another's answer by id —
+ *     an IDOR the scans do not look at at all.
+ *  5. The DB trigger's cap message becomes friendly copy, and the match is
+ *     generic over the digits so a future cap change needs no code edit.
+ *
+ * MUTATION PROOF (2026-08-02, each reverted). The old scan stayed 11/11 green
+ * under EVERY one of these, including the last.
+ *
+ *   | mutation                                          | this suite |
+ *   |---------------------------------------------------|------------|
+ *   | drop `sanitiseText(...)` from the UPDATE path only | 2 failed   |
+ *   | drop `.eq('profile_id', profileId)` from update    | 1 failed   |
+ *   | drop `.slice(0, ANSWER_MAX)` from update only      | no change  |
+ *   | raise `sanitiseText`'s default 500 -> 2000         | no change  |
+ *   | remove BOTH cap layers                             | 2 failed   |
+ *
+ * THE 500 CAP IS DOUBLY ENFORCED, which is worth knowing and is not obvious
+ * from either the code or the scan. `sanitiseText(input, maxLength = 500)`
+ * slices internally, so the caller's `.slice(0, ANSWER_MAX)` is redundant
+ * today — removing either alone changes nothing. That is defence in depth, not
+ * dead code: the two must stay in agreement, because the DB CHECK is 500 and a
+ * caller that opts into a longer `maxLength` for some other field would
+ * otherwise let this path exceed it.
+ *
+ * So the cap cases here guard the EFFECTIVE cap, whichever layer supplies it —
+ * and they do bite, as the last row shows. What no substring match can do is
+ * notice the cap disappearing entirely: `/500/` is satisfied by the doc comment
+ * alone, so the scan is green even with both layers gone.
+ */
+type Call = { table: string; op: string; args: unknown[] };
+
+const calls: Call[] = [];
+let dbError: { message: string; code?: string } | null = null;
+
+function makeClient() {
+  const chain = (table: string) => {
+    const self: Record<string, unknown> = {};
+    const rec = (op: string) => (...args: unknown[]) => {
+      calls.push({ table, op, args });
+      return self;
+    };
+    for (const op of ['select', 'eq', 'insert', 'update', 'delete']) self[op] = rec(op);
+    self.single = async () => ({ data: { id: 'profile-1' }, error: null });
+    self.then = (resolve: (v: unknown) => unknown) => resolve({ error: dbError });
+    return self;
+  };
+  return {
+    auth: { getUser: async () => ({ data: { user: { id: 'user-1' } } }) },
+    from: (t: string) => chain(t),
+  };
+}
+
+jest.mock('next/cache', () => ({ revalidatePath: jest.fn() }));
+jest.mock('@/lib/supabase-server', () => ({
+  createClient: jest.fn(async () => makeClient()),
+}));
+jest.mock('@/lib/profile-rate-limit', () => ({
+  checkProfileWriteRateLimit: jest.fn(async () => ({ allowed: true })),
+}));
+// Moderation is a separate concern with its own tests; allow everything so the
+// sanitising and capping are what these cases actually exercise.
+jest.mock('@/lib/moderation-audit', () => ({
+  moderateAndAudit: jest.fn(async () => ({ ok: true })),
+}));
+
+import {
+  addConversationStarter,
+  updateConversationStarter,
+} from '@/app/dashboard/profile/conversation-starters-actions';
+
+const PROMPT_ID = '11111111-2222-3333-4444-555555555555';
+
+/** The payload actually handed to the DB, per operation. */
+function payload(op: 'insert' | 'update'): Record<string, unknown> {
+  const c = calls.find((x) => x.op === op);
+  return (c?.args[0] ?? {}) as Record<string, unknown>;
+}
+
+beforeEach(() => {
+  calls.length = 0;
+  dbError = null;
+});
+
+describe('conversation-starter actions — sanitising and capping on BOTH paths', () => {
+  it('strips HTML on ADD', async () => {
+    const res = await addConversationStarter({
+      promptId: PROMPT_ID,
+      answer: 'I like <b>books</b><script>alert(1)</script>',
+    });
+
+    expect(res.success).toBe(true);
+    // These answers render on the public profile.
+    expect(String(payload('insert').answer)).not.toContain('<script');
+    expect(String(payload('insert').answer)).not.toContain('<b>');
+  });
+
+  it('strips HTML on UPDATE — the sibling the scan cannot distinguish', async () => {
+    const res = await updateConversationStarter('answer-1', 'Also <i>poems</i>');
+
+    expect(res.success).toBe(true);
+    expect(String(payload('update').answer)).not.toContain('<i>');
+  });
+
+  it('caps at 500 characters on ADD', async () => {
+    await addConversationStarter({ promptId: PROMPT_ID, answer: 'a'.repeat(600) });
+
+    // Mirrors the DB CHECK; an un-capped path fails with a raw 22001 instead.
+    expect(String(payload('insert').answer)).toHaveLength(500);
+  });
+
+  it('caps at 500 characters on UPDATE', async () => {
+    await updateConversationStarter('answer-1', 'b'.repeat(600));
+
+    expect(String(payload('update').answer)).toHaveLength(500);
+  });
+
+  it('refuses an empty or whitespace-only answer, writing nothing', async () => {
+    const blank = await addConversationStarter({ promptId: PROMPT_ID, answer: '   ' });
+    const stripped = await updateConversationStarter('answer-1', '<b></b>');
+
+    expect(blank.success).toBe(false);
+    expect(stripped.success).toBe(false);
+    expect(calls.some((c) => c.op === 'insert' || c.op === 'update')).toBe(false);
+  });
+});
+
+describe('conversation-starter actions — ownership and error mapping', () => {
+  it('scopes an UPDATE to the caller’s own profile (IDOR guard)', async () => {
+    await updateConversationStarter('answer-belonging-to-someone-else', 'mine now');
+
+    const eqs = calls
+      .filter((c) => c.table === 'profile_conversation_starters' && c.op === 'eq')
+      .map((c) => c.args as [string, unknown]);
+
+    // Filtering by id ALONE would let any member edit any answer they can name.
+    expect(eqs).toContainEqual(['profile_id', 'profile-1']);
+    expect(eqs).toContainEqual(['id', 'answer-belonging-to-someone-else']);
+  });
+
+  it('rejects a non-UUID prompt id before touching the database', async () => {
+    const res = await addConversationStarter({ promptId: 'not-a-uuid', answer: 'hi' });
+
+    expect(res.success).toBe(false);
+    expect(calls.some((c) => c.op === 'insert')).toBe(false);
+  });
+
+  it('turns the DB cap trigger into friendly copy, for any digit count', async () => {
+    // The trigger message carries the live cap. Matching it generically is why
+    // raising the cap needs no code edit — so both forms must map.
+    for (const n of [5, 10, 25]) {
+      calls.length = 0;
+      dbError = { message: `Conversation-starter answer limit (${n}) reached` };
+      const res = await addConversationStarter({ promptId: PROMPT_ID, answer: 'hi' });
+
+      expect(res.success).toBe(false);
+      if (!res.success) expect(res.error).toContain('up to 10 prompts');
+    }
+  });
+
+  it('turns a duplicate-answer collision into an edit-instead hint', async () => {
+    dbError = { message: 'duplicate key value', code: '23505' };
+
+    const res = await addConversationStarter({ promptId: PROMPT_ID, answer: 'hi' });
+
+    expect(res.success).toBe(false);
+    if (!res.success) expect(res.error).toMatch(/already answered/i);
+  });
+});

--- a/tests/unit/service-worker-auth-bypass.test.ts
+++ b/tests/unit/service-worker-auth-bypass.test.ts
@@ -1,0 +1,222 @@
+/**
+ * KAN-414 F4 (KAN-417 §8 group 3) — behavioural replacement for the fetch- and
+ * activate-handler scans in tests/unit/pwa-service-worker.test.ts.
+ *
+ * WHY IT MATTERS
+ * --------------
+ * A service worker that intercepts an authed response can serve it back to a
+ * different person on the same device. `public/sw.js` therefore refuses to
+ * touch `/api`, `/oauth`, `/auth`, `/dashboard`, `/r/`, `/login`, `/signup`,
+ * `/reset-password` and `/forgot-password`.
+ *
+ * WHAT THE SCAN CANNOT SEE
+ * ------------------------
+ * It asserts six `url.pathname.startsWith('…')` literals — and nothing else:
+ *
+ *   1. It never checks the guard **returns**. Keep the whole `if (…)` condition
+ *      and delete the `return;` inside it and all six regexes still match,
+ *      while every authed request starts being intercepted. That is the entire
+ *      security property, and the scan is blind to it.
+ *   2. Three of the nine paths — `/signup`, `/reset-password`,
+ *      `/forgot-password` — are not asserted at all.
+ *   3. The **cache allowlist is entirely unasserted**. Nothing stops `.html`
+ *      being added to it, which would put rendered pages in a shared cache.
+ *
+ * HOW IT RUNS
+ * -----------
+ * `public/sw.js` is a browser worker script, not a module — there is nothing to
+ * import. It is executed for real in a `node:vm` sandbox with a stub
+ * `ServiceWorkerGlobalScope`, and the registered handlers are captured and
+ * driven. The real file runs; nothing here reimplements it (CTL-038).
+ *
+ * MUTATION PROOF (2026-08-02, each reverted):
+ *
+ *   | mutation to public/sw.js                        | this suite | old scan |
+ *   |-------------------------------------------------|------------|----------|
+ *   | delete the `return;` in the auth guard           | 10 failed  | 21 PASS  |
+ *   | drop `/dashboard` from the skip list             | 2 failed   | 1 failed |
+ *   | cache rendered HTML as well as static assets     | 1 failed   | 21 PASS  |
+ *   | `!n.endsWith(CACHE_VERSION)` -> `n.endsWith(…)`  | 1 failed   | 21 PASS  |
+ *
+ * Row 2 is worth stating plainly: **the scan does catch that one.** Dropping a
+ * path removes the literal it greps for, so it is not blind to everything, and
+ * this file is not a wholesale replacement for it.
+ *
+ * Row 1 is why the file exists. Deleting one `return;` while leaving the
+ * condition intact removes the entire security property — every authed request
+ * becomes interceptable — and all six of the scan's regexes still match. It
+ * greps for the *test*, never for the *consequence*.
+ */
+import { readFileSync } from 'node:fs';
+import { createContext, runInContext } from 'node:vm';
+import { resolve } from 'node:path';
+import { SRC } from '../support/source-paths.json';
+
+const ORIGIN = 'https://checklyra.com';
+
+type Handler = (event: Record<string, unknown>) => void;
+
+interface Harness {
+  handlers: Record<string, Handler>;
+  deleted: string[];
+  cachePuts: string[];
+  skipWaitingCalled: boolean;
+  claimCalled: boolean;
+  setCacheKeys: (keys: string[]) => void;
+}
+
+/** Execute the REAL worker in a sandbox and capture what it registers. */
+function loadWorker(): Harness {
+  const source = readFileSync(resolve(__dirname, '../..', SRC.sw), 'utf-8');
+
+  const handlers: Record<string, Handler> = {};
+  const deleted: string[] = [];
+  const cachePuts: string[] = [];
+  let cacheKeys: string[] = [];
+  const state = { skipWaiting: false, claim: false };
+
+  const caches = {
+    open: async () => ({
+      addAll: async () => undefined,
+      put: async (req: { url: string }) => void cachePuts.push(req.url),
+    }),
+    keys: async () => cacheKeys,
+    delete: async (n: string) => void deleted.push(n),
+    match: async () => undefined,
+  };
+
+  const self = {
+    addEventListener: (name: string, fn: Handler) => void (handlers[name] = fn),
+    skipWaiting: () => void (state.skipWaiting = true),
+    clients: { claim: () => void (state.claim = true) },
+    location: { origin: ORIGIN },
+    caches,
+  };
+
+  const sandbox = {
+    self,
+    caches,
+    URL,
+    Promise,
+    Error,
+    console,
+    fetch: async () => ({ ok: true, clone: () => ({}) }),
+  };
+  runInContext(source, createContext(sandbox));
+
+  return {
+    handlers,
+    deleted,
+    cachePuts,
+    get skipWaitingCalled() {
+      return state.skipWaiting;
+    },
+    get claimCalled() {
+      return state.claim;
+    },
+    setCacheKeys: (k: string[]) => void (cacheKeys = k),
+  } as Harness;
+}
+
+/** Drive the fetch handler; returns true if the SW INTERCEPTED the request. */
+function intercepts(
+  h: Harness,
+  path: string,
+  { method = 'GET', origin = ORIGIN } = {},
+): boolean {
+  let respondedWith = false;
+  h.handlers.fetch({
+    request: {
+      url: `${origin}${path}`,
+      method,
+      mode: 'navigate',
+      headers: { get: () => 'text/html' },
+    },
+    respondWith: (p: Promise<unknown>) => {
+      respondedWith = true;
+      // Swallow the stubbed-network rejection; interception is the claim.
+      void Promise.resolve(p).catch(() => undefined);
+    },
+  });
+  return respondedWith;
+}
+
+let sw: Harness;
+beforeEach(() => {
+  sw = loadWorker();
+});
+
+describe('service worker — never intercepts an authed response', () => {
+  // Every path the worker lists, including the three the scan omits.
+  const AUTH_PATHS = [
+    '/api/profile',
+    '/oauth/token',
+    '/auth/callback',
+    '/dashboard',
+    '/dashboard/profile',
+    '/r/abc123',
+    '/login',
+    '/signup',
+    '/reset-password',
+    '/forgot-password',
+  ];
+
+  it.each(AUTH_PATHS)('passes %s straight to the network', (path) => {
+    // A cached authed response can be served to a different person on a shared
+    // device. The guard must RETURN, not merely test the path.
+    expect(intercepts(sw, path)).toBe(false);
+  });
+
+  it('does intercept an ordinary public page, so the guard is not a blanket opt-out', () => {
+    // Without this, deleting the whole fetch handler would pass every case
+    // above — the suite would prove nothing.
+    expect(intercepts(sw, '/ada')).toBe(true);
+  });
+
+  it('ignores non-GET requests', () => {
+    expect(intercepts(sw, '/ada', { method: 'POST' })).toBe(false);
+  });
+
+  it('ignores cross-origin requests', () => {
+    expect(intercepts(sw, '/ada', { origin: 'https://evil.test' })).toBe(false);
+  });
+});
+
+describe('service worker — cache hygiene', () => {
+  it('install calls skipWaiting so a fix rolls out immediately', async () => {
+    const waits: Promise<unknown>[] = [];
+    sw.handlers.install({ waitUntil: (p: Promise<unknown>) => void waits.push(p) });
+    await Promise.all(waits);
+
+    expect(sw.skipWaitingCalled).toBe(true);
+  });
+
+  it('activate prunes stale lyra- caches but keeps the current version', async () => {
+    sw.setCacheKeys([
+      'lyra-static-v0-old',
+      'lyra-static-v1-2026-05-18',
+      'someone-elses-cache',
+    ]);
+    const waits: Promise<unknown>[] = [];
+    sw.handlers.activate({ waitUntil: (p: Promise<unknown>) => void waits.push(p) });
+    await Promise.all(waits);
+
+    expect(sw.deleted).toContain('lyra-static-v0-old');
+    // Deleting the live cache on every activate would evict the offline shell
+    // the worker just installed; touching another origin's cache is worse.
+    expect(sw.deleted).not.toContain('lyra-static-v1-2026-05-18');
+    expect(sw.deleted).not.toContain('someone-elses-cache');
+    expect(sw.claimCalled).toBe(true);
+  });
+
+  it('caches static assets but NOT rendered HTML', async () => {
+    intercepts(sw, '/lyra-icon-192.png');
+    intercepts(sw, '/ada');
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(sw.cachePuts.some((u) => u.endsWith('.png'))).toBe(true);
+    // An HTML page in a shared cache is the same exposure as an authed
+    // response, one step removed. The scan asserts nothing about this list.
+    expect(sw.cachePuts.some((u) => u.endsWith('/ada'))).toBe(false);
+  });
+});


### PR DESCRIPTION
KAN-414 F4 / KAN-417 §8 group 3. Additive only — nothing deleted or weakened. Two conversions from the adversarially-verified survivor queue.

## 1. Conversation-starter actions — sibling drift, IDOR, and the real cap

Scans are `toMatch(/sanitiseText/)` and `toMatch(/500/)`; both are satisfied by the file's own doc comment, so CTL-039 flags them `comment-shadowed`.

`sanitiseText(...).slice(0, ANSWER_MAX)` appears **twice** — add l.65, update l.118. Remove it from **one** and the whole-file regex stays green. That is the most repeated defect shape here: CLAUDE.md records eight tickets for a suspension guard added to one call site but not its siblings.

| Mutation | This suite |
|---|---|
| drop `sanitiseText` from the UPDATE path only | **2 failed** |
| drop `.eq('profile_id', profileId)` from update | **1 failed** |
| drop `.slice(0, ANSWER_MAX)` from update only | no change |
| raise `sanitiseText`'s default 500 → 2000 | no change |
| remove **both** cap layers | **2 failed** |

The old scan stayed 11/11 green under every one — including the last.

**The two "no change" rows correct my own first draft.** `sanitiseText(input, maxLength = 500)` slices internally, so the caller's slice is redundant and either layer alone enforces the cap. That's defence in depth, not dead code — the DB CHECK is 500 — and the docblock now records it, since it's obvious from neither the code nor the scan.

Also covers an **IDOR the scans never look at**: `updateConversationStarter` filters `.eq('id', id).eq('profile_id', profileId)`. Filtering by id alone would let any member edit any answer they can name.

## 2. Service worker — never intercept an authed response

A SW that intercepts an authed response can serve it back to a different person on the same device.

| Mutation | This suite | Old scan |
|---|---|---|
| **delete the `return;` in the auth guard** | **10 failed** | **21 PASS** |
| drop `/dashboard` from the skip list | 2 failed | 1 failed |
| cache rendered HTML as well as static assets | 1 failed | 21 PASS |
| `!n.endsWith(CACHE_VERSION)` → `n.endsWith(…)` | 1 failed | 21 PASS |

Row 1 is the point: deleting **one** `return;` while leaving the condition intact removes the entire security property, and all six of the scan's regexes still match. It greps for the *test*, never for the *consequence*.

Row 2 is recorded honestly — **the scan does catch that one**, so this is not a wholesale replacement for it.

Three of the nine paths (`/signup`, `/reset-password`, `/forgot-password`) weren't asserted at all, and the cache allowlist was entirely unasserted.

**How it runs:** `sw.js` is a browser worker script, not a module, so there is nothing to import. It executes for real in a `node:vm` sandbox with a stub `ServiceWorkerGlobalScope`; handlers are captured and driven. Includes a positive control — an ordinary public page **is** intercepted — so deleting the whole fetch handler couldn't make every other case pass vacuously.

Docs / system map updated — N/A, test-only.