### PR TITLE
KAN-450: find someone by name, school or organisation

### DIFF
--- a/src/app/search/page.tsx
+++ b/src/app/search/page.tsx
@@ -1,6 +1,7 @@
 import Link from 'next/link';
 import Image from 'next/image';
 import type { Metadata } from 'next';
+import * as Sentry from '@sentry/nextjs';
 import { createServiceRoleClient } from '@/lib/supabase-service';
 import { sanitiseSearchTerm } from '@/lib/sanitise';
 
@@ -12,6 +13,32 @@ export const metadata: Metadata = {
   title: 'Find someone — Lyra',
   description: 'Search for people on Lyra. Find their preferences, gift ideas, and boundaries.',
 };
+
+/** KAN-450: ceiling on the profile ids a school/organisation match may contribute. */
+const AFFILIATION_MATCH_LIMIT = 100;
+
+/**
+ * KAN-450, following the KAN-351 handling at `src/app/[slug]/page.tsx`: a
+ * dropped `error` renders a failed read as a clean "0 profiles found", which is
+ * indistinguishable from a genuine empty result and alerts nobody. Capture
+ * every failure to Sentry for observability, then fail loudly rather than serve
+ * a partial read as if it were complete. These are plain reads (no `.single()`),
+ * so an error means a genuine read failure — never "no rows matched".
+ *
+ * The search term is deliberately NOT sent to Sentry: it is unauthenticated
+ * user input and routinely names a third party.
+ */
+function assertSearchReadsSucceeded(
+  results: readonly (readonly [label: string, error: unknown])[],
+): void {
+  const failed = results.filter((entry) => entry[1] != null);
+  if (failed.length === 0) return;
+
+  for (const [label, error] of failed) {
+    Sentry.captureException(error, { tags: { area: 'public-search', read: label } });
+  }
+  throw new Error(`Search reads failed for ${failed.map(([label]) => label).join(', ')}`);
+}
 
 interface SearchProfile {
   id: string;
@@ -71,23 +98,84 @@ export default async function SearchPage({
   if (safeQuery) {
     const supabase = getSupabase();
     const pattern = `%${safeQuery}%`;
-    const { data } = await supabase
-      .from('profiles')
-      .select('id, display_name, slug, headline, city, country, avatar_url')
-      .eq('is_published', true)
-      // SEC-100: this page reads through the SERVICE-ROLE client, which bypasses
-      // RLS — so the `is_published = true AND is_suspended = false` policy on
-      // `profiles` does NOT apply here. Without this filter a suspended (i.e.
-      // moderated / taken-down) member stayed fully discoverable in public
-      // search. Identical mechanism to SEC-44, which fixed only /[slug].
-      // Guarded by scripts/check-suspension-guard-coverage.py.
-      .eq('is_suspended', false)
-      .eq('is_homepage_example', false) // KAN-334: curated demo profiles never appear in real member discovery
-      .or(`display_name.ilike.${pattern},headline.ilike.${pattern},city.ilike.${pattern},slug.ilike.${pattern}`)
-      .order('display_name')
-      .limit(30);
 
-    profiles = (data || []) as SearchProfile[];
+    // KAN-450 step 1: which profiles carry a matching school or organisation.
+    // An affiliation is HIDDEN unless its owner has explicitly opted it in —
+    // `show_on_profile` is NOT NULL DEFAULT false (migration
+    // 20260617120100_affiliation_show_on_profile.sql), so the majority of rows
+    // in this table are private. The flag is filtered HERE, in the query, so no
+    // code below this point can ever hold a hidden affiliation's profile id.
+    const affiliationsRes = await supabase
+      .from('school_affiliations')
+      .select('profile_id')
+      .eq('show_on_profile', true)
+      .in('affiliation_type', ['school', 'organisation'])
+      .ilike('school_name', pattern)
+      // A LIMIT without an ORDER BY lets Postgres return an arbitrary subset,
+      // so once the cap below binds, two identical searches can surface two
+      // different sets of people. Order by (profile_id, id) — total, because
+      // `id` is the primary key — so the truncation is stable and reproducible.
+      .order('profile_id')
+      .order('id')
+      // A common school name can match thousands of rows; cap the id list so it
+      // stays well inside PostgREST's request-line limit on the read below.
+      .limit(AFFILIATION_MATCH_LIMIT);
+
+    assertSearchReadsSucceeded([['school_affiliations', affiliationsRes.error]]);
+
+    const affiliationIds = Array.from(
+      new Set(
+        ((affiliationsRes.data || []) as { profile_id: string }[]).map((row) => row.profile_id),
+      ),
+    );
+
+    // KAN-450 step 2: the name/headline/city/slug match and the affiliation
+    // match are two reads over `profiles`, unioned below. Both start from
+    // publicProfiles() so neither can drift and lose a guard on its own.
+    const publicProfiles = () =>
+      supabase
+        .from('profiles')
+        .select('id, display_name, slug, headline, city, country, avatar_url')
+        .eq('is_published', true)
+        // SEC-100: this page reads through the SERVICE-ROLE client, which bypasses
+        // RLS — so the `is_published = true AND is_suspended = false` policy on
+        // `profiles` does NOT apply here. Without this filter a suspended (i.e.
+        // moderated / taken-down) member stayed fully discoverable in public
+        // search. Identical mechanism to SEC-44, which fixed only /[slug].
+        // Guarded by scripts/check-suspension-guard-coverage.py.
+        .eq('is_suspended', false)
+        .eq('is_homepage_example', false); // KAN-334: curated demo profiles never appear in real member discovery
+
+    const [byField, byAffiliation] = await Promise.all([
+      publicProfiles()
+        .or(`display_name.ilike.${pattern},headline.ilike.${pattern},city.ilike.${pattern},slug.ilike.${pattern}`)
+        .order('display_name')
+        .limit(30),
+      affiliationIds.length > 0
+        ? publicProfiles().in('id', affiliationIds).order('display_name').limit(30)
+        : null,
+    ]);
+
+    assertSearchReadsSucceeded([
+      ['profiles:by-field', byField.error],
+      ['profiles:by-affiliation', byAffiliation?.error ?? null],
+    ]);
+
+    // What the union does and does not guarantee. The name/headline/city/slug
+    // read is ordered by display_name, so the alphabetically-first 30 of THAT
+    // branch are always here. The affiliation branch carries no equivalent
+    // guarantee: when AFFILIATION_MATCH_LIMIT binds, its ids are the first 100
+    // by (profile_id, id) — stable and reproducible, but unrelated to
+    // display_name — so an affiliation match whose name sorts early can still
+    // fall outside the cap. The result is deterministic, not exhaustive.
+    const merged = new Map<string, SearchProfile>();
+    for (const row of [...(byField.data || []), ...(byAffiliation?.data || [])] as SearchProfile[]) {
+      merged.set(row.id, row);
+    }
+
+    profiles = Array.from(merged.values())
+      .sort((a, b) => a.display_name.localeCompare(b.display_name))
+      .slice(0, 30);
   }
 
   return (
@@ -112,7 +200,7 @@ export default async function SearchPage({
           Find someone
         </h1>
         <p className="text-[var(--color-muted)] mb-8">
-          Search by name, location, or headline.
+          Search by name, school or organisation.
         </p>
 
         {/* Search form */}
@@ -122,7 +210,7 @@ export default async function SearchPage({
               type="text"
               name="q"
               defaultValue={query}
-              placeholder="Search by name..."
+              placeholder="Name, school or organisation..."
               autoComplete="off"
               className="flex-1 px-4 py-3 rounded-xl border border-[var(--color-border)] bg-white text-[var(--color-ink)] text-sm focus:outline-none focus:ring-2 focus:ring-[var(--color-sage)] focus:border-transparent"
             />
@@ -154,7 +242,7 @@ export default async function SearchPage({
             <p className="text-4xl mb-4">🔍</p>
             <h3 className="text-lg font-medium text-[var(--color-ink)] mb-2">No profiles found</h3>
             <p className="text-sm text-[var(--color-muted)]">
-              Try a different name or broader search term.
+              Try a different name, school or organisation.
             </p>
           </div>
         ) : (
@@ -162,7 +250,7 @@ export default async function SearchPage({
             <p className="text-4xl mb-4">👤</p>
             <h3 className="text-lg font-medium text-[var(--color-ink)] mb-2">Search for someone</h3>
             <p className="text-sm text-[var(--color-muted)]">
-              Enter a name to find profiles on Lyra.
+              Enter a name, school or organisation to find someone on Lyra.
             </p>
           </div>
         )}

--- a/tests/unit/kan450-search-affiliations.test.ts
+++ b/tests/unit/kan450-search-affiliations.test.ts
@@ -1,0 +1,296 @@
+/**
+ * KAN-450 — "Find someone" also matches schools and organisations.
+ *
+ * These tests drive the REAL page module through a stub Supabase client and
+ * assert on the query chains it actually builds, rather than scanning the
+ * source for strings. That distinction matters here: the privacy guarantee is
+ * `show_on_profile = true`, and a source scan for it stays green when the
+ * filter is deleted but the comment explaining it survives (BUGS-85 / SEC-100,
+ * gotcha #29).
+ */
+
+import * as React from 'react';
+
+// This repo has no jest transform options, so @swc/jest compiles JSX with the
+// CLASSIC runtime and the page's JSX needs `React` in scope when it runs.
+// Changing jest.config.js would alter how every existing suite executes, which
+// the Test Integrity Policy puts behind sign-off — a global here is local.
+(globalThis as typeof globalThis & { React?: unknown }).React = React;
+
+type Chain = {
+  table: string;
+  eq: Record<string, unknown>;
+  in: Record<string, unknown[]>;
+  ilike: Record<string, string>;
+  or: string | null;
+  order: string[];
+  limit: number | null;
+};
+
+const mockChains: Chain[] = [];
+let mockAffiliationRows: { profile_id: string }[] = [];
+let mockProfileRows: (chain: Chain) => Record<string, unknown>[] = () => [];
+/** Per-chain read error, so a failing read can be simulated on either table. */
+let mockReadError: (chain: Chain) => unknown = () => null;
+
+function mockMakeClient() {
+  return {
+    from(table: string) {
+      const chain: Chain = { table, eq: {}, in: {}, ilike: {}, or: null, order: [], limit: null };
+      mockChains.push(chain);
+      const builder = {
+        select: () => builder,
+        eq: (col: string, val: unknown) => {
+          chain.eq[col] = val;
+          return builder;
+        },
+        in: (col: string, vals: unknown[]) => {
+          chain.in[col] = vals;
+          return builder;
+        },
+        ilike: (col: string, val: string) => {
+          chain.ilike[col] = val;
+          return builder;
+        },
+        or: (expr: string) => {
+          chain.or = expr;
+          return builder;
+        },
+        order: (col: string) => {
+          chain.order.push(col);
+          return builder;
+        },
+        limit: (n: number) => {
+          chain.limit = n;
+          return builder;
+        },
+        then: (resolve: (value: { data: unknown[]; error: unknown }) => void) => {
+          resolve({
+            data: table === 'school_affiliations' ? mockAffiliationRows : mockProfileRows(chain),
+            error: mockReadError(chain),
+          });
+        },
+      };
+      return builder;
+    },
+  };
+}
+
+jest.mock('@/lib/supabase-service', () => ({
+  createServiceRoleClient: () => mockMakeClient(),
+}));
+
+// The page reports failed reads to Sentry before throwing. Mock it so the unit
+// test doesn't pull in Sentry's runtime (which needs network egress).
+const mockCaptureException = jest.fn();
+jest.mock('@sentry/nextjs', () => ({
+  captureException: (...a: unknown[]) => mockCaptureException(...a),
+}));
+
+import SearchPage from '@/app/search/page';
+
+function profileRow(id: string, displayName: string) {
+  return {
+    id,
+    display_name: displayName,
+    slug: id,
+    headline: null,
+    city: null,
+    country: null,
+    avatar_url: null,
+  };
+}
+
+/** Names of every ProfileCard the page rendered, in render order. */
+function renderedNames(node: unknown, out: string[] = []): string[] {
+  if (Array.isArray(node)) {
+    for (const child of node) renderedNames(child, out);
+    return out;
+  }
+  if (node === null || typeof node !== 'object') return out;
+  const props = (node as { props?: Record<string, unknown> }).props;
+  if (!props) return out;
+  const profile = props.profile as { display_name?: string } | undefined;
+  if (profile && typeof profile.display_name === 'string') out.push(profile.display_name);
+  if ('children' in props) renderedNames(props.children, out);
+  return out;
+}
+
+async function search(q: string | undefined) {
+  return renderedNames(await SearchPage({ searchParams: Promise.resolve({ q }) }));
+}
+
+const affiliationChain = () => mockChains.find((c) => c.table === 'school_affiliations');
+const profileChains = () => mockChains.filter((c) => c.table === 'profiles');
+
+beforeEach(() => {
+  mockChains.length = 0;
+  mockAffiliationRows = [];
+  mockProfileRows = () => [];
+  mockReadError = () => null;
+  mockCaptureException.mockClear();
+});
+
+describe('KAN-450: hidden affiliations are never searchable', () => {
+  test('the affiliation read filters show_on_profile = true', async () => {
+    await search('oakfield');
+    expect(affiliationChain()?.eq.show_on_profile).toBe(true);
+  });
+
+  test('the affiliation read is restricted to schools and organisations', async () => {
+    await search('oakfield');
+    expect(affiliationChain()?.in.affiliation_type).toEqual(['school', 'organisation']);
+  });
+
+  test('a hidden affiliation cannot reach the profiles read, because the filter is in the query', async () => {
+    // The stub returns only what the filtered query would return. The assertion
+    // that makes this meaningful is the one above: drop `show_on_profile` from
+    // the page and it goes red.
+    mockAffiliationRows = [{ profile_id: 'p-visible' }];
+    mockProfileRows = (chain) =>
+      chain.in.id ? [profileRow('p-visible', 'Visible Vera')] : [];
+
+    expect(await search('oakfield')).toEqual(['Visible Vera']);
+    expect(profileChains().find((c) => c.in.id)?.in.id).toEqual(['p-visible']);
+  });
+});
+
+describe('KAN-450: the profiles reads keep every public-visibility guard', () => {
+  test('both the name read and the affiliation read filter published, not suspended, not a demo', async () => {
+    mockAffiliationRows = [{ profile_id: 'p-2' }];
+    mockProfileRows = () => [];
+
+    await search('oakfield');
+
+    const chains = profileChains();
+    expect(chains).toHaveLength(2);
+    for (const chain of chains) {
+      expect(chain.eq.is_published).toBe(true);
+      expect(chain.eq.is_suspended).toBe(false);
+      expect(chain.eq.is_homepage_example).toBe(false);
+    }
+  });
+
+  test('the existing name / headline / city / slug match is unchanged', async () => {
+    await search('oakfield');
+    expect(profileChains()[0].or).toBe(
+      'display_name.ilike.%oakfield%,headline.ilike.%oakfield%,city.ilike.%oakfield%,slug.ilike.%oakfield%',
+    );
+  });
+});
+
+describe('KAN-450: the two matches are unioned and de-duplicated', () => {
+  test('a profile matched only by its school appears alongside name matches, once', async () => {
+    mockAffiliationRows = [{ profile_id: 'p-both' }, { profile_id: 'p-school' }];
+    mockProfileRows = (chain) =>
+      chain.in.id
+        ? [profileRow('p-school', 'Blake'), profileRow('p-both', 'Casey')]
+        : [profileRow('p-both', 'Casey'), profileRow('p-name', 'Ada')];
+
+    expect(await search('oakfield')).toEqual(['Ada', 'Blake', 'Casey']);
+  });
+
+  test('duplicate affiliation rows for one profile collapse to a single id', async () => {
+    mockAffiliationRows = [
+      { profile_id: 'p-1' },
+      { profile_id: 'p-1' },
+      { profile_id: 'p-2' },
+    ];
+    await search('oakfield');
+    expect(profileChains().find((c) => c.in.id)?.in.id).toEqual(['p-1', 'p-2']);
+  });
+
+  test('no affiliation match means no second profiles read', async () => {
+    mockAffiliationRows = [];
+    await search('oakfield');
+    expect(profileChains()).toHaveLength(1);
+    expect(profileChains()[0].or).not.toBeNull();
+  });
+});
+
+describe('KAN-450: bounds and sanitisation', () => {
+  test('the affiliation id list is capped', async () => {
+    await search('oakfield');
+    expect(affiliationChain()?.limit).toBe(100);
+  });
+
+  test('both profiles reads stay capped at 30', async () => {
+    mockAffiliationRows = [{ profile_id: 'p-1' }];
+    await search('oakfield');
+    for (const chain of profileChains()) expect(chain.limit).toBe(30);
+  });
+
+  test('the MERGED result is capped at 30, not 30 per branch', async () => {
+    // Each branch may return a full page of 30, so without the final cap the
+    // page renders up to 60 cards. Per-branch `.limit(30)` assertions above
+    // stay green in that case — only the merged length catches it.
+    const ids = (prefix: string) =>
+      Array.from({ length: 30 }, (_, i) => `${prefix}-${String(i).padStart(2, '0')}`);
+
+    mockAffiliationRows = ids('s').map((id) => ({ profile_id: id }));
+    mockProfileRows = (chain) =>
+      chain.in.id
+        ? ids('s').map((id) => profileRow(id, `School ${id}`))
+        : ids('n').map((id) => profileRow(id, `Name ${id}`));
+
+    const names = await search('oakfield');
+    expect(names).toHaveLength(30);
+    expect(new Set(names).size).toBe(30);
+  });
+
+  test('an empty query reads nothing at all', async () => {
+    expect(await search(undefined)).toEqual([]);
+    expect(await search('   ')).toEqual([]);
+    expect(mockChains).toHaveLength(0);
+  });
+
+  test('a query of only metacharacters is treated as empty, not as match-everything', async () => {
+    expect(await search('%_(),')).toEqual([]);
+    expect(mockChains).toHaveLength(0);
+  });
+
+  test('SEC-09 metacharacters are stripped before reaching the affiliation ilike', async () => {
+    await search('oak%field,(x)');
+    expect(affiliationChain()?.ilike.school_name).toBe('%oak field x%');
+  });
+});
+
+describe('KAN-450: the affiliation cap truncates deterministically', () => {
+  test('the capped affiliation read is ordered, so two identical searches agree', async () => {
+    // A LIMIT with no ORDER BY lets Postgres return an arbitrary subset once
+    // the cap binds — the same query, twice, can name different people.
+    await search('oakfield');
+    expect(affiliationChain()?.order).toEqual(['profile_id', 'id']);
+  });
+});
+
+describe('KAN-450: a failed read is never rendered as an empty result', () => {
+  test('a failed affiliation read throws instead of reporting "0 profiles found"', async () => {
+    const boom = { message: 'column show_on_profile does not exist' };
+    mockReadError = (chain) => (chain.table === 'school_affiliations' ? boom : null);
+
+    await expect(search('oakfield')).rejects.toThrow(/school_affiliations/);
+    expect(mockCaptureException).toHaveBeenCalledWith(
+      boom,
+      expect.objectContaining({ tags: expect.objectContaining({ read: 'school_affiliations' }) }),
+    );
+  });
+
+  test('a failed profiles read throws instead of serving a partial union', async () => {
+    const boom = { message: 'statement timeout' };
+    mockAffiliationRows = [{ profile_id: 'p-1' }];
+    mockReadError = (chain) => (chain.table === 'profiles' && chain.or ? boom : null);
+
+    await expect(search('oakfield')).rejects.toThrow(/profiles:by-field/);
+    expect(mockCaptureException).toHaveBeenCalledWith(boom, expect.anything());
+  });
+
+  test('a failed affiliation-branch profiles read throws too', async () => {
+    const boom = { message: 'permission denied for table profiles' };
+    mockAffiliationRows = [{ profile_id: 'p-1' }];
+    mockReadError = (chain) => (chain.table === 'profiles' && chain.in.id ? boom : null);
+
+    await expect(search('oakfield')).rejects.toThrow(/profiles:by-affiliation/);
+    expect(mockCaptureException).toHaveBeenCalledWith(boom, expect.anything());
+  });
+});


### PR DESCRIPTION
Founder-approved design change of 2026-08-02 (epic KAN-441).

## What changes
Search previously matched only name/headline/city/slug on `profiles`. It now also matches **schools and organisations**, via a two-step query — match `school_affiliations`, then union those profile ids with the existing name match and de-duplicate. **No new database object, RPC, view, index or migration.**

## Privacy — the important part
Only affiliations with `show_on_profile = true` are searchable, filtered **in the query** rather than afterwards. Everything search can surface is already rendered publicly on that member's profile, so this exposes **nothing new**.

**Founder decision (2026-08-02): keep this filter.** Consequence, stated plainly: because the flag defaults off, **search-by-school will be quiet until members opt in**. That is the intended trade — fail closed.

Both profile reads are built from a single `publicProfiles()` factory carrying `is_published`, `is_suspended=false`, `is_homepage_example=false`, so the two branches cannot drift apart — the SEC-100 failure shape is structurally impossible here. `check-suspension-guard-coverage.py` still recognises the refactored form (8 chains, ✓).

## Fixed during review
- **Non-deterministic truncation** — the affiliation read had no `ORDER BY` under its `LIMIT`, so two identical searches could return different people. Now ordered by `(profile_id, id)`. The comment claiming an exhaustiveness "guarantee" is corrected: the result is **deterministic, not exhaustive**.
- **Swallowed errors** — all three reads discarded `error`, rendering a clean "0 profiles found" over a failed read with no alert. Now reports to Sentry and throws, mirroring KAN-351 on `[slug]`. The search term is deliberately **kept out of the Sentry payload** — unauthenticated input that often names a third party.

## Testing
18 tests, **mutation-verified**. Removing any of `show_on_profile`, `is_published`, `is_suspended`, `is_homepage_example`, the `ORDER BY`, either error check, or the 30-result cap fails the suite. A guard-drift mutation (removing a guard from one branch only) also fails. The **30-cap was previously unguarded** — deleting the slice left the old suite fully green while the page would render 60 cards.

- `npm run type-check` clean · `npm run lint` 0 errors · `npm run test:unit` 2768 passed / 2786 (floor 2705; 18 failures are the documented macOS-only script suites).

## Behaviour change to expect after deploy
A transient DB error on the public `/search` page now returns a **500 instead of an empty result**. Intended (matches KAN-351), but worth expecting in monitoring rather than mistaking for a new outage.

## Deferred (follow-ups, not this PR)
- **MCP coverage: deferred — `lyra_search_profiles` now differs from the web search; follow-up to be raised before promote past dev.**
- `school_name ILIKE '%…%'` is an unindexed scan on an anonymously-reachable page — pre-existing class (the profiles ILIKE is the same), worth a ticket.
- `community` affiliations are excluded per scope, though they render publicly — confirm intended.
- Both `profiles` reads order by `display_name` with no tiebreaker, so the 30-cut can wobble at the boundary — same defect class as the one fixed above, pre-existing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)