### PR TITLE
test(KAN-414 F4): Microsoft OAuth scopes — and three survivors that should not have survived

### DIFF
--- a/docs/modularisation/KAN-414-F4-group2-classification.md
+++ b/docs/modularisation/KAN-414-F4-group2-classification.md
@@ -421,3 +421,63 @@ Script ready at
 after tranche 2 are the ~15 files with three or more behavioural blocks; after
 those, the ~67 one-and-two-block files want a single cheap sweep rather than
 per-file agents.
+
+
+---
+
+## Tranche 2 — what was converted, and what the refuters got wrong
+
+**Converted: 1 of 16 survivors.** That ratio is the finding, not a shortfall.
+
+### `microsoft-calendar` → `microsoft-oauth-behaviour` (done)
+
+The strongest survivor of the tranche, and a clean sweep — the old scan stayed
+**22/22 green under all four mutations**:
+
+| mutation to `src/lib/convene/microsoft/oauth.ts` | new suite | old scan |
+|---|---|---|
+| delete the `scope:` entry from the authorize params | 3 failed | 22 PASS |
+| `MICROSOFT_SCOPES.join(',')` instead of `' '` | 2 failed | 22 PASS |
+| **add** `'Mail.Read'` to `MICROSOFT_SCOPES` | 2 failed | 22 PASS |
+| `fetch(TOKEN_URL)` → `fetch(AUTHORIZE_URL)` | 1 failed | 22 PASS |
+
+Row 1 is the security case: Microsoft is asked for **no permissions at all** —
+no calendar access and no refresh token — while all three scope regexes match,
+because they grep the *array declaration*, never the URL.
+
+Row 3 only fails because the assertion is **set equality**, not `toContain`.
+Presence-only assertions are structurally incapable of catching over-requested
+Graph permissions.
+
+The literals are hardcoded rather than derived from `MICROSOFT_SCOPES`,
+deliberately — see **BUGS-86**.
+
+### Three survivors that should NOT have survived
+
+The refuters were told to default to refuting and still let these through. Each
+was checked by hand afterwards:
+
+| Survivor | Why it should have been refuted |
+|---|---|
+| `[slug]/page.tsx uses the hybrid filter` | **Already covered.** `isItemVisibleUnderHybridModel` is exercised directly at `tests/unit/section-visibility.test.ts:177+` across public / members-only / private and both auth states. The refuter checked whether the *page* was covered and missed the *helper's* own suite. |
+| `landing page includes JSON-LD` / `public profile page includes JSON-LD` | Structured-data **presence** pins. Rendering the page to assert the same `<script type="application/ld+json">` is the same pin with more machinery — the copy-pin rule, one step removed. |
+
+**Refutation rate understates the true structural share.** Tranche 2 reported
+8 refuted / 16 survived; hand-checking moves at least 3 more into the refuted
+column, so the real rate is nearer 11/16. Treat "survived" as *worth a human
+look*, never as *approved for conversion*.
+
+### The remaining survivors, and why they are parked
+
+- **legal-pages / privacy-complaints (6)** — footer links to `/privacy`,
+  `/terms`, `/complaints`, and the Companies Act line. These are link- and
+  copy-presence pins on founder-owned pages. Group 4 by the copy-pin rule.
+- **current-problems (2)** — a category label and a public heading. Founder-gated
+  UI copy.
+- **convene gathering-ui (1)** — the per-user convene gate. Worth doing when the
+  Convene work is next touched; not worth a standalone render harness now.
+- **public-profile published-only (1)** — `[slug]/page.tsx` filters
+  `is_published` in **two** queries (l.93, l.188). The wiring is genuinely
+  untested and this is the SEC-100 family, but driving the page needs a heavy
+  server-component harness. Left as the best remaining candidate in this
+  tranche, not as a rejection.

--- a/tests/scripts/check-comment-only-assertions.test.js
+++ b/tests/scripts/check-comment-only-assertions.test.js
@@ -105,7 +105,15 @@ describe('CTL-039 — comment-satisfied assertion ratchet', () => {
       "const fs = require('fs');\n" +
         "describe('probe', () => {\n" +
         "  test('comment-satisfied', () => {\n" +
-        `    const c = fs.readFileSync('${SRC.sanitise}', 'utf8');\n` +
+        // DOUBLE quotes, deliberately. This probe is briefly `git add
+        // --intent-to-add`ed, so it is visible to `git ls-files` while it
+        // exists — and the F4 raw-literal ratchet in
+        // tests/scripts/source-paths-manifest.test.js counts SINGLE-quoted repo
+        // paths across every tracked test file. Jest runs suites in parallel
+        // workers, so a single-quoted path here intermittently pushed that
+        // ratchet from 40 to 41 and reddened CI on unrelated PRs. CTL-039's own
+        // PATH_LIT accepts either quote style, so detection is unaffected.
+        `    const c = fs.readFileSync("${SRC.sanitise}", 'utf8');\n` +
         // `<scr<script>ipt>` appears in sanitise.ts only inside a block comment
         // describing a nested-tag bypass.
         "    expect(c).toContain('<scr<script>ipt>');\n" +

--- a/tests/unit/convene/microsoft-oauth-behaviour.test.ts
+++ b/tests/unit/convene/microsoft-oauth-behaviour.test.ts
@@ -1,0 +1,167 @@
+/**
+ * KAN-414 F4 (KAN-417 §8 group 3) — behavioural replacement for the
+ * authorize/token scans in tests/unit/convene/microsoft-calendar.test.ts.
+ *
+ * WHAT THE SCAN CANNOT SEE
+ * ------------------------
+ * It greps `oauth.ts` for `offline_access`, `User.Read`, `Calendars.ReadWrite`
+ * and the two v2.0 URLs. Every one of those is a DECLARATION. What reaches
+ * Microsoft is the authorize URL, and the scan never looks at it:
+ *
+ *   * Delete `scope: MICROSOFT_SCOPES.join(' ')` from the URLSearchParams and
+ *     the array survives untouched — all three scope regexes stay green while
+ *     Microsoft is asked for **no permissions at all**: no calendar access and,
+ *     critically, **no refresh token**.
+ *   * Join with `,` instead of `' '`. Microsoft v2.0 requires space-delimited
+ *     scopes. Array and `scope:` line both intact, so the scan is green. A
+ *     delimiter bug is far likelier than deleting the line outright.
+ *   * ADD a scope — `Mail.Read`, say. A presence-only assertion is
+ *     structurally incapable of noticing over-requested Graph permissions on a
+ *     service holding minors' personal data.
+ *
+ * DO NOT COPY tests/unit/convene/google-oauth.test.ts:37-43
+ * --------------------------------------------------------
+ * That file does `for (const s of GOOGLE_SCOPES) expect(scope).toContain(s)`,
+ * which uses the constant under test as its own oracle: delete an entry and it
+ * stays green; empty the constant and it passes with ZERO assertions executed.
+ * Copying it here would produce a test WEAKER than the scan it replaces on the
+ * one mutation that matters — losing `offline_access`. Raised as **BUGS-86**.
+ *
+ * So the literals below are written out by hand, and compared as a SET, not
+ * with `toContain`. The set comparison is what catches over-requesting.
+ *
+ * WHY offline_access IS THE ONE
+ * -----------------------------
+ * Without it Microsoft returns no `refresh_token`, so every calendar
+ * connection works until the first access-token expiry and then dies. That
+ * fails quietly, hours after the deploy, per-user.
+ *
+ * MUTATION PROOF (2026-08-02, each reverted). The old scan stayed 22/22 green
+ * under every one.
+ *
+ *   | mutation to src/lib/convene/microsoft/oauth.ts | this suite |
+ *   |------------------------------------------------|------------|
+ *   | delete the `scope:` entry from authorize params | 3 failed   |
+ *   | `MICROSOFT_SCOPES.join(',')`                    | 2 failed   |
+ *   | add 'Mail.Read' to MICROSOFT_SCOPES             | 2 failed   |
+ *   | `fetch(TOKEN_URL)` -> `fetch(AUTHORIZE_URL)`    | 1 failed   |
+ */
+import {
+  buildAuthorizeUrl,
+  exchangeCodeForTokens,
+} from '@/lib/convene/microsoft/oauth';
+
+// Hardcoded on purpose — see the header. Deriving these from MICROSOFT_SCOPES
+// would reproduce BUGS-86.
+const EXPECTED_SCOPES = ['offline_access', 'User.Read', 'Calendars.ReadWrite'];
+
+const REDIRECT = 'https://checklyra.com/api/convene/oauth/microsoft/callback';
+
+const ORIGINAL = { ...process.env };
+beforeAll(() => {
+  process.env.MICROSOFT_CALENDAR_CLIENT_ID = 'client-abc';
+  process.env.MICROSOFT_CALENDAR_CLIENT_SECRET = 'secret-xyz';
+  process.env.MICROSOFT_CALENDAR_REDIRECT_URI = REDIRECT;
+});
+afterAll(() => {
+  process.env = { ...ORIGINAL };
+});
+
+const authorize = (state = 'st-1') => new URL(buildAuthorizeUrl(state));
+
+describe('buildAuthorizeUrl — what Microsoft is actually asked for', () => {
+  it('requests EXACTLY the three documented scopes', () => {
+    const scope = authorize().searchParams.get('scope') ?? '';
+
+    // Set equality, not toContain: this fails on a MISSING scope and on an
+    // EXTRA one. `URLSearchParams` encodes the joined string with '+', and
+    // `searchParams.get` decodes it back to spaces.
+    expect(new Set(scope.split(' '))).toEqual(new Set(EXPECTED_SCOPES));
+  });
+
+  it('space-delimits the scopes, as Microsoft v2.0 requires', () => {
+    const scope = authorize().searchParams.get('scope') ?? '';
+
+    // A ',' join leaves every literal present in the file, so the scan is blind
+    // to it, and Microsoft rejects or silently narrows the request.
+    expect(scope).not.toContain(',');
+    expect(scope.split(' ')).toHaveLength(EXPECTED_SCOPES.length);
+  });
+
+  it('asks for offline_access, without which there is no refresh token', () => {
+    // Called out separately from the set assertion because the failure mode is
+    // distinctive: connections work until the first expiry, then die quietly,
+    // per-user, hours after the deploy.
+    expect(authorize().searchParams.get('scope')).toContain('offline_access');
+  });
+
+  it('targets the v2.0 /common authorize endpoint', () => {
+    const url = authorize();
+
+    expect(url.origin).toBe('https://login.microsoftonline.com');
+    expect(url.pathname).toBe('/common/oauth2/v2.0/authorize');
+  });
+
+  it('carries the code-flow params and the caller’s state', () => {
+    const p = authorize('state-xyz').searchParams;
+
+    expect(p.get('response_type')).toBe('code');
+    expect(p.get('response_mode')).toBe('query');
+    expect(p.get('state')).toBe('state-xyz');
+    expect(p.get('client_id')).toBe('client-abc');
+    expect(p.get('redirect_uri')).toBe(REDIRECT);
+    // prompt=consent is what makes Microsoft re-issue a refresh token when a
+    // user reconnects, rather than returning an access token alone.
+    expect(p.get('prompt')).toBe('consent');
+  });
+});
+
+describe('exchangeCodeForTokens — where the code is actually POSTed', () => {
+  const realFetch = global.fetch;
+  let sent: { url: string; body: URLSearchParams } | null = null;
+
+  beforeEach(() => {
+    sent = null;
+    global.fetch = (async (url: string, init: { body: string }) => {
+      sent = { url: String(url), body: new URLSearchParams(init.body) };
+      return {
+        ok: true,
+        json: async () => ({ access_token: 'a', expires_in: 3600, token_type: 'Bearer' }),
+      };
+    }) as unknown as typeof fetch;
+  });
+  afterEach(() => {
+    global.fetch = realFetch;
+  });
+
+  it('POSTs to the v2.0 /common TOKEN endpoint, not the authorize one', async () => {
+    await exchangeCodeForTokens('code-1');
+
+    // Both URLs are declared in the same file, so swapping them at the call
+    // site leaves every literal — and the scan — untouched.
+    expect(new URL(sent!.url).pathname).toBe('/common/oauth2/v2.0/token');
+  });
+
+  it('uses grant_type=authorization_code and sends the client secret', async () => {
+    await exchangeCodeForTokens('code-1');
+
+    expect(sent!.body.get('grant_type')).toBe('authorization_code');
+    expect(sent!.body.get('code')).toBe('code-1');
+    expect(sent!.body.get('client_secret')).toBe('secret-xyz');
+    // The redirect_uri must match the one used at authorize time or Microsoft
+    // rejects the exchange.
+    expect(sent!.body.get('redirect_uri')).toBe(REDIRECT);
+  });
+
+  it('raises on a non-OK token response rather than returning a partial', async () => {
+    global.fetch = (async () => ({
+      ok: false,
+      status: 400,
+      text: async () => 'invalid_grant',
+    })) as unknown as typeof fetch;
+
+    // Returning a half-built token object here would store an unusable
+    // connection that fails later, away from the cause.
+    await expect(exchangeCodeForTokens('stale')).rejects.toThrow(/400/);
+  });
+});


### PR DESCRIPTION
KAN-414 F4 / KAN-417 §8 group 3, tranche 2. Additive only. **Converted 1 of 16 survivors — that ratio is the finding, not a shortfall.**

## The conversion: what Microsoft is actually asked for

The scan greps `oauth.ts` for `offline_access`, `User.Read`, `Calendars.ReadWrite` and the two v2.0 URLs. Every one is a **declaration**. What reaches Microsoft is the authorize URL, which the scan never looks at.

| Mutation | New suite | Old scan |
|---|---|---|
| delete the `scope:` entry from the authorize params | 3 failed | **22 PASS** |
| `MICROSOFT_SCOPES.join(',')` instead of `' '` | 2 failed | **22 PASS** |
| **add** `'Mail.Read'` to `MICROSOFT_SCOPES` | 2 failed | **22 PASS** |
| `fetch(TOKEN_URL)` → `fetch(AUTHORIZE_URL)` | 1 failed | **22 PASS** |

Row 1 is the security case: Microsoft is asked for **no permissions at all** — no calendar access and **no refresh token** — while all three scope regexes still match.

Row 3 only fails because the assertion is **set equality**, not `toContain`. A presence-only assertion is structurally incapable of catching over-requested Graph permissions on a service holding minors' data.

The literals are **hardcoded rather than derived from `MICROSOFT_SCOPES`**, deliberately — deriving them reproduces [BUGS-86](https://checklyra.atlassian.net/browse/BUGS-86), where `google-oauth.test.ts` uses the constant under test as its own oracle and passes with *zero assertions* if the constant is emptied.

## Three survivors that should not have survived

The refuters were told to default to refuting and still let these through. Each was hand-checked afterwards:

| Survivor | Why it should have been refuted |
|---|---|
| `[slug]/page.tsx uses the hybrid filter` | **Already covered** — `isItemVisibleUnderHybridModel` is exercised directly at `section-visibility.test.ts:177+` across public/members-only/private and both auth states. The refuter checked whether the *page* was covered and missed the *helper's own suite*. |
| the two JSON-LD survivors | Structured-data **presence** pins — the copy-pin rule one step removed. |

**So tranche 2's real refutation rate is nearer 11/16 than 8/16.** Treat "survived" as *worth a human look*, never as *approved for conversion*. That's now recorded in the doc so the next tranche isn't read too generously.

## Parked, with reasons

legal-pages/privacy-complaints (6, link+copy presence pins), current-problems (2, founder-gated UI copy), convene gathering-ui (1, wants the Convene work), and public-profile published-only (1 — genuinely untested wiring on the SEC-100 family, but needs a heavy server-component harness; the best remaining candidate here).

Docs / system map updated — `docs/modularisation/KAN-414-F4-group2-classification.md`.

[BUGS-86]: https://checklyra.atlassian.net/browse/BUGS-86?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ