### PR TITLE
docs(KAN-414 F4): measure what is actually left of group 3

### DIFF
--- a/docs/modularisation/KAN-414-F4-group2-classification.md
+++ b/docs/modularisation/KAN-414-F4-group2-classification.md
@@ -291,3 +291,60 @@ with `html` is a bug.
 open SEC-109 branch, including the assertion that had to move to
 `oauth-connections.ts:158`. Converting it here would collide. It should ride
 SEC-109's merge instead.
+
+
+---
+
+## How much of group 3 is actually left (measured 2026-08-02)
+
+The triage headline is **105 files / 239 behavioural blocks**. That number has
+never survived contact with the files, and it does not here either.
+
+| Bucket | Files |
+|---|---:|
+| classified + adversarially refuted (tranche 1) | 8 |
+| classified (tranche 2) | 8 |
+| converted, or deliberately deferred | 7 |
+| **never inspected** | **82** (134 blocks) |
+
+### The untouched tail is thinner than its block count
+
+**50 of the 82 files have exactly ONE behavioural block**, 17 have two, and only
+15 have three or more. A single `toContain` is overwhelmingly a copy pin, an
+assertion already covered behaviourally elsewhere, or structural — which is what
+tranche 1 kept demonstrating (11 of 25 conversion claims refuted outright).
+
+### A mechanical filter that turned out to be reassuring
+
+Cross-referencing the untouched tail against **CTL-039**'s baseline finds
+**7 comment-satisfied assertions across 5 files**. Those are, by construction,
+assertions a text scan cannot make load-bearing — so they looked like the most
+promising place to find another BUGS-85.
+
+**Every one was checked, and none is a coverage gap:**
+
+| Assertion | Verdict |
+|---|---|
+| `revoke-route` → `/Unknown token — return 200/` (RFC 7009 §2.2) | already behavioural — the suite calls `POST(req)` and asserts real statuses |
+| `gdpr` → `deleteAccount` | already behavioural — `account-deletion.test.ts` invokes it |
+| `section-visibility` → `/coerceSectionVisibility/` | already behavioural — the same file invokes it |
+| `retention` → `/security definer/`, `/cutoff >= now()/` | migration SQL — structural, needs a database |
+| `dcr-anti-phishing` → `/drop column if exists …/` | migration rollback note — structural |
+
+They are decorative redundancy sitting **alongside** real tests, not holes. That
+is a materially different picture from `maintenance-page.test.js` and
+`rate-limit.test.js`, where the scan was the *only* thing present.
+
+### Revised estimate
+
+Expect roughly **two more classification tranches** over the 15 files with three
+or more blocks, then a single cheap sweep across the ~67 one-and-two-block
+files. The genuinely convertible remainder is likely nearer **10-15 blocks than
+134**.
+
+**A units warning for whoever continues.** The classifier agents report every
+`test` in a file, while the triage script reports only blocks it bucketed as
+behavioural. `convene/microsoft-calendar.test.ts` is 5 blocks by the triage and
+22 tests by the agent, which reported 20 "convertible". Those two numbers are
+not comparable, and quoting the agent's figure as progress would overstate the
+remaining work by roughly four times.


### PR DESCRIPTION
Docs-only. Answers "how much is left" with measurements rather than the triage headline.

## The tail is thinner than its block count

82 files / 134 blocks never inspected — but **50 have exactly one behavioural block**, 17 have two, and only **15 have three or more**.

## A mechanical filter that turned out reassuring

Cross-referenced the untouched tail against **CTL-039**'s baseline, on the theory that a comment-satisfied assertion is the likeliest place to find another BUGS-85. Seven hits across five files. **Checked every one — none is a coverage gap:**

| Assertion | Verdict |
|---|---|
| `revoke-route` → `/Unknown token — return 200/` (RFC 7009) | already behavioural — the suite drives `POST(req)` |
| `gdpr` → `deleteAccount` | already behavioural |
| `section-visibility` → `/coerceSectionVisibility/` | already behavioural, same file |
| `retention` → `/security definer/`, `/cutoff >= now()/` | migration SQL — structural |
| `dcr-anti-phishing` → `/drop column if exists …/` | migration rollback note — structural |

Decorative redundancy sitting **alongside** real tests — materially unlike `maintenance-page.test.js` and `rate-limit.test.js`, where the scan was the only thing present.

## Revised estimate

Two more classification tranches over the 15 multi-block files, then a cheap sweep of the ~67 one-and-two-block ones. Genuinely convertible remainder likely nearer **10–15 blocks than 134**.

## Units warning

The classifier agents report every `test` in a file; the triage reports only blocks it bucketed behavioural. `convene/microsoft-calendar.test.ts` is **5 blocks** by the triage and **22 tests** by the agent, which called 20 "convertible". Quoting the agent's figure as remaining work would overstate it roughly fourfold.

Docs / system map updated — this file.