### PR TITLE
KAN-445: "A bit more about me" — the original ten prompts, plus three you write yourself

### DIFF
--- a/src/app/[slug]/page.tsx
+++ b/src/app/[slug]/page.tsx
@@ -228,7 +228,12 @@ export default async function PublicProfilePage({ params }: Props) {
       .maybeSingle(),
     getSupabase()
       .from('profile_conversation_starters')
-      .select('id, answer, prompt:conversation_starter_prompts!profile_conversation_starters_prompt_id_fkey(prompt, sort_order)')
+      // KAN-445: `*` rather than a column list. `custom_prompt` arrives with
+      // migration 20260803160000, and code reaches an environment before its
+      // migration runs — naming a column PostgREST does not know 42703s the
+      // whole read, which here would take the public profile down entirely
+      // (the section-read errors below throw).
+      .select('*, prompt:conversation_starter_prompts!profile_conversation_starters_prompt_id_fkey(prompt, sort_order)')
       .eq('profile_id', typedProfile.id)
       .order('created_at', { ascending: true }),
   ]);
@@ -278,11 +283,14 @@ export default async function PublicProfilePage({ params }: Props) {
     const joined = Array.isArray(promptCandidate)
       ? (promptCandidate[0] as { prompt: string; sort_order: number } | undefined)
       : (promptCandidate as { prompt: string; sort_order: number } | null);
+    // KAN-445: a question the member wrote themselves has no seeded prompt to
+    // join to. It sorts after the offered set, in the order they added them.
+    const customPrompt = (r.custom_prompt as string | null | undefined) ?? null;
     return {
       id: r.id as string,
       answer: r.answer as string,
-      prompt: joined?.prompt ?? '',
-      sort_order: joined?.sort_order ?? 0,
+      prompt: customPrompt ?? joined?.prompt ?? '',
+      sort_order: customPrompt ? Number.MAX_SAFE_INTEGER : (joined?.sort_order ?? 0),
     };
   }).sort((a, b) => a.sort_order - b.sort_order);
 
@@ -498,10 +506,14 @@ export default async function PublicProfilePage({ params }: Props) {
           <CardSection heading="🧰 Tips & life hacks I can share" items={groupedItems['life_hacks']} />
           <CardSection heading="🧩 Problems I'm trying to solve — ideas welcome" items={groupedItems['current_problems']} />
 
-          {/* A few more things about me (Q&A) */}
+          {/* Q&A — answered prompts, the member's own questions, and the
+              "questions I wish people asked" items. The heading is NOT
+              repeated in this comment on purpose: CTL-039 recorded the old
+              wording here as a comment-shadowed assertion, so the guard was
+              matching the prose rather than the rendered heading. */}
           {(typedStarters.length > 0 || has('questions')) && (
             <section className="mt-11">
-              <SectionQ>💬 A few more things about me</SectionQ>
+              <SectionQ>💬 A bit more about me</SectionQ>
               <div className="mt-3 space-y-5">
                 {typedStarters.map((s) => (
                   <div key={s.id}>

--- a/src/app/dashboard/profile/conversation-starters-actions.ts
+++ b/src/app/dashboard/profile/conversation-starters-actions.ts
@@ -5,6 +5,7 @@ import { revalidatePath } from 'next/cache';
 import { sanitiseText, type ActionResult } from '@/lib/sanitise';
 import { moderateAndAudit } from '@/lib/moderation-audit';
 import { checkProfileWriteRateLimit } from '@/lib/profile-rate-limit';
+import { ANSWER_MAX, CUSTOM_PROMPT_MAX } from './conversation-starters-fields';
 
 /**
  * KAN-181: server actions for `profile_conversation_starters`.
@@ -21,9 +22,26 @@ import { checkProfileWriteRateLimit } from '@/lib/profile-rate-limit';
  *
  * The answer cap is enforced by the DB trigger `pcs_cap`; we surface
  * it as a user-facing error instead of a raw Postgres exception.
+ *
+ * KAN-445 — a row is now EITHER a seeded prompt (`prompt_id`) OR a question
+ * the member wrote themselves (`custom_prompt`), never both and never
+ * neither. The database enforces that with `pcs_prompt_source_xor`; these
+ * actions enforce it first so the member gets a sentence rather than a 23514.
+ *
+ * A member-written question renders on the PUBLIC profile exactly like a
+ * seeded one, so it goes through the same `sanitiseText` + `moderateAndAudit`
+ * pipeline as the answer. Sanitising only the answer would leave the question
+ * as an unmoderated public text field.
+ *
+ * ⚠️ `custom_prompt` is a column added by 20260803160000, and code reaches an
+ * environment before its migration runs. PostgREST builds the INSERT/UPDATE
+ * column list from the payload KEYS, so sending `custom_prompt: null` against
+ * a database that lacks the column fails the WHOLE request with PGRST204 —
+ * the value being null does not save you. Every write below therefore adds the
+ * key ONLY when there is something to write. `npm run type-check` cannot catch
+ * this: `src/lib/supabase-server.ts` builds an untyped client. Pinned by
+ * `tests/unit/conversation-starters-custom-prompts.test.ts`.
  */
-
-const ANSWER_MAX = 500;
 
 interface AuthedRequest {
   supabase: Awaited<ReturnType<typeof createClient>>;
@@ -44,8 +62,45 @@ async function getAuthedRequest(): Promise<AuthedRequest | { error: string }> {
   return { supabase, profileId: profile.id as string, userId: user.id };
 }
 
+/**
+ * Map a Postgres error from either cap trigger onto member-facing copy.
+ *
+ * Order matters: the custom-cap message ('Custom question limit (3) reached')
+ * also matches the generic `limit (\d+) reached` pattern, so it has to be
+ * tested first or a member who filled their three own questions would be told
+ * to remove one of their ten answers.
+ */
+function capErrorCopy(message: string): string | null {
+  if (/custom question limit \(\d+\) reached/i.test(message)) {
+    return 'You can write up to 3 of your own questions. Remove one to add another.';
+  }
+  // The DB trigger raises a custom message for the answer cap; surface
+  // it as a clean toast. Match the limit generically (any digits) so the
+  // copy survives future cap changes without a code edit.
+  if (/limit \(\d+\) reached/.test(message)) {
+    return 'You can answer up to 10 prompts. Remove one to add another.';
+  }
+  return null;
+}
+
+/**
+ * Validate + clean the question a member wrote themselves.
+ *
+ * Returns the cleaned text, or an error string. Kept separate from the answer
+ * so both the add and the update path use identical rules — the sibling-drift
+ * shape that BUGS-74 and the eight suspension-guard tickets all share.
+ */
+function cleanCustomPrompt(raw: string): { text: string } | { error: string } {
+  const cleaned = sanitiseText(raw ?? '').slice(0, CUSTOM_PROMPT_MAX);
+  if (cleaned.trim().length === 0) {
+    return { error: 'Your question cannot be empty' };
+  }
+  return { text: cleaned };
+}
+
 export async function addConversationStarter(input: {
-  promptId: string;
+  promptId?: string;
+  customPrompt?: string;
   answer: string;
 }): Promise<ActionResult> {
   const authed = await getAuthedRequest();
@@ -56,10 +111,25 @@ export async function addConversationStarter(input: {
   const rl = await checkProfileWriteRateLimit(userId);
   if (!rl.allowed) return rl.result;
 
+  // KAN-445 — mirror the DB's `pcs_prompt_source_xor`: a seeded prompt or a
+  // question of your own, never both and never neither.
+  const hasPromptId = typeof input.promptId === 'string' && input.promptId.length > 0;
+  const hasCustom = typeof input.customPrompt === 'string' && input.customPrompt.trim().length > 0;
+  if (hasPromptId === hasCustom) {
+    return { success: false, error: 'Choose a prompt, or write a question of your own' };
+  }
+
   // UUID-ish sanity check on the prompt_id — DB will FK-validate either
   // way, but a clear application-level error is friendlier than a 22P02.
-  if (typeof input.promptId !== 'string' || !/^[0-9a-f-]{36}$/i.test(input.promptId)) {
+  if (hasPromptId && !/^[0-9a-f-]{36}$/i.test(input.promptId as string)) {
     return { success: false, error: 'Invalid prompt' };
+  }
+
+  let customPrompt: string | null = null;
+  if (hasCustom) {
+    const res = cleanCustomPrompt(input.customPrompt as string);
+    if ('error' in res) return { success: false, error: res.error };
+    customPrompt = res.text;
   }
 
   const cleaned = sanitiseText(input.answer ?? '').slice(0, ANSWER_MAX);
@@ -67,9 +137,10 @@ export async function addConversationStarter(input: {
     return { success: false, error: 'Answer cannot be empty' };
   }
 
-  // KAN-241 + KAN-244 — content moderation + audit log.
+  // KAN-241 + KAN-244 — content moderation + audit log. A member-written
+  // question is public text too, so it is moderated alongside the answer.
   const mod = await moderateAndAudit(supabase, {
-    text: cleaned,
+    text: customPrompt ? `${customPrompt}\n${cleaned}` : cleaned,
     fieldType: 'public',
     field: 'profile_conversation_starters.answer',
     profileId,
@@ -81,17 +152,17 @@ export async function addConversationStarter(input: {
     .from('profile_conversation_starters')
     .insert({
       profile_id: profileId,
-      prompt_id: input.promptId,
       answer: cleaned,
+      // Spread-when-present, NOT `?? null`: a key for a column that does not
+      // exist yet fails the whole request with PGRST204 even when its value is
+      // null (see the module header).
+      ...(hasPromptId ? { prompt_id: input.promptId } : {}),
+      ...(customPrompt ? { custom_prompt: customPrompt } : {}),
     });
 
   if (error) {
-    // The DB trigger raises a custom message for the answer cap; surface
-    // it as a clean toast. Match the limit generically (any digits) so the
-    // copy survives future cap changes without a code edit.
-    if (/limit \(\d+\) reached/.test(error.message)) {
-      return { success: false, error: 'You can answer up to 10 prompts. Remove one to add another.' };
-    }
+    const capCopy = capErrorCopy(error.message);
+    if (capCopy) return { success: false, error: capCopy };
     // 23505 = unique_violation on (profile_id, prompt_id)
     if (error.code === '23505') {
       return { success: false, error: 'You already answered this prompt — edit your existing answer instead.' };
@@ -106,6 +177,7 @@ export async function addConversationStarter(input: {
 export async function updateConversationStarter(
   id: string,
   answer: string,
+  customPrompt?: string,
 ): Promise<ActionResult> {
   const authed = await getAuthedRequest();
   if ('error' in authed) return { success: false, error: authed.error };
@@ -115,6 +187,17 @@ export async function updateConversationStarter(
   const rl = await checkProfileWriteRateLimit(userId);
   if (!rl.allowed) return rl.result;
 
+  // KAN-445 — `undefined` means "the caller did not edit the question", which
+  // must leave the column ALONE. Coercing it to null here would blank a
+  // member's own question every time they edited only the answer — BUGS-74's
+  // exact shape, on a column that is half of an XOR check.
+  let cleanedPrompt: string | null = null;
+  if (customPrompt !== undefined) {
+    const res = cleanCustomPrompt(customPrompt);
+    if ('error' in res) return { success: false, error: res.error };
+    cleanedPrompt = res.text;
+  }
+
   const cleaned = sanitiseText(answer ?? '').slice(0, ANSWER_MAX);
   if (cleaned.trim().length === 0) {
     return { success: false, error: 'Answer cannot be empty' };
@@ -122,7 +205,7 @@ export async function updateConversationStarter(
 
   // KAN-241 + KAN-244 — content moderation + audit, same as the add path.
   const mod = await moderateAndAudit(supabase, {
-    text: cleaned,
+    text: cleanedPrompt ? `${cleanedPrompt}\n${cleaned}` : cleaned,
     fieldType: 'public',
     field: 'profile_conversation_starters.answer',
     profileId,
@@ -132,11 +215,18 @@ export async function updateConversationStarter(
 
   const { error } = await supabase
     .from('profile_conversation_starters')
-    .update({ answer: cleaned })
+    .update({
+      answer: cleaned,
+      // Same PGRST204 rule as the insert: the key exists only when there is a
+      // value for it.
+      ...(cleanedPrompt ? { custom_prompt: cleanedPrompt } : {}),
+    })
     .eq('id', id)
     .eq('profile_id', profileId);
 
   if (error) {
+    const capCopy = capErrorCopy(error.message);
+    if (capCopy) return { success: false, error: capCopy };
     return { success: false, error: error.message };
   }
 

--- a/src/app/dashboard/profile/conversation-starters-fields.ts
+++ b/src/app/dashboard/profile/conversation-starters-fields.ts
@@ -1,0 +1,27 @@
+/**
+ * KAN-445 — shared limits for the "A bit more about me" section.
+ *
+ * Lives here rather than in `conversation-starters-actions.ts` because that
+ * file is `'use server'`, and a `'use server'` module may export ONLY async
+ * functions — a plain `export const` there is accepted by the build and then
+ * throws at action-invocation time in production (gotcha #18 / BUGS-12).
+ *
+ * Every number below mirrors a database constraint, so the two must move
+ * together:
+ *   ANSWER_MAX         -> profile_conversation_starters_answer_check (500)
+ *   CUSTOM_PROMPT_MAX  -> pcs_custom_prompt_length (140)
+ *   CUSTOM_ANSWER_CAP  -> enforce_pcs_custom_cap() (3)
+ *   ANSWER_CAP         -> enforce_pcs_cap() (10 on dev/staging/prod today)
+ */
+
+/** Longest answer, mirroring the DB CHECK on `answer`. */
+export const ANSWER_MAX = 500;
+
+/** Longest member-written question, mirroring `pcs_custom_prompt_length`. */
+export const CUSTOM_PROMPT_MAX = 140;
+
+/** How many questions a member may write themselves. */
+export const CUSTOM_ANSWER_CAP = 3;
+
+/** Total answered prompts per profile, mirroring `enforce_pcs_cap()`. */
+export const ANSWER_CAP = 10;

--- a/src/app/dashboard/profile/edit-profile-form.tsx
+++ b/src/app/dashboard/profile/edit-profile-form.tsx
@@ -152,10 +152,10 @@ const SECTIONS: SectionDef[] = [
   },
   {
     id: 'starters',
-    label: 'A few more things about me',
+    label: 'A bit more about me',
     icon: '💬',
     kind: 'starters',
-    description: 'Pick a question and answer it in your own words.',
+    description: 'Random things about you — answer any that take your fancy, or write your own.',
   },
   {
     id: 'extras',
@@ -424,8 +424,8 @@ export function EditProfileForm({
                           // edits, so a moderation block surfaces on the answer
                           // being edited instead of only flipping the section
                           // status to error.
-                          onUpdate={async (id, answer) => {
-                            const res = await updateConversationStarter(id, answer);
+                          onUpdate={async (id, answer, customPrompt) => {
+                            const res = await updateConversationStarter(id, answer, customPrompt);
                             if (res.success) router.refresh();
                             return { success: res.success, error: res.success ? undefined : res.error };
                           }}

--- a/src/app/dashboard/profile/legacy/page.tsx
+++ b/src/app/dashboard/profile/legacy/page.tsx
@@ -79,7 +79,9 @@ export default async function LegacyProfilePage() {
     .order('sort_order', { ascending: true });
   const { data: starterRows } = await supabase
     .from('profile_conversation_starters')
-    .select('id, prompt_id, answer, prompt:conversation_starter_prompts!profile_conversation_starters_prompt_id_fkey(prompt)')
+    // KAN-445: `*` for the same migration-ordering reason as the live editor —
+    // naming `custom_prompt` before 20260803160000 lands 42703s the whole read.
+    .select('*, prompt:conversation_starter_prompts!profile_conversation_starters_prompt_id_fkey(prompt)')
     .eq('profile_id', profile.id)
     .order('created_at', { ascending: true });
   const conversationAnswers = (starterRows ?? []).map((r) => {
@@ -87,11 +89,13 @@ export default async function LegacyProfilePage() {
     const joinedPrompt = Array.isArray(promptCandidate)
       ? ((promptCandidate[0] as { prompt: string } | undefined)?.prompt ?? '')
       : ((promptCandidate as { prompt: string } | null)?.prompt ?? '');
+    const customPrompt = (r.custom_prompt as string | null | undefined) ?? null;
     return {
       id: r.id as string,
-      prompt_id: r.prompt_id as string,
+      prompt_id: (r.prompt_id as string | null) ?? null,
       answer: r.answer as string,
-      prompt: joinedPrompt,
+      prompt: customPrompt ?? joinedPrompt,
+      custom_prompt: customPrompt,
     };
   });
 

--- a/src/app/dashboard/profile/page.tsx
+++ b/src/app/dashboard/profile/page.tsx
@@ -74,7 +74,12 @@ export default async function ProfilePage() {
     .order('sort_order', { ascending: true });
   const { data: starterRows } = await supabase
     .from('profile_conversation_starters')
-    .select('id, prompt_id, answer, prompt:conversation_starter_prompts!profile_conversation_starters_prompt_id_fkey(prompt)')
+    // KAN-445: `*` rather than a column list, deliberately. `custom_prompt`
+    // arrives with migration 20260803160000, and code reaches an environment
+    // before its migration runs — PostgREST rejects the WHOLE query with 42703
+    // if a named column is absent, which would blank the profile editor. `*`
+    // returns the column once it exists and simply omits it before then.
+    .select('*, prompt:conversation_starter_prompts!profile_conversation_starters_prompt_id_fkey(prompt)')
     .eq('profile_id', profile.id)
     .order('created_at', { ascending: true });
   const conversationAnswers = (starterRows ?? []).map((r) => {
@@ -84,11 +89,14 @@ export default async function ProfilePage() {
     const joinedPrompt = Array.isArray(promptCandidate)
       ? ((promptCandidate[0] as { prompt: string } | undefined)?.prompt ?? '')
       : ((promptCandidate as { prompt: string } | null)?.prompt ?? '');
+    const customPrompt = (r.custom_prompt as string | null | undefined) ?? null;
     return {
       id: r.id as string,
-      prompt_id: r.prompt_id as string,
+      prompt_id: (r.prompt_id as string | null) ?? null,
       answer: r.answer as string,
-      prompt: joinedPrompt,
+      // A member-written question IS the question shown above the answer.
+      prompt: customPrompt ?? joinedPrompt,
+      custom_prompt: customPrompt,
     };
   });
 

--- a/src/app/dashboard/profile/steps/conversation-starters-step.tsx
+++ b/src/app/dashboard/profile/steps/conversation-starters-step.tsx
@@ -2,26 +2,32 @@
 
 import { useState } from 'react';
 import { SaveButton, type ConversationPrompt, type ConversationAnswer } from './types';
+import {
+  ANSWER_MAX,
+  ANSWER_CAP,
+  CUSTOM_PROMPT_MAX,
+  CUSTOM_ANSWER_CAP,
+} from '../conversation-starters-fields';
 
 /**
- * KAN-181: conversation-starter prompts wizard step.
+ * KAN-181 / KAN-445: the "A bit more about me" step.
  *
- * Two sections, each rendered conditionally:
+ * Three sections, each rendered conditionally:
  *
- *   1. **Answered** — prompts the user has already answered, with inline
+ *   1. **Answered** — questions the user has already answered, with inline
  *      edit + remove. Edit is in-place (no separate route) to keep the
- *      flow tight in a multi-step wizard.
- *   2. **Unanswered** — prompts not yet answered, each clickable to
+ *      flow tight in a multi-step wizard. A question the member wrote
+ *      themselves can have its wording edited too.
+ *   2. **Unanswered** — offered prompts not yet answered, each clickable to
  *      expand into an answer form. Hidden when the answer cap is hit
  *      so the user isn't tempted by something they can't add.
+ *   3. **Write your own** (KAN-445) — up to three questions of the member's
+ *      own, question and answer both supplied by them.
  *
- * The answer cap is enforced at the DB layer (BEFORE INSERT trigger); the
- * UI mirrors it for a friendly nudge and to hide the "add" affordances
+ * Both caps are enforced at the DB layer (BEFORE INSERT/UPDATE triggers); the
+ * UI mirrors them for a friendly nudge and to hide the "add" affordances
  * when at limit.
  */
-
-const ANSWER_MAX = 500;
-const ANSWER_CAP = 10;
 
 export function ConversationStartersStep({
   prompts,
@@ -35,11 +41,19 @@ export function ConversationStartersStep({
 }: {
   prompts: ConversationPrompt[];
   answers: ConversationAnswer[];
-  onAdd: (input: { promptId: string; answer: string }) => void;
+  // KAN-445: exactly one of promptId / customPrompt, mirroring the DB's
+  // `pcs_prompt_source_xor`.
+  onAdd: (input: { promptId?: string; customPrompt?: string; answer: string }) => void;
   // KAN-448 — the caller awaits the update action and hands back its result so
   // a moderation rejection surfaces on the row it belongs to, rather than
   // disappearing into a transition. Same shape as ItemsStep's onEdit.
-  onUpdate: (id: string, answer: string) => Promise<{ success: boolean; error?: string }>;
+  // `customPrompt` is omitted when the member edited only the answer, so the
+  // saved question is left untouched.
+  onUpdate: (
+    id: string,
+    answer: string,
+    customPrompt?: string,
+  ) => Promise<{ success: boolean; error?: string }>;
   onRemove: (id: string) => void;
   onNext: () => void;
   isPending: boolean;
@@ -51,12 +65,18 @@ export function ConversationStartersStep({
   const [newAnswer, setNewAnswer] = useState('');
   const [editingId, setEditingId] = useState<string | null>(null);
   const [editingAnswer, setEditingAnswer] = useState('');
+  const [editingPrompt, setEditingPrompt] = useState('');
   const [editError, setEditError] = useState<string | null>(null);
   const [editSaving, setEditSaving] = useState(false);
+  const [ownOpen, setOwnOpen] = useState(false);
+  const [ownPrompt, setOwnPrompt] = useState('');
+  const [ownAnswer, setOwnAnswer] = useState('');
 
   const answeredPromptIds = new Set(answers.map((a) => a.prompt_id));
   const unanswered = prompts.filter((p) => !answeredPromptIds.has(p.id));
   const atCap = answers.length >= ANSWER_CAP;
+  const ownCount = answers.filter((a) => a.prompt_id === null).length;
+  const ownLeft = Math.max(0, CUSTOM_ANSWER_CAP - ownCount);
 
   function handleStartAnswer(promptId: string) {
     setOpenPromptId(promptId);
@@ -70,17 +90,33 @@ export function ConversationStartersStep({
     setNewAnswer('');
   }
 
+  function handleSubmitOwn() {
+    if (!ownPrompt.trim() || !ownAnswer.trim()) return;
+    onAdd({ customPrompt: ownPrompt.trim(), answer: ownAnswer.trim() });
+    setOwnOpen(false);
+    setOwnPrompt('');
+    setOwnAnswer('');
+  }
+
   function handleStartEdit(answer: ConversationAnswer) {
     setEditingId(answer.id);
     setEditingAnswer(answer.answer);
+    setEditingPrompt(answer.custom_prompt ?? '');
     setEditError(null);
   }
 
-  async function handleSaveEdit() {
+  async function handleSaveEdit(isOwnQuestion: boolean) {
     if (!editingId || !editingAnswer.trim()) return;
+    if (isOwnQuestion && !editingPrompt.trim()) return;
     setEditSaving(true);
     setEditError(null);
-    const res = await onUpdate(editingId, editingAnswer.trim());
+    // A seeded prompt has no editable question, so nothing is sent for it —
+    // which is also what keeps `custom_prompt` out of that payload entirely.
+    const res = await onUpdate(
+      editingId,
+      editingAnswer.trim(),
+      isOwnQuestion ? editingPrompt.trim() : undefined,
+    );
     setEditSaving(false);
     if (!res.success) {
       setEditError(res.error ?? 'Could not save. Please try again.');
@@ -88,15 +124,16 @@ export function ConversationStartersStep({
     }
     setEditingId(null);
     setEditingAnswer('');
+    setEditingPrompt('');
   }
 
   return (
     <div className="space-y-6">
       <div>
-        <h2 className="text-xl font-medium text-[var(--color-ink)]">Things to ask me about</h2>
+        <h2 className="text-xl font-medium text-[var(--color-ink)]">A bit more about me</h2>
         <p className="text-sm text-[var(--color-muted)] mt-1">
-          Pick a prompt and write a short answer. These give people something to ask you about
-          beyond &ldquo;how are you?&rdquo;.
+          Random things about you. Answer any that take your fancy, skip the rest — or write a
+          question of your own.
         </p>
       </div>
 
@@ -112,6 +149,15 @@ export function ConversationStartersStep({
               </p>
               {editingId === a.id ? (
                 <div className="space-y-2">
+                  {a.prompt_id === null && (
+                    <input
+                      value={editingPrompt}
+                      onChange={(e) => setEditingPrompt(e.target.value.slice(0, CUSTOM_PROMPT_MAX))}
+                      aria-label="Your question"
+                      placeholder="Your question"
+                      className="w-full p-2 text-sm rounded border border-[var(--color-border)] bg-white"
+                    />
+                  )}
                   <textarea
                     value={editingAnswer}
                     onChange={(e) => setEditingAnswer(e.target.value.slice(0, ANSWER_MAX))}
@@ -124,7 +170,7 @@ export function ConversationStartersStep({
                     <div className="flex gap-2">
                       <button
                         type="button"
-                        onClick={() => { setEditingId(null); setEditingAnswer(''); setEditError(null); }}
+                        onClick={() => { setEditingId(null); setEditingAnswer(''); setEditingPrompt(''); setEditError(null); }}
                         disabled={editSaving}
                         className="text-[var(--color-muted)] hover:text-[var(--color-ink)]"
                       >
@@ -132,8 +178,13 @@ export function ConversationStartersStep({
                       </button>
                       <button
                         type="button"
-                        onClick={handleSaveEdit}
-                        disabled={editSaving || isPending || !editingAnswer.trim()}
+                        onClick={() => handleSaveEdit(a.prompt_id === null)}
+                        disabled={
+                          editSaving
+                          || isPending
+                          || !editingAnswer.trim()
+                          || (a.prompt_id === null && !editingPrompt.trim())
+                        }
                         className="px-3 py-1 rounded-full bg-[var(--color-sage)] text-white disabled:opacity-50"
                       >
                         {editSaving ? 'Saving…' : 'Save'}
@@ -180,7 +231,7 @@ export function ConversationStartersStep({
       ) : (
         <div className="space-y-2">
           <p className="text-xs font-medium text-[var(--color-muted)] uppercase tracking-wide">
-            Prompts to try ({ANSWER_CAP - answers.length} answer{ANSWER_CAP - answers.length === 1 ? '' : 's'} left)
+            Questions you could answer ({ANSWER_CAP - answers.length} answer{ANSWER_CAP - answers.length === 1 ? '' : 's'} left)
           </p>
           {unanswered.map((p) => (
             <div
@@ -230,6 +281,69 @@ export function ConversationStartersStep({
               )}
             </div>
           ))}
+        </div>
+      )}
+
+      {/* KAN-445 — write your own. Hidden at either cap so the member is never
+          offered something the database would refuse. */}
+      {!atCap && ownLeft > 0 && (
+        <div className="space-y-2">
+          <p className="text-xs font-medium text-[var(--color-muted)] uppercase tracking-wide">
+            Or ask yourself something ({ownLeft} of your own left)
+          </p>
+          <div className="bg-white rounded-lg border border-[var(--color-border)]">
+            <button
+              type="button"
+              onClick={() => setOwnOpen((open) => !open)}
+              disabled={isPending}
+              className="w-full text-left px-4 py-3 text-sm text-[var(--color-ink)] hover:bg-[var(--color-paper)] disabled:opacity-60"
+            >
+              {ownOpen ? '▼' : '▸'} Write your own question
+            </button>
+            {ownOpen && (
+              <div className="p-4 pt-0 space-y-2">
+                <input
+                  autoFocus
+                  value={ownPrompt}
+                  onChange={(e) => setOwnPrompt(e.target.value.slice(0, CUSTOM_PROMPT_MAX))}
+                  aria-label="Your question"
+                  placeholder="Example: What's the best thing in my kitchen?"
+                  className="w-full p-2 text-sm rounded border border-[var(--color-border)] bg-white"
+                />
+                <textarea
+                  value={ownAnswer}
+                  onChange={(e) => setOwnAnswer(e.target.value.slice(0, ANSWER_MAX))}
+                  rows={3}
+                  aria-label="Your answer"
+                  placeholder="Your answer"
+                  className="w-full p-2 text-sm rounded border border-[var(--color-border)] bg-white"
+                />
+                <div className="flex items-center justify-between text-xs">
+                  <span className="text-[var(--color-muted)]">
+                    {ownPrompt.length} / {CUSTOM_PROMPT_MAX} · {ownAnswer.length} / {ANSWER_MAX}
+                  </span>
+                  <div className="flex gap-2">
+                    <button
+                      type="button"
+                      onClick={() => { setOwnOpen(false); setOwnPrompt(''); setOwnAnswer(''); }}
+                      disabled={isPending}
+                      className="text-[var(--color-muted)] hover:text-[var(--color-ink)]"
+                    >
+                      Cancel
+                    </button>
+                    <button
+                      type="button"
+                      onClick={handleSubmitOwn}
+                      disabled={isPending || !ownPrompt.trim() || !ownAnswer.trim()}
+                      className="px-3 py-1 rounded-full bg-[var(--color-sage)] text-white disabled:opacity-50"
+                    >
+                      Save answer
+                    </button>
+                  </div>
+                </div>
+              </div>
+            )}
+          </div>
         </div>
       )}
 

--- a/src/app/dashboard/profile/steps/types.tsx
+++ b/src/app/dashboard/profile/steps/types.tsx
@@ -80,9 +80,12 @@ export interface ConversationPrompt {
 
 export interface ConversationAnswer {
   id: string;
-  prompt_id: string;
+  // KAN-445: null when the member wrote the question themselves.
+  prompt_id: string | null;
   answer: string;
-  prompt: string; // joined for display
+  prompt: string; // the seeded prompt joined for display, or the member's own
+  /** The member's own question text; null for a seeded prompt. */
+  custom_prompt: string | null;
 }
 
 export function Field({ label, value, onChange, placeholder }: {

--- a/src/app/dashboard/profile/wizard.tsx
+++ b/src/app/dashboard/profile/wizard.tsx
@@ -243,8 +243,8 @@ export function ProfileWizard({
             prompts={conversationPrompts}
             answers={conversationAnswers}
             onAdd={(input) => { startTransition(async () => { await addConversationStarter(input); router.refresh(); }); }}
-            onUpdate={async (id, answer) => {
-              const res = await updateConversationStarter(id, answer);
+            onUpdate={async (id, answer, customPrompt) => {
+              const res = await updateConversationStarter(id, answer, customPrompt);
               if (res.success) router.refresh();
               return { success: res.success, error: res.success ? undefined : res.error };
             }}

--- a/supabase/migrations/20260803160000_kan445_custom_conversation_prompts.sql
+++ b/supabase/migrations/20260803160000_kan445_custom_conversation_prompts.sql
@@ -1,0 +1,260 @@
+-- ============================================================================
+-- KAN-445 — "A bit more about me": the founder's ten prompts + three
+--           member-written questions.
+-- ============================================================================
+--
+-- WHAT THE LIVE DATA ACTUALLY LOOKED LIKE BEFORE THIS RAN (read 2026-08-03)
+-- -------------------------------------------------------------------------
+-- `conversation_starter_prompts` held the SAME eight generic prompts, all
+-- active, on dev / staging / production — the 2026-05-16 seed, never revised:
+--
+--     A book that changed how I think            (10)
+--     The best advice I've ever received         (20)
+--     A skill I'm practising right now           (30)
+--     Something I've changed my mind about recently (40)
+--     A small thing that makes my day            (50)
+--     A question I'm sitting with                (60)
+--     What I wish more people asked me           (70)
+--     A weird hobby of mine                      (80)
+--
+-- The founder's own set — recorded in "Lyra-Profile-Mockups-Questions-and-
+-- Answers.docx" ("The set questions people can answer") and in
+-- "Lyra-Profile-Content-Spec.docx" §8 — never reached the database. Two of the
+-- eight ("The best advice I've ever received", "Something I've changed my mind
+-- about recently") ARE in the founder's set and are kept, re-ordered; the other
+-- six are retired.
+--
+-- RETIRE, NEVER DELETE. `profile_conversation_starters.prompt_id` is a FK onto
+-- these rows, so deleting a prompt would either fail or orphan a member's saved
+-- answer. Retirement is `is_active = false`, which the editor query already
+-- filters on (`.eq('is_active', true)`), so a retired prompt stops being
+-- OFFERED while every existing answer keeps rendering.
+--
+-- CUSTOM QUESTIONS. The old model FORBADE them: `prompt_id` was `not null` and
+-- there was no column for member-supplied question text. This migration drops
+-- that NOT NULL, adds `custom_prompt`, and adds an XOR check so a row is either
+-- a seeded prompt or a member-written one — never both, never neither.
+--
+-- `unique (profile_id, prompt_id)` is NULLS DISTINCT (verified on dev:
+-- `pg_index.indnullsnotdistinct = false`), so several custom rows per profile
+-- do not collide on it. The three-custom cap is enforced by its own trigger.
+--
+-- ⚠️ THE TOTAL ANSWER CAP IS DELIBERATELY UNTOUCHED HERE.
+-- `public.enforce_pcs_cap()` is left exactly as it is, in every environment.
+-- Raising the production cap is an open founder decision and is out of scope,
+-- so this migration adds a SECOND, independent trigger for the custom subset
+-- rather than rewriting `enforce_pcs_cap()` with a hard-coded total. Rewriting
+-- it would bake one number into every environment the migration reaches, which
+-- is precisely the change that is not ours to make. Seeded-prompt behaviour is
+-- therefore preserved by construction, not by careful copying.
+--
+-- (For the record, and NOT acted on here: `enforce_pcs_cap()` currently reads
+-- `>= 10` on dev, staging AND production, even though
+-- 20260704130000_raise_pcs_cap_to_10.sql is headed "prod: DO NOT APPLY".
+-- Verified 2026-08-03 via `pg_get_functiondef` on all three projects.)
+--
+-- Safe to apply to dev, staging and production on the normal promotion chain:
+-- nothing below changes an existing row's meaning, and the new column is
+-- nullable.
+--
+-- ----------------------------------------------------------------------------
+-- ROLLBACK
+-- ----------------------------------------------------------------------------
+--   drop trigger if exists pcs_custom_cap on public.profile_conversation_starters;
+--   drop function if exists public.enforce_pcs_custom_cap();
+--   alter table public.profile_conversation_starters
+--     drop constraint if exists pcs_prompt_source_xor;
+--   alter table public.profile_conversation_starters
+--     drop constraint if exists pcs_custom_prompt_length;
+--   -- Only after moving/removing any custom rows, which have prompt_id null:
+--   --   delete from public.profile_conversation_starters where prompt_id is null;
+--   alter table public.profile_conversation_starters
+--     drop column if exists custom_prompt;
+--   alter table public.profile_conversation_starters
+--     alter column prompt_id set not null;
+--   drop index if exists public.conversation_starter_prompts_prompt_key;
+--   -- Restore the previous offered set (no prompt row was deleted):
+--   update public.conversation_starter_prompts set is_active = true;
+-- ----------------------------------------------------------------------------
+
+-- ---------------------------------------------------------------------------
+-- 1. Give the seed an idempotency key.
+--    The table had no unique constraint on `prompt`, so `on conflict do
+--    nothing` had nothing to conflict ON and a re-run would have duplicated
+--    every row. All three environments hold 8 distinct prompts today, so this
+--    index builds cleanly.
+-- ---------------------------------------------------------------------------
+create unique index if not exists conversation_starter_prompts_prompt_key
+  on public.conversation_starter_prompts (prompt);
+
+-- ---------------------------------------------------------------------------
+-- 2. Seed the founder's ten prompts. Idempotent: the two that already exist
+--    are skipped here and re-ordered in step 3.
+-- ---------------------------------------------------------------------------
+insert into public.conversation_starter_prompts (prompt, sort_order) values
+  ('If you could invite anyone, living or dead, to a dinner party — who would you have?', 10),
+  ('What are you most proud of that wouldn''t make it onto your CV?', 20),
+  ('If you could have any job — real or not — what would it be?', 30),
+  ('Skills I''m trying to learn', 40),
+  ('Something I''ve changed my mind about recently', 50),
+  ('What qualities do you most appreciate in your closest friends?', 60),
+  ('The best advice I''ve ever received', 70),
+  ('If you could master any skill instantly, what would it be?', 80),
+  ('What''s a small, daily act of kindness that usually goes unappreciated?', 90),
+  ('What''s your best childhood memory?', 100)
+on conflict (prompt) do nothing;
+
+-- ---------------------------------------------------------------------------
+-- 3. Activate and order the canonical ten. This is what makes the two
+--    survivors land in the founder's order rather than their 2026-05 order,
+--    and it re-activates any of the ten a previous run had retired.
+-- ---------------------------------------------------------------------------
+update public.conversation_starter_prompts p
+   set is_active  = true,
+       sort_order = v.sort_order
+  from (values
+    ('If you could invite anyone, living or dead, to a dinner party — who would you have?', 10),
+    ('What are you most proud of that wouldn''t make it onto your CV?', 20),
+    ('If you could have any job — real or not — what would it be?', 30),
+    ('Skills I''m trying to learn', 40),
+    ('Something I''ve changed my mind about recently', 50),
+    ('What qualities do you most appreciate in your closest friends?', 60),
+    ('The best advice I''ve ever received', 70),
+    ('If you could master any skill instantly, what would it be?', 80),
+    ('What''s a small, daily act of kindness that usually goes unappreciated?', 90),
+    ('What''s your best childhood memory?', 100)
+  ) as v(prompt, sort_order)
+ where p.prompt = v.prompt
+   and (p.is_active is distinct from true or p.sort_order is distinct from v.sort_order);
+
+-- ---------------------------------------------------------------------------
+-- 4. Retire everything else. NO DELETE — answers reference these rows.
+-- ---------------------------------------------------------------------------
+update public.conversation_starter_prompts
+   set is_active = false
+ where is_active is distinct from false
+   and prompt not in (
+     'If you could invite anyone, living or dead, to a dinner party — who would you have?',
+     'What are you most proud of that wouldn''t make it onto your CV?',
+     'If you could have any job — real or not — what would it be?',
+     'Skills I''m trying to learn',
+     'Something I''ve changed my mind about recently',
+     'What qualities do you most appreciate in your closest friends?',
+     'The best advice I''ve ever received',
+     'If you could master any skill instantly, what would it be?',
+     'What''s a small, daily act of kindness that usually goes unappreciated?',
+     'What''s your best childhood memory?'
+   );
+
+-- ---------------------------------------------------------------------------
+-- 4b. Keep retired prompts READABLE by the members who answered them.
+--
+-- Retiring a prompt in step 4 removes it from the OFFERED list, which is the
+-- intent. But the only select policy on this table is `using (is_active =
+-- true)`, and both editors read the question text for a SAVED answer through
+-- the RLS-scoped cookie client via a PostgREST embedded resource — which RLS
+-- filters. So without this, every member who answered one of the retired
+-- prompts opens their editor and sees their own answer with NO question above
+-- it, un-labelled and unidentifiable, while the PUBLIC profile still shows the
+-- question correctly (that page uses the service-role client, which bypasses
+-- RLS). The editor and the live profile would disagree.
+--
+-- Policies for the same command are OR'd, so this only ADDS visibility: a
+-- member may read a prompt that one of their OWN answers references. It grants
+-- nothing about anyone else's answers, and nothing about prompts they have not
+-- answered.
+do $$
+begin
+  if not exists (
+    select 1 from pg_policies
+     where schemaname = 'public'
+       and tablename = 'conversation_starter_prompts'
+       and policyname = 'Members can read prompts their own answers reference'
+  ) then
+    create policy "Members can read prompts their own answers reference"
+      on public.conversation_starter_prompts
+      for select
+      using (
+        exists (
+          select 1
+            from public.profile_conversation_starters pcs
+            join public.profiles p on p.id = pcs.profile_id
+           where pcs.prompt_id = conversation_starter_prompts.id
+             and p.user_id = auth.uid()
+        )
+      );
+  end if;
+end
+$$;
+
+-- ---------------------------------------------------------------------------
+-- 5. Allow a member-written question.
+-- ---------------------------------------------------------------------------
+alter table public.profile_conversation_starters
+  alter column prompt_id drop not null;
+
+alter table public.profile_conversation_starters
+  add column if not exists custom_prompt text;
+
+-- 140 chars mirrors the founder spec's "up to 20 words" guide for F8.8a/9a/10a
+-- and matches the application-side cap in conversation-starters-fields.ts.
+alter table public.profile_conversation_starters
+  drop constraint if exists pcs_custom_prompt_length;
+alter table public.profile_conversation_starters
+  add constraint pcs_custom_prompt_length
+  check (
+    custom_prompt is null
+    or (length(custom_prompt) <= 140 and length(btrim(custom_prompt)) > 0)
+  );
+
+-- Exactly one source of the question. Without this, a row could carry both a
+-- seeded prompt and a member-written one (which renders twice) or neither
+-- (which renders an answer with no question above it).
+alter table public.profile_conversation_starters
+  drop constraint if exists pcs_prompt_source_xor;
+alter table public.profile_conversation_starters
+  add constraint pcs_prompt_source_xor
+  check ((prompt_id is null) <> (custom_prompt is null));
+
+-- ---------------------------------------------------------------------------
+-- 6. Cap member-written questions at three, independently of the total cap.
+--
+--    `id <> new.id` makes one function correct for both INSERT (where new.id
+--    is not yet in the table, so nothing is excluded) and UPDATE (where the
+--    row must not count itself). The UPDATE arm matters: without it, a member
+--    could sidestep the cap by inserting seeded rows and then flipping them to
+--    custom.
+--
+--    Not SECURITY DEFINER — it only reads the table the caller is already
+--    writing, so it needs no elevation, and RLS still applies to the caller's
+--    own statement. EXECUTE is revoked anyway (gotcha #26 / BUGS-48/65/69):
+--    trigger functions fire on the table privilege, not on EXECUTE of the
+--    function, and PostgREST cannot supply TriggerData via /rpc.
+-- ---------------------------------------------------------------------------
+create or replace function public.enforce_pcs_custom_cap()
+returns trigger
+language plpgsql
+set search_path to ''
+as $$
+begin
+  if new.prompt_id is null then
+    if (
+      select count(*)
+        from public.profile_conversation_starters
+       where profile_id = new.profile_id
+         and prompt_id is null
+         and id <> new.id
+    ) >= 3 then
+      raise exception 'Custom question limit (3) reached';
+    end if;
+  end if;
+  return new;
+end$$;
+
+revoke execute on function public.enforce_pcs_custom_cap() from public, anon, authenticated;
+grant execute on function public.enforce_pcs_custom_cap() to service_role;
+
+drop trigger if exists pcs_custom_cap on public.profile_conversation_starters;
+create trigger pcs_custom_cap
+  before insert or update on public.profile_conversation_starters
+  for each row execute function public.enforce_pcs_custom_cap();

--- a/tests/e2e/profile-redesign.spec.ts
+++ b/tests/e2e/profile-redesign.spec.ts
@@ -198,7 +198,7 @@ test.describe('Redesign — populated public profile structure', () => {
     const humanised = [
       /A few of my favourite things/i,
       /To understand me a little better/i,
-      /A few more things about me/i,
+      /A bit more about me/i,
       /Things I love/i,
     ];
     const matches = await Promise.all(

--- a/tests/support/comment-assertion-baseline.json
+++ b/tests/support/comment-assertion-baseline.json
@@ -34,12 +34,6 @@
     },
     {
       "test": "tests/unit/conversation-starters.test.ts",
-      "subject": "src/app/[slug]/page.tsx",
-      "assertion": "/A few more things about me/",
-      "severity": "comment-shadowed"
-    },
-    {
-      "test": "tests/unit/conversation-starters.test.ts",
       "subject": "src/app/dashboard/profile/conversation-starters-actions.ts",
       "assertion": "/500/",
       "severity": "comment-shadowed"

--- a/tests/support/source-paths.json
+++ b/tests/support/source-paths.json
@@ -1,7 +1,7 @@
 {
   "$comment": "GENERATED — regenerate with `npm run gen:test-paths`. Mirror of tests/support/source-paths.ts for .cjs and shell consumers (KAN-414 F4).",
   "generated_from": "literals referenced by tracked files under tests/",
-  "count": 174,
+  "count": 175,
   "SRC": {
     "codeowners": ".github/CODEOWNERS",
     "pullRequestTemplate": ".github/PULL_REQUEST_TEMPLATE.md",
@@ -176,6 +176,7 @@
     "migrations20260707193000Sec76OauthClientsIsFirstParty": "supabase/migrations/20260707193000_sec76_oauth_clients_is_first_party.sql",
     "migrations20260712033000Sec74AffiliateClicksRetentionPurge": "supabase/migrations/20260712033000_sec74_affiliate_clicks_retention_purge.sql",
     "migrations20260717033000Sec74GatheringsRetentionPurge": "supabase/migrations/20260717033000_sec74_gatherings_retention_purge.sql",
+    "migrations20260803160000Kan445CustomConversationPrompts": "supabase/migrations/20260803160000_kan445_custom_conversation_prompts.sql",
     "schemaDriftBaseline": "supabase/schema-drift-baseline.json"
   }
 }

--- a/tests/support/source-paths.ts
+++ b/tests/support/source-paths.ts
@@ -13,7 +13,7 @@
 // cannot drift from reality — a hand-maintained list is what let BUGS-74's
 // first fix miss the legacy editor.
 //
-// 174 entries.
+// 175 entries.
 
 export const SRC = {
   codeowners: '.github/CODEOWNERS',
@@ -189,6 +189,7 @@ export const SRC = {
   migrations20260707193000Sec76OauthClientsIsFirstParty: 'supabase/migrations/20260707193000_sec76_oauth_clients_is_first_party.sql',
   migrations20260712033000Sec74AffiliateClicksRetentionPurge: 'supabase/migrations/20260712033000_sec74_affiliate_clicks_retention_purge.sql',
   migrations20260717033000Sec74GatheringsRetentionPurge: 'supabase/migrations/20260717033000_sec74_gatherings_retention_purge.sql',
+  migrations20260803160000Kan445CustomConversationPrompts: 'supabase/migrations/20260803160000_kan445_custom_conversation_prompts.sql',
   schemaDriftBaseline: 'supabase/schema-drift-baseline.json',
 } as const;
 

--- a/tests/unit/conversation-starters-custom-prompts.test.ts
+++ b/tests/unit/conversation-starters-custom-prompts.test.ts
@@ -1,0 +1,517 @@
+/**
+ * KAN-445 — "A bit more about me": the founder's ten prompts, three questions
+ * a member writes themselves, and the migration-ordering hazard that comes
+ * with the new `custom_prompt` column.
+ *
+ * WHY THIS FILE EXISTS
+ * --------------------
+ * Three separate defect shapes converge on this change, and each one has
+ * already shipped to production in this repo at least once.
+ *
+ * 1. PGRST204 — THE KEY IS THE PAYLOAD, NOT THE VALUE.
+ *    PostgREST builds the INSERT/UPDATE column list from the payload KEYS, so
+ *    sending `custom_prompt: null` against a database that has not run
+ *    20260803160000 yet fails the WHOLE request — the null value does not
+ *    save you. Code reaches an environment before its migration does, so this
+ *    is the normal case, not the edge case. `npm run type-check` is blind to
+ *    it: `src/lib/supabase-server.ts` builds an UNTYPED client, so no column
+ *    name in any payload is ever checked against a schema. The only thing that
+ *    can catch it is a test that looks at the payload actually handed to the
+ *    driver, which is what the first describe below does.
+ *
+ * 2. BUGS-74 — `undefined` AND `null` ARE DIFFERENT INSTRUCTIONS.
+ *    "The caller did not edit the question" must leave the column alone;
+ *    "the caller cleared it" would write NULL. Collapsing the two with
+ *    `?? null` is what wiped real members' `good_to_know` and `boundaries` on
+ *    all four environments. Here it would blank a member's own question every
+ *    time they edited only the answer — and because `custom_prompt` is half of
+ *    an XOR check, the write would then fail outright.
+ *
+ * 3. THE SIBLING-DRIFT SHAPE.
+ *    `addConversationStarter` and `updateConversationStarter` both clean the
+ *    member-written question. Any whole-file substring scan is satisfied by
+ *    either one, so the cases below exercise BOTH paths separately — the same
+ *    reason tests/unit/conversation-starters-actions-behaviour.test.ts exists.
+ *
+ * WHAT IS DELIBERATELY *NOT* ASSERTED
+ * -----------------------------------
+ * The total answer cap. `enforce_pcs_cap()` is out of scope for KAN-445 and is
+ * left untouched in every environment; the migration case below asserts that
+ * the migration does not redefine it, which is the only claim this change is
+ * entitled to make about it.
+ *
+ * MUTATION PROOF — see the session report. Every case here was verified to go
+ * RED against a deliberate break of the real subject, and the subject restored
+ * byte-identically afterwards (shasum-checked).
+ */
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { SRC } from '../support/source-paths';
+
+// ---------------------------------------------------------------------------
+// Supabase stub — per-STATEMENT, not pooled.
+//
+// A pooled `calls.find(op === 'eq')` cannot tell the ownership pre-read on
+// `profiles` from the filter on the UPDATE, which is exactly how an assertion
+// meant for a write ends up satisfied by an earlier SELECT. Every recorded
+// call therefore carries its table and its position, and every assertion
+// below names both.
+// ---------------------------------------------------------------------------
+type Call = { seq: number; table: string; op: string; args: unknown[] };
+
+const calls: Call[] = [];
+let dbError: { message: string; code?: string } | null = null;
+let seq = 0;
+
+function makeClient() {
+  const chain = (table: string) => {
+    const self: Record<string, unknown> = {};
+    const rec = (op: string) => (...args: unknown[]) => {
+      calls.push({ seq: seq++, table, op, args });
+      return self;
+    };
+    for (const op of ['select', 'eq', 'insert', 'update', 'delete']) self[op] = rec(op);
+    self.single = async () => ({ data: { id: 'profile-1' }, error: null });
+    self.then = (resolveFn: (v: unknown) => unknown) => resolveFn({ error: dbError });
+    return self;
+  };
+  return {
+    auth: { getUser: async () => ({ data: { user: { id: 'user-1' } } }) },
+    from: (t: string) => chain(t),
+  };
+}
+
+const mockModerate = jest.fn(async () => ({ ok: true }) as { ok: boolean; error?: string });
+
+jest.mock('next/cache', () => ({ revalidatePath: jest.fn() }));
+jest.mock('@/lib/supabase-server', () => ({
+  createClient: jest.fn(async () => makeClient()),
+}));
+jest.mock('@/lib/profile-rate-limit', () => ({
+  checkProfileWriteRateLimit: jest.fn(async () => ({ allowed: true })),
+}));
+jest.mock('@/lib/moderation-audit', () => ({
+  moderateAndAudit: (...args: unknown[]) => mockModerate(...(args as [])),
+}));
+
+import {
+  addConversationStarter,
+  updateConversationStarter,
+} from '@/app/dashboard/profile/conversation-starters-actions';
+
+const PROMPT_ID = '11111111-2222-3333-4444-555555555555';
+const STARTERS = 'profile_conversation_starters';
+
+/** The payload of the single write statement issued against the starters table. */
+function writePayload(op: 'insert' | 'update'): Record<string, unknown> {
+  const matching = calls.filter((c) => c.table === STARTERS && c.op === op);
+  // More than one would make "the payload" ambiguous and quietly hide a second
+  // write; zero means the action never reached the database.
+  expect(matching).toHaveLength(1);
+  return (matching[0].args[0] ?? {}) as Record<string, unknown>;
+}
+
+function wrote(): boolean {
+  return calls.some((c) => c.table === STARTERS && (c.op === 'insert' || c.op === 'update'));
+}
+
+beforeEach(() => {
+  calls.length = 0;
+  seq = 0;
+  dbError = null;
+  mockModerate.mockClear();
+  mockModerate.mockImplementation(async () => ({ ok: true }));
+});
+
+// ===========================================================================
+describe('KAN-445 payload-key safety — a key only when there is a value', () => {
+  it('OMITS custom_prompt entirely when answering a seeded prompt', async () => {
+    const res = await addConversationStarter({ promptId: PROMPT_ID, answer: 'Middlemarch' });
+
+    expect(res.success).toBe(true);
+    const payload = writePayload('insert');
+    // `'custom_prompt' in payload`, NOT `payload.custom_prompt === undefined`:
+    // the second passes for `{ custom_prompt: undefined }`, which is exactly
+    // the shape PostgREST turns into a PGRST204 on a pre-migration database.
+    expect(Object.prototype.hasOwnProperty.call(payload, 'custom_prompt')).toBe(false);
+    expect(payload.prompt_id).toBe(PROMPT_ID);
+  });
+
+  it('OMITS custom_prompt when an update touches only the answer', async () => {
+    const res = await updateConversationStarter('answer-1', 'A better answer');
+
+    expect(res.success).toBe(true);
+    const payload = writePayload('update');
+    expect(Object.prototype.hasOwnProperty.call(payload, 'custom_prompt')).toBe(false);
+    // …and the answer still goes, so the omission is not the action bailing out.
+    expect(payload.answer).toBe('A better answer');
+  });
+
+  it('OMITS prompt_id when the member wrote the question themselves', async () => {
+    const res = await addConversationStarter({
+      customPrompt: 'What is in my kitchen?',
+      answer: 'A very old kettle.',
+    });
+
+    expect(res.success).toBe(true);
+    const payload = writePayload('insert');
+    // A null prompt_id is what the XOR check wants, and omitting the key is
+    // how the column default supplies it without naming it.
+    expect(Object.prototype.hasOwnProperty.call(payload, 'prompt_id')).toBe(false);
+    expect(payload.custom_prompt).toBe('What is in my kitchen?');
+  });
+
+  it('sends custom_prompt on an update ONLY when the question was edited', async () => {
+    await updateConversationStarter('answer-1', 'Still an old kettle.', 'What is in my kitchen?');
+
+    const payload = writePayload('update');
+    expect(payload.custom_prompt).toBe('What is in my kitchen?');
+    expect(payload.answer).toBe('Still an old kettle.');
+  });
+});
+
+// ===========================================================================
+describe('KAN-445 XOR — a seeded prompt or your own, never both, never neither', () => {
+  it('refuses both at once, writing nothing', async () => {
+    const res = await addConversationStarter({
+      promptId: PROMPT_ID,
+      customPrompt: 'Mine too',
+      answer: 'hi',
+    });
+
+    expect(res.success).toBe(false);
+    // The DB constraint would catch this as a 23514; refusing here is what
+    // turns it into a sentence a member can act on.
+    expect(wrote()).toBe(false);
+  });
+
+  it('refuses neither, writing nothing', async () => {
+    const res = await addConversationStarter({ answer: 'an answer to nothing' });
+
+    expect(res.success).toBe(false);
+    expect(wrote()).toBe(false);
+  });
+
+  it('still refuses a malformed prompt id before touching the database', async () => {
+    const res = await addConversationStarter({ promptId: 'not-a-uuid', answer: 'hi' });
+
+    expect(res.success).toBe(false);
+    expect(wrote()).toBe(false);
+  });
+});
+
+// ===========================================================================
+describe('KAN-445 the member-written question is public text — BOTH paths', () => {
+  it('strips HTML from the question on ADD', async () => {
+    await addConversationStarter({
+      customPrompt: 'What is <b>in</b> my kitchen?<script>alert(1)</script>',
+      answer: 'A kettle.',
+    });
+
+    const question = String(writePayload('insert').custom_prompt);
+    // This renders on the public profile, above the answer.
+    expect(question).not.toContain('<script');
+    expect(question).not.toContain('<b>');
+  });
+
+  it('strips HTML from the question on UPDATE — the sibling a scan cannot separate', async () => {
+    await updateConversationStarter('a1', 'A kettle.', 'What is <i>really</i> in my kitchen?');
+
+    expect(String(writePayload('update').custom_prompt)).not.toContain('<i>');
+  });
+
+  it('caps the question at 140 characters on ADD', async () => {
+    await addConversationStarter({ customPrompt: 'q'.repeat(400), answer: 'A kettle.' });
+
+    // Mirrors `pcs_custom_prompt_length`; an uncapped path fails with a raw
+    // 23514 instead of a clean truncation.
+    expect(String(writePayload('insert').custom_prompt)).toHaveLength(140);
+  });
+
+  it('caps the question at 140 characters on UPDATE', async () => {
+    await updateConversationStarter('a1', 'A kettle.', 'q'.repeat(400));
+
+    expect(String(writePayload('update').custom_prompt)).toHaveLength(140);
+  });
+
+  it('refuses a question that is empty once stripped, writing nothing', async () => {
+    const blank = await addConversationStarter({ customPrompt: '   ', answer: 'A kettle.' });
+    const stripped = await updateConversationStarter('a1', 'A kettle.', '<b></b>');
+
+    // '   ' fails the XOR check (nothing supplied); '<b></b>' survives to the
+    // cleaner and is rejected there. Both must end with nothing written.
+    expect(blank.success).toBe(false);
+    expect(stripped.success).toBe(false);
+    expect(wrote()).toBe(false);
+  });
+
+  it('sends the question through moderation, not just the answer', async () => {
+    await addConversationStarter({ customPrompt: 'What is in my kitchen?', answer: 'A kettle.' });
+
+    expect(mockModerate).toHaveBeenCalledTimes(1);
+    const submitted = String(
+      (mockModerate.mock.calls[0] as unknown[])[1] &&
+        ((mockModerate.mock.calls[0] as unknown[])[1] as { text: string }).text,
+    );
+    // Moderating only the answer would leave the question an unmoderated
+    // public field that any member can fill with anything.
+    expect(submitted).toContain('What is in my kitchen?');
+    expect(submitted).toContain('A kettle.');
+  });
+
+  // The UPDATE twin of the test above. Without it, the edit path could
+  // moderate only the answer and nothing would notice — so a member could
+  // save an innocuous question, pass moderation, then EDIT it to anything at
+  // all, and that text renders as a public heading on their profile. The
+  // question is the half that most needs moderating, and edit is the path
+  // that gets used after the first save.
+  it('sends an EDITED question through moderation too, not just the answer', async () => {
+    await updateConversationStarter('answer-1', 'Still an old kettle.', 'What is in my kitchen now?');
+
+    expect(mockModerate).toHaveBeenCalledTimes(1);
+    const submitted = String(
+      (mockModerate.mock.calls[0] as unknown[])[1] &&
+        ((mockModerate.mock.calls[0] as unknown[])[1] as { text: string }).text,
+    );
+    expect(submitted).toContain('What is in my kitchen now?');
+    expect(submitted).toContain('Still an old kettle.');
+  });
+
+  it('does not write when moderation rejects a member-written question', async () => {
+    mockModerate.mockImplementation(async () => ({ ok: false, error: 'Blocked' }));
+
+    const res = await addConversationStarter({ customPrompt: 'something vile', answer: 'x' });
+
+    expect(res.success).toBe(false);
+    expect(wrote()).toBe(false);
+  });
+});
+
+// ===========================================================================
+describe('KAN-445 cap errors — the custom cap must be read BEFORE the general one', () => {
+  it('maps the custom-question cap to its own copy', async () => {
+    dbError = { message: 'Custom question limit (3) reached' };
+
+    const res = await addConversationStarter({ customPrompt: 'A fourth?', answer: 'x' });
+
+    expect(res.success).toBe(false);
+    // 'Custom question limit (3) reached' ALSO matches the general
+    // /limit \(\d+\) reached/ pattern. Test the general one first and a member
+    // who filled their three own questions is told to delete one of their ten
+    // answers — advice that does not fix anything.
+    if (!res.success) {
+      expect(res.error).toMatch(/up to 3 of your own questions/i);
+      expect(res.error).not.toMatch(/up to 10 prompts/i);
+    }
+  });
+
+  it('still maps the general answer cap to the general copy', async () => {
+    for (const n of [5, 10, 25]) {
+      calls.length = 0;
+      dbError = { message: `Conversation-starter answer limit (${n}) reached` };
+
+      const res = await addConversationStarter({ promptId: PROMPT_ID, answer: 'x' });
+
+      expect(res.success).toBe(false);
+      if (!res.success) expect(res.error).toContain('up to 10 prompts');
+    }
+  });
+
+  it('maps the custom cap on the UPDATE path too', async () => {
+    dbError = { message: 'Custom question limit (3) reached' };
+
+    const res = await updateConversationStarter('a1', 'x', 'A fourth?');
+
+    expect(res.success).toBe(false);
+    if (!res.success) expect(res.error).toMatch(/up to 3 of your own questions/i);
+  });
+});
+
+// ===========================================================================
+// The migration is data + DDL; there is no runtime here to exercise, so this
+// is a source scan — but a comment-stripped one. The migration's own header
+// quotes the eight prompts it retires and names `enforce_pcs_cap()`, so an
+// unstripped scan would match the prose that documents the change rather than
+// the change (SEC-100 / CTL-039's shape, and the reason `is_published` stayed
+// green while suspended members were being indexed).
+// ===========================================================================
+describe('KAN-445 migration — the offered set, and what it must not touch', () => {
+  const ROOT = resolve(__dirname, '../..');
+  const raw = readFileSync(resolve(ROOT, SRC.migrations20260803160000Kan445CustomConversationPrompts), 'utf-8');
+  /** SQL with every `--` comment removed, so only executable text is matched. */
+  const sql = raw
+    .split('\n')
+    .map((line) => line.replace(/--.*$/, ''))
+    .join('\n');
+
+  // Hard-coded from the founder's own document ("Lyra-Profile-Mockups-
+  // Questions-and-Answers.docx" → "The set questions people can answer"),
+  // NOT read out of the migration. A list pinned by mapping over the thing
+  // under test cannot fail.
+  const FOUNDER_PROMPTS = [
+    'If you could invite anyone, living or dead, to a dinner party — who would you have?',
+    "What are you most proud of that wouldn't make it onto your CV?",
+    'If you could have any job — real or not — what would it be?',
+    "Skills I'm trying to learn",
+    "Something I've changed my mind about recently",
+    'What qualities do you most appreciate in your closest friends?',
+    "The best advice I've ever received",
+    'If you could master any skill instantly, what would it be?',
+    "What's a small, daily act of kindness that usually goes unappreciated?",
+    "What's your best childhood memory?",
+  ];
+
+  /**
+   * The statement between two markers.
+   *
+   * Each canonical prompt is named in THREE separate statements — the seed,
+   * the activate/re-order, and the retire-everything-else exclusion list — and
+   * a whole-file `toContain` is satisfied by any one of them. Mutation-proved
+   * on 2026-08-03: dropping a prompt from the seed VALUES list alone left the
+   * whole-file version of this case green, because the other two statements
+   * still named it. Same family as the sibling-drift shape the actions suite
+   * guards against, and the reason each block is now asserted separately.
+   */
+  function block(start: string, end: string): string {
+    const i = sql.indexOf(start);
+    expect(i).toBeGreaterThan(-1);
+    const j = sql.indexOf(end, i + start.length);
+    expect(j).toBeGreaterThan(i);
+    return sql.slice(i, j);
+  }
+
+  const seedBlock = block(
+    'insert into public.conversation_starter_prompts',
+    'on conflict (prompt) do nothing',
+  );
+  const orderBlock = block(
+    'update public.conversation_starter_prompts p',
+    'where p.prompt = v.prompt',
+  );
+  const retireBlock = block('set is_active = false', ');');
+
+  it.each(FOUNDER_PROMPTS)('offers the founder prompt: %s', (prompt) => {
+    // Postgres escapes a literal apostrophe by doubling it.
+    const literal = prompt.replace(/'/g, "''");
+    // Seeded, so a fresh database has it…
+    expect(seedBlock).toContain(literal);
+    // …activated and ordered, so an environment that already had it retired
+    // (or in the 2026-05 order) is corrected…
+    expect(orderBlock).toContain(literal);
+    // …and excluded from the retirement sweep, so step 4 does not immediately
+    // switch off what steps 2 and 3 just turned on.
+    expect(retireBlock).toContain(literal);
+  });
+
+  it('retires exactly the prompts that are not the founder ten', () => {
+    // Counting is what catches an ELEVENTH prompt smuggled into the exclusion
+    // list, which would silently keep a retired prompt on offer.
+    const quoted = retireBlock.match(/'(?:[^']|'')*'/g) ?? [];
+    expect(quoted).toHaveLength(FOUNDER_PROMPTS.length);
+  });
+
+  it('activates the ten and retires the rest without deleting a single row', () => {
+    expect(sql).toMatch(/set\s+is_active\s*=\s*false/i);
+    // A prompt row is the FK target of every answer that chose it. Deleting
+    // one either fails or orphans a member's saved answer.
+    expect(sql).not.toMatch(/delete\s+from\s+public\.conversation_starter_prompts/i);
+  });
+
+  it('makes the seed genuinely idempotent', () => {
+    // `on conflict do nothing` needs something to conflict ON; the table had
+    // no unique key on `prompt`, so without this index a re-run duplicates
+    // every row instead of skipping it.
+    expect(sql).toMatch(/create unique index if not exists[\s\S]*conversation_starter_prompts \(prompt\)/i);
+    expect(sql).toMatch(/on conflict \(prompt\) do nothing/i);
+  });
+
+  it('permits a custom question: nullable prompt_id, a column, and an XOR', () => {
+    expect(sql).toMatch(/alter column prompt_id drop not null/i);
+    expect(sql).toMatch(/add column if not exists custom_prompt text/i);
+    // (a is null) <> (b is null) is true for exactly one of them being set.
+    expect(sql).toMatch(/\(prompt_id is null\) <> \(custom_prompt is null\)/i);
+  });
+
+  it('caps member-written questions at three, on INSERT *and* UPDATE', () => {
+    expect(sql).toMatch(/Custom question limit \(3\) reached/);
+    // INSERT-only would let a member add three custom rows, then flip seeded
+    // rows to custom and sail past the cap.
+    expect(sql).toMatch(/before insert or update on public\.profile_conversation_starters/i);
+  });
+
+  it('renames the section heading everywhere a member can see it', () => {
+    // Not the migration — the two surfaces. Kept here because the rename and
+    // the prompt set are one decision and should fail together.
+    const strip = (text: string) =>
+      text
+        .replace(/\{\/\*[\s\S]*?\*\/\}/g, '') // JSX comments
+        .replace(/\/\*[\s\S]*?\*\//g, '')
+        .replace(/^\s*\/\/.*$/gm, '');
+
+    const publicPage = strip(readFileSync(resolve(ROOT, SRC.slugPage), 'utf-8'));
+    const editor = strip(readFileSync(resolve(ROOT, SRC.editProfileForm), 'utf-8'));
+
+    // CTL-039 had the OLD heading baselined as comment-shadowed on the public
+    // page: the JSX comment above the heading repeated it word for word, so
+    // deleting the heading left the guard green. Stripping comments first is
+    // what makes this assertion about what a member reads.
+    expect(publicPage).toContain('A bit more about me');
+    expect(publicPage).not.toContain('A few more things about me');
+    expect(editor).toContain('A bit more about me');
+  });
+
+  it('does NOT redefine enforce_pcs_cap — the total cap is out of scope', () => {
+    // Raising the production answer cap is an open founder decision. Rewriting
+    // this function here would bake one number into every environment the
+    // migration reaches, which is precisely the change that is not ours.
+    // The header comment discusses it at length; comment-stripping is what
+    // makes this assertion about the SQL rather than about the prose.
+    expect(sql).not.toMatch(/create or replace function public\.enforce_pcs_cap/i);
+  });
+});
+
+// ───────────── The read sites and the member-facing surface ─────────────
+
+// Review found the 42703 read-side defence pinned on only ONE of the three
+// read sites, and the two user-visible halves of the feature completely
+// unguarded. Each of these four mutations previously left the FULL suite
+// green: naming custom_prompt in an explicit column list on the public page
+// or the legacy editor (a 42703 on a pre-migration environment, which the
+// public page's error handler turns into a hard 500 on EVERY published
+// profile); dropping `customPrompt ??` so the public profile ignores the
+// member's own question entirely; and deleting the whole write-your-own UI
+// block — KAN-445's headline deliverable — which even left type-check green.
+// Comments are stripped so none of these can be satisfied by prose.
+describe('KAN-445: every read site and the write-your-own surface', () => {
+  const root = resolve(__dirname, '../..');
+  const noComments = (text: string) =>
+    text
+      .replace(/\{\s*\/\*[\s\S]*?\*\/\s*\}/g, ' ')
+      .replace(/\/\*[\s\S]*?\*\//g, ' ')
+      .replace(/(^|[^:])\/\/[^\n]*/g, '$1');
+  const src = (rel: string) => noComments(readFileSync(resolve(root, rel), 'utf-8'));
+  const publicPage = src(SRC.slugPage);
+  const legacyPage = src(SRC.legacyPage);
+  const step = src(SRC.conversationStartersStep);
+
+  // select('*') tolerates a missing column; naming it does not.
+  it('the public profile reads starters with select(*), never a column list naming custom_prompt', () => {
+    expect(publicPage).toContain("select('*, prompt:conversation_starter_prompts");
+    expect(publicPage).not.toMatch(/select\('[^']*custom_prompt/);
+  });
+
+  it('the legacy editor reads starters with select(*) too', () => {
+    expect(legacyPage).toContain("select('*, prompt:conversation_starter_prompts");
+    expect(legacyPage).not.toMatch(/select\('[^']*custom_prompt/);
+  });
+
+  it('the public profile prefers the member-written question over the seeded one', () => {
+    expect(publicPage).toMatch(/customPrompt\s*\?\?\s*joined\?\.prompt/);
+  });
+
+  it('the write-your-own UI exists in the editor', () => {
+    expect(step).toContain('Write your own question');
+    expect(step).toContain('ownOpen');
+  });
+});
+

--- a/tests/unit/conversation-starters.test.ts
+++ b/tests/unit/conversation-starters.test.ts
@@ -117,8 +117,12 @@ describe('KAN-181 conversation starters — surface-area regression guards', () 
       'utf-8',
     );
     expect(src).toMatch(/profile_conversation_starters/);
-    // KAN-265 redesign renamed the public heading to "A few more things about me".
-    expect(src).toMatch(/A few more things about me/);
+    // KAN-265 named the public heading; KAN-445 renamed it again, to the
+    // founder's wording. The old literal also appeared in the JSX comment two
+    // lines above the heading, which is why CTL-039 had this assertion
+    // baselined as comment-shadowed — the comment no longer repeats the
+    // heading, so this now matches the rendered text and nothing else.
+    expect(src).toMatch(/A bit more about me/);
   });
 
   test('dashboard profile page fetches conversation starter data', () => {

--- a/tests/unit/profile-page-conversation-starters.test.tsx
+++ b/tests/unit/profile-page-conversation-starters.test.tsx
@@ -107,7 +107,13 @@ jest.mock('@/app/dashboard/profile/edit-profile-form', () => ({
 
 import ProfilePage from '@/app/dashboard/profile/page';
 
-type Answer = { id: string; prompt_id: string; answer: string; prompt: string };
+type Answer = {
+  id: string;
+  prompt_id: string | null;
+  answer: string;
+  prompt: string;
+  custom_prompt: string | null;
+};
 
 async function renderProps(): Promise<Record<string, unknown>> {
   const el = (await ProfilePage()) as ReactElement;
@@ -168,8 +174,17 @@ describe('profile editor page — conversation starters (behavioural, KAN-414 F4
 
     const answers = (await renderProps()).conversationAnswers as Answer[];
 
+    // KAN-445 added `custom_prompt` to the shape the page hands the editor.
+    // Kept as an exact `toEqual` — asserting the WHOLE object is what makes a
+    // silently dropped field fail, so it is not relaxed to a subset match.
     expect(answers).toEqual([
-      { id: 'a1', prompt_id: 'p1', answer: 'Middlemarch', prompt: 'What are you reading?' },
+      {
+        id: 'a1',
+        prompt_id: 'p1',
+        answer: 'Middlemarch',
+        prompt: 'What are you reading?',
+        custom_prompt: null,
+      },
     ]);
   });
 
@@ -198,5 +213,79 @@ describe('profile editor page — conversation starters (behavioural, KAN-414 F4
     // take it down.
     expect(answers.map((a) => a.prompt)).toEqual(['', '']);
     expect(answers.map((a) => a.answer)).toEqual(['Middlemarch', 'Solaris']);
+  });
+});
+
+// ===========================================================================
+// KAN-445 — questions the member wrote themselves, and the migration-ordering
+// hazard on the READ side.
+//
+// The write-side hazard (a payload KEY for a column that does not exist yet)
+// is pinned in tests/unit/conversation-starters-custom-prompts.test.ts. The
+// read side is the mirror of it and is arguably worse: PostgREST rejects the
+// WHOLE query with 42703 when a SELECT names a column it does not know, so
+// naming `custom_prompt` before 20260803160000 lands would blank the profile
+// editor for every member on that environment.
+// ===========================================================================
+describe('profile editor page — member-written questions (KAN-445)', () => {
+  it('never NAMES custom_prompt in the select, so a pre-migration read still works', async () => {
+    await renderProps();
+
+    const selects = argsFor('profile_conversation_starters', 'select').map((a) => String(a[0]));
+    expect(selects).toHaveLength(1);
+    // Asserted on the query the code actually ISSUES, not on the source text —
+    // a comment mentioning the column cannot satisfy this.
+    expect(selects[0]).not.toContain('custom_prompt');
+    // …and it is a real read, not an empty one: the prompt join must survive.
+    expect(selects[0]).toContain('conversation_starter_prompts');
+  });
+
+  it('shows the member’s own question as the question, with prompt_id null', async () => {
+    tables.profile_conversation_starters = [
+      {
+        id: 'a1',
+        prompt_id: null,
+        answer: 'A very old kettle.',
+        custom_prompt: 'What is in my kitchen?',
+        prompt: null,
+      },
+    ];
+
+    const answers = (await renderProps()).conversationAnswers as Answer[];
+
+    // There is no seeded prompt to join to, so falling back to the join would
+    // render the answer under a blank heading.
+    expect(answers[0].prompt).toBe('What is in my kitchen?');
+    expect(answers[0].custom_prompt).toBe('What is in my kitchen?');
+    expect(answers[0].prompt_id).toBeNull();
+  });
+
+  it('renders a row from a database that has no custom_prompt column at all', async () => {
+    // Exactly the shape a pre-migration environment returns: the key is simply
+    // absent from the row.
+    tables.profile_conversation_starters = [
+      { id: 'a1', prompt_id: 'p1', answer: 'Middlemarch', prompt: { prompt: 'What are you reading?' } },
+    ];
+
+    const answers = (await renderProps()).conversationAnswers as Answer[];
+
+    expect(answers[0].custom_prompt).toBeNull();
+    expect(answers[0].prompt).toBe('What are you reading?');
+  });
+
+  it('keeps a seeded prompt winning over an absent custom question', async () => {
+    tables.profile_conversation_starters = [
+      {
+        id: 'a1',
+        prompt_id: 'p1',
+        answer: 'Middlemarch',
+        custom_prompt: null,
+        prompt: { prompt: 'What are you reading?' },
+      },
+    ];
+
+    const answers = (await renderProps()).conversationAnswers as Answer[];
+
+    expect(answers[0].prompt).toBe('What are you reading?');
   });
 });

--- a/tests/unit/profile-sections.test.js
+++ b/tests/unit/profile-sections.test.js
@@ -137,7 +137,8 @@ describe('KAN-137 / KAN-265: Public profile renders all categories (redesign)', 
 
   test('questions + conversation starters render as a Q&A section', () => {
     expect(content).toContain("groupedItems['questions']");
-    expect(content).toContain('A few more things about me');
+    // KAN-445 renamed the heading to the founder's wording.
+    expect(content).toContain('A bit more about me');
   });
 
   test('billboard has special large-quote rendering', () => {


### PR DESCRIPTION
Founder-approved design change of 2026-08-02 (epic KAN-441).

## What changes
Renames the section to **"A bit more about me"** with a softer intro, restores your **ten original prompts** as the offered set, and lets a member **write up to three questions of their own**.

## Migration `20260803160000` — written, **not applied**
The current model **forbids** a member-written question: `prompt_id` is `NOT NULL` with no custom text column. So `prompt_id` becomes nullable, `custom_prompt` is added with a length check, an **XOR constraint** makes a row either a seeded prompt or a custom one (never both, never neither), and a second independent trigger caps custom questions at three. Prompts leaving the offered set are **deactivated, never deleted** — answers reference them.

## ⚠️ The part that needed a second pass
Deactivating a prompt would have **blanked the question above every existing answer to it**.

The only select policy on `conversation_starter_prompts` is `using (is_active = true)`, and both editors read the question for a **saved** answer through the RLS-scoped cookie client via a PostgREST embedded resource — which RLS filters. Members would have opened their editor to an **unlabelled block of their own text**, while the public profile still showed the question correctly (that page uses the service-role client and bypasses RLS). Editor and live profile would disagree.

**Step 4b** adds a policy letting a member read prompts their *own* answers reference. Policies for the same command are OR'd, so it only **adds** visibility — nothing about anyone else's answers, nothing about prompts they haven't answered.

## Scope — production cap untouched
The **total answer cap is not changed**. Migration `20260704130000` (5→10) is still dev/staging-only, and raising it on production **remains an open decision for you**. The new custom cap is a separate trigger counting only custom rows.

## PGRST204 and its read-side twin
`custom_prompt` enters a payload **only when there's a value** — proven on both insert and update. The read side uses `select('*')` at **all three** sites rather than naming the column, so a pre-migration environment degrades instead of 42703-ing. That matters most on the public page, whose section error handler *throws* — a named column there would be a hard **500 on every published profile**.

## Testing — 39 tests, mutation-verified
Six defects that previously left the **full suite green** now fail it:

| Mutation | Was | Now |
|---|---|---|
| Public page names `custom_prompt` in its column list | green | **RED** |
| Legacy editor names `custom_prompt` | green | **RED** |
| Public render drops the member's own question | green | **RED** |
| Entire write-your-own UI deleted (type-check stayed green too) | green | **RED** |
| **Edit path moderates only the answer, not the question** | green | **RED** |

That last one mattered: a member could save an innocuous question, pass moderation, then **edit it to anything** and have it render as a public heading.

`type-check` clean · `lint` 0 errors · `test:unit` 2924 passed / 2942 (floor 2705); the 18 failures are the two documented macOS-only script suites. `check-migration-privileges.py` green.

## ⚠️ Needs your sign-off — four pre-existing assertions changed
Three are the **intentional rename** ("A few more things about me" → "A bit more about me") in `conversation-starters.test.ts`, `profile-sections.test.js` and an e2e OR-list. The fourth **gained** `custom_prompt: null` in an exact `toEqual` — strengthened, not relaxed. None deleted, skipped or loosened.

## Known gaps (documented, not blockers)
- The migration's numeric DDL limits (custom cap `3`, length `140`) are asserted by their **labels** rather than their values, so a threshold could drift from the app's without failing. Same family as **[KAN-459](https://checklyra.atlassian.net/browse/KAN-459)**.
- `updateConversationStarter` doesn't check the target row *is* a custom row, so a hand-crafted call violating the XOR returns a raw Postgres error rather than a sentence. Auth, ownership and rate-limiting are all correctly enforced — this is robustness, not a hole.
- **Two founder documents disagree** on the prompt set (ten offered vs seven + three custom), and on one prompt's wording ("to your CV" vs "onto your CV"). I used ten offered; worth confirming.

MCP coverage: deferred — `custom_prompt` is a new user-writable column; follow-up to be raised before promote past dev (KAN-222 lockstep).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[KAN-459]: https://checklyra.atlassian.net/browse/KAN-459?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ