### PR TITLE
KAN-444/458: five favourites groups + add-your-own; causes verified as its own section

### DIFF
--- a/src/app/[slug]/page.tsx
+++ b/src/app/[slug]/page.tsx
@@ -15,6 +15,7 @@ import {
   isManualOfMeEmpty,
   type ManualOfMe,
 } from '@/app/dashboard/profile/manual-of-me-fields';
+import { groupFavourites } from '@/app/dashboard/profile/favourites';
 import { getRecommendations } from '@/lib/recommend';
 import RecommendationsSection from './recommendations-section';
 import V2RecommendationsSection from './v2-recommendations-section';
@@ -56,6 +57,8 @@ interface ProfileItem {
   description: string | null;
   url: string | null;
   visibility: string | null;
+  // KAN-444: only set on custom favourites — the heading the member chose.
+  group_label?: string | null;
 }
 
 interface SchoolAffiliation {
@@ -343,21 +346,11 @@ export default async function PublicProfilePage({ params }: Props) {
     ['drains_me', 'What drains me'],
   ];
 
-  // Favourites grid — one card per non-empty list.
-  const FAV_DEFS: Array<[string, string]> = [
-    ['favourite_media', 'Favourite films'],
-    ['favourite_books', 'Favourite books'],
-    ['favourite_tv', 'Favourite TV shows'],
-    ['plays', 'Favourite plays'],
-    ['quotes', 'Favourite quotes'],
-    ['favourite_places', 'Favourite places'],
-    ['favourite_music', 'Favourite music & bands'],
-  ];
-  const favCards = FAV_DEFS.filter(([cat]) => has(cat)).map(([cat, label]) => ({
-    key: cat,
-    label,
-    items: groupedItems[cat] ?? [],
-  }));
+  // KAN-444: favourites grid — one card per non-empty group, built by the
+  // SAME function the editor groups by (see dashboard/profile/favourites).
+  // Sharing it is the point: the groups a member arranges while editing are
+  // by construction the groups their visitors see, so the two cannot drift.
+  const favCards = groupFavourites(typedItems);
 
   // Affiliations — hidden by default, shown only where the owner opted in.
   const affGroups: Array<{ key: string; label: string }> = [

--- a/src/app/dashboard/profile/actions.ts
+++ b/src/app/dashboard/profile/actions.ts
@@ -144,6 +144,9 @@ export async function addProfileItem(data: {
   description?: string;
   url?: string;
   visibility?: string;
+  // KAN-444 — the member's own heading for a custom favourites group. Public
+  // text, so it is sanitised and moderated exactly like a title.
+  groupLabel?: string;
 }): Promise<ActionResult> {
   const { user, supabase, error: authError } = await getAuthenticatedUser();
   if (authError) return { success: false, error: authError };
@@ -200,6 +203,30 @@ export async function addProfileItem(data: {
     if (!descMod.ok) return { success: false, error: descMod.error };
   }
 
+  // KAN-444 — a member-named favourites group. The heading is shown on the
+  // public profile, so it goes through the same sanitise + moderation path
+  // as the item's own text rather than straight into the row.
+  const sanitisedGroupLabel = data.groupLabel && data.groupLabel.trim() !== ''
+    ? sanitiseText(data.groupLabel, 60)
+    : null;
+  if (sanitisedGroupLabel) {
+    const groupMod = await moderateAndAudit(supabase, {
+      text: sanitisedGroupLabel,
+      fieldType: 'public',
+      field: 'profile_items.group_label',
+      profileId: profile.id,
+      source: 'web_app',
+    });
+    if (!groupMod.ok) return { success: false, error: groupMod.error };
+  }
+
+  // Only send group_label when there is one. PostgREST builds the INSERT
+  // column list from the payload keys, so an unknown key fails the WHOLE
+  // request with PGRST204 even when the value is null — which would break
+  // every add path here (9 editor sections + 6 legacy wizard steps) on any
+  // environment where 20260803114500_favourites_custom_group.sql has not run
+  // yet. Omitting the key keeps existing adds byte-identical to before, so
+  // only the new add-your-own path depends on the new column.
   const { error } = await supabase
     .from('profile_items')
     .insert({
@@ -209,6 +236,7 @@ export async function addProfileItem(data: {
       description: sanitisedDesc,
       url: sanitisedUrl,
       visibility,
+      ...(sanitisedGroupLabel ? { group_label: sanitisedGroupLabel } : {}),
     });
 
   if (error) return { success: false, error: error.message };

--- a/src/app/dashboard/profile/edit-profile-form.tsx
+++ b/src/app/dashboard/profile/edit-profile-form.tsx
@@ -55,6 +55,12 @@ import {
   type AutoSaveStatus,
 } from './sections';
 import type { ManualOfMe } from './manual-of-me-fields';
+import {
+  FAVOURITE_CATEGORIES,
+  FAVOURITE_CATEGORY_OPTIONS,
+  CUSTOM_FAVOURITE_CATEGORY,
+  favouriteLabelForItem,
+} from './favourites';
 
 type SectionKind = 'basic' | 'affiliations' | 'bio' | 'manual' | 'items' | 'starters' | 'links';
 
@@ -65,6 +71,12 @@ interface SectionDef {
   kind: SectionKind;
   categories?: string[];
   description?: string;
+  // KAN-444: a section whose categories are grouped under fewer headings
+  // supplies its own picker options, so the member chooses a group rather
+  // than a raw category. See ./favourites.
+  categoryOptions?: ReadonlyArray<{ value: string; label: string }>;
+  groupLabelCategory?: string;
+  labelForItem?: (item: WizardItem) => string | null;
 }
 
 // KAN-266: section order + headings mirror the public profile (the redesign's
@@ -108,12 +120,19 @@ const SECTIONS: SectionDef[] = [
     description: 'Moments and achievements that mean something to you.',
   },
   {
+    // KAN-444: five fixed groups plus one you name yourself. Categories,
+    // group headings and the picker all come from ./favourites, which the
+    // public profile reads too — so the groups a member edits are exactly
+    // the groups they get. 'causes' is not here: it has its own section.
     id: 'favourites',
     label: 'A few of my favourite things',
     icon: '⭐',
     kind: 'items',
-    categories: ['favourite_books', 'favourite_media', 'favourite_tv', 'plays', 'quotes', 'favourite_places', 'favourite_music'],
-    description: 'Books, films, TV, plays, music, places, and the quotes you come back to.',
+    categories: FAVOURITE_CATEGORIES,
+    categoryOptions: FAVOURITE_CATEGORY_OPTIONS,
+    groupLabelCategory: CUSTOM_FAVOURITE_CATEGORY,
+    labelForItem: favouriteLabelForItem,
+    description: 'Books, films, plays and TV, music, places, and the quotes you come back to — or add a group of your own.',
   },
   {
     id: 'tips',
@@ -227,6 +246,9 @@ export function EditProfileForm({
       title=""
       description={s.description ?? ''}
       categories={s.categories ?? []}
+      categoryOptions={s.categoryOptions}
+      groupLabelCategory={s.groupLabelCategory}
+      labelForItem={s.labelForItem}
       items={items.filter((i) => (s.categories ?? []).includes(i.category))}
       // KAN-266: redesign drops per-item visibility.
       hideVisibility

--- a/src/app/dashboard/profile/favourites.ts
+++ b/src/app/dashboard/profile/favourites.ts
@@ -1,0 +1,167 @@
+/**
+ * KAN-444 — "A few of my favourite things": five fixed groups + add-your-own.
+ *
+ * WHY THIS MODULE EXISTS
+ * ----------------------
+ * The favourites grouping is rendered TWICE — once in the editor
+ * (`edit-profile-form.tsx` → `ItemsStep`) and once on the public profile
+ * (`src/app/[slug]/page.tsx`). Before KAN-444 each surface carried its own
+ * literal list of categories, so the two could drift silently and a member
+ * would see one set of groups while editing and a different set once
+ * published. Both surfaces now derive their groups from the single
+ * `FAVOURITE_GROUPS` table below, which makes that drift impossible rather
+ * than merely detectable.
+ *
+ * Import-only: no Supabase calls, no server actions, safe from both client
+ * and server components (same rule as `section-visibility.ts`, and the
+ * reason it is not declared in the `'use server'` action file — BUGS-12).
+ *
+ * MAPPING ONTO THE EXISTING ENUM
+ * ------------------------------
+ * The five fixed groups are a pure regrouping of `item_category` values that
+ * already exist, so they need no migration:
+ *
+ *   Books                 favourite_books
+ *   Movies, plays & TV    favourite_media + plays + favourite_tv   (merged)
+ *   Quotes                quotes
+ *   Music                 favourite_music
+ *   Places                favourite_places
+ *
+ * The merge is read-compatible in both directions: existing `plays` and
+ * `favourite_tv` rows keep rendering (under the merged heading), while new
+ * items in that group are written under the group's primary category. No
+ * backfill, no data migration.
+ *
+ * `causes` is deliberately ABSENT. It is its own section — "Causes close to
+ * my heart" (KAN-458) — and must never reappear as a favourites group, or a
+ * member's causes would be listed twice under two different headings.
+ */
+
+export interface FavouriteGroupDef {
+  /** Stable key — used as a React key and in tests; never shown to members. */
+  key: string;
+  /** The heading a member sees, in the editor and on the public profile. */
+  label: string;
+  /**
+   * Every `profile_items.category` that renders under this group. The FIRST
+   * entry is the group's primary category — the one new items are written
+   * under. The rest are historical categories that still render here.
+   */
+  categories: string[];
+}
+
+export const FAVOURITE_GROUPS: readonly FavouriteGroupDef[] = [
+  { key: 'books', label: 'Books', categories: ['favourite_books'] },
+  { key: 'screen', label: 'Movies, plays & TV', categories: ['favourite_media', 'plays', 'favourite_tv'] },
+  { key: 'quotes', label: 'Quotes', categories: ['quotes'] },
+  { key: 'music', label: 'Music', categories: ['favourite_music'] },
+  { key: 'places', label: 'Places', categories: ['favourite_places'] },
+];
+
+/**
+ * The member-named group. Items land in their own `favourite_custom`
+ * category so that every other reader of `profile_items` — the MCP tools,
+ * the gift recommender, search — sees an unfamiliar category and leaves it
+ * alone, rather than mis-filing a "Board games" entry as a book.
+ */
+export const CUSTOM_FAVOURITE_CATEGORY = 'favourite_custom';
+
+/** What the member picks in the editor to start a group of their own. */
+export const CUSTOM_FAVOURITE_LABEL = 'Add your own';
+
+/**
+ * Heading used when a custom item somehow has no group name (a row written
+ * before the column existed, or whitespace). Never blank: a card with no
+ * heading reads as a rendering bug.
+ */
+export const CUSTOM_FAVOURITE_FALLBACK_LABEL = 'A few more favourites';
+
+/** The primary category new items in a group are written under. */
+export function primaryCategory(group: FavouriteGroupDef): string {
+  return group.categories[0];
+}
+
+/**
+ * Every category the favourites section owns — what the editor filters the
+ * member's items by, so a group that renders is also a group that edits.
+ */
+export const FAVOURITE_CATEGORIES: string[] = [
+  ...FAVOURITE_GROUPS.flatMap((g) => g.categories),
+  CUSTOM_FAVOURITE_CATEGORY,
+];
+
+export function isFavouriteCategory(category: string): boolean {
+  return FAVOURITE_CATEGORIES.includes(category);
+}
+
+/**
+ * The editor's "which group?" choices: the five fixed groups, then
+ * add-your-own. One option per GROUP, not per category — merging films,
+ * plays and TV into one heading while still offering three separate
+ * choices would be the drift this module exists to prevent.
+ */
+export const FAVOURITE_CATEGORY_OPTIONS: ReadonlyArray<{ value: string; label: string }> = [
+  ...FAVOURITE_GROUPS.map((g) => ({ value: primaryCategory(g), label: g.label })),
+  { value: CUSTOM_FAVOURITE_CATEGORY, label: CUSTOM_FAVOURITE_LABEL },
+];
+
+/** The minimum an item needs for grouping. Both surfaces pass a wider row. */
+export interface GroupableFavourite {
+  category: string;
+  group_label?: string | null;
+}
+
+export interface FavouriteCard<T> {
+  key: string;
+  label: string;
+  items: T[];
+}
+
+/**
+ * Group a member's items into the cards the favourites grid renders.
+ *
+ * Order: the five fixed groups in their declared order, then any custom
+ * groups in the order the member first used them. Empty groups are dropped
+ * — a favourites grid should show what someone shared, not a row of blanks.
+ *
+ * Custom groups are keyed by their name, case- and whitespace-insensitively,
+ * so "Board games" and "board games " are one group rather than two.
+ */
+export function groupFavourites<T extends GroupableFavourite>(items: T[]): FavouriteCard<T>[] {
+  const cards: FavouriteCard<T>[] = [];
+
+  for (const group of FAVOURITE_GROUPS) {
+    const groupItems = items.filter((item) => group.categories.includes(item.category));
+    if (groupItems.length > 0) {
+      cards.push({ key: group.key, label: group.label, items: groupItems });
+    }
+  }
+
+  const byName = new Map<string, FavouriteCard<T>>();
+  for (const item of items) {
+    if (item.category !== CUSTOM_FAVOURITE_CATEGORY) continue;
+    const name = (item.group_label ?? '').trim() || CUSTOM_FAVOURITE_FALLBACK_LABEL;
+    const key = `custom:${name.toLowerCase()}`;
+    let card = byName.get(key);
+    if (!card) {
+      card = { key, label: name, items: [] };
+      byName.set(key, card);
+      cards.push(card);
+    }
+    card.items.push(item);
+  }
+
+  return cards;
+}
+
+/**
+ * The heading to show above a single item in the editor's list, so the
+ * editor labels an item with the same words the public profile will.
+ */
+export function favouriteLabelForItem(item: GroupableFavourite): string | null {
+  if (item.category === CUSTOM_FAVOURITE_CATEGORY) {
+    return (item.group_label ?? '').trim() || CUSTOM_FAVOURITE_FALLBACK_LABEL;
+  }
+  const group = FAVOURITE_GROUPS.find((g) => g.categories.includes(item.category));
+  return group ? group.label : null;
+}

--- a/src/app/dashboard/profile/steps/items-step.tsx
+++ b/src/app/dashboard/profile/steps/items-step.tsx
@@ -28,13 +28,13 @@ const visibilityShort: Record<string, string> = {
 // KAN-234: short label for the NULL/inherit case in the per-item selector.
 const INHERIT_SHORT = '↗ Inherit';
 
-export function ItemsStep({ title, description, categories, items, onAdd, onRemove, onUpdateVisibility, onEdit, onNext, isPending, hideVisibility = false, showContinue = true }: {
+export function ItemsStep({ title, description, categories, items, onAdd, onRemove, onUpdateVisibility, onEdit, onNext, isPending, hideVisibility = false, showContinue = true, categoryOptions, groupLabelCategory, labelForItem }: {
   title: string; description: string; categories: string[]; items: WizardItem[];
   // KAN-219 — items now carry an optional URL (Python `lyra-app` parity).
   // Server-side `addProfileItem` runs the value through `sanitiseUrl`, which
   // rejects anything not http(s). UI emits the trimmed string; empty is
   // treated as "no URL".
-  onAdd: (data: { category: string; title: string; description?: string; url?: string; visibility?: string }) => void;
+  onAdd: (data: { category: string; title: string; description?: string; url?: string; visibility?: string; groupLabel?: string }) => void;
   onRemove: (id: string) => void;
   onUpdateVisibility: (id: string, visibility: string) => void;
   // KAN-404 (#12) — edit an existing item's text (title/description/url).
@@ -55,11 +55,29 @@ export function ItemsStep({ title, description, categories, items, onAdd, onRemo
   // read as navigation that went nowhere). The legacy wizard keeps the default
   // true so "Continue →" still advances steps there — zero legacy change.
   showContinue?: boolean;
+  // KAN-444: the favourites section groups several categories under one
+  // heading (films + plays + TV are one group), so its picker offers one
+  // choice per GROUP rather than one per category. When supplied, these
+  // options replace the default one-option-per-category list; the value is
+  // the category a new item is written under. Sections that map 1:1 onto
+  // categories omit it and keep the existing behaviour untouched.
+  categoryOptions?: ReadonlyArray<{ value: string; label: string }>;
+  // KAN-444: when the chosen category equals this, the member is naming a
+  // group of their own, so a "Group name" field appears and its value is
+  // passed to onAdd. Omitted everywhere else.
+  groupLabelCategory?: string;
+  // KAN-444: how to label an existing row in the list. Lets the favourites
+  // section show the group heading a member will actually see on their
+  // public profile instead of the raw per-category label. Returning null
+  // falls back to the built-in category labels below.
+  labelForItem?: (item: WizardItem) => string | null;
 }) {
-  const [category, setCategory] = useState(categories[0]);
+  const [category, setCategory] = useState(categoryOptions ? categoryOptions[0].value : categories[0]);
   const [itemTitle, setItemTitle] = useState('');
   const [itemDesc, setItemDesc] = useState('');
   const [itemUrl, setItemUrl] = useState('');
+  // KAN-444: the member's heading for their own favourites group.
+  const [groupLabel, setGroupLabel] = useState('');
   // KAN-234: new items default to '' (inherit from section default).
   const [itemVisibility, setItemVisibility] = useState<string>('');
 
@@ -117,21 +135,30 @@ export function ItemsStep({ title, description, categories, items, onAdd, onRemo
     current_problems: '🧩 Currently solving',
     // KAN-263: favourites split out for the redesign favourites grid.
     favourite_tv: '📺 TV show', plays: '🎭 Play', favourite_places: '📍 Place', favourite_music: '🎵 Music',
+    // KAN-444: a group the member named themselves.
+    favourite_custom: '⭐ Your own group',
   };
 
+  // KAN-444: the picker offers groups when the section supplies them.
+  const pickerOptions = categoryOptions ?? categories.map((c) => ({ value: c, label: categoryLabels[c] || c }));
+  const needsGroupLabel = groupLabelCategory != null && category === groupLabelCategory;
+  const canAdd = itemTitle.trim() !== '' && (!needsGroupLabel || groupLabel.trim() !== '');
+
   const handleAdd = () => {
-    if (!itemTitle.trim()) return;
+    if (!canAdd) return;
     const trimmedUrl = itemUrl.trim();
     onAdd({
       category,
       title: itemTitle,
       ...(itemDesc ? { description: itemDesc } : {}),
       ...(trimmedUrl ? { url: trimmedUrl } : {}),
+      ...(needsGroupLabel ? { groupLabel: groupLabel.trim() } : {}),
       visibility: itemVisibility,
     });
     setItemTitle('');
     setItemDesc('');
     setItemUrl('');
+    setGroupLabel('');
     setItemVisibility(''); // KAN-234: reset to inherit
   };
 
@@ -200,7 +227,9 @@ export function ItemsStep({ title, description, categories, items, onAdd, onRemo
                 <div className="flex items-center justify-between">
                   <div className="flex-1 min-w-0">
                     <p className="text-sm font-medium text-[var(--color-ink)]">
-                      <span className="opacity-60">{categoryLabels[item.category] || item.category}</span> — {item.title}
+                      {/* KAN-444: label the row with the heading it will
+                          appear under publicly, when the section knows it. */}
+                      <span className="opacity-60">{labelForItem?.(item) ?? categoryLabels[item.category] ?? item.category}</span> — {item.title}
                       {/* KAN-219: ↗ chip when an item has a URL. Open in new tab
                           with noopener+noreferrer to prevent tab-nabbing. */}
                       {item.url && (
@@ -266,15 +295,36 @@ export function ItemsStep({ title, description, categories, items, onAdd, onRemo
         </div>
       )}
       <div className="space-y-3 bg-white rounded-lg border border-[var(--color-border)] p-4">
-        {categories.length > 1 && (
+        {pickerOptions.length > 1 && (
           <div>
-            <label className="block text-sm font-medium text-[var(--color-ink)] mb-1">Category</label>
-            <select value={category} onChange={(e) => setCategory(e.target.value)}
+            <label className="block text-sm font-medium text-[var(--color-ink)] mb-1" htmlFor="new-item-category">
+              {categoryOptions ? 'Group' : 'Category'}
+            </label>
+            <select id="new-item-category" value={category} onChange={(e) => setCategory(e.target.value)}
               className="w-full px-3 py-2 rounded-lg border border-[var(--color-border)] bg-white text-sm">
-              {categories.map((c: string) => (
-                <option key={c} value={c}>{categoryLabels[c] || c}</option>
+              {pickerOptions.map((opt) => (
+                <option key={opt.value} value={opt.value}>{opt.label}</option>
               ))}
             </select>
+          </div>
+        )}
+        {/* KAN-444: naming a group of your own. Only shown once the member
+            has chosen to add one, so the common path stays a single pick. */}
+        {needsGroupLabel && (
+          <div>
+            <label className="block text-sm font-medium text-[var(--color-ink)] mb-1" htmlFor="new-item-group-label">
+              Group name
+            </label>
+            <input
+              id="new-item-group-label"
+              value={groupLabel}
+              onChange={(e) => setGroupLabel(e.target.value)}
+              className="w-full px-3 py-2 rounded-lg border border-[var(--color-border)] bg-white text-sm focus:outline-none focus:ring-2 focus:ring-[var(--color-sage)]"
+              placeholder="Example: Board games"
+            />
+            <p className="text-xs text-[var(--color-muted)] mt-1">
+              Use the same name again to add more to this group.
+            </p>
           </div>
         )}
         <Field label="Title" value={itemTitle} onChange={setItemTitle} placeholder="Example: Dark chocolate, hiking boots" />
@@ -317,7 +367,7 @@ export function ItemsStep({ title, description, categories, items, onAdd, onRemo
             </select>
           </div>
         )}
-        <button onClick={handleAdd} disabled={isPending || !itemTitle.trim()}
+        <button onClick={handleAdd} disabled={isPending || !canAdd}
           className="px-4 py-2 rounded-lg bg-[#f4efe7] text-sm font-medium text-[var(--color-ink)] hover:bg-[#ece7df] disabled:opacity-40 transition-colors">
           + Add item
         </button>

--- a/src/app/dashboard/profile/steps/types.tsx
+++ b/src/app/dashboard/profile/steps/types.tsx
@@ -30,6 +30,10 @@ export interface WizardItem {
   // Older rows from before KAN-221 always had an explicit value; new items
   // default to NULL when the form chooses "Use section default".
   visibility: string | null;
+  // KAN-444: the member's own heading for a custom favourites group. Only
+  // meaningful for category 'favourite_custom'; optional because every other
+  // caller (and every row written before the column existed) simply omits it.
+  group_label?: string | null;
 }
 
 export interface WizardSchool {

--- a/supabase/migrations/20260803114500_favourites_custom_group.sql
+++ b/supabase/migrations/20260803114500_favourites_custom_group.sql
@@ -1,0 +1,47 @@
+-- KAN-444: "Add your own" — a member-named favourites group.
+--
+-- The five fixed favourites groups (Books · Movies/Plays/TV · Quotes · Music ·
+-- Places) are a pure regrouping of item_category values that already exist and
+-- need nothing here. This migration exists only for the sixth, member-named
+-- group, which needs somewhere to keep the name the member chose.
+--
+-- WHY A COLUMN RATHER THAN AN ENCODING
+-- ------------------------------------
+-- profile_items carries exactly three member-supplied text fields — title,
+-- description and url — and a favourite already spends all three on
+-- name / note / link. The group's name is a fourth value with nowhere to
+-- live. Every encoding alternative corrupts a reader that is already using
+-- those fields: putting the name in `title` changes what the MCP profile
+-- tools and the gift recommender return, and `url` is rejected outright by
+-- sanitiseUrl unless it is http(s). An additive nullable column costs one
+-- DDL and leaves every existing reader untouched.
+--
+-- WHY A SEPARATE ENUM VALUE TOO
+-- -----------------------------
+-- Custom items could technically be stored under an existing favourites
+-- category, but then a "Board games" entry would read as a book to the MCP
+-- tools, the recommender and search. Their own category means an unfamiliar
+-- reader skips them rather than mis-filing them. Reusing a spare value was
+-- ruled out: `likes` is still live in the legacy wizard and feeds the gift
+-- recommender (src/lib/recommend/preferences.ts), and `favourite_venues`
+-- belongs to Convene.
+--
+-- Additive and reversible. No backfill, no data migration, no new table (so
+-- no RLS obligation — profile_items keeps the policies it already has, which
+-- cover this column automatically because they are row-scoped).
+--
+-- Rollback:
+--   alter table public.profile_items drop column if exists group_label;
+--   -- the enum value cannot be dropped in place; leaving 'favourite_custom'
+--   -- unused is harmless (this is why the enum add is `if not exists`).
+
+-- Note: `alter type ... add value` may not be USED in the same transaction
+-- that adds it. Nothing below uses it — the column add is independent DDL —
+-- so the two statements sit safely in one migration.
+alter type public.item_category add value if not exists 'favourite_custom';
+
+alter table public.profile_items
+  add column if not exists group_label text;
+
+comment on column public.profile_items.group_label is
+  'KAN-444: member-supplied heading for a custom favourites group. Only read for category = favourite_custom; NULL everywhere else.';

--- a/tests/support/source-paths.json
+++ b/tests/support/source-paths.json
@@ -1,7 +1,7 @@
 {
   "$comment": "GENERATED — regenerate with `npm run gen:test-paths`. Mirror of tests/support/source-paths.ts for .cjs and shell consumers (KAN-414 F4).",
   "generated_from": "literals referenced by tracked files under tests/",
-  "count": 173,
+  "count": 174,
   "SRC": {
     "codeowners": ".github/CODEOWNERS",
     "pullRequestTemplate": ".github/PULL_REQUEST_TEMPLATE.md",
@@ -102,6 +102,7 @@
     "conversationStartersActions": "src/app/dashboard/profile/conversation-starters-actions.ts",
     "deliveryCountryActions": "src/app/dashboard/profile/delivery-country-actions.ts",
     "editProfileForm": "src/app/dashboard/profile/edit-profile-form.tsx",
+    "favourites": "src/app/dashboard/profile/favourites.ts",
     "filesActions": "src/app/dashboard/profile/files-actions.ts",
     "legacyPage": "src/app/dashboard/profile/legacy/page.tsx",
     "manualOfMeActions": "src/app/dashboard/profile/manual-of-me-actions.ts",

--- a/tests/support/source-paths.ts
+++ b/tests/support/source-paths.ts
@@ -13,7 +13,7 @@
 // cannot drift from reality — a hand-maintained list is what let BUGS-74's
 // first fix miss the legacy editor.
 //
-// 173 entries.
+// 174 entries.
 
 export const SRC = {
   codeowners: '.github/CODEOWNERS',
@@ -115,6 +115,7 @@ export const SRC = {
   conversationStartersActions: 'src/app/dashboard/profile/conversation-starters-actions.ts',
   deliveryCountryActions: 'src/app/dashboard/profile/delivery-country-actions.ts',
   editProfileForm: 'src/app/dashboard/profile/edit-profile-form.tsx',
+  favourites: 'src/app/dashboard/profile/favourites.ts',
   filesActions: 'src/app/dashboard/profile/files-actions.ts',
   legacyPage: 'src/app/dashboard/profile/legacy/page.tsx',
   manualOfMeActions: 'src/app/dashboard/profile/manual-of-me-actions.ts',

--- a/tests/unit/kan444-custom-group-persistence.test.ts
+++ b/tests/unit/kan444-custom-group-persistence.test.ts
@@ -1,0 +1,185 @@
+/**
+ * KAN-444 — the member's own group name reaches the database, safely.
+ *
+ * `group_label` is the one genuinely new piece of stored data in KAN-444, and
+ * it is PUBLIC text: it becomes a heading on the member's profile. So it must
+ * travel the same path as any other public field the member types — sanitise,
+ * then moderate, then write — rather than being appended to the insert as a
+ * trusted string. These cases assert that path behaviourally, by capturing the
+ * row `addProfileItem` actually inserts.
+ *
+ * The mock shape mirrors `tests/unit/profile-item-url.test.ts` (KAN-219),
+ * which covers the sibling `url` field on the same action.
+ *
+ * MUTATION PROOF (2026-08-03). Each mutation was applied to the real
+ * `addProfileItem`, this suite re-run, and actions.ts restored from a /tmp
+ * copy and confirmed byte-identical by shasum. Baseline: 5 passed, 0 failed.
+ *
+ *   mutation                                            failures it causes
+ *   ----------------------------------------------------------------------
+ *   drop `group_label` from the insert payload                    3
+ *   delete the group_label moderation block (write it raw)        2
+ *   coerce a blank/absent label to '' instead of NULL             2
+ */
+
+const mockInsertCapture = jest.fn();
+const mockRevalidatePath = jest.fn();
+const mockModerate = jest.fn();
+
+jest.mock('next/cache', () => ({
+  revalidatePath: (...args: unknown[]) => mockRevalidatePath(...args),
+}));
+
+// Record every field moderation is asked to check, so we can assert the group
+// name is not quietly exempted from it. The factory RETURNS the spy's result
+// rather than a fixed `{ ok: true }` — a factory that swallows it would make
+// the "blocked name" case below unable to fail, which is precisely the
+// vacuous-guard shape this repo keeps finding.
+jest.mock('@/lib/moderation-audit', () => ({
+  moderateAndAudit: (_supabase: unknown, args: { text: string; field: string }) => mockModerate(args),
+}));
+
+jest.mock('@/lib/supabase-server', () => ({
+  createClient: jest.fn().mockResolvedValue({
+    auth: {
+      getUser: jest.fn().mockResolvedValue({ data: { user: { id: 'test-user-id' } } }),
+    },
+    from: jest.fn().mockImplementation((tableName: string) => {
+      if (tableName === 'profiles') {
+        return {
+          select: () => ({
+            eq: () => ({ single: () => Promise.resolve({ data: { id: 'test-profile-id' } }) }),
+          }),
+        };
+      }
+      if (tableName === 'profile_items') {
+        return {
+          insert: (data: unknown) => {
+            mockInsertCapture(data);
+            return Promise.resolve({ error: null });
+          },
+        };
+      }
+      throw new Error(`Unexpected table in mock: ${tableName}`);
+    }),
+  }),
+}));
+
+import { addProfileItem } from '@/app/dashboard/profile/actions';
+import { CUSTOM_FAVOURITE_CATEGORY } from '@/app/dashboard/profile/favourites';
+
+beforeEach(() => {
+  mockInsertCapture.mockClear();
+  mockRevalidatePath.mockClear();
+  mockModerate.mockReset();
+  mockModerate.mockImplementation(() => Promise.resolve({ ok: true }));
+});
+
+describe('KAN-444: addProfileItem — the member’s custom group name', () => {
+  test('persists the group name alongside the item', async () => {
+    const result = await addProfileItem({
+      category: CUSTOM_FAVOURITE_CATEGORY,
+      title: 'Wingspan',
+      description: 'best with four players',
+      groupLabel: 'Board games',
+    });
+
+    expect(result).toEqual({ success: true });
+    expect(mockInsertCapture).toHaveBeenCalledWith(
+      expect.objectContaining({
+        category: CUSTOM_FAVOURITE_CATEGORY,
+        title: 'Wingspan',
+        group_label: 'Board games',
+      }),
+    );
+  });
+
+  test('moderates the group name — it is a public heading, not metadata', async () => {
+    await addProfileItem({
+      category: CUSTOM_FAVOURITE_CATEGORY,
+      title: 'Wingspan',
+      groupLabel: 'Board games',
+    });
+
+    const moderatedFields = mockModerate.mock.calls.map((c) => c[0].field);
+    expect(moderatedFields).toContain('profile_items.group_label');
+
+    const groupCall = mockModerate.mock.calls.find(
+      (c) => c[0].field === 'profile_items.group_label',
+    );
+    expect(groupCall[0].text).toBe('Board games');
+  });
+
+  test('a blocked group name stops the write entirely', async () => {
+    mockModerate.mockImplementation((args: { field: string }) =>
+      args.field === 'profile_items.group_label'
+        ? Promise.resolve({ ok: false, error: 'That name cannot be used.' })
+        : Promise.resolve({ ok: true }),
+    );
+
+    const result = await addProfileItem({
+      category: CUSTOM_FAVOURITE_CATEGORY,
+      title: 'Wingspan',
+      groupLabel: 'something blocked',
+    });
+
+    expect(result.success).toBe(false);
+    // Nothing partial reaches the table.
+    expect(mockInsertCapture).not.toHaveBeenCalled();
+  });
+
+  // The group name becomes a HEADING on the public profile, so it must travel
+  // the same sanitise path as any other public text — not just moderation.
+  // Replacing sanitiseText() with a bare .trim() previously left the whole
+  // suite green, because the only assertion checked the moderated value, which
+  // an unsanitised string satisfies identically.
+  test('an over-long group name is capped, not stored whole', async () => {
+    await addProfileItem({
+      category: CUSTOM_FAVOURITE_CATEGORY,
+      title: 'Wingspan',
+      groupLabel: 'B'.repeat(200),
+    });
+    const payload = mockInsertCapture.mock.calls[0][0] as Record<string, unknown>;
+    expect((payload.group_label as string).length).toBeLessThanOrEqual(60);
+  });
+
+  test('HTML in a group name is stripped before it becomes a public heading', async () => {
+    await addProfileItem({
+      category: CUSTOM_FAVOURITE_CATEGORY,
+      title: 'Wingspan',
+      groupLabel: '<b>Board</b> games',
+    });
+    const payload = mockInsertCapture.mock.calls[0][0] as Record<string, unknown>;
+    expect(payload.group_label).not.toContain('<b>');
+  });
+
+  // The next two are the migration-ordering guard, not a style preference.
+  // PostgREST derives the INSERT column list from the payload keys, so sending
+  // `group_label: null` on an environment where the column does not exist yet
+  // fails the WHOLE request with PGRST204 — breaking every add path in the
+  // editor and the legacy wizard, not just add-your-own. The key must be
+  // ABSENT, so assert on the keys rather than on the value.
+  test('an item with no group name omits group_label entirely (never null)', async () => {
+    await addProfileItem({ category: 'favourite_books', title: 'Piranesi' });
+    const payload = mockInsertCapture.mock.calls[0][0] as Record<string, unknown>;
+    expect(Object.keys(payload)).not.toContain('group_label');
+  });
+
+  test('a whitespace-only group name is treated as no name, and omits the key', async () => {
+    await addProfileItem({
+      category: CUSTOM_FAVOURITE_CATEGORY,
+      title: 'Azul',
+      groupLabel: '   ',
+    });
+    const payload = mockInsertCapture.mock.calls[0][0] as Record<string, unknown>;
+    expect(Object.keys(payload)).not.toContain('group_label');
+  });
+
+  test('every other column is still written when there is no group name', async () => {
+    await addProfileItem({ category: 'favourite_books', title: 'Piranesi' });
+    const payload = mockInsertCapture.mock.calls[0][0] as Record<string, unknown>;
+    expect(Object.keys(payload).sort()).toEqual(
+      ['category', 'description', 'profile_id', 'title', 'url', 'visibility'],
+    );
+  });
+});

--- a/tests/unit/kan444-favourites-groups.test.ts
+++ b/tests/unit/kan444-favourites-groups.test.ts
@@ -1,0 +1,402 @@
+/**
+ * KAN-444 — favourites as five fixed groups plus add-your-own.
+ * KAN-458 — causes as its own section (regression guard).
+ *
+ * WHAT THIS SUITE IS FOR
+ * ----------------------
+ * The favourites grouping is rendered on two surfaces — the editor
+ * (`edit-profile-form.tsx` → `ItemsStep`) and the public profile
+ * (`src/app/[slug]/page.tsx`). Before KAN-444 each carried its own literal
+ * list, and they had already drifted once: KAN-404 records Play items that
+ * saved in the editor and never appeared publicly, because the public
+ * `FAV_DEFS` had no `'plays'` entry. A member arranged their page one way
+ * and visitors saw another.
+ *
+ * So the assertions below are deliberately weighted towards the two things
+ * that actually go wrong: PARITY between the surfaces, and `causes` staying
+ * out of favourites (it is its own section — KAN-458 — and a member whose
+ * causes appeared in both places would be listed twice).
+ *
+ * WHY BEHAVIOURAL, NOT A SOURCE SCAN
+ * ----------------------------------
+ * The guard KAN-404 left behind was `expect(page).toContain("'plays'")`. A
+ * string match cannot tell a rendered category from a mentioned one, which
+ * is BUGS-85 / SEC-100's shape: `toContain('is_published')` stayed green
+ * while suspended members were being published, because the string also
+ * appeared in the comment explaining the filter. Every case here runs the
+ * real `groupFavourites` over real item rows, so it can only pass if the
+ * grouping actually groups. The handful of structural assertions at the end
+ * exist solely to prove both surfaces are WIRED to that function — they
+ * strip comments first, so no comment can satisfy them.
+ *
+ * MUTATION PROOF (2026-08-03). Each mutation was applied to the real source,
+ * this file plus profile-sections/public-profile were re-run, and the source
+ * was restored from a /tmp copy and confirmed byte-identical by shasum.
+ * Baseline across those four suites: 65 passed, 0 failed.
+ *
+ *   mutation                                            failures it causes
+ *   ----------------------------------------------------------------------
+ *   drop 'plays' from the merged screen group                     3
+ *   add 'causes' to a favourites group                            3
+ *   make groupFavourites ignore group_label entirely              4
+ *   offer a picker category no group renders (parity drift)       2
+ *   relabel one picker option away from its heading (drift)       1
+ *   re-hardcode a favourites list in [slug]/page.tsx (drift)      2
+ *   delete the causes section from the editor  (KAN-458)          1
+ *   delete the causes heading from [slug]/page (KAN-458)          2
+ *   stop passing groupLabel through to onAdd                      1
+ */
+
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { SRC } from '../support/source-paths';
+
+import {
+  FAVOURITE_GROUPS,
+  FAVOURITE_CATEGORIES,
+  FAVOURITE_CATEGORY_OPTIONS,
+  CUSTOM_FAVOURITE_CATEGORY,
+  CUSTOM_FAVOURITE_FALLBACK_LABEL,
+  groupFavourites,
+  favouriteLabelForItem,
+  isFavouriteCategory,
+  primaryCategory,
+} from '@/app/dashboard/profile/favourites';
+
+const ROOT = resolve(__dirname, '../..');
+
+/**
+ * Strip // and block comments so a source assertion is answered by the code
+ * and not by the prose describing it. This is the failure mode CTL-039 was
+ * built for: `sitemap.ts` mentioned `is_published` twice — once in the query
+ * and once in the comment explaining the query — so deleting the query left
+ * the scan matching the comment.
+ */
+function stripComments(source: string): string {
+  return source.replace(/\/\*[\s\S]*?\*\//g, ' ').replace(/(^|[^:])\/\/[^\n]*/g, '$1');
+}
+
+function readSource(relPath: string): string {
+  return stripComments(readFileSync(resolve(ROOT, relPath), 'utf-8'));
+}
+
+interface Row {
+  id: string;
+  category: string;
+  title: string;
+  group_label?: string | null;
+}
+
+let nextId = 0;
+function item(category: string, title: string, groupLabel?: string | null): Row {
+  nextId += 1;
+  return { id: `i${nextId}`, category, title, ...(groupLabel !== undefined ? { group_label: groupLabel } : {}) };
+}
+
+// ───────────── The five fixed groups ─────────────
+
+describe('KAN-444: five fixed favourites groups', () => {
+  test('are exactly Books · Movies, plays & TV · Quotes · Music · Places, in that order', () => {
+    expect(FAVOURITE_GROUPS.map((g) => g.label)).toEqual([
+      'Books',
+      'Movies, plays & TV',
+      'Quotes',
+      'Music',
+      'Places',
+    ]);
+  });
+
+  test('merges films, plays and TV into ONE group (KAN-404 regression, behavioural)', () => {
+    const cards = groupFavourites([
+      item('favourite_media', 'Amélie'),
+      item('plays', 'Hamlet'),
+      item('favourite_tv', 'Detectorists'),
+    ]);
+
+    // One card, not three — and every one of the three items inside it.
+    expect(cards).toHaveLength(1);
+    expect(cards[0].label).toBe('Movies, plays & TV');
+    expect(cards[0].items.map((i) => i.title)).toEqual(['Amélie', 'Hamlet', 'Detectorists']);
+  });
+
+  test('each of the five groups renders its own card when populated', () => {
+    const rows = FAVOURITE_GROUPS.map((g) => item(primaryCategory(g), `a ${g.label} entry`));
+    const cards = groupFavourites(rows);
+    expect(cards.map((c) => c.label)).toEqual(FAVOURITE_GROUPS.map((g) => g.label));
+  });
+
+  test('an empty group produces no card — the grid shows what was shared, not blanks', () => {
+    const cards = groupFavourites([item('favourite_books', 'Piranesi')]);
+    expect(cards.map((c) => c.label)).toEqual(['Books']);
+  });
+
+  test('no item is invented, dropped or duplicated by grouping', () => {
+    const rows = [
+      item('favourite_books', 'Piranesi'),
+      item('plays', 'Hamlet'),
+      item('quotes', 'Still I rise'),
+      item(CUSTOM_FAVOURITE_CATEGORY, 'Wingspan', 'Board games'),
+      item('favourite_music', 'Nina Simone'),
+    ];
+    const grouped = groupFavourites(rows).flatMap((c) => c.items.map((i) => i.id));
+    expect(grouped.sort()).toEqual(rows.map((r) => r.id).sort());
+  });
+});
+
+// ───────────── The category list itself (independent pin) ─────────────
+
+// Deliberately an explicit literal, NOT derived from FAVOURITE_CATEGORIES.
+// The parity tests below build their fixtures FROM that array, so shrinking it
+// also shrinks their domain and they stay green — a test that cannot fail.
+// This matters because edit-profile-form.tsx filters the editor's items by
+// `categories.includes(item.category)`: drop a category here and every existing
+// member's items in it VANISH from the editor — invisible, un-editable,
+// un-deletable — while still rendering on their public profile.
+describe('KAN-444: the favourites category list is pinned', () => {
+  test('FAVOURITE_CATEGORIES is exactly the expected set', () => {
+    expect([...FAVOURITE_CATEGORIES].sort()).toEqual([
+      'favourite_books',
+      'favourite_custom',
+      'favourite_media',
+      'favourite_music',
+      'favourite_places',
+      'favourite_tv',
+      'plays',
+      'quotes',
+    ]);
+  });
+
+  // Every category belongs to exactly one FIXED group — except the custom one,
+  // which is deliberately outside FAVOURITE_GROUPS because it renders as
+  // member-named cards rather than a fixed heading. Pinning that asymmetry
+  // stops a category being silently claimed twice (it would render in two
+  // cards) or by none (it would render nowhere while still being editable).
+  test('every pinned category is claimed by exactly one fixed group', () => {
+    for (const category of FAVOURITE_CATEGORIES) {
+      const owners = FAVOURITE_GROUPS.filter((g) => g.categories.includes(category));
+      expect({ category, owners: owners.length }).toEqual({
+        category,
+        owners: category === CUSTOM_FAVOURITE_CATEGORY ? 0 : 1,
+      });
+    }
+  });
+});
+
+// ───────────── The editor actually consumes the shared table ─────────────
+
+// The parity guarantee is only structural for groupFavourites(). The editor's
+// CONSUMPTION of it lives in ItemsStep, and the repo has no component test
+// library — so these are comment-stripped source assertions on the specific
+// wiring whose removal is invisible to every other test. Each was proven to
+// survive deletion before these were added: the group-name input could be
+// disabled (add-your-own permanently un-addable), the picker could fall back
+// to raw per-category options, and the row label could bypass labelForItem —
+// all with the suite fully green, reintroducing exactly the editor-vs-public
+// drift this feature exists to prevent.
+describe('KAN-444: the editor is wired to the shared grouping', () => {
+  // Via the manifest, not raw literals — raw paths feed the KAN-414 F4
+  // shrink-only ratchet, and a path that moves must move in one place.
+  const itemsStep = readSource(SRC.itemsStep);
+  const editor = readSource(SRC.editProfileForm);
+
+  test('the group-name input is gated only on needsGroupLabel', () => {
+    expect(itemsStep).toMatch(/\{\s*needsGroupLabel\s*&&\s*\(/);
+    expect(itemsStep).not.toMatch(/\{\s*false\s*&&\s*needsGroupLabel/);
+  });
+
+  test('a group name is required before a custom item can be added', () => {
+    expect(itemsStep).toMatch(/canAdd[\s\S]{0,120}needsGroupLabel[\s\S]{0,60}groupLabel\.trim\(\)\s*!==\s*''/);
+  });
+
+  test('the picker prefers the shared group options over raw categories', () => {
+    expect(itemsStep).toMatch(/pickerOptions\s*=\s*categoryOptions\s*\?\?/);
+  });
+
+  test('row labels go through labelForItem, so the editor names match the public cards', () => {
+    expect(itemsStep).toContain('labelForItem?.(item)');
+  });
+
+  test('the favourites section passes both the group options and the label fn', () => {
+    expect(editor).toContain('categoryOptions: FAVOURITE_CATEGORY_OPTIONS');
+    expect(editor).toContain('labelForItem: favouriteLabelForItem');
+    expect(editor).toMatch(/categoryOptions=\{s\.categoryOptions\}/);
+  });
+});
+
+// ───────────── Causes is NOT a favourite (KAN-458) ─────────────
+
+describe('KAN-458: causes is its own section, never a favourites group', () => {
+  test("'causes' is not a favourites category", () => {
+    expect(FAVOURITE_CATEGORIES).not.toContain('causes');
+    expect(isFavouriteCategory('causes')).toBe(false);
+  });
+
+  test('no favourites group claims the causes category', () => {
+    for (const group of FAVOURITE_GROUPS) {
+      expect(group.categories).not.toContain('causes');
+    }
+  });
+
+  test('a causes item is not grouped into any favourites card', () => {
+    const cards = groupFavourites([
+      item('causes', 'Refuge'),
+      item('favourite_books', 'Piranesi'),
+    ]);
+    expect(cards.map((c) => c.label)).toEqual(['Books']);
+    expect(cards.flatMap((c) => c.items.map((i) => i.title))).not.toContain('Refuge');
+  });
+
+  test('the editor never offers causes as a favourites choice', () => {
+    expect(FAVOURITE_CATEGORY_OPTIONS.map((o) => o.value)).not.toContain('causes');
+  });
+
+  test('causes is its own editor section, with name + note + link fields', () => {
+    const editor = readSource(SRC.editProfileForm);
+    // A standalone SECTIONS entry keyed 'causes' whose only category is 'causes'.
+    expect(editor).toMatch(/id:\s*'causes'[\s\S]{0,400}?categories:\s*\['causes'\]/);
+    expect(editor).toContain('Causes close to my heart');
+    // Its rows are ItemsStep rows, which is where title / description / url
+    // (name / note / link) come from.
+    expect(editor).toMatch(/kind:\s*'items'/);
+  });
+
+  test('causes renders under its own heading on the public profile', () => {
+    const page = readSource(SRC.slugPage);
+    expect(page).toContain("groupedItems['causes']");
+    expect(page).toContain('Causes close to my heart');
+  });
+});
+
+// ───────────── Editor ↔ public parity ─────────────
+
+describe('KAN-444: the editor and the public profile group identically', () => {
+  test('every category the editor can write is rendered by the public grouping', () => {
+    // One item per editable category; nothing may fall on the floor.
+    const rows = FAVOURITE_CATEGORIES.map((c) => item(c, `entry for ${c}`));
+    const rendered = groupFavourites(rows).flatMap((c) => c.items.map((i) => i.category));
+    for (const category of FAVOURITE_CATEGORIES) {
+      expect(rendered).toContain(category);
+    }
+  });
+
+  test('every category the picker offers is one the public grouping renders', () => {
+    for (const option of FAVOURITE_CATEGORY_OPTIONS) {
+      const cards = groupFavourites([item(option.value, 'x', 'Board games')]);
+      expect(cards).toHaveLength(1);
+      expect(cards[0].items).toHaveLength(1);
+    }
+  });
+
+  test('the picker labels ARE the public headings — same words, same order', () => {
+    const pickerFixedLabels = FAVOURITE_CATEGORY_OPTIONS.filter(
+      (o) => o.value !== CUSTOM_FAVOURITE_CATEGORY,
+    ).map((o) => o.label);
+
+    const rows = FAVOURITE_CATEGORY_OPTIONS.filter((o) => o.value !== CUSTOM_FAVOURITE_CATEGORY).map(
+      (o) => item(o.value, `entry for ${o.label}`),
+    );
+    const publicLabels = groupFavourites(rows).map((c) => c.label);
+
+    expect(pickerFixedLabels).toEqual(publicLabels);
+  });
+
+  test("the editor's row label matches the card the item will appear under", () => {
+    const rows = [
+      item('favourite_books', 'Piranesi'),
+      item('plays', 'Hamlet'),
+      item(CUSTOM_FAVOURITE_CATEGORY, 'Wingspan', 'Board games'),
+    ];
+    for (const card of groupFavourites(rows)) {
+      for (const row of card.items) {
+        expect(favouriteLabelForItem(row)).toBe(card.label);
+      }
+    }
+  });
+});
+
+// ───────────── Add your own ─────────────
+
+describe('KAN-444: add-your-own — a group the member names', () => {
+  test('a named group becomes a card carrying the member’s own words', () => {
+    const cards = groupFavourites([item(CUSTOM_FAVOURITE_CATEGORY, 'Wingspan', 'Board games')]);
+    expect(cards).toHaveLength(1);
+    expect(cards[0].label).toBe('Board games');
+    expect(cards[0].items.map((i) => i.title)).toEqual(['Wingspan']);
+  });
+
+  test('items sharing a name collect into one group, whatever the casing or spacing', () => {
+    const cards = groupFavourites([
+      item(CUSTOM_FAVOURITE_CATEGORY, 'Wingspan', 'Board games'),
+      item(CUSTOM_FAVOURITE_CATEGORY, 'Azul', ' board games '),
+    ]);
+    expect(cards).toHaveLength(1);
+    expect(cards[0].items.map((i) => i.title)).toEqual(['Wingspan', 'Azul']);
+  });
+
+  test('two different names stay two groups, in the order first used', () => {
+    const cards = groupFavourites([
+      item(CUSTOM_FAVOURITE_CATEGORY, 'Wingspan', 'Board games'),
+      item(CUSTOM_FAVOURITE_CATEGORY, 'Sourdough', 'Baking'),
+      item(CUSTOM_FAVOURITE_CATEGORY, 'Azul', 'Board games'),
+    ]);
+    expect(cards.map((c) => c.label)).toEqual(['Board games', 'Baking']);
+    expect(cards[0].items.map((i) => i.title)).toEqual(['Wingspan', 'Azul']);
+  });
+
+  test('custom groups come after the five fixed ones', () => {
+    const cards = groupFavourites([
+      item(CUSTOM_FAVOURITE_CATEGORY, 'Wingspan', 'Board games'),
+      item('favourite_books', 'Piranesi'),
+    ]);
+    expect(cards.map((c) => c.label)).toEqual(['Books', 'Board games']);
+  });
+
+  test('a missing or blank name still gets a heading, never an unlabelled card', () => {
+    // A row written before the column existed reads back undefined.
+    const cards = groupFavourites([
+      item(CUSTOM_FAVOURITE_CATEGORY, 'Wingspan'),
+      item(CUSTOM_FAVOURITE_CATEGORY, 'Azul', '   '),
+      item(CUSTOM_FAVOURITE_CATEGORY, 'Carcassonne', null),
+    ]);
+    expect(cards).toHaveLength(1);
+    expect(cards[0].label).toBe(CUSTOM_FAVOURITE_FALLBACK_LABEL);
+    expect(cards[0].label.trim()).not.toBe('');
+    expect(cards[0].items).toHaveLength(3);
+  });
+
+  test('"Add your own" is offered last in the editor, after the five groups', () => {
+    const values = FAVOURITE_CATEGORY_OPTIONS.map((o) => o.value);
+    expect(values[values.length - 1]).toBe(CUSTOM_FAVOURITE_CATEGORY);
+    expect(FAVOURITE_CATEGORY_OPTIONS[FAVOURITE_CATEGORY_OPTIONS.length - 1].label).toBe('Add your own');
+  });
+});
+
+// ───────────── Both surfaces are wired to the shared module ─────────────
+
+describe('KAN-444: both surfaces render from the shared grouping', () => {
+  test('the public profile groups via groupFavourites and keeps no list of its own', () => {
+    const page = readSource(SRC.slugPage);
+    expect(page).toContain("from '@/app/dashboard/profile/favourites'");
+    expect(page).toContain('groupFavourites(typedItems)');
+    // The old per-surface table is gone; if a future change re-hardcodes the
+    // categories here, the two surfaces can drift again.
+    expect(page).not.toContain('FAV_DEFS');
+    expect(page).not.toContain("'favourite_books'");
+    expect(page).not.toContain("'favourite_music'");
+  });
+
+  test('the editor favourites section takes its categories and picker from the module', () => {
+    const editor = readSource(SRC.editProfileForm);
+    expect(editor).toContain("from './favourites'");
+    expect(editor).toMatch(/id:\s*'favourites'[\s\S]{0,500}?categories:\s*FAVOURITE_CATEGORIES/);
+    expect(editor).toMatch(/categoryOptions:\s*FAVOURITE_CATEGORY_OPTIONS/);
+    expect(editor).toMatch(/groupLabelCategory:\s*CUSTOM_FAVOURITE_CATEGORY/);
+  });
+
+  test('ItemsStep hands the member’s group name to onAdd', () => {
+    const step = readSource(SRC.itemsStep);
+    expect(step).toMatch(/needsGroupLabel\s*\?\s*\{\s*groupLabel:\s*groupLabel\.trim\(\)\s*\}/);
+    // And will not let them create an unnamed group.
+    expect(step).toMatch(/canAdd\s*=[\s\S]{0,120}groupLabel\.trim\(\)\s*!==\s*''/);
+  });
+});

--- a/tests/unit/profile-sections.test.js
+++ b/tests/unit/profile-sections.test.js
@@ -88,11 +88,40 @@ describe('KAN-137 / KAN-265: Public profile renders all categories (redesign)', 
   // left-rule on each heading, a favourites grid, a Q&A block). Every category is
   // still rendered — these guards prove each is referenced so a future refactor
   // can't silently drop one (which would make those items vanish from profiles).
+  // KAN-444 moved the favourites category table out of [slug]/page.tsx and
+  // into the shared `favourites` module that the public page and the editor
+  // now BOTH render from. The guarantee these guards exist for is unchanged
+  // — every category is still rendered on the public profile — but the
+  // render path is now two files, so they read both. Reading the module
+  // would prove nothing on its own, so the import is pinned separately
+  // below: if page.tsx stopped importing it, that assertion goes red and
+  // the concatenation stops being a fair reading of the render path.
   const profilePath = path.join(root, SRC.slugPage);
+  // Built from the manifest's profile-directory entry rather than a raw repo
+  // path, so this adds no new path coupling to the KAN-414 F4 ratchet.
+  const favouritesPath = path.join(root, SRC.profile, 'favourites.ts');
+  let pageContent;
   let content;
 
+  // KAN-459: strip comments before matching. `expect(pageContent).toContain(
+  // 'A few of my favourite things')` was satisfied by the JSX comment sitting
+  // above the real heading, so the entire favourites grid could be disabled
+  // and the heading renamed with this suite still fully green. The prose
+  // documenting a fix is what conceals its removal — same shape as SEC-100.
+  const stripComments = (source) =>
+    source
+      .replace(/\{\s*\/\*[\s\S]*?\*\/\s*\}/g, ' ') // JSX {/* ... */}
+      .replace(/\/\*[\s\S]*?\*\//g, ' ') //           block /* ... */
+      .replace(/(^|[^:])\/\/.*$/gm, '$1'); //         line   // ...
+
   beforeAll(() => {
-    content = fs.readFileSync(profilePath, 'utf8');
+    pageContent = stripComments(fs.readFileSync(profilePath, 'utf8'));
+    content = pageContent + stripComments(fs.readFileSync(favouritesPath, 'utf8'));
+  });
+
+  test('public page renders favourites through the shared groups module (KAN-444)', () => {
+    expect(pageContent).toContain("from '@/app/dashboard/profile/favourites'");
+    expect(pageContent).toContain('groupFavourites(typedItems)');
   });
 
   test.each(NEW_CATEGORIES)('page renders category: %s', (cat) => {
@@ -100,7 +129,7 @@ describe('KAN-137 / KAN-265: Public profile renders all categories (redesign)', 
   });
 
   test('favourites render in a dedicated favourites grid', () => {
-    expect(content).toContain('A few of my favourite things');
+    expect(pageContent).toContain('A few of my favourite things');
     expect(content).toContain("['favourite_books'");
     expect(content).toContain("['favourite_media'");
     expect(content).toContain("['quotes'");

--- a/tests/unit/public-profile.test.js
+++ b/tests/unit/public-profile.test.js
@@ -54,9 +54,22 @@ describe('Public Profile', () => {
   // KAN-404: Play (🎭) favourites are addable in the editor but were not being
   // rendered on the public profile (FAV_DEFS had no 'plays' entry, so Play items
   // saved but never showed). Guard that the public favourites grid includes it.
-  test("public profile renders the 'plays' favourites category (KAN-404)", () => {
-    const content = fs.readFileSync(path.join(root, SRC.slugPage), 'utf8');
+  //
+  // KAN-444 folded plays into the merged "Movies, plays & TV" group and moved
+  // the table into the shared favourites module, so the standalone heading
+  // 'Favourite plays' no longer exists anywhere — a deliberate copy change,
+  // not a dropped category. What KAN-404 was actually protecting (a saved
+  // Play still reaches the public profile) is asserted BEHAVIOURALLY over the
+  // real grouping function in kan444-favourites-groups.test.ts, which is
+  // strictly stronger than either string match: it fails if 'plays' is
+  // dropped from the group, whereas a source scan cannot tell a rendered
+  // category from a mentioned one.
+  test("public profile renders the 'plays' favourites category (KAN-404/KAN-444)", () => {
+    const content = fs.readFileSync(path.join(root, SRC.profile, 'favourites.ts'), 'utf8');
     expect(content).toContain("'plays'");
-    expect(content).toContain('Favourite plays');
+    // Assert the group DEFINITION, not its heading: the heading text also
+    // appears in that module's explanatory comment, so matching it would
+    // survive deleting the group (CTL-039 flags exactly that shape).
+    expect(content).toContain("categories: ['favourite_media', 'plays', 'favourite_tv']");
   });
 });


### PR DESCRIPTION
Founder-approved design batch of 2026-08-02 (epic KAN-441).

## KAN-458 — already complete, verified not rebuilt
The standalone **"Causes close to my heart"** section already exists on develop — editor `SECTIONS` entry and public `[slug]/page.tsx` render, via the existing `profile_items` category `causes`. **Its "(DB)" marker was misleading: no migration, no decoupled table.** This PR only adds regression guards so the section can't be silently deleted.

## KAN-444 — five fixed groups + add-your-own
Books · Movies, plays & TV · Quotes · Music · Places, plus a member-named group. Grouping moves into one shared module (`favourites.ts`) that **both** the editor and public profile read — they previously carried separate literal lists and had already drifted once (KAN-404: Play items saved but never rendered publicly).

**No member data moves.** Old and new category sets are identical; three categories merge under one heading.

## ⚠️ The reason this took a second pass
`group_label` is now included in the `addProfileItem` payload **only when a group name exists**. PostgREST derives the INSERT column list from the payload keys, so sending `group_label: null` on an environment where the migration hasn't run fails the **whole request** with PGRST204 — breaking **every** profile-item add (9 editor sections + 6 legacy wizard steps), not just add-your-own. `type-check` can't catch this: `supabase-server.ts` builds an untyped client.

## Testing — 39 tests, all mutation-verified
Eight defects that previously left the suite **fully green** now fail it:

| Mutation | Was | Now |
|---|---|---|
| `group_label` sent unconditionally | green | **RED** |
| Disable the add-your-own input (feature dead) | green | **RED** |
| Picker ignores `categoryOptions` (editor/public drift) | green | **RED** |
| Bypass `labelForItem` (drift) | green | **RED** |
| Drop the `labelForItem` prop | green | **RED** |
| Shrink `FAVOURITE_CATEGORIES` (items vanish from editor) | green | **RED** |
| Disable the public favourites grid | green | **RED** |
| `sanitiseText` → `trim` (unbounded public heading) | green | **RED** |

Two test-quality fixes behind that:
- **`FAVOURITE_CATEGORIES` is pinned by an explicit literal, not derived from the array under test.** The parity tests build fixtures *from* that array, so shrinking it shrank their domain too — they could not fail.
- **`profile-sections.test.js` now strips comments before matching.** Its heading assertion was satisfied by the JSX comment above the real heading, so the whole grid could be deleted with the suite green. Raised as **[KAN-459](https://checklyra.atlassian.net/browse/KAN-459)**.

`type-check` clean · `lint` 0 errors · `test:unit` 2836 passed / 2854 (floor 2705); the 18 failures are the two documented macOS-only script suites.

## ⚠️ Needs your sign-off — one pre-existing assertion changed
`tests/unit/public-profile.test.js` asserted the heading `'Favourite plays'`. **This approved design deliberately removes that heading** (plays now render under "Movies, plays & TV"), so the assertion tests something that no longer exists. Replaced with an assertion on the group definition; the KAN-404 guarantee — *a saved Play reaches the public profile* — is now covered **behaviourally** over the real grouping function, where dropping `'plays'` fails 3 tests. Stronger than the string match, but it is an assertion change under the Test Integrity Policy and is flagged as one.

## Known gaps (not blockers, deliberately not widened here)
- Custom groups **fork on re-typing** ('Board Games' vs 'board game') and can't be renamed — `updateProfileItem` doesn't touch `group_label`. Worth a follow-up before this is heavily used.
- Public-profile visibility filtering (`typedItems = visibleItems`) is **unguarded estate-wide** — pre-existing, not introduced here, but this file was open. Worth its own ticket.

MCP coverage: deferred — new `profile_items` category and column; follow-up to be raised before promote past dev (KAN-222 lockstep).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[KAN-459]: https://checklyra.atlassian.net/browse/KAN-459?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ