### PR TITLE
fix(deps): close npm-audit HIGH advisories (brace-expansion/fast-uri/ip-address)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2809,9 +2809,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2827,9 +2824,6 @@
       "integrity": "sha512-0qjhiYBaKAqF63LA1ZWAAnKTzFUguAaZiRa5etMLGGPj/B6uEVjtIZldIzFEp3wHlB0koK6aTzqPtSdplTCjoA==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -2847,9 +2841,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2865,9 +2856,6 @@
       "integrity": "sha512-qSjL/uppm+cbh21s72Ss8gkiOhQ4dExWHNGOWy6eZV7STj5WsKehgxT61beSsOj+YYQuTplL376lOCdMQU5T8w==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -6777,9 +6765,9 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
@@ -8950,9 +8938,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
-      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
       "funding": [
         {
           "type": "github",
@@ -10095,9 +10083,9 @@
       }
     },
     "node_modules/ip-address": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
-      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.4.0.tgz",
+      "integrity": "sha512-oSK96Grm3aP6OrS263xVxbNDGVL7rzBtYdpGqlDG8iQdoenDoTs/nkki+DflYbAEE8Xl6o5YxhxlrKvI3nqKXQ==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
   "overrides": {
     "postcss": "^8.5.18",
     "tmp": "^0.2.7",
-    "brace-expansion": "5.0.8",
+    "brace-expansion": "5.0.9",
     "@eslint/config-array": {
       "minimatch": "^10.2.5"
     },
@@ -66,7 +66,8 @@
     },
     "js-yaml@^3.0.0": "3.15.0",
     "js-yaml@^4.0.0": "4.3.0",
-    "fast-uri@^3.0.0": "3.1.4",
-    "sharp": "0.35.3"
+    "fast-uri@^3.0.0": "3.1.5",
+    "sharp": "0.35.3",
+    "ip-address": "^10.4.0"
   }
 }


### PR DESCRIPTION
## Summary

The weekly health+regression routine's `audit` phase (`npm audit --audit-level=high`) went red on develop. Three advisories, none present when SEC-94 last touched these packages:

- **brace-expansion** `GHSA-rgw5-rvv9-x895` — bypasses the exact SEC-94 5.0.8 mitigation. Bumped to 5.0.9.
- **fast-uri** `GHSA-7p8r-x3mc-p8w7` — the SEC-94 override pinned exactly the vulnerable 3.1.4. Bumped to 3.1.5.
- **ip-address** `GHSA-mwp4-54f8-5fhr` — dev-only (`@lhci/cli` chain). Bumped to `^10.4.0`.

`ajv` and `minimatch` high findings were downstream of the above two and clear automatically. All three are patch-level bumps within already-vetted major versions (no new eslint-minimatch incompatibility — see CLAUDE.md gotcha #23).

`npm audit --audit-level=high`: 8 high → 0 (2 moderate remain, non-blocking per policy).

## Jira Ticket

SEC-123

## Checklist

- [ ] Unit tests added/updated for new/changed functionality — n/a, dependency-version-only change, no code touched
- [x] All existing tests pass (`npm run test:unit`) — 250/250 suites, 2996/2996 tests
- [x] Lint passes (`npm run lint`) — 0 errors, 31 pre-existing warnings, byte-identical to baseline
- [x] Type check passes (`npm run type-check`)
- [x] Build succeeds (`npm run build`)
- [ ] Coverage has not decreased — no code changed, coverage unaffected
- [x] No eslint-disable or ts-ignore without KAN-XX reference — n/a, no source changes
- [x] Dependency-rule gate reviewed — n/a, `package.json`/`package-lock.json` only, no import graph change
- [ ] ARCHITECTURE.md updated if architectural changes were made — N/A, dependency patch only
- [ ] Ops routine / Control-Room registry updated — N/A, no routine/cadence/ownership change
- [ ] Docs / system map updated — N/A with reason: pure dependency-version bump, no architecture/env/route/table/job change

MCP coverage: deferred — dependency-only fix, no user-facing surface change (N/A, not a KAN feature ticket)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rvto19CtK5JbdxaMo1yqof)_