### PR TITLE
KAN-446/447/448: example-first copy, link editing, inline edit everywhere

### DIFF
--- a/src/app/dashboard/profile/actions.ts
+++ b/src/app/dashboard/profile/actions.ts
@@ -449,6 +449,128 @@ export async function addSchoolAffiliation(data: {
   return { success: true };
 }
 
+/**
+ * KAN-448 — edit an existing affiliation's name / location / description.
+ * Mirrors `addSchoolAffiliation` for sanitise + moderation and the KAN-404
+ * postcode rule, and `updateProfileItem` for the partial-update shape: only
+ * the fields the caller passes are written, so an omitted field keeps its
+ * stored value (BUGS-74). `affiliation_type` is deliberately NOT editable
+ * here — the row's stored type is what decides whether a postcode is required.
+ *
+ * KAN-451's schools picker will reuse this action and supplies a school
+ * description and location alongside the name, so the signature already
+ * carries both and won't need changing.
+ */
+export async function updateSchoolAffiliation(
+  affiliationId: string,
+  data: { school_name?: string; school_location?: string; description?: string },
+): Promise<ActionResult> {
+  const { user, supabase, error: authError } = await getAuthenticatedUser();
+  if (authError) return { success: false, error: authError };
+
+  // KAN-231 — profile-save rate limiting (edits are user-driven writes too).
+  const rl = await checkProfileWriteRateLimit(user!.id);
+  if (!rl.allowed) return rl.result;
+
+  // KAN-260 — belt-and-braces ownership: scope both the read and the write to
+  // the caller's own profile in code, not by RLS alone.
+  const profile = await getUserProfile(supabase, user!.id);
+  if (!profile) return { success: false, error: 'Profile not found' };
+
+  const { data: current } = await supabase
+    .from('school_affiliations')
+    .select('affiliation_type')
+    .eq('id', affiliationId)
+    .eq('profile_id', profile.id)
+    .maybeSingle();
+
+  if (!current) return { success: false, error: 'Affiliation not found' };
+
+  // KAN-404 — a school must still carry a postcode after an edit, so a member
+  // can't clear it by editing. Only checked when the caller is actually
+  // changing the location; the stored type decides, not a caller-supplied one.
+  const affiliationType = coerceAffiliationType(
+    (current as { affiliation_type?: string }).affiliation_type,
+  );
+  if (
+    data.school_location !== undefined
+    && requiresPostcode(affiliationType)
+    && !isSchoolPostcodeValid(data.school_location)
+  ) {
+    return {
+      success: false,
+      error: 'Schools need a postcode (full or partial) so people can tell schools with the same name apart.',
+    };
+  }
+
+  const updates: Record<string, string | null> = {};
+
+  if (data.school_name !== undefined) {
+    const sanitisedName = sanitiseText(data.school_name, 200);
+    if (sanitisedName.trim() === '') {
+      return { success: false, error: 'Name cannot be empty' };
+    }
+    const nameMod = await moderateAndAudit(supabase, {
+      text: sanitisedName,
+      fieldType: 'public',
+      field: 'school_affiliations.school_name',
+      profileId: profile.id,
+      source: 'web_app',
+    });
+    if (!nameMod.ok) return { success: false, error: nameMod.error };
+    updates.school_name = sanitisedName;
+  }
+
+  if (data.school_location !== undefined) {
+    // Empty string clears the location to NULL (mirrors the add path, where an
+    // absent location is inserted as NULL).
+    const sanitisedLoc = data.school_location.trim() !== ''
+      ? sanitiseText(data.school_location, 200)
+      : null;
+    if (sanitisedLoc) {
+      const locMod = await moderateAndAudit(supabase, {
+        text: sanitisedLoc,
+        fieldType: 'public',
+        field: 'school_affiliations.school_location',
+        profileId: profile.id,
+        source: 'web_app',
+      });
+      if (!locMod.ok) return { success: false, error: locMod.error };
+    }
+    updates.school_location = sanitisedLoc;
+  }
+
+  if (data.description !== undefined) {
+    const sanitisedDesc = data.description.trim() !== ''
+      ? sanitiseText(data.description, 200)
+      : null;
+    if (sanitisedDesc) {
+      const descMod = await moderateAndAudit(supabase, {
+        text: sanitisedDesc,
+        fieldType: 'public',
+        field: 'school_affiliations.description',
+        profileId: profile.id,
+        source: 'web_app',
+      });
+      if (!descMod.ok) return { success: false, error: descMod.error };
+    }
+    updates.description = sanitisedDesc;
+  }
+
+  // Empty-patch guard — no-op rather than firing an UPDATE with empty SET.
+  if (Object.keys(updates).length === 0) return { success: true };
+
+  const { error } = await supabase
+    .from('school_affiliations')
+    .update(updates)
+    .eq('id', affiliationId)
+    .eq('profile_id', profile.id);
+
+  if (error) return { success: false, error: error.message };
+  revalidatePath('/dashboard/profile');
+  return { success: true };
+}
+
 export async function removeSchoolAffiliation(affiliationId: string): Promise<ActionResult> {
   const { user, supabase, error: authError } = await getAuthenticatedUser();
   if (authError) return { success: false, error: authError };
@@ -496,6 +618,9 @@ export async function addExternalLink(data: {
   title: string;
   url: string;
   link_type?: string;
+  // KAN-447 — `external_links.description` has existed since the first schema
+  // migration but nothing ever wrote it. Optional; absent or empty → NULL.
+  description?: string;
 }): Promise<ActionResult> {
   const { user, supabase, error: authError } = await getAuthenticatedUser();
   if (authError) return { success: false, error: authError };
@@ -523,6 +648,21 @@ export async function addExternalLink(data: {
   });
   if (!linkTitleMod.ok) return { success: false, error: linkTitleMod.error };
 
+  // KAN-447 — the optional one-line description shown next to the title.
+  const sanitisedDesc = data.description && data.description.trim() !== ''
+    ? sanitiseText(data.description, 200)
+    : null;
+  if (sanitisedDesc) {
+    const descMod = await moderateAndAudit(supabase, {
+      text: sanitisedDesc,
+      fieldType: 'public',
+      field: 'external_links.description',
+      profileId: profile.id,
+      source: 'web_app',
+    });
+    if (!descMod.ok) return { success: false, error: descMod.error };
+  }
+
   const { error } = await supabase
     .from('external_links')
     .insert({
@@ -530,7 +670,88 @@ export async function addExternalLink(data: {
       title: sanitisedLinkTitle,
       url: sanitisedUrl,
       link_type: data.link_type || 'general',
+      description: sanitisedDesc,
     });
+
+  if (error) return { success: false, error: error.message };
+  revalidatePath('/dashboard/profile');
+  return { success: true };
+}
+
+/**
+ * KAN-447 — edit an existing link's title / description / url. Mirrors
+ * `addExternalLink` for sanitise + moderation and `updateProfileItem` for the
+ * partial-update shape: only the fields the caller passes are written, and an
+ * empty description clears it to NULL so a member can remove a description via
+ * edit, not only replace it. The URL is required on a link, so an empty one is
+ * an error rather than a clear. `link_type` is intentionally NOT editable here
+ * (text-only edit — changing the type is a separate concern).
+ */
+export async function updateExternalLink(
+  linkId: string,
+  data: { title?: string; url?: string; description?: string },
+): Promise<ActionResult> {
+  const { user, supabase, error: authError } = await getAuthenticatedUser();
+  if (authError) return { success: false, error: authError };
+
+  // KAN-231 — profile-save rate limiting (edits are user-driven writes too).
+  const rl = await checkProfileWriteRateLimit(user!.id);
+  if (!rl.allowed) return rl.result;
+
+  // KAN-260 — belt-and-braces ownership: scope the write to the caller's own
+  // profile in code, not by RLS alone.
+  const profile = await getUserProfile(supabase, user!.id);
+  if (!profile) return { success: false, error: 'Profile not found' };
+
+  const updates: Record<string, string | null> = {};
+
+  if (data.title !== undefined) {
+    const sanitisedTitle = sanitiseText(data.title, 200);
+    if (sanitisedTitle.trim() === '') {
+      return { success: false, error: 'Title cannot be empty' };
+    }
+    const titleMod = await moderateAndAudit(supabase, {
+      text: sanitisedTitle,
+      fieldType: 'public',
+      field: 'external_links.title',
+      profileId: profile.id,
+      source: 'web_app',
+    });
+    if (!titleMod.ok) return { success: false, error: titleMod.error };
+    updates.title = sanitisedTitle;
+  }
+
+  if (data.description !== undefined) {
+    const sanitisedDesc = data.description.trim() !== ''
+      ? sanitiseText(data.description, 200)
+      : null;
+    if (sanitisedDesc) {
+      const descMod = await moderateAndAudit(supabase, {
+        text: sanitisedDesc,
+        fieldType: 'public',
+        field: 'external_links.description',
+        profileId: profile.id,
+        source: 'web_app',
+      });
+      if (!descMod.ok) return { success: false, error: descMod.error };
+    }
+    updates.description = sanitisedDesc;
+  }
+
+  if (data.url !== undefined) {
+    const cleaned = sanitiseUrl(data.url);
+    if (!cleaned) return { success: false, error: 'Invalid URL — must start with http:// or https://' };
+    updates.url = cleaned;
+  }
+
+  // Empty-patch guard — no-op rather than firing an UPDATE with empty SET.
+  if (Object.keys(updates).length === 0) return { success: true };
+
+  const { error } = await supabase
+    .from('external_links')
+    .update(updates)
+    .eq('id', linkId)
+    .eq('profile_id', profile.id);
 
   if (error) return { success: false, error: error.message };
   revalidatePath('/dashboard/profile');

--- a/src/app/dashboard/profile/edit-profile-form.tsx
+++ b/src/app/dashboard/profile/edit-profile-form.tsx
@@ -27,6 +27,7 @@ import {
   updateProfileItemVisibility,
   addExternalLink,
   removeExternalLink,
+  updateExternalLink,
   publishProfile,
 } from './actions';
 import {
@@ -371,6 +372,15 @@ export function EditProfileForm({
                           onRemove={(id) => {
                             runSectionSave(s.id, () => removeExternalLink(id));
                           }}
+                          // KAN-447: inline edit — same shape as the items
+                          // section. Awaited directly so a moderation block
+                          // surfaces on the row rather than in the section
+                          // status; router.refresh() re-pulls the saved row.
+                          onEdit={async (id, data) => {
+                            const res = await updateExternalLink(id, data);
+                            if (res.success) router.refresh();
+                            return { success: res.success, error: res.success ? undefined : res.error };
+                          }}
                           showContinue={false}
                           onNext={() => toggleSection(s.id)}
                           isPending={isPending}
@@ -388,8 +398,14 @@ export function EditProfileForm({
                           onAdd={(input) => {
                             runSectionSave(s.id, () => addConversationStarter(input));
                           }}
-                          onUpdate={(id, answer) => {
-                            runSectionSave(s.id, () => updateConversationStarter(id, answer));
+                          // KAN-448: awaited directly, like the items and links
+                          // edits, so a moderation block surfaces on the answer
+                          // being edited instead of only flipping the section
+                          // status to error.
+                          onUpdate={async (id, answer) => {
+                            const res = await updateConversationStarter(id, answer);
+                            if (res.success) router.refresh();
+                            return { success: res.success, error: res.success ? undefined : res.error };
                           }}
                           onRemove={(id) => {
                             runSectionSave(s.id, () => removeConversationStarter(id));

--- a/src/app/dashboard/profile/sections/affiliations-section.tsx
+++ b/src/app/dashboard/profile/sections/affiliations-section.tsx
@@ -22,7 +22,12 @@ import {
   isSchoolPostcodeValid,
   type AffiliationType,
 } from '../affiliation-fields';
-import { addSchoolAffiliation, removeSchoolAffiliation, updateAffiliationVisibility } from '../actions';
+import {
+  addSchoolAffiliation,
+  removeSchoolAffiliation,
+  updateAffiliationVisibility,
+  updateSchoolAffiliation,
+} from '../actions';
 import { useRouter } from 'next/navigation';
 
 const AFFILIATION_ORDER: AffiliationType[] = ['school', 'organisation', 'community'];
@@ -74,6 +79,14 @@ export function AffiliationsSection({ schools }: { schools: WizardSchool[] }) {
               if (result.success) router.refresh();
             });
           }}
+          // KAN-448: inline edit is awaited directly rather than fired into the
+          // transition, so a moderation or postcode rejection comes back to the
+          // row and is shown in place instead of being swallowed.
+          onEdit={async (id, data) => {
+            const result = await updateSchoolAffiliation(id, data);
+            if (result.success) router.refresh();
+            return result;
+          }}
           onToggleVisibility={(id, show) => {
             startTransition(async () => {
               const result = await updateAffiliationVisibility(id, show);
@@ -88,35 +101,95 @@ export function AffiliationsSection({ schools }: { schools: WizardSchool[] }) {
 }
 
 function AffiliationGroup({
-  type, items, onAdd, onRemove, onToggleVisibility, isPending,
+  type, items, onAdd, onRemove, onToggleVisibility, onEdit, isPending,
 }: {
   type: AffiliationType;
   items: WizardSchool[];
   onAdd: (name: string, location: string) => void;
   onRemove: (id: string) => void;
   onToggleVisibility: (id: string, show: boolean) => void;
+  // KAN-448 — edit an existing row's name / location / description. Returns
+  // the action result so the row can surface a rejection in place.
+  onEdit: (
+    id: string,
+    data: { school_name?: string; school_location?: string; description?: string },
+  ) => Promise<{ success: boolean; error?: string }>;
   isPending: boolean;
 }) {
   const [name, setName] = useState('');
   const [location, setLocation] = useState('');
   const [locationError, setLocationError] = useState('');
 
+  // KAN-448: inline edit state. Only one row edits at a time.
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [editName, setEditName] = useState('');
+  const [editLocation, setEditLocation] = useState('');
+  const [editDescription, setEditDescription] = useState('');
+  const [editError, setEditError] = useState<string | null>(null);
+  const [editSaving, setEditSaving] = useState(false);
+
   const needsPostcode = requiresPostcode(type);
   const postcodeInvalid = needsPostcode && !isSchoolPostcodeValid(location);
+  const editPostcodeInvalid = needsPostcode && !isSchoolPostcodeValid(editLocation);
+
+  const namePlaceholder =
+    type === 'school' ? 'Example: Greenfield Primary' :
+    type === 'organisation' ? 'Example: Acme Ltd' :
+    'Example: Local running club';
+  const locationPlaceholder = needsPostcode ? 'Example: SW1A 1AA' : 'Example: London';
+  const POSTCODE_HINT =
+    'Enter a postcode (full or partial) so people can tell schools with the same name apart.';
 
   const handleAdd = () => {
     if (!name.trim()) return;
     // KAN-404 — schools require a valid postcode before we add the row.
     if (postcodeInvalid) {
-      setLocationError(
-        'Enter a postcode (full or partial) so people can tell schools with the same name apart.',
-      );
+      setLocationError(POSTCODE_HINT);
       return;
     }
     onAdd(name.trim(), location.trim());
     setName('');
     setLocation('');
     setLocationError('');
+  };
+
+  const startEdit = (s: WizardSchool) => {
+    setEditingId(s.id);
+    setEditName(s.school_name);
+    setEditLocation(s.school_location ?? '');
+    setEditDescription(s.description ?? '');
+    setEditError(null);
+  };
+
+  const cancelEdit = () => {
+    setEditingId(null);
+    setEditError(null);
+  };
+
+  const saveEdit = async (id: string) => {
+    if (!editName.trim()) return;
+    // KAN-404 — the postcode rule applies to an edit too, so a school can't
+    // lose its postcode by being edited. The server enforces it as well.
+    if (editPostcodeInvalid) {
+      setEditError(POSTCODE_HINT);
+      return;
+    }
+    setEditSaving(true);
+    setEditError(null);
+    const result = await onEdit(id, {
+      school_name: editName.trim(),
+      // Send location and description even when empty so the member can CLEAR
+      // them (the action treats '' as null).
+      school_location: editLocation.trim(),
+      description: editDescription,
+    });
+    setEditSaving(false);
+    if (result.success) {
+      setEditingId(null);
+      setEditError(null);
+    } else {
+      setEditError(result.error ?? 'Could not save. Please try again.');
+    }
   };
 
   return (
@@ -128,32 +201,93 @@ function AffiliationGroup({
       {items.length > 0 && (
         <div className="space-y-2">
           {items.map((s) => (
-            <div key={s.id} className="flex items-center justify-between bg-white rounded-lg border border-[var(--color-border)] px-4 py-3 gap-3">
-              <div className="min-w-0">
-                <p className="text-sm font-medium text-[var(--color-ink)] truncate">{s.school_name}</p>
-                {s.school_location && (
-                  <p className="text-xs text-[var(--color-muted)] truncate">{s.school_location}</p>
-                )}
-              </div>
-              <div className="flex items-center gap-3 shrink-0">
-                <label className="flex items-center gap-1.5 text-xs text-[var(--color-muted)] cursor-pointer select-none">
-                  <input
-                    type="checkbox"
-                    checked={s.show_on_profile}
-                    onChange={(e) => onToggleVisibility(s.id, e.target.checked)}
-                    disabled={isPending}
-                    className="w-4 h-4 accent-[var(--color-sage)]"
+            <div key={s.id} className="bg-white rounded-lg border border-[var(--color-border)] px-4 py-3">
+              {editingId === s.id ? (
+                /* KAN-448: inline edit mode — reuses the add-form inputs. */
+                <div className="space-y-3">
+                  <Field
+                    label="Name"
+                    value={editName}
+                    onChange={setEditName}
+                    placeholder={namePlaceholder}
                   />
-                  Show on my profile
-                </label>
-                <button
-                  onClick={() => onRemove(s.id)}
-                  disabled={isPending}
-                  className="text-xs text-red-400 hover:text-red-600 disabled:opacity-40"
-                >
-                  Remove
-                </button>
-              </div>
+                  <Field
+                    label={needsPostcode ? 'Postcode' : 'Location (optional)'}
+                    value={editLocation}
+                    onChange={(v) => {
+                      setEditLocation(v);
+                      if (editError) setEditError(null);
+                    }}
+                    placeholder={locationPlaceholder}
+                  />
+                  <Field
+                    label="Description (optional)"
+                    value={editDescription}
+                    onChange={setEditDescription}
+                    placeholder="Example: Class of 2008"
+                  />
+                  {editError && <p role="alert" className="text-xs text-red-600">{editError}</p>}
+                  <div className="flex items-center gap-2">
+                    <button
+                      type="button"
+                      onClick={() => saveEdit(s.id)}
+                      disabled={editSaving || isPending || !editName.trim()}
+                      className="px-4 py-2 rounded-lg bg-[var(--color-sage)] text-white text-sm font-medium hover:opacity-90 disabled:opacity-40 transition-opacity"
+                    >
+                      {editSaving ? 'Saving…' : 'Save'}
+                    </button>
+                    <button
+                      type="button"
+                      onClick={cancelEdit}
+                      disabled={editSaving}
+                      className="px-4 py-2 rounded-lg text-sm font-medium text-[var(--color-muted)] hover:text-[var(--color-ink)] transition-colors"
+                    >
+                      Cancel
+                    </button>
+                  </div>
+                </div>
+              ) : (
+                <div className="flex items-center justify-between gap-3">
+                  <div className="min-w-0">
+                    <p className="text-sm font-medium text-[var(--color-ink)] truncate">
+                      {s.school_name}
+                      {s.description && (
+                        <span className="ml-2 text-xs font-normal text-[var(--color-muted)]">{s.description}</span>
+                      )}
+                    </p>
+                    {s.school_location && (
+                      <p className="text-xs text-[var(--color-muted)] truncate">{s.school_location}</p>
+                    )}
+                  </div>
+                  <div className="flex items-center gap-3 shrink-0">
+                    <label className="flex items-center gap-1.5 text-xs text-[var(--color-muted)] cursor-pointer select-none">
+                      <input
+                        type="checkbox"
+                        checked={s.show_on_profile}
+                        onChange={(e) => onToggleVisibility(s.id, e.target.checked)}
+                        disabled={isPending}
+                        className="w-4 h-4 accent-[var(--color-sage)]"
+                      />
+                      Show on my profile
+                    </label>
+                    <button
+                      type="button"
+                      onClick={() => startEdit(s)}
+                      disabled={isPending}
+                      className="text-xs text-[var(--color-muted)] hover:text-[var(--color-ink)] disabled:opacity-40"
+                    >
+                      Edit
+                    </button>
+                    <button
+                      onClick={() => onRemove(s.id)}
+                      disabled={isPending}
+                      className="text-xs text-red-400 hover:text-red-600 disabled:opacity-40"
+                    >
+                      Remove
+                    </button>
+                  </div>
+                </div>
+              )}
             </div>
           ))}
         </div>
@@ -164,11 +298,7 @@ function AffiliationGroup({
           label={`${AFFILIATION_LABELS[type].slice(0, -1)} name`}
           value={name}
           onChange={setName}
-          placeholder={
-            type === 'school' ? 'Greenfield Primary' :
-            type === 'organisation' ? 'Acme Ltd' :
-            'Local running club'
-          }
+          placeholder={namePlaceholder}
         />
         <div>
           <Field
@@ -178,7 +308,7 @@ function AffiliationGroup({
               setLocation(v);
               if (locationError) setLocationError('');
             }}
-            placeholder={needsPostcode ? 'SW1A 1AA' : 'London'}
+            placeholder={locationPlaceholder}
           />
           {locationError && (
             <p className="mt-1 text-xs text-red-500">{locationError}</p>

--- a/src/app/dashboard/profile/sections/manual-of-me-section.tsx
+++ b/src/app/dashboard/profile/sections/manual-of-me-section.tsx
@@ -74,8 +74,8 @@ export function ManualOfMeSection({ manualOfMe }: { manualOfMe: ManualOfMe }) {
 
       <MoMField
         label="Good to know about me / Things I'm into"
-        helper="The little things that help people get you — and the things you're into."
-        placeholder="I'm a slow texter but I always reply. I think out loud, so half of what I say is me working it out."
+        helper="What you're into, and the little things that help people get you."
+        placeholder="Example: I'm a slow texter but I always reply. I think out loud, so half of what I say is me working it out."
         value={draft.good_to_know}
         onChange={(v) => set('good_to_know', v)}
         onBlur={flush}
@@ -86,7 +86,7 @@ export function ManualOfMeSection({ manualOfMe }: { manualOfMe: ManualOfMe }) {
       <MoMField
         label="My boundaries"
         helper="Anything you'd gently ask people to respect."
-        placeholder="Please don't drop by unannounced — I love seeing you, I just need a heads-up."
+        placeholder="Example: Please don't drop by unannounced — I love seeing you, I just need a heads-up."
         value={draft.boundaries}
         onChange={(v) => set('boundaries', v)}
         onBlur={flush}
@@ -97,7 +97,7 @@ export function ManualOfMeSection({ manualOfMe }: { manualOfMe: ManualOfMe }) {
       <MoMField
         label="How I find communication easier"
         helper="How you like people to reach you."
-        placeholder="Plain and direct, kindly meant. If something's off, just tell me — I'd rather know."
+        placeholder="Example: Plain and direct, kindly meant. If something's off, just tell me — I'd rather know."
         value={draft.communication_style}
         onChange={(v) => set('communication_style', v)}
         onBlur={flush}
@@ -108,7 +108,7 @@ export function ManualOfMeSection({ manualOfMe }: { manualOfMe: ManualOfMe }) {
       <MoMField
         label="If you ever come to my house"
         helper="Anything a visitor would love to know."
-        placeholder="Shoes off, the dog is friendly, help yourself to tea — the good biscuits are behind the cereal."
+        placeholder="Example: Shoes off, the dog is friendly, help yourself to tea — the good biscuits are behind the cereal."
         value={draft.working_preferences}
         onChange={(v) => set('working_preferences', v)}
         onBlur={flush}
@@ -119,7 +119,7 @@ export function ManualOfMeSection({ manualOfMe }: { manualOfMe: ManualOfMe }) {
       <MoMField
         label="What gives me energy"
         helper="The things that fill you up."
-        placeholder="A morning with no plans, a full pot of coffee, and live music in the evening."
+        placeholder="Example: A morning with no plans, a full pot of coffee, and live music in the evening."
         value={draft.energises_me}
         onChange={(v) => set('energises_me', v)}
         onBlur={flush}
@@ -130,7 +130,7 @@ export function ManualOfMeSection({ manualOfMe }: { manualOfMe: ManualOfMe }) {
       <MoMField
         label="What drains me"
         helper="The things that wear you out."
-        placeholder="Open-plan noise and small talk about the weather."
+        placeholder="Example: Open-plan noise and small talk about the weather."
         value={draft.drains_me}
         onChange={(v) => set('drains_me', v)}
         onBlur={flush}

--- a/src/app/dashboard/profile/steps/conversation-starters-step.tsx
+++ b/src/app/dashboard/profile/steps/conversation-starters-step.tsx
@@ -36,7 +36,10 @@ export function ConversationStartersStep({
   prompts: ConversationPrompt[];
   answers: ConversationAnswer[];
   onAdd: (input: { promptId: string; answer: string }) => void;
-  onUpdate: (id: string, answer: string) => void;
+  // KAN-448 — the caller awaits the update action and hands back its result so
+  // a moderation rejection surfaces on the row it belongs to, rather than
+  // disappearing into a transition. Same shape as ItemsStep's onEdit.
+  onUpdate: (id: string, answer: string) => Promise<{ success: boolean; error?: string }>;
   onRemove: (id: string) => void;
   onNext: () => void;
   isPending: boolean;
@@ -48,6 +51,8 @@ export function ConversationStartersStep({
   const [newAnswer, setNewAnswer] = useState('');
   const [editingId, setEditingId] = useState<string | null>(null);
   const [editingAnswer, setEditingAnswer] = useState('');
+  const [editError, setEditError] = useState<string | null>(null);
+  const [editSaving, setEditSaving] = useState(false);
 
   const answeredPromptIds = new Set(answers.map((a) => a.prompt_id));
   const unanswered = prompts.filter((p) => !answeredPromptIds.has(p.id));
@@ -68,11 +73,19 @@ export function ConversationStartersStep({
   function handleStartEdit(answer: ConversationAnswer) {
     setEditingId(answer.id);
     setEditingAnswer(answer.answer);
+    setEditError(null);
   }
 
-  function handleSaveEdit() {
+  async function handleSaveEdit() {
     if (!editingId || !editingAnswer.trim()) return;
-    onUpdate(editingId, editingAnswer.trim());
+    setEditSaving(true);
+    setEditError(null);
+    const res = await onUpdate(editingId, editingAnswer.trim());
+    setEditSaving(false);
+    if (!res.success) {
+      setEditError(res.error ?? 'Could not save. Please try again.');
+      return;
+    }
     setEditingId(null);
     setEditingAnswer('');
   }
@@ -105,13 +118,14 @@ export function ConversationStartersStep({
                     rows={3}
                     className="w-full p-2 text-sm rounded border border-[var(--color-border)] bg-white"
                   />
+                  {editError && <p role="alert" className="text-xs text-red-600">{editError}</p>}
                   <div className="flex items-center justify-between text-xs">
                     <span className="text-[var(--color-muted)]">{editingAnswer.length} / {ANSWER_MAX}</span>
                     <div className="flex gap-2">
                       <button
                         type="button"
-                        onClick={() => { setEditingId(null); setEditingAnswer(''); }}
-                        disabled={isPending}
+                        onClick={() => { setEditingId(null); setEditingAnswer(''); setEditError(null); }}
+                        disabled={editSaving}
                         className="text-[var(--color-muted)] hover:text-[var(--color-ink)]"
                       >
                         Cancel
@@ -119,10 +133,10 @@ export function ConversationStartersStep({
                       <button
                         type="button"
                         onClick={handleSaveEdit}
-                        disabled={isPending || !editingAnswer.trim()}
+                        disabled={editSaving || isPending || !editingAnswer.trim()}
                         className="px-3 py-1 rounded-full bg-[var(--color-sage)] text-white disabled:opacity-50"
                       >
-                        Save
+                        {editSaving ? 'Saving…' : 'Save'}
                       </button>
                     </div>
                   </div>
@@ -188,7 +202,7 @@ export function ConversationStartersStep({
                     value={newAnswer}
                     onChange={(e) => setNewAnswer(e.target.value.slice(0, ANSWER_MAX))}
                     rows={3}
-                    placeholder="Write a short, honest answer — a few sentences."
+                    placeholder="Example: I'd take one battered paperback and a very large pot of coffee."
                     className="w-full p-2 text-sm rounded border border-[var(--color-border)] bg-white"
                   />
                   <div className="flex items-center justify-between text-xs">

--- a/src/app/dashboard/profile/steps/items-step.tsx
+++ b/src/app/dashboard/profile/steps/items-step.tsx
@@ -153,14 +153,14 @@ export function ItemsStep({ title, description, categories, items, onAdd, onRemo
                 /* KAN-404 (#12): inline edit mode — reuses the add-form input
                    styling. Save runs onEdit; a moderation block shows in place. */
                 <div className="space-y-3">
-                  <Field label="Title" value={editTitle} onChange={setEditTitle} placeholder="e.g. Dark chocolate, hiking boots" />
+                  <Field label="Title" value={editTitle} onChange={setEditTitle} placeholder="Example: Dark chocolate, hiking boots" />
                   <div>
                     <label className="block text-sm font-medium text-[var(--color-ink)] mb-1">Description (optional)</label>
                     <input
                       value={editDesc}
                       onChange={(e) => setEditDesc(e.target.value)}
                       className="w-full px-3 py-2 rounded-lg border border-[var(--color-border)] bg-white text-sm focus:outline-none focus:ring-2 focus:ring-[var(--color-sage)]"
-                      placeholder="Any extra detail"
+                      placeholder="Example: the really dark one with sea salt"
                     />
                   </div>
                   <div>
@@ -173,7 +173,7 @@ export function ItemsStep({ title, description, categories, items, onAdd, onRemo
                       value={editUrl}
                       onChange={(e) => setEditUrl(e.target.value)}
                       className="w-full px-3 py-2 rounded-lg border border-[var(--color-border)] bg-white text-sm focus:outline-none focus:ring-2 focus:ring-[var(--color-sage)]"
-                      placeholder="https://example.com/this-book"
+                      placeholder="Example: https://example.com/this-book"
                     />
                   </div>
                   {editError && <p role="alert" className="text-sm text-red-600">{editError}</p>}
@@ -277,12 +277,12 @@ export function ItemsStep({ title, description, categories, items, onAdd, onRemo
             </select>
           </div>
         )}
-        <Field label="Title" value={itemTitle} onChange={setItemTitle} placeholder="e.g. Dark chocolate, hiking boots" />
+        <Field label="Title" value={itemTitle} onChange={setItemTitle} placeholder="Example: Dark chocolate, hiking boots" />
         <div>
           <label className="block text-sm font-medium text-[var(--color-ink)] mb-1">Description (optional)</label>
           <input value={itemDesc} onChange={(e) => setItemDesc(e.target.value)}
             className="w-full px-3 py-2 rounded-lg border border-[var(--color-border)] bg-white text-sm focus:outline-none focus:ring-2 focus:ring-[var(--color-sage)]"
-            placeholder="Any extra detail" />
+            placeholder="Example: the really dark one with sea salt" />
         </div>
         {/* KAN-219: optional URL on items (Python lyra-app parity).
             Server-side sanitiseUrl rejects anything that's not http(s);
@@ -297,7 +297,7 @@ export function ItemsStep({ title, description, categories, items, onAdd, onRemo
             value={itemUrl}
             onChange={(e) => setItemUrl(e.target.value)}
             className="w-full px-3 py-2 rounded-lg border border-[var(--color-border)] bg-white text-sm focus:outline-none focus:ring-2 focus:ring-[var(--color-sage)]"
-            placeholder="https://example.com/this-book"
+            placeholder="Example: https://example.com/this-book"
           />
         </div>
         {!hideVisibility && (

--- a/src/app/dashboard/profile/steps/links-step.tsx
+++ b/src/app/dashboard/profile/steps/links-step.tsx
@@ -3,23 +3,79 @@
 import { useState } from 'react';
 import { Field, SaveButton, type WizardLink } from './types';
 
-export function LinksStep({ links, onAdd, onRemove, onNext, isPending, showContinue = true }: {
+export function LinksStep({ links, onAdd, onRemove, onEdit, onNext, isPending, showContinue = true }: {
   links: WizardLink[];
-  onAdd: (data: { title: string; url: string; link_type?: string }) => void;
-  onRemove: (id: string) => void; onNext: () => void; isPending: boolean;
+  // KAN-447 — links carry an optional one-line description. The column has
+  // existed since the first schema migration; the editor now writes it.
+  onAdd: (data: { title: string; url: string; link_type?: string; description?: string }) => void;
+  onRemove: (id: string) => void;
+  // KAN-447 — edit an existing link's title/description/url. Optional so the
+  // legacy wizard, which doesn't pass it, keeps compiling and simply doesn't
+  // render the inline Edit affordance. Returns the action result so the row can
+  // surface a moderation error in place (same pattern as ItemsStep).
+  onEdit?: (id: string, data: { title?: string; description?: string; url?: string }) => Promise<{ success: boolean; error?: string }>;
+  onNext: () => void; isPending: boolean;
   // KAN-404 (#8/#9): the single-page editor sets showContinue={false} to drop
   // the misleading "Continue →" button; the legacy wizard keeps the default.
   showContinue?: boolean;
 }) {
   const [title, setTitle] = useState('');
   const [url, setUrl] = useState('');
+  const [description, setDescription] = useState('');
   const [linkType, setLinkType] = useState('general');
+
+  // KAN-447: inline edit state. Only one row edits at a time.
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [editTitle, setEditTitle] = useState('');
+  const [editDesc, setEditDesc] = useState('');
+  const [editUrl, setEditUrl] = useState('');
+  const [editError, setEditError] = useState<string | null>(null);
+  const [editSaving, setEditSaving] = useState(false);
+
+  const startEdit = (link: WizardLink) => {
+    setEditingId(link.id);
+    setEditTitle(link.title);
+    setEditDesc(link.description ?? '');
+    setEditUrl(link.url);
+    setEditError(null);
+  };
+
+  const cancelEdit = () => {
+    setEditingId(null);
+    setEditError(null);
+  };
+
+  const saveEdit = async (id: string) => {
+    if (!onEdit || !editTitle.trim() || !editUrl.trim()) return;
+    setEditSaving(true);
+    setEditError(null);
+    const res = await onEdit(id, {
+      title: editTitle.trim(),
+      // Send the description even when empty so the user can CLEAR it
+      // (the action treats '' as null).
+      description: editDesc,
+      url: editUrl.trim(),
+    });
+    setEditSaving(false);
+    if (res.success) {
+      setEditingId(null);
+      setEditError(null);
+    } else {
+      setEditError(res.error ?? 'Could not save. Please try again.');
+    }
+  };
 
   const handleAdd = () => {
     if (!title.trim() || !url.trim()) return;
-    onAdd({ title, url, link_type: linkType });
+    onAdd({
+      title,
+      url,
+      link_type: linkType,
+      ...(description.trim() ? { description } : {}),
+    });
     setTitle('');
     setUrl('');
+    setDescription('');
   };
 
   return (
@@ -31,19 +87,70 @@ export function LinksStep({ links, onAdd, onRemove, onNext, isPending, showConti
       {links.length > 0 && (
         <div className="space-y-2">
           {links.map((l: WizardLink) => (
-            <div key={l.id} className="flex items-center justify-between bg-white rounded-lg border border-[var(--color-border)] px-4 py-3">
-              <div>
-                <p className="text-sm font-medium text-[var(--color-ink)]">{l.title}</p>
-                <p className="text-xs text-[var(--color-muted)] truncate max-w-xs">{l.url}</p>
-              </div>
-              <button onClick={() => onRemove(l.id)} disabled={isPending} className="text-xs text-red-400 hover:text-red-600">Remove</button>
+            <div key={l.id} className="bg-white rounded-lg border border-[var(--color-border)] px-4 py-3">
+              {onEdit && editingId === l.id ? (
+                /* KAN-447: inline edit mode — reuses the add-form input
+                   styling. Save runs onEdit; a moderation block shows in place. */
+                <div className="space-y-3">
+                  <Field label="Title" value={editTitle} onChange={setEditTitle} placeholder="Example: My birthday wishlist" />
+                  <Field label="Description (optional)" value={editDesc} onChange={setEditDesc} placeholder="Example: things I've had my eye on all year" />
+                  <Field label="URL" value={editUrl} onChange={setEditUrl} placeholder="Example: https://example.com/my-wishlist" />
+                  {editError && <p role="alert" className="text-sm text-red-600">{editError}</p>}
+                  <div className="flex items-center gap-2">
+                    <button
+                      type="button"
+                      onClick={() => saveEdit(l.id)}
+                      disabled={editSaving || isPending || !editTitle.trim() || !editUrl.trim()}
+                      className="px-4 py-2 rounded-lg bg-[var(--color-sage)] text-white text-sm font-medium hover:opacity-90 disabled:opacity-40 transition-opacity"
+                    >
+                      {editSaving ? 'Saving…' : 'Save'}
+                    </button>
+                    <button
+                      type="button"
+                      onClick={cancelEdit}
+                      disabled={editSaving}
+                      className="px-4 py-2 rounded-lg text-sm font-medium text-[var(--color-muted)] hover:text-[var(--color-ink)] transition-colors"
+                    >
+                      Cancel
+                    </button>
+                  </div>
+                </div>
+              ) : (
+                <div className="flex items-center justify-between gap-3">
+                  {/* KAN-447: title and description sit on one line, with the
+                      link itself underneath. */}
+                  <div className="min-w-0">
+                    <p className="text-sm font-medium text-[var(--color-ink)]">
+                      {l.title}
+                      {l.description && (
+                        <span className="ml-2 text-xs font-normal text-[var(--color-muted)]">{l.description}</span>
+                      )}
+                    </p>
+                    <p className="text-xs text-[var(--color-muted)] truncate max-w-xs">{l.url}</p>
+                  </div>
+                  <div className="flex items-center gap-2 shrink-0">
+                    {onEdit && (
+                      <button
+                        type="button"
+                        onClick={() => startEdit(l)}
+                        disabled={isPending}
+                        className="text-xs text-[var(--color-muted)] hover:text-[var(--color-ink)]"
+                      >
+                        Edit
+                      </button>
+                    )}
+                    <button onClick={() => onRemove(l.id)} disabled={isPending} className="text-xs text-red-400 hover:text-red-600">Remove</button>
+                  </div>
+                </div>
+              )}
             </div>
           ))}
         </div>
       )}
       <div className="space-y-3 bg-white rounded-lg border border-[var(--color-border)] p-4">
-        <Field label="Title" value={title} onChange={setTitle} placeholder="My Amazon wishlist" />
-        <Field label="URL" value={url} onChange={setUrl} placeholder="https://amazon.co.uk/hz/wishlist/..." />
+        <Field label="Title" value={title} onChange={setTitle} placeholder="Example: My birthday wishlist" />
+        <Field label="Description (optional)" value={description} onChange={setDescription} placeholder="Example: things I've had my eye on all year" />
+        <Field label="URL" value={url} onChange={setUrl} placeholder="Example: https://example.com/my-wishlist" />
         <div>
           <label className="block text-sm font-medium text-[var(--color-ink)] mb-1">Type</label>
           <select value={linkType} onChange={(e) => setLinkType(e.target.value)}

--- a/src/app/dashboard/profile/wizard.tsx
+++ b/src/app/dashboard/profile/wizard.tsx
@@ -243,7 +243,11 @@ export function ProfileWizard({
             prompts={conversationPrompts}
             answers={conversationAnswers}
             onAdd={(input) => { startTransition(async () => { await addConversationStarter(input); router.refresh(); }); }}
-            onUpdate={(id, answer) => { startTransition(async () => { await updateConversationStarter(id, answer); router.refresh(); }); }}
+            onUpdate={async (id, answer) => {
+              const res = await updateConversationStarter(id, answer);
+              if (res.success) router.refresh();
+              return { success: res.success, error: res.success ? undefined : res.error };
+            }}
             onRemove={(id) => { startTransition(async () => { await removeConversationStarter(id); router.refresh(); }); }}
             onNext={next} isPending={isPending}
           />

--- a/tests/unit/kan447-kan448-inline-edit.test.ts
+++ b/tests/unit/kan447-kan448-inline-edit.test.ts
@@ -1,0 +1,424 @@
+/**
+ * KAN-447 / KAN-448 — per-entry edit for links and affiliations.
+ *
+ * Both new actions are partial updates, so they carry two obligations the
+ * existing add-paths don't:
+ *
+ *   1. **Only the fields the caller passes are written** — an omitted field
+ *      must keep its stored value. This is the BUGS-74 contract; a whole-row
+ *      write here would let an editor that renders a subset of the columns
+ *      NULL the rest.
+ *   2. **Every rule the add-path enforces still applies on edit** — sanitise,
+ *      moderation, the http(s)-only URL check (KAN-219) and the KAN-404 school
+ *      postcode requirement. An edit that skips them is a way around them.
+ *
+ * The tests drive the real server actions through a mocked Supabase client and
+ * assert on the payload that reaches `.update()`, so deleting a check in
+ * `actions.ts` turns them red. Filters are recorded PER STATEMENT — see the
+ * `MockStatement` note below for why a per-table pool is not good enough.
+ */
+
+const mockInsertCapture = jest.fn();
+const mockUpdateCapture = jest.fn();
+const mockRevalidatePath = jest.fn();
+
+/**
+ * One `.from()` call === one statement, so each statement keeps its OWN `.eq()`
+ * log rather than a pool shared per table.
+ *
+ * Pooling per table is what made the owner-scoping and row-id assertions
+ * vacuous. `updateSchoolAffiliation` reads the row before it writes, and the
+ * SELECT's `.eq('id', …)` / `.eq('profile_id', …)` satisfied assertions that
+ * were meant to be about the UPDATE — so deleting either `.eq()` from the
+ * UPDATE left all 27 tests green while an attacker could edit another member's
+ * affiliation, or bulk-overwrite every affiliation the owner has. Read-satisfied
+ * assertions about a write are the SEC-100 shape: the check fires constantly and
+ * answers a different question.
+ */
+type MockStatement = {
+  table: string;
+  kind: 'select' | 'update' | 'insert' | 'unknown';
+  eq: Array<[string, unknown]>;
+};
+const mockStatements: MockStatement[] = [];
+
+const mockState: {
+  userId: string | null;
+  affiliationRow: { affiliation_type: string } | null;
+} = {
+  userId: 'kan447-user',
+  affiliationRow: { affiliation_type: 'school' },
+};
+
+jest.mock('next/cache', () => ({
+  revalidatePath: (...args: unknown[]) => mockRevalidatePath(...args),
+}));
+
+jest.mock('@/lib/supabase-server', () => {
+  type Builder = {
+    select: () => Builder;
+    update: (data: unknown) => Builder;
+    insert: (data: unknown) => Promise<{ error: null }>;
+    eq: (col: string, val: unknown) => Builder;
+    single: () => Promise<{ data: unknown; error: null }>;
+    maybeSingle: () => Promise<{ data: unknown; error: null }>;
+    then: (
+      resolve: (v: { error: null }) => unknown,
+      reject?: (e: unknown) => unknown,
+    ) => Promise<unknown>;
+  };
+
+  const build = (table: string): Builder => {
+    // Recorded per builder, i.e. per statement — never pooled across the
+    // pre-read and the write (see the MockStatement note above).
+    const statement: MockStatement = { table, kind: 'unknown', eq: [] };
+    mockStatements.push(statement);
+
+    const b: Builder = {
+      select: () => {
+        statement.kind = 'select';
+        return b;
+      },
+      update: (data: unknown) => {
+        statement.kind = 'update';
+        mockUpdateCapture(table, data);
+        return b;
+      },
+      insert: (data: unknown) => {
+        statement.kind = 'insert';
+        mockInsertCapture(table, data);
+        return Promise.resolve({ error: null });
+      },
+      eq: (col: string, val: unknown) => {
+        statement.eq.push([col, val]);
+        return b;
+      },
+      single: () =>
+        Promise.resolve(
+          table === 'profiles'
+            ? { data: { id: 'profile-1' }, error: null }
+            : { data: null, error: null },
+        ),
+      maybeSingle: () =>
+        Promise.resolve(
+          table === 'school_affiliations'
+            ? { data: mockState.affiliationRow, error: null }
+            : { data: null, error: null },
+        ),
+      then: (resolve, reject) => Promise.resolve({ error: null }).then(resolve, reject),
+    };
+    return b;
+  };
+
+  return {
+    createClient: jest.fn().mockResolvedValue({
+      auth: {
+        getUser: () =>
+          Promise.resolve({
+            data: { user: mockState.userId ? { id: mockState.userId } : null },
+          }),
+      },
+      from: (table: string) => build(table),
+    }),
+  };
+});
+
+import {
+  addExternalLink,
+  updateExternalLink,
+  updateSchoolAffiliation,
+} from '@/app/dashboard/profile/actions';
+
+// Each test gets its own user id so the in-memory per-user write rate limit
+// (KAN-231, 30/min) can never make a later test fail for an earlier test's
+// reason.
+let userCounter = 0;
+
+beforeEach(() => {
+  mockInsertCapture.mockClear();
+  mockUpdateCapture.mockClear();
+  mockRevalidatePath.mockClear();
+  mockStatements.length = 0;
+  userCounter += 1;
+  mockState.userId = `kan447-user-${userCounter}`;
+  mockState.affiliationRow = { affiliation_type: 'school' };
+});
+
+function statementsFor(table: string, kind: MockStatement['kind']): MockStatement[] {
+  return mockStatements.filter((s) => s.table === table && s.kind === kind);
+}
+
+/**
+ * The one statement of `kind` against `table`. Asserting there is exactly one
+ * is part of the point: "some statement somewhere carried this filter" is the
+ * weak form that let a read stand in for a write.
+ */
+function onlyStatement(table: string, kind: MockStatement['kind']): MockStatement {
+  const found = statementsFor(table, kind);
+  expect(found).toHaveLength(1);
+  return found[0];
+}
+
+/**
+ * A write is safe only if the UPDATE statement ITSELF carries both filters:
+ * `id` alone would let it touch another member's row, `profile_id` alone would
+ * bulk-overwrite every row the owner has.
+ */
+function expectUpdateScopedTo(table: string, rowId: string): void {
+  const update = onlyStatement(table, 'update');
+  expect(update.eq).toContainEqual(['id', rowId]);
+  expect(update.eq).toContainEqual(['profile_id', 'profile-1']);
+}
+
+// ───────────── KAN-447: addExternalLink description ─────────────
+
+describe('KAN-447: addExternalLink writes the description column', () => {
+  test('a supplied description is sanitised and inserted', async () => {
+    const result = await addExternalLink({
+      title: 'My birthday wishlist',
+      url: 'https://example.com/my-wishlist',
+      description: 'Things <b>I have</b> had my eye on',
+    });
+    expect(result).toEqual({ success: true });
+    expect(mockInsertCapture).toHaveBeenCalledWith(
+      'external_links',
+      expect.objectContaining({ description: 'Things I have had my eye on' }),
+    );
+  });
+
+  test('no description → NULL rather than an empty string', async () => {
+    await addExternalLink({
+      title: 'My birthday wishlist',
+      url: 'https://example.com/my-wishlist',
+    });
+    expect(mockInsertCapture).toHaveBeenCalledWith(
+      'external_links',
+      expect.objectContaining({ description: null }),
+    );
+  });
+
+  test('profane description → blocked, no write to external_links', async () => {
+    const result = await addExternalLink({
+      title: 'My birthday wishlist',
+      url: 'https://example.com/my-wishlist',
+      description: 'fuck this list',
+    });
+    expect(result.success).toBe(false);
+    expect(mockInsertCapture).not.toHaveBeenCalledWith('external_links', expect.anything());
+  });
+});
+
+// ───────────── KAN-447: updateExternalLink ─────────────
+
+describe('KAN-447: updateExternalLink', () => {
+  test('writes sanitised title/description/url, owner-scoped', async () => {
+    const result = await updateExternalLink('link-1', {
+      title: 'My <b>birthday</b> wishlist',
+      description: 'Updated note',
+      url: 'https://example.com/new-list',
+    });
+    expect(result).toEqual({ success: true });
+    expect(mockUpdateCapture).toHaveBeenCalledWith('external_links', {
+      title: 'My birthday wishlist',
+      description: 'Updated note',
+      url: 'https://example.com/new-list',
+    });
+    expectUpdateScopedTo('external_links', 'link-1');
+    // `updateExternalLink` has no pre-read, so today nothing else COULD have
+    // supplied those filters. Pinned so that a pre-read added later cannot
+    // quietly start satisfying the assertion above on the UPDATE's behalf —
+    // which is exactly how the sibling affiliations assertion went vacuous.
+    expect(statementsFor('external_links', 'select')).toHaveLength(0);
+  });
+
+  test('omitted fields are not written at all (BUGS-74 partial-write contract)', async () => {
+    await updateExternalLink('link-1', { title: 'Only the title' });
+    expect(mockUpdateCapture).toHaveBeenCalledWith('external_links', { title: 'Only the title' });
+  });
+
+  test('empty description clears it to null', async () => {
+    await updateExternalLink('link-1', { description: '' });
+    expect(mockUpdateCapture).toHaveBeenCalledWith('external_links', { description: null });
+  });
+
+  test('empty title is rejected — a link needs a name', async () => {
+    const result = await updateExternalLink('link-1', { title: '   ' });
+    expect(result).toEqual({ success: false, error: 'Title cannot be empty' });
+    expect(mockUpdateCapture).not.toHaveBeenCalledWith('external_links', expect.anything());
+  });
+
+  test('a non-http(s) url is rejected rather than silently dropped', async () => {
+    const result = await updateExternalLink('link-1', { url: 'javascript:alert(1)' });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error).toMatch(/http:\/\/ or https:\/\//i);
+    }
+    expect(mockUpdateCapture).not.toHaveBeenCalledWith('external_links', expect.anything());
+  });
+
+  test('an empty url is rejected — a link cannot lose its url by being edited', async () => {
+    const result = await updateExternalLink('link-1', { url: '' });
+    expect(result.success).toBe(false);
+    expect(mockUpdateCapture).not.toHaveBeenCalledWith('external_links', expect.anything());
+  });
+
+  test('profane title → blocked, no update', async () => {
+    const result = await updateExternalLink('link-1', { title: 'fuck this list' });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error).toMatch(/inappropriate language/i);
+    }
+    expect(mockUpdateCapture).not.toHaveBeenCalledWith('external_links', expect.anything());
+  });
+
+  test('PII in the description → blocked, no update', async () => {
+    const result = await updateExternalLink('link-1', {
+      description: 'Call me on +44 7700 900123',
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error).toMatch(/personal information/i);
+    }
+    expect(mockUpdateCapture).not.toHaveBeenCalledWith('external_links', expect.anything());
+  });
+
+  test('an empty patch is a no-op success, not an UPDATE with an empty SET', async () => {
+    const result = await updateExternalLink('link-1', {});
+    expect(result).toEqual({ success: true });
+    expect(mockUpdateCapture).not.toHaveBeenCalledWith('external_links', expect.anything());
+  });
+
+  test('not authenticated → no write attempted', async () => {
+    mockState.userId = null;
+    const result = await updateExternalLink('link-1', { title: 'Hi' });
+    expect(result).toEqual({ success: false, error: 'Not authenticated' });
+    expect(mockUpdateCapture).not.toHaveBeenCalled();
+  });
+});
+
+// ───────────── KAN-448: updateSchoolAffiliation ─────────────
+
+describe('KAN-448: updateSchoolAffiliation', () => {
+  const POSTCODE_ERROR =
+    'Schools need a postcode (full or partial) so people can tell schools with the same name apart.';
+
+  test('writes sanitised name/location/description, owner-scoped', async () => {
+    const result = await updateSchoolAffiliation('aff-1', {
+      school_name: 'Greenfield <b>Primary</b>',
+      school_location: 'SW1A 1AA',
+      description: 'Class of 2008',
+    });
+    expect(result).toEqual({ success: true });
+    expect(mockUpdateCapture).toHaveBeenCalledWith('school_affiliations', {
+      school_name: 'Greenfield Primary',
+      school_location: 'SW1A 1AA',
+      description: 'Class of 2008',
+    });
+    // Asserted on the UPDATE statement specifically: the pre-read carries the
+    // same two filters, so a pooled-per-table assertion passes here even when
+    // the UPDATE itself carries neither.
+    expectUpdateScopedTo('school_affiliations', 'aff-1');
+  });
+
+  test('the UPDATE carries the row id AND the owner scope, not just the pre-read', async () => {
+    await updateSchoolAffiliation('aff-1', { description: 'Class of 2008' });
+
+    const update = onlyStatement('school_affiliations', 'update');
+    // Dropping `.eq('id', …)` from the UPDATE would bulk-overwrite every
+    // affiliation this owner has; dropping `.eq('profile_id', …)` would let a
+    // caller edit someone else's row. Both must be on the write.
+    expect(update.eq).toContainEqual(['id', 'aff-1']);
+    expect(update.eq).toContainEqual(['profile_id', 'profile-1']);
+  });
+
+  test('omitted fields are not written at all (BUGS-74 partial-write contract)', async () => {
+    await updateSchoolAffiliation('aff-1', { description: 'Class of 2008' });
+    expect(mockUpdateCapture).toHaveBeenCalledWith('school_affiliations', {
+      description: 'Class of 2008',
+    });
+  });
+
+  test('KAN-404: a school cannot lose its postcode by being edited', async () => {
+    const result = await updateSchoolAffiliation('aff-1', { school_location: '' });
+    expect(result).toEqual({ success: false, error: POSTCODE_ERROR });
+    expect(mockUpdateCapture).not.toHaveBeenCalledWith('school_affiliations', expect.anything());
+  });
+
+  test('KAN-404: a location with no digit is rejected for a school', async () => {
+    const result = await updateSchoolAffiliation('aff-1', { school_location: 'London' });
+    expect(result).toEqual({ success: false, error: POSTCODE_ERROR });
+    expect(mockUpdateCapture).not.toHaveBeenCalledWith('school_affiliations', expect.anything());
+  });
+
+  test('the postcode rule follows the STORED type, not a caller-supplied one', async () => {
+    mockState.affiliationRow = { affiliation_type: 'organisation' };
+    const result = await updateSchoolAffiliation('aff-1', { school_location: 'London' });
+    expect(result).toEqual({ success: true });
+    expect(mockUpdateCapture).toHaveBeenCalledWith('school_affiliations', {
+      school_location: 'London',
+    });
+  });
+
+  test('an organisation can clear its location to null', async () => {
+    mockState.affiliationRow = { affiliation_type: 'organisation' };
+    await updateSchoolAffiliation('aff-1', { school_location: '' });
+    expect(mockUpdateCapture).toHaveBeenCalledWith('school_affiliations', {
+      school_location: null,
+    });
+  });
+
+  test('empty description clears it to null', async () => {
+    await updateSchoolAffiliation('aff-1', { description: '' });
+    expect(mockUpdateCapture).toHaveBeenCalledWith('school_affiliations', { description: null });
+  });
+
+  test('empty name is rejected', async () => {
+    const result = await updateSchoolAffiliation('aff-1', { school_name: '  ' });
+    expect(result).toEqual({ success: false, error: 'Name cannot be empty' });
+    expect(mockUpdateCapture).not.toHaveBeenCalledWith('school_affiliations', expect.anything());
+  });
+
+  test('profane name → blocked, no update', async () => {
+    const result = await updateSchoolAffiliation('aff-1', { school_name: 'fuck primary' });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error).toMatch(/inappropriate language/i);
+    }
+    expect(mockUpdateCapture).not.toHaveBeenCalledWith('school_affiliations', expect.anything());
+  });
+
+  test('profane description → blocked, no update', async () => {
+    const result = await updateSchoolAffiliation('aff-1', { description: 'fuck that place' });
+    expect(result.success).toBe(false);
+    expect(mockUpdateCapture).not.toHaveBeenCalledWith('school_affiliations', expect.anything());
+  });
+
+  test('a row the caller does not own is not found → no update', async () => {
+    mockState.affiliationRow = null;
+    const result = await updateSchoolAffiliation('aff-someone-else', { description: 'Hi' });
+    expect(result).toEqual({ success: false, error: 'Affiliation not found' });
+    expect(mockUpdateCapture).not.toHaveBeenCalledWith('school_affiliations', expect.anything());
+  });
+
+  test('the ownership lookup itself is scoped to the caller profile', async () => {
+    await updateSchoolAffiliation('aff-1', { description: 'Class of 2008' });
+
+    const read = onlyStatement('school_affiliations', 'select');
+    expect(read.eq).toContainEqual(['id', 'aff-1']);
+    expect(read.eq).toContainEqual(['profile_id', 'profile-1']);
+  });
+
+  test('an empty patch is a no-op success', async () => {
+    const result = await updateSchoolAffiliation('aff-1', {});
+    expect(result).toEqual({ success: true });
+    expect(mockUpdateCapture).not.toHaveBeenCalledWith('school_affiliations', expect.anything());
+  });
+
+  test('not authenticated → no read and no write attempted', async () => {
+    mockState.userId = null;
+    const result = await updateSchoolAffiliation('aff-1', { description: 'Hi' });
+    expect(result).toEqual({ success: false, error: 'Not authenticated' });
+    expect(mockUpdateCapture).not.toHaveBeenCalled();
+    expect(mockStatements.filter((s) => s.table === 'school_affiliations')).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
Founder-approved design batch of 2026-08-02 (epic KAN-441). Cards reviewed and approved in the Claude Design change console; design source is version-controlled in `luisa-sys/lyra-design-system`.

## What changes
- **KAN-446** — every editor placeholder leads with "Example:"; the "Good to know" helper is trimmed and now covers both halves of its label.
- **KAN-447** — new `updateExternalLink` action; `addExternalLink` now writes the `description` column that already existed but was never used. Title + description on one line, link underneath, Edit per entry.
- **KAN-448** — new `updateSchoolAffiliation`; inline edit on affiliations. Conversation-starter inline edit **already existed** (KAN-181) — the real defect was swallowed moderation errors, now surfaced in place.

## Notable
`updateSchoolAffiliation` reads the row owner-scoped **first**, so the KAN-404 postcode rule is decided by the *stored* `affiliation_type` — a school cannot shed its postcode by being edited. Its signature already carries `description`/`school_location` so **KAN-451 can reuse it without a signature change**.

## Testing
New suite, 28 tests, **mutation-verified**. Assertions are per-**statement**, not pooled per table: an earlier revision passed 27/27 *even with the UPDATE's `.eq('profile_id')` and `.eq('id')` deleted*, because the ownership pre-read satisfied the pooled assertion. Deleting either filter now fails.

- `npm run type-check` — clean
- `npm run lint` — 0 errors (31 pre-existing warnings, none in changed files)
- `npm run test:unit` — 2778 passed / 2796 (floor 2705). The 18 failures are the two documented macOS-only script suites (gotcha #28); they pass on ubuntu-latest and neither reads a changed file.
- Guards re-run green: `check-server-action-exports.sh`, `check-partial-write-safety.py`, CTL-038, CTL-039.

## Deferred (not in this PR)
- **MCP parity (KAN-222)** — `updateExternalLink` / `updateSchoolAffiliation` have no matching `lyra_*` tools yet. **MCP coverage: deferred — new editor-only write paths; follow-up to be raised before promote past dev.**
- No migration needed — both columns already exist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)