### PR TITLE
KAN-451: school & organisation type-ahead picker with a short description

### DIFF
--- a/src/app/dashboard/profile/actions.ts
+++ b/src/app/dashboard/profile/actions.ts
@@ -379,6 +379,12 @@ export async function removeProfileItem(itemId: string): Promise<ActionResult> {
 export async function addSchoolAffiliation(data: {
   school_name: string;
   school_location?: string;
+  // KAN-451: a short note added at the same time as the affiliation
+  // ("Year 2 teacher"). Optional; the edit path (updateSchoolAffiliation)
+  // has carried it since KAN-448 and gets identical sanitise + moderation
+  // treatment here, so a member cannot use the add path to write something
+  // the edit path would refuse.
+  description?: string;
   relationship?: string;
   // KAN-220: one of school|organisation|community. Defaults to 'school'
   // for backward compat with pre-KAN-220 callers; coerced on write so
@@ -415,6 +421,10 @@ export async function addSchoolAffiliation(data: {
   const sanitisedLoc = data.school_location
     ? sanitiseText(data.school_location, 200)
     : null;
+  // KAN-451 — same 200-char cap and empty-means-NULL rule as the edit path.
+  const sanitisedDesc = data.description && data.description.trim() !== ''
+    ? sanitiseText(data.description, 200)
+    : null;
   const nameMod = await moderateAndAudit(supabase, {
     text: sanitisedName,
     fieldType: 'public',
@@ -433,6 +443,16 @@ export async function addSchoolAffiliation(data: {
     });
     if (!locMod.ok) return { success: false, error: locMod.error };
   }
+  if (sanitisedDesc) {
+    const descMod = await moderateAndAudit(supabase, {
+      text: sanitisedDesc,
+      fieldType: 'public',
+      field: 'school_affiliations.description',
+      profileId: profile.id,
+      source: 'web_app',
+    });
+    if (!descMod.ok) return { success: false, error: descMod.error };
+  }
 
   const { error } = await supabase
     .from('school_affiliations')
@@ -440,6 +460,7 @@ export async function addSchoolAffiliation(data: {
       profile_id: profile.id,
       school_name: sanitisedName,
       school_location: sanitisedLoc,
+      description: sanitisedDesc,
       relationship: data.relationship || 'parent',
       affiliation_type: affiliationType,
     });

--- a/src/app/dashboard/profile/affiliation-search-actions.ts
+++ b/src/app/dashboard/profile/affiliation-search-actions.ts
@@ -1,0 +1,46 @@
+'use server';
+
+/**
+ * KAN-451 — type-ahead suggestions for the schools / organisations /
+ * communities picker.
+ *
+ * Same shape as the KAN-341 town/city lookup (`city-actions.ts`): a thin
+ * authenticated wrapper around a pure Places client that lives in
+ * `src/lib/geo/places-schools.ts`. Constants and types stay in that module —
+ * a `'use server'` file may export only async functions (BUGS-12 / gotcha #18).
+ *
+ * This is a SUGGESTION service, not a gate. When it returns nothing — no key
+ * configured, provider down, nothing matched — the picker falls back to a plain
+ * text input and the member types their school in themselves. That is why an
+ * empty list is a success and not an error.
+ */
+
+import { createClient } from '@/lib/supabase-server';
+import { shouldSuggest, type PlaceSuggestion } from '@/lib/geo/places-schools';
+import { lookupPlaceSuggestions } from '@/lib/geo/places-schools-lookup';
+import { coerceAffiliationType } from './affiliation-fields';
+
+export type SuggestAffiliationsResult =
+  | { success: true; suggestions: PlaceSuggestion[] }
+  | { success: false; error: string };
+
+export async function suggestAffiliations(
+  query: string,
+  affiliationType?: string,
+): Promise<SuggestAffiliationsResult> {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) return { success: false, error: 'Not authenticated' };
+
+  // Too short to be worth a lookup — an empty list, not an error, so the picker
+  // just shows nothing until there is enough to match on.
+  if (!shouldSuggest(query)) return { success: true, suggestions: [] };
+
+  const suggestions = await lookupPlaceSuggestions(
+    query,
+    coerceAffiliationType(affiliationType),
+  );
+  return { success: true, suggestions };
+}

--- a/src/app/dashboard/profile/sections/affiliation-name-picker.tsx
+++ b/src/app/dashboard/profile/sections/affiliation-name-picker.tsx
@@ -1,0 +1,164 @@
+'use client';
+
+/**
+ * KAN-451 — name field with type-ahead suggestions for the affiliations
+ * editor.
+ *
+ * Deliberately thin: every decision it makes (when to look up, what the list
+ * contains, what a pick does to the postcode) is a pure function in
+ * `src/lib/geo/places-schools.ts`, so the behaviour is unit-tested rather than
+ * locked inside JSX the repo's `node` jest environment cannot render.
+ *
+ * The list ALWAYS ends with "add your own", and the input is an ordinary text
+ * field throughout — suggestions are an offer, never a requirement. If the
+ * lookup returns nothing, this behaves exactly like the plain field it
+ * replaced.
+ */
+
+import { useEffect, useId, useState } from 'react';
+import {
+  buildSuggestionOptions,
+  resolvePickedLocation,
+  shouldSuggest,
+  type PlaceSuggestion,
+  type SuggestionOption,
+} from '@/lib/geo/places-schools';
+import { suggestAffiliations } from '../affiliation-search-actions';
+
+const DEBOUNCE_MS = 350;
+
+export function AffiliationNamePicker({
+  label,
+  value,
+  onChange,
+  onPick,
+  placeholder,
+  affiliationType,
+  location,
+  disabled,
+}: {
+  label: string;
+  value: string;
+  onChange: (v: string) => void;
+  /** Called when a row is chosen — with the name and the postcode to keep. */
+  onPick: (name: string, location: string) => void;
+  placeholder?: string;
+  affiliationType: string;
+  /** Current postcode/location, so a picked suggestion never overwrites it. */
+  location: string;
+  disabled?: boolean;
+}) {
+  const baseId = useId();
+  const inputId = `${baseId}-name`;
+  const listId = `${baseId}-suggestions`;
+  const hintId = `${baseId}-hint`;
+
+  // The last answer we got, tagged with the text it was an answer to. Kept as
+  // one piece of state so the visible list can be DERIVED during render rather
+  // than cleared from inside the effect — synchronous setState in an effect
+  // cascades renders, and deriving is what the rule asks for anyway.
+  const [matches, setMatches] = useState<{ query: string; places: PlaceSuggestion[] }>({
+    query: '',
+    places: [],
+  });
+  // The name that was just chosen — closes the list and suppresses the lookup
+  // the pick would otherwise trigger. State rather than a ref because the
+  // derived list below reads it during render.
+  const [chosen, setChosen] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (chosen === value) return;
+    if (!shouldSuggest(value)) return;
+
+    let cancelled = false;
+    const timer = setTimeout(async () => {
+      const result = await suggestAffiliations(value, affiliationType);
+      if (cancelled) return;
+      setMatches({ query: value, places: result.success ? result.suggestions : [] });
+    }, DEBOUNCE_MS);
+
+    return () => {
+      cancelled = true;
+      clearTimeout(timer);
+    };
+  }, [value, affiliationType, chosen]);
+
+  // Only show an answer that belongs to the text currently in the box. With no
+  // matches there is nothing to choose between, so we don't open a list holding
+  // only "add your own" — the plain field already does that.
+  const isFresh = matches.query === value && chosen !== value;
+  const options: SuggestionOption[] =
+    isFresh && matches.places.length > 0 ? buildSuggestionOptions(value, matches.places) : [];
+  const open = options.length > 0;
+
+  const choose = (option: SuggestionOption) => {
+    setChosen(option.name);
+    if (option.kind === 'place') {
+      onPick(option.name, resolvePickedLocation(option, location));
+    } else {
+      onPick(option.name, location);
+    }
+  };
+
+  return (
+    <div className="relative">
+      <label
+        htmlFor={inputId}
+        className="block text-sm font-medium text-[var(--color-ink)] mb-1"
+      >
+        {label}
+      </label>
+      {/* Ordinary labelled text input with a plain list of buttons beneath —
+          NOT an ARIA combobox. A combobox role commits us to arrow-key
+          navigation and aria-activedescendant; announcing a pattern we only
+          half-implement is worse for a screen-reader user than native
+          semantics that already work, and it would fail the axe gate. */}
+      <input
+        id={inputId}
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        placeholder={placeholder}
+        disabled={disabled}
+        autoComplete="off"
+        aria-describedby={hintId}
+        className="w-full px-3 py-2 rounded-lg border border-[var(--color-border)] bg-white text-[var(--color-ink)] text-sm focus:outline-none focus:ring-2 focus:ring-[var(--color-sage)] focus:border-transparent"
+      />
+      <p id={hintId} className="mt-1 text-xs text-[var(--color-muted)]">
+        Start typing and we&apos;ll suggest matches. Can&apos;t see yours? Type it in yourself.
+      </p>
+
+      {open && (
+        <ul
+          id={listId}
+          aria-label={`Matches for ${label}`}
+          className="absolute z-10 mt-1 w-full overflow-hidden rounded-lg border border-[var(--color-border)] bg-white shadow-sm"
+        >
+          {options.map((option, i) => (
+            <li key={`${option.kind}-${option.name}-${i}`}>
+              <button
+                type="button"
+                onClick={() => choose(option)}
+                className="block w-full px-3 py-2 text-left text-sm text-[var(--color-ink)] hover:bg-[#f4efe7]"
+              >
+                {option.kind === 'place' ? (
+                  <>
+                    <span className="block truncate">{option.name}</span>
+                    {option.address && (
+                      <span className="block truncate text-xs text-[var(--color-muted)]">
+                        {option.address}
+                      </span>
+                    )}
+                  </>
+                ) : (
+                  <span className="block truncate text-[var(--color-sage)]">
+                    Add &ldquo;{option.name}&rdquo; as I typed it
+                  </span>
+                )}
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/src/app/dashboard/profile/sections/affiliations-section.tsx
+++ b/src/app/dashboard/profile/sections/affiliations-section.tsx
@@ -28,6 +28,7 @@ import {
   updateAffiliationVisibility,
   updateSchoolAffiliation,
 } from '../actions';
+import { AffiliationNamePicker } from './affiliation-name-picker';
 import { useRouter } from 'next/navigation';
 
 const AFFILIATION_ORDER: AffiliationType[] = ['school', 'organisation', 'community'];
@@ -63,11 +64,13 @@ export function AffiliationsSection({ schools }: { schools: WizardSchool[] }) {
           key={type}
           type={type}
           items={grouped[type]}
-          onAdd={(name, location) => {
+          onAdd={(name, location, description) => {
             startTransition(async () => {
               const result = await addSchoolAffiliation({
                 school_name: name,
                 school_location: location || undefined,
+                // KAN-451 — sent even when empty; the action treats '' as null.
+                description,
                 affiliation_type: type,
               });
               if (result.success) router.refresh();
@@ -105,7 +108,7 @@ function AffiliationGroup({
 }: {
   type: AffiliationType;
   items: WizardSchool[];
-  onAdd: (name: string, location: string) => void;
+  onAdd: (name: string, location: string, description: string) => void;
   onRemove: (id: string) => void;
   onToggleVisibility: (id: string, show: boolean) => void;
   // KAN-448 — edit an existing row's name / location / description. Returns
@@ -119,6 +122,9 @@ function AffiliationGroup({
   const [name, setName] = useState('');
   const [location, setLocation] = useState('');
   const [locationError, setLocationError] = useState('');
+  // KAN-451: a short note captured at the same time as the row, so a member
+  // doesn't have to add the affiliation and then edit it to say what they do.
+  const [description, setDescription] = useState('');
 
   // KAN-448: inline edit state. Only one row edits at a time.
   const [editingId, setEditingId] = useState<string | null>(null);
@@ -137,6 +143,10 @@ function AffiliationGroup({
     type === 'organisation' ? 'Example: Acme Ltd' :
     'Example: Local running club';
   const locationPlaceholder = needsPostcode ? 'Example: SW1A 1AA' : 'Example: London';
+  const descriptionPlaceholder =
+    type === 'school' ? 'Example: Year 2 teacher' :
+    type === 'organisation' ? 'Example: Ops team' :
+    'Example: Saturday runner';
   const POSTCODE_HINT =
     'Enter a postcode (full or partial) so people can tell schools with the same name apart.';
 
@@ -147,9 +157,10 @@ function AffiliationGroup({
       setLocationError(POSTCODE_HINT);
       return;
     }
-    onAdd(name.trim(), location.trim());
+    onAdd(name.trim(), location.trim(), description.trim());
     setName('');
     setLocation('');
+    setDescription('');
     setLocationError('');
   };
 
@@ -294,11 +305,21 @@ function AffiliationGroup({
       )}
 
       <div className="space-y-3 bg-white rounded-lg border border-[var(--color-border)] p-4">
-        <Field
+        {/* KAN-451: type-ahead with an explicit "add your own" row, so a name
+            that isn't in the list can still be entered by hand. */}
+        <AffiliationNamePicker
           label={`${AFFILIATION_LABELS[type].slice(0, -1)} name`}
           value={name}
           onChange={setName}
+          onPick={(pickedName, pickedLocation) => {
+            setName(pickedName);
+            setLocation(pickedLocation);
+            if (locationError) setLocationError('');
+          }}
           placeholder={namePlaceholder}
+          affiliationType={type}
+          location={location}
+          disabled={isPending}
         />
         <div>
           <Field
@@ -314,6 +335,14 @@ function AffiliationGroup({
             <p className="mt-1 text-xs text-red-500">{locationError}</p>
           )}
         </div>
+        {/* KAN-451: short description on add — the edit path has had one since
+            KAN-448, so adding then editing was the only way to set it. */}
+        <Field
+          label="Description (optional)"
+          value={description}
+          onChange={setDescription}
+          placeholder={descriptionPlaceholder}
+        />
         <button
           onClick={handleAdd}
           disabled={isPending || !name.trim() || postcodeInvalid}

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -31,5 +31,10 @@ export const env = {
   // comparison site uses (/join, signup, actions, resolveBetaAccess); a
   // whitespace-only value collapses to '' = feature off.
   inviteCode: () => optionalEnv('LYRA_INVITE_CODE', '').trim(),
+  // KAN-451 — the same Google Places key the KAN-341 town/city lookup already
+  // uses. Optional on purpose: with no key the school type-ahead simply returns
+  // nothing and members type their school in themselves, so an unset value
+  // degrades the feature rather than breaking it.
+  placesApiKey: () => optionalEnv('GOOGLE_PLACES_API_KEY', '').trim(),
 };
 // Force rebuild 20260329011858

--- a/src/lib/geo/places-schools-lookup.ts
+++ b/src/lib/geo/places-schools-lookup.ts
@@ -1,0 +1,71 @@
+/**
+ * KAN-451 — the Places call behind the schools / organisations / communities
+ * picker.
+ *
+ * Reuses the KAN-341 town/city integration (`src/lib/geo/places-city.ts`) —
+ * same Google Places (New) Text Search endpoint, same existing key, no new
+ * vendor and no new secret. The key is read via `src/lib/env.ts` rather than
+ * `process.env` directly (CTL-037 — a new file reading env fails the ratchet),
+ * which is also why this module is kept SEPARATE from the pure picker logic:
+ * the client component must not pull the env accessor into the browser bundle.
+ *
+ * Every failure path returns an empty list. See `places-schools.ts` for the
+ * degrade-never-block rule this serves.
+ */
+
+import { env } from '@/lib/env';
+import {
+  MAX_SUGGESTIONS,
+  extractSuggestion,
+  placeTypeForAffiliation,
+  shouldSuggest,
+  type PlaceSuggestion,
+  type PlacesResult,
+} from './places-schools';
+
+const PLACES_TEXT_SEARCH_ENDPOINT = 'https://places.googleapis.com/v1/places:searchText';
+
+/**
+ * Look up matching places by name. Returns [] on ANY failure so the caller can
+ * fall back to free text — never throws, never logs the query.
+ */
+export async function lookupPlaceSuggestions(
+  query: string,
+  affiliationType: string,
+  // Injected for tests; defaults to the global fetch.
+  fetchImpl: typeof fetch = fetch,
+): Promise<PlaceSuggestion[]> {
+  const key = env.placesApiKey();
+  const textQuery = (query ?? '').trim();
+  if (!key || !shouldSuggest(textQuery)) return [];
+
+  const includedType = placeTypeForAffiliation(affiliationType);
+
+  try {
+    const res = await fetchImpl(PLACES_TEXT_SEARCH_ENDPOINT, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-Goog-Api-Key': key,
+        // Name, address and address components only — no place id, no lat/lng,
+        // no opening hours or ratings (data minimisation, as KAN-341).
+        'X-Goog-FieldMask':
+          'places.displayName,places.formattedAddress,places.addressComponents',
+      },
+      body: JSON.stringify({
+        textQuery,
+        maxResultCount: MAX_SUGGESTIONS,
+        ...(includedType ? { includedType } : {}),
+      }),
+    });
+    if (!res.ok) return [];
+    const data = (await res.json()) as { places?: PlacesResult[] };
+    return (data.places ?? [])
+      .map(extractSuggestion)
+      .filter((s): s is PlaceSuggestion => s !== null)
+      .slice(0, MAX_SUGGESTIONS);
+  } catch {
+    // Swallow — a lookup failure must never stop someone adding their school.
+    return [];
+  }
+}

--- a/src/lib/geo/places-schools.ts
+++ b/src/lib/geo/places-schools.ts
@@ -1,0 +1,132 @@
+/**
+ * KAN-451 — the pure half of the schools / organisations / communities picker:
+ * types, and every decision the UI makes about what to show.
+ *
+ * CLIENT-SAFE BY CONSTRUCTION. This module imports nothing — in particular not
+ * `src/lib/env.ts` — so the picker component can use it without dragging the
+ * environment accessor (or the Places client) into the browser bundle. The
+ * network call lives next door in `places-schools-lookup.ts`, which only the
+ * server action imports.
+ *
+ * DEGRADE, NEVER BLOCK. A member whose school is not in any list must always be
+ * able to add it, which is why `buildSuggestionOptions` always ends with an
+ * explicit "add your own" option. Nothing here decides whether an affiliation
+ * can be SAVED — that is the server action's job, and the KAN-404 postcode rule
+ * lives there.
+ */
+
+/**
+ * Don't call out until there is enough to match on. One or two characters
+ * matches half the world and costs a request per keystroke.
+ */
+export const MIN_SUGGEST_QUERY_LENGTH = 3;
+
+/** Enough to choose from, few enough to read without scrolling. */
+export const MAX_SUGGESTIONS = 5;
+
+export interface PlaceSuggestion {
+  /** The place's display name — what goes into `school_name`. */
+  name: string;
+  /** Short address line, so two same-named schools can be told apart. */
+  address: string | null;
+  /**
+   * The `postal_code` component when Places returned one. Used to pre-fill the
+   * postcode field; it is still validated by `isSchoolPostcodeValid` before any
+   * school is saved.
+   */
+  postcode: string | null;
+}
+
+/** One row of the picker: either a real match, or the "add your own" escape. */
+export type SuggestionOption =
+  | ({ kind: 'place' } & PlaceSuggestion)
+  | { kind: 'custom'; name: string };
+
+export interface PlacesAddressComponent {
+  longText?: string;
+  shortText?: string;
+  types?: string[];
+}
+
+/** One row of a Places response, narrowed to the fields we ask for. */
+export interface PlacesResult {
+  displayName?: { text?: string };
+  formattedAddress?: string;
+  addressComponents?: PlacesAddressComponent[];
+}
+
+/**
+ * Pure: has the member typed enough for a lookup to be worth making?
+ * Whitespace doesn't count.
+ */
+export function shouldSuggest(query: string | null | undefined): boolean {
+  return (query ?? '').trim().length >= MIN_SUGGEST_QUERY_LENGTH;
+}
+
+/**
+ * Pure: the Places primary type to bias the search towards, or null for no
+ * bias. Schools are a well-defined place type; "organisation" and "community"
+ * are not, so those searches stay unrestricted rather than guessing.
+ */
+export function placeTypeForAffiliation(affiliationType: string): string | null {
+  return affiliationType === 'school' ? 'school' : null;
+}
+
+/**
+ * Pure: reshape one Places result into a suggestion. Returns null when there is
+ * no usable name — a nameless row is not something anyone can pick.
+ * Exported for direct unit testing without a network call.
+ */
+export function extractSuggestion(place: PlacesResult): PlaceSuggestion | null {
+  const name = (place.displayName?.text ?? '').trim();
+  if (!name) return null;
+
+  const components = place.addressComponents ?? [];
+  const postal = components.find((c) => c.types?.includes('postal_code'));
+  const postcode = (postal?.shortText ?? postal?.longText ?? '').trim();
+
+  const address = (place.formattedAddress ?? '').trim();
+
+  return {
+    name,
+    address: address || null,
+    postcode: postcode || null,
+  };
+}
+
+/**
+ * Pure: the list the picker renders. Real matches first, then ALWAYS an
+ * explicit "add your own" option carrying exactly what the member typed.
+ *
+ * That last option is the whole safety net of this feature: a school missing
+ * from the provider's data, a newly opened one, a home-education group, a
+ * community that exists only on a noticeboard. It is built here rather than in
+ * the component so that removing it is a test failure and not a silent
+ * regression in JSX.
+ */
+export function buildSuggestionOptions(
+  query: string,
+  suggestions: readonly PlaceSuggestion[],
+): SuggestionOption[] {
+  const typed = (query ?? '').trim();
+  const options: SuggestionOption[] = suggestions
+    .slice(0, MAX_SUGGESTIONS)
+    .map((s) => ({ kind: 'place' as const, ...s }));
+
+  if (typed) options.push({ kind: 'custom', name: typed });
+  return options;
+}
+
+/**
+ * Pure: what the location field should hold after a suggestion is picked.
+ * A postcode the member typed themselves is never overwritten — picking a
+ * suggestion may only fill a blank.
+ */
+export function resolvePickedLocation(
+  picked: PlaceSuggestion,
+  currentLocation: string | null | undefined,
+): string {
+  const current = (currentLocation ?? '').trim();
+  if (current !== '') return current;
+  return picked.postcode ?? '';
+}

--- a/tests/unit/kan451-schools-picker.test.ts
+++ b/tests/unit/kan451-schools-picker.test.ts
@@ -1,0 +1,602 @@
+/**
+ * KAN-451 — schools: type-ahead picker, short description on add, and the
+ * KAN-404 postcode rule that must survive both.
+ *
+ * Three subjects, all driven for real:
+ *
+ *   1. `src/lib/geo/places-schools.ts` (pure picker logic) and its sibling
+ *      `places-schools-lookup.ts` (the Places call). Every decision the React
+ *      component makes lives in the pure module on purpose: the repo's jest
+ *      environment is `node` with no DOM, and changing that is a Test-Integrity
+ *      sign-off matter, so behaviour that would otherwise be untestable inside
+ *      JSX is a pure function instead.
+ *   2. `suggestAffiliations` — the server action, through a mocked Supabase
+ *      client and an injected fetch.
+ *   3. `addSchoolAffiliation` — description persistence and the postcode gate,
+ *      asserted on the payload that actually reaches `.insert()`.
+ *
+ * MUTATION-VERIFIED (2026-08-03). Each of these eight edits, applied to the
+ * real source and then reverted, turns this suite red:
+ *   - deleting the `requiresPostcode(…) && !isSchoolPostcodeValid(…)` gate
+ *     from `addSchoolAffiliation`                            → 3 failures
+ *   - weakening `isSchoolPostcodeValid` to `s.length >= 2`   → 2 failures
+ *   - dropping `description: sanitisedDesc` from the insert  → 7 failures
+ *   - deleting the description moderation block              → 1 failure
+ *   - removing the "add your own" option from
+ *     `buildSuggestionOptions`                               → 4 failures
+ *   - making `lookupPlaceSuggestions` rethrow instead of
+ *     returning [] when the provider fails                   → 2 failures
+ *   - letting `resolvePickedLocation` overwrite a postcode
+ *     the member typed themselves                            → 1 failure
+ *   - removing the auth check from `suggestAffiliations`     → 1 failure
+ *
+ * Note what is deliberately NOT asserted by reading source text: the SEC-100 /
+ * BUGS-85 lesson is that a `toContain` over a file stays green when the feature
+ * is deleted but the comment describing it survives. Everything below observes
+ * the real module's behaviour.
+ */
+
+const mockInsertCapture = jest.fn();
+const mockRevalidatePath = jest.fn();
+
+const mockState: { userId: string | null } = { userId: 'kan451-user' };
+
+jest.mock('next/cache', () => ({
+  revalidatePath: (...args: unknown[]) => mockRevalidatePath(...args),
+}));
+
+jest.mock('@/lib/supabase-server', () => ({
+  createClient: jest.fn().mockImplementation(() =>
+    Promise.resolve({
+      auth: {
+        getUser: () =>
+          Promise.resolve({
+            data: { user: mockState.userId ? { id: mockState.userId } : null },
+          }),
+      },
+      from: (table: string) => {
+        if (table === 'profiles') {
+          return {
+            select: () => ({
+              eq: () => ({
+                single: () => Promise.resolve({ data: { id: 'profile-1' } }),
+              }),
+            }),
+          };
+        }
+        if (table === 'school_affiliations') {
+          return {
+            insert: (data: unknown) => {
+              mockInsertCapture(data);
+              return Promise.resolve({ error: null });
+            },
+          };
+        }
+        // KAN-244 audit trail — moderateAndAudit writes a flag row whenever it
+        // warns or blocks. Accepted (and ignored) so the moderation cases below
+        // don't fill the run with swallowed-insert warnings; asserting on the
+        // audit row is KAN-244's own suite, not this one.
+        if (table === 'content_moderation_flags') {
+          return { insert: () => Promise.resolve({ error: null }) };
+        }
+        throw new Error(`Unexpected table in mock: ${table}`);
+      },
+    }),
+  ),
+}));
+
+import {
+  MIN_SUGGEST_QUERY_LENGTH,
+  MAX_SUGGESTIONS,
+  buildSuggestionOptions,
+  extractSuggestion,
+  placeTypeForAffiliation,
+  resolvePickedLocation,
+  shouldSuggest,
+  type PlaceSuggestion,
+} from '@/lib/geo/places-schools';
+import { lookupPlaceSuggestions } from '@/lib/geo/places-schools-lookup';
+import { suggestAffiliations } from '@/app/dashboard/profile/affiliation-search-actions';
+import { addSchoolAffiliation } from '@/app/dashboard/profile/actions';
+import { isSchoolPostcodeValid } from '@/app/dashboard/profile/affiliation-fields';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { SRC } from '../support/source-paths';
+
+// Each test gets its own user id so the in-memory per-user write rate limit
+// (KAN-231, 30/min) can never make a later test fail for an earlier one's reason.
+let userCounter = 0;
+
+const ORIGINAL_KEY = process.env.GOOGLE_PLACES_API_KEY;
+
+beforeEach(() => {
+  mockInsertCapture.mockClear();
+  mockRevalidatePath.mockClear();
+  userCounter += 1;
+  mockState.userId = `kan451-user-${userCounter}`;
+  process.env.GOOGLE_PLACES_API_KEY = 'test-key';
+});
+
+afterAll(() => {
+  if (ORIGINAL_KEY === undefined) delete process.env.GOOGLE_PLACES_API_KEY;
+  else process.env.GOOGLE_PLACES_API_KEY = ORIGINAL_KEY;
+});
+
+function place(name: string, address?: string, postcode?: string) {
+  return {
+    displayName: { text: name },
+    ...(address ? { formattedAddress: address } : {}),
+    ...(postcode
+      ? { addressComponents: [{ shortText: postcode, longText: postcode, types: ['postal_code'] }] }
+      : {}),
+  };
+}
+
+// ───────────────── 1. pure lookup + picker logic ─────────────────
+
+describe('KAN-451: shouldSuggest', () => {
+  test('waits for enough characters before a lookup is worth making', () => {
+    expect(MIN_SUGGEST_QUERY_LENGTH).toBeGreaterThanOrEqual(2);
+    expect(shouldSuggest('Gr')).toBe(false);
+    expect(shouldSuggest('Gre')).toBe(true);
+  });
+
+  test('whitespace does not count as typing', () => {
+    expect(shouldSuggest('   ')).toBe(false);
+    expect(shouldSuggest('  Greenfield  ')).toBe(true);
+  });
+
+  test('nullish input is not a lookup', () => {
+    expect(shouldSuggest(null)).toBe(false);
+    expect(shouldSuggest(undefined)).toBe(false);
+    expect(shouldSuggest('')).toBe(false);
+  });
+});
+
+describe('KAN-451: placeTypeForAffiliation', () => {
+  test('schools are biased towards the school place type', () => {
+    expect(placeTypeForAffiliation('school')).toBe('school');
+  });
+
+  test('organisations and communities search unrestricted', () => {
+    // "organisation" and "community" have no meaningful provider type, so we
+    // must not invent one — an unrestricted search finds a village hall.
+    expect(placeTypeForAffiliation('organisation')).toBeNull();
+    expect(placeTypeForAffiliation('community')).toBeNull();
+    expect(placeTypeForAffiliation('')).toBeNull();
+  });
+});
+
+describe('KAN-451: extractSuggestion', () => {
+  test('takes the name, address and postal_code component', () => {
+    expect(
+      extractSuggestion(place('Greenfield Primary', '1 High St, London SW1A 1AA', 'SW1A 1AA')),
+    ).toEqual({
+      name: 'Greenfield Primary',
+      address: '1 High St, London SW1A 1AA',
+      postcode: 'SW1A 1AA',
+    });
+  });
+
+  test('a result with no postcode still yields a pickable suggestion', () => {
+    expect(extractSuggestion(place('Acme Ltd', '2 Low St'))).toEqual({
+      name: 'Acme Ltd',
+      address: '2 Low St',
+      postcode: null,
+    });
+  });
+
+  test('ignores non-postal address components', () => {
+    expect(
+      extractSuggestion({
+        displayName: { text: 'Greenfield Primary' },
+        addressComponents: [{ longText: 'London', types: ['postal_town'] }],
+      }),
+    ).toEqual({ name: 'Greenfield Primary', address: null, postcode: null });
+  });
+
+  test('a nameless result is dropped — nobody can pick it', () => {
+    expect(extractSuggestion({ formattedAddress: '1 High St' })).toBeNull();
+    expect(extractSuggestion({ displayName: { text: '   ' } })).toBeNull();
+    expect(extractSuggestion({})).toBeNull();
+  });
+});
+
+describe('KAN-451: buildSuggestionOptions always offers "add your own"', () => {
+  const matches: PlaceSuggestion[] = [
+    { name: 'Greenfield Primary', address: '1 High St', postcode: 'SW1A 1AA' },
+    { name: 'Greenfield Academy', address: '2 Low St', postcode: 'M1 1AE' },
+  ];
+
+  test('the LAST option is always the member’s own wording', () => {
+    const options = buildSuggestionOptions('Greenfields Free School', matches);
+    expect(options).toHaveLength(3);
+    expect(options[options.length - 1]).toEqual({
+      kind: 'custom',
+      name: 'Greenfields Free School',
+    });
+  });
+
+  test('a school missing from the list can still be added', () => {
+    // The whole point of the fallback: no matches at all must not be a dead end.
+    const options = buildSuggestionOptions('Tiny Village Home-Ed Group', []);
+    expect(options).toEqual([{ kind: 'custom', name: 'Tiny Village Home-Ed Group' }]);
+  });
+
+  test('the custom option carries the trimmed query verbatim, not a match', () => {
+    const options = buildSuggestionOptions('  Greenfield Primary  ', matches);
+    const custom = options.filter((o) => o.kind === 'custom');
+    expect(custom).toHaveLength(1);
+    expect(custom[0].name).toBe('Greenfield Primary');
+  });
+
+  test('real matches come first and keep their address + postcode', () => {
+    const options = buildSuggestionOptions('Greenfield', matches);
+    expect(options[0]).toEqual({
+      kind: 'place',
+      name: 'Greenfield Primary',
+      address: '1 High St',
+      postcode: 'SW1A 1AA',
+    });
+  });
+
+  test('nothing typed → no option at all (an empty name is not addable)', () => {
+    expect(buildSuggestionOptions('   ', [])).toEqual([]);
+  });
+
+  test('the list is capped so it stays readable', () => {
+    const many: PlaceSuggestion[] = Array.from({ length: 20 }, (_, i) => ({
+      name: `School ${i}`,
+      address: null,
+      postcode: null,
+    }));
+    const options = buildSuggestionOptions('School', many);
+    expect(options.filter((o) => o.kind === 'place')).toHaveLength(MAX_SUGGESTIONS);
+    // …and the fallback survives the cap.
+    expect(options[options.length - 1].kind).toBe('custom');
+  });
+});
+
+describe('KAN-451: resolvePickedLocation', () => {
+  const picked: PlaceSuggestion = { name: 'Greenfield Primary', address: null, postcode: 'SW1A 1AA' };
+
+  test('fills a blank postcode from the picked place', () => {
+    expect(resolvePickedLocation(picked, '')).toBe('SW1A 1AA');
+    expect(resolvePickedLocation(picked, '   ')).toBe('SW1A 1AA');
+    expect(resolvePickedLocation(picked, null)).toBe('SW1A 1AA');
+  });
+
+  test('never overwrites a postcode the member typed themselves', () => {
+    expect(resolvePickedLocation(picked, 'M1 1AE')).toBe('M1 1AE');
+  });
+
+  test('a place with no postcode leaves the field blank rather than guessing', () => {
+    expect(resolvePickedLocation({ name: 'X', address: null, postcode: null }, '')).toBe('');
+  });
+});
+
+// ───────────────── 2. the Places call itself ─────────────────
+
+describe('KAN-451: lookupPlaceSuggestions', () => {
+  const okResponse = (places: unknown[]) => ({ ok: true, json: async () => ({ places }) });
+
+  test('returns the suggestions from a provider response', async () => {
+    const fetchMock = jest
+      .fn()
+      .mockResolvedValue(okResponse([place('Greenfield Primary', '1 High St', 'SW1A 1AA')]));
+    await expect(
+      lookupPlaceSuggestions('Greenfield', 'school', fetchMock as unknown as typeof fetch),
+    ).resolves.toEqual([
+      { name: 'Greenfield Primary', address: '1 High St', postcode: 'SW1A 1AA' },
+    ]);
+  });
+
+  test('asks only for name, address and address components (data minimisation)', async () => {
+    const fetchMock = jest.fn().mockResolvedValue(okResponse([]));
+    await lookupPlaceSuggestions('Greenfield', 'school', fetchMock as unknown as typeof fetch);
+    const [, init] = fetchMock.mock.calls[0];
+    expect((init as RequestInit).headers).toMatchObject({
+      'X-Goog-FieldMask': 'places.displayName,places.formattedAddress,places.addressComponents',
+    });
+  });
+
+  test('biases a school search towards schools, and leaves others unrestricted', async () => {
+    const fetchMock = jest.fn().mockResolvedValue(okResponse([]));
+    await lookupPlaceSuggestions('Greenfield', 'school', fetchMock as unknown as typeof fetch);
+    expect(JSON.parse((fetchMock.mock.calls[0][1] as RequestInit).body as string)).toMatchObject({
+      textQuery: 'Greenfield',
+      includedType: 'school',
+    });
+
+    fetchMock.mockClear();
+    await lookupPlaceSuggestions('Acme', 'organisation', fetchMock as unknown as typeof fetch);
+    const body = JSON.parse((fetchMock.mock.calls[0][1] as RequestInit).body as string);
+    expect(body).toMatchObject({ textQuery: 'Acme' });
+    expect(body).not.toHaveProperty('includedType');
+  });
+
+  test('no key configured → no call, empty list (feature simply absent)', async () => {
+    delete process.env.GOOGLE_PLACES_API_KEY;
+    const fetchMock = jest.fn();
+    await expect(
+      lookupPlaceSuggestions('Greenfield', 'school', fetchMock as unknown as typeof fetch),
+    ).resolves.toEqual([]);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  test('too-short query → no call', async () => {
+    const fetchMock = jest.fn();
+    await expect(
+      lookupPlaceSuggestions('Gr', 'school', fetchMock as unknown as typeof fetch),
+    ).resolves.toEqual([]);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  test('a provider error degrades to an empty list — it never throws', async () => {
+    const rejecting = jest.fn().mockRejectedValue(new Error('network'));
+    await expect(
+      lookupPlaceSuggestions('Greenfield', 'school', rejecting as unknown as typeof fetch),
+    ).resolves.toEqual([]);
+  });
+
+  test('a non-OK response degrades to an empty list', async () => {
+    const notOk = jest.fn().mockResolvedValue({ ok: false, json: async () => ({}) });
+    await expect(
+      lookupPlaceSuggestions('Greenfield', 'school', notOk as unknown as typeof fetch),
+    ).resolves.toEqual([]);
+  });
+
+  test('a malformed body degrades to an empty list', async () => {
+    const malformed = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => {
+        throw new Error('not json');
+      },
+    });
+    await expect(
+      lookupPlaceSuggestions('Greenfield', 'school', malformed as unknown as typeof fetch),
+    ).resolves.toEqual([]);
+  });
+
+  test('nameless provider rows are dropped rather than rendered blank', async () => {
+    const fetchMock = jest
+      .fn()
+      .mockResolvedValue(okResponse([{ formattedAddress: '1 High St' }, place('Real School')]));
+    await expect(
+      lookupPlaceSuggestions('School', 'school', fetchMock as unknown as typeof fetch),
+    ).resolves.toEqual([{ name: 'Real School', address: null, postcode: null }]);
+  });
+});
+
+// ───────────────── 3. the server action ─────────────────
+
+describe('KAN-451: suggestAffiliations', () => {
+  test('not authenticated → refused', async () => {
+    mockState.userId = null;
+    await expect(suggestAffiliations('Greenfield', 'school')).resolves.toEqual({
+      success: false,
+      error: 'Not authenticated',
+    });
+  });
+
+  test('a too-short query is an empty list, not an error', async () => {
+    await expect(suggestAffiliations('Gr', 'school')).resolves.toEqual({
+      success: true,
+      suggestions: [],
+    });
+  });
+
+  test('no key configured → success with nothing, so the picker degrades quietly', async () => {
+    delete process.env.GOOGLE_PLACES_API_KEY;
+    await expect(suggestAffiliations('Greenfield Primary', 'school')).resolves.toEqual({
+      success: true,
+      suggestions: [],
+    });
+  });
+});
+
+// ───────────────── 4. description persistence on add ─────────────────
+
+describe('KAN-451: addSchoolAffiliation persists the description', () => {
+  test('a supplied description is sanitised and written to the row', async () => {
+    const result = await addSchoolAffiliation({
+      school_name: 'Greenfield Primary',
+      school_location: 'SW1A 1AA',
+      description: '<b>Year 2</b> teacher',
+      affiliation_type: 'school',
+    });
+    expect(result).toEqual({ success: true });
+    expect(mockInsertCapture).toHaveBeenCalledWith(
+      expect.objectContaining({ description: 'Year 2 teacher' }),
+    );
+  });
+
+  test('the description reaches the row for organisations and communities too', async () => {
+    await addSchoolAffiliation({
+      school_name: 'Acme Ltd',
+      description: 'Ops team',
+      affiliation_type: 'organisation',
+    });
+    expect(mockInsertCapture).toHaveBeenCalledWith(
+      expect.objectContaining({ description: 'Ops team' }),
+    );
+  });
+
+  test('no description → NULL rather than an empty string', async () => {
+    await addSchoolAffiliation({
+      school_name: 'Greenfield Primary',
+      school_location: 'SW1A 1AA',
+      affiliation_type: 'school',
+    });
+    expect(mockInsertCapture).toHaveBeenCalledWith(
+      expect.objectContaining({ description: null }),
+    );
+  });
+
+  test('a whitespace-only description → NULL', async () => {
+    await addSchoolAffiliation({
+      school_name: 'Greenfield Primary',
+      school_location: 'SW1A 1AA',
+      description: '   ',
+      affiliation_type: 'school',
+    });
+    expect(mockInsertCapture).toHaveBeenCalledWith(
+      expect.objectContaining({ description: null }),
+    );
+  });
+
+  test('a profane description is blocked and NOTHING is inserted', async () => {
+    const result = await addSchoolAffiliation({
+      school_name: 'Greenfield Primary',
+      school_location: 'SW1A 1AA',
+      description: 'fuck this place',
+      affiliation_type: 'school',
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error).toMatch(/inappropriate language/i);
+    }
+    // The add path must not be a way round the moderation the edit path applies.
+    expect(mockInsertCapture).not.toHaveBeenCalled();
+  });
+
+  test('the description is capped like every other public field', async () => {
+    // Varied words rather than a repeated character, so the length cap is what
+    // is being measured and not the spam heuristic.
+    const longNote = 'Year two teacher and reading lead for the lower school. '.repeat(20);
+    expect(longNote.length).toBeGreaterThan(400);
+    await addSchoolAffiliation({
+      school_name: 'Greenfield Primary',
+      school_location: 'SW1A 1AA',
+      description: longNote,
+      affiliation_type: 'school',
+    });
+    const written = mockInsertCapture.mock.calls[0][0] as { description: string };
+    expect(written.description.length).toBeLessThanOrEqual(200);
+  });
+});
+
+// ───────────────── 5. the KAN-404 postcode rule still holds ─────────────────
+
+describe('KAN-451: the school postcode requirement survives the picker work', () => {
+  const POSTCODE_ERROR =
+    'Schools need a postcode (full or partial) so people can tell schools with the same name apart.';
+
+  test('isSchoolPostcodeValid still needs BOTH a letter and a digit', () => {
+    // The disambiguating signal — a name-only "London" or a bare house number
+    // cannot tell two same-named schools apart.
+    expect(isSchoolPostcodeValid('SW1A 1AA')).toBe(true);
+    expect(isSchoolPostcodeValid('M1')).toBe(true);
+    expect(isSchoolPostcodeValid('London')).toBe(false);
+    expect(isSchoolPostcodeValid('12345')).toBe(false);
+    expect(isSchoolPostcodeValid('')).toBe(false);
+    expect(isSchoolPostcodeValid(null)).toBe(false);
+    expect(isSchoolPostcodeValid('A')).toBe(false);
+    expect(isSchoolPostcodeValid('ABCDEFGHIJK12')).toBe(false);
+  });
+
+  test('a school added WITH a description but no postcode is still refused', async () => {
+    // The description is the new field; it must not become a way in.
+    const result = await addSchoolAffiliation({
+      school_name: 'Greenfield Primary',
+      description: 'Year 2 teacher',
+      affiliation_type: 'school',
+    });
+    expect(result).toEqual({ success: false, error: POSTCODE_ERROR });
+    expect(mockInsertCapture).not.toHaveBeenCalled();
+  });
+
+  test('a school with a letters-only location is refused even with a description', async () => {
+    const result = await addSchoolAffiliation({
+      school_name: 'Greenfield Primary',
+      school_location: 'London',
+      description: 'Year 2 teacher',
+      affiliation_type: 'school',
+    });
+    expect(result).toEqual({ success: false, error: POSTCODE_ERROR });
+    expect(mockInsertCapture).not.toHaveBeenCalled();
+  });
+
+  test('a suggestion with no postcode does not let a school through', async () => {
+    // resolvePickedLocation leaves the field blank when the provider had no
+    // postcode; the member must supply one, and the server is what enforces it.
+    const picked: PlaceSuggestion = { name: 'Greenfield Primary', address: '1 High St', postcode: null };
+    const location = resolvePickedLocation(picked, '');
+    const result = await addSchoolAffiliation({
+      school_name: picked.name,
+      school_location: location || undefined,
+      affiliation_type: 'school',
+    });
+    expect(result).toEqual({ success: false, error: POSTCODE_ERROR });
+    expect(mockInsertCapture).not.toHaveBeenCalled();
+  });
+
+  test('a postcode carried over from a picked suggestion is accepted and stored', async () => {
+    const picked: PlaceSuggestion = {
+      name: 'Greenfield Primary',
+      address: '1 High St',
+      postcode: 'SW1A 1AA',
+    };
+    const location = resolvePickedLocation(picked, '');
+    const result = await addSchoolAffiliation({
+      school_name: picked.name,
+      school_location: location,
+      description: 'Year 2 teacher',
+      affiliation_type: 'school',
+    });
+    expect(result).toEqual({ success: true });
+    expect(mockInsertCapture).toHaveBeenCalledWith(
+      expect.objectContaining({
+        school_name: 'Greenfield Primary',
+        school_location: 'SW1A 1AA',
+        description: 'Year 2 teacher',
+        affiliation_type: 'school',
+      }),
+    );
+  });
+
+  test('organisations and communities keep an optional location', async () => {
+    await addSchoolAffiliation({
+      school_name: 'Local running club',
+      description: 'Saturday runner',
+      affiliation_type: 'community',
+    });
+    expect(mockInsertCapture).toHaveBeenCalledWith(
+      expect.objectContaining({ school_location: null, description: 'Saturday runner' }),
+    );
+  });
+});
+
+// ───────────── The editor is actually wired to the picker ─────────────
+
+// Everything above tests the modules. NONE of it observes the member-facing
+// half: reverting <AffiliationNamePicker> to the plain <Field> it replaced,
+// and dropping `description` from the add call, BOTH left this suite green —
+// so the whole feature could vanish from the UI with CI still passing.
+// The repo has no component test library, so these are comment-stripped
+// source assertions on the specific wiring whose removal is otherwise
+// invisible. Comments are stripped so no comment can satisfy them (KAN-459).
+describe('KAN-451: the add form is wired to the picker and the description', () => {
+  const ROOT = resolve(__dirname, '../..');
+  const stripComments = (src: string): string =>
+    src
+      .replace(/\{\s*\/\*[\s\S]*?\*\/\s*\}/g, ' ')
+      .replace(/\/\*[\s\S]*?\*\//g, ' ')
+      .replace(/(^|[^:])\/\/[^\n]*/g, '$1');
+  const section = stripComments(
+    readFileSync(resolve(ROOT, SRC.profile, 'sections/affiliations-section.tsx'), 'utf-8'),
+  );
+
+  test('the picker component is imported AND rendered in the add form', () => {
+    expect(section).toContain("from './affiliation-name-picker'");
+    expect(section).toContain('<AffiliationNamePicker');
+  });
+
+  test('the add call passes the member-entered description through', () => {
+    expect(section).toMatch(/addSchoolAffiliation\([\s\S]{0,400}?description,/);
+  });
+
+  test('the description input is present in the add form', () => {
+    expect(section).toContain('setDescription');
+  });
+});


### PR DESCRIPTION
Founder-approved design change of 2026-08-02 (epic KAN-441).

## What changes
A **type-ahead picker** for choosing a school, organisation or community, plus a **short description** field on the add form (the edit path already had one, added under KAN-448).

## No migration
`school_affiliations.description` **already exists** on dev and prod (KAN-263) — the editor simply never wrote it on add. The school postcode isn't its own column either: it lives in `school_affiliations.school_location`, validated for `affiliation_type='school'` by `isSchoolPostcodeValid`, which is **byte-identical to develop** here. "Keep the postcode" means exactly that.

## A member can never be blocked from adding their school
The picker **always** offers "add your own", built from what the member typed. If no key is configured, the provider errors, or nothing matches, it degrades to the plain text field it replaced. Reuses the existing Google Places integration and key (as the town/city lookup does) — no new vendor, no new secret.

## Deliberate module split — please keep it
`places-schools.ts` is **pure with zero imports** and is what the client component uses; `places-schools-lookup.ts` is server-only and holds the Places client. Without the split, the build pulled `src/lib/env.ts` into the `/dashboard/profile` **client bundle**. No key value was ever exposed (not `NEXT_PUBLIC_`, read lazily), but env resolution belongs server-side. **CTL-037 baseline unchanged.**

## Consistency with the edit path
`addSchoolAffiliation` now gives `description` the same treatment the edit path gives it — `sanitiseText(200)`, empty → NULL, `moderateAndAudit` on `school_affiliations.description` — so **the add path cannot write something the edit path would refuse**. `updateSchoolAffiliation` is reused unchanged (its signature was built for this in #673).

## Testing — 45 tests, mutation-verified
Ten defects fail the suite, including: deleting the postcode gate; weakening `isSchoolPostcodeValid`; dropping `description` from the insert; removing the auth check from `suggestAffiliations`; and letting a picked place overwrite a member-typed postcode.

**Added after review found a real gap:** reverting `<AffiliationNamePicker>` to the plain `<Field>` it replaced, and dropping `description` from the add call, **both previously left the suite fully green** — the entire member-facing half could vanish with CI passing. Both now fail. Those two are comment-stripped source assertions (no component test library in the repo), so no comment can satisfy them — see **[KAN-459](https://checklyra.atlassian.net/browse/KAN-459)**.

`type-check` clean · `lint` 0 errors · `test:unit` 2841 passed / 2859 (floor 2705); the 18 failures are the two documented macOS-only script suites. `check-env-access.py` (CTL-037), `check-server-action-exports.sh` both green.

## Note
`suggestAffiliations` lives in a sibling `'use server'` file (`affiliation-search-actions.ts`) following the existing `city-actions.ts` / `files-actions.ts` convention in that directory, rather than in `actions.ts`. Gotcha #18 is satisfied either way; say the word and it moves.

MCP coverage: deferred — school description on add is a new write field; follow-up to be raised before promote past dev (KAN-222 lockstep).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[KAN-459]: https://checklyra.atlassian.net/browse/KAN-459?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ