### PR TITLE
fix(KAN-459): CTL-039 resolve indirected reads — it was blind to all of tests/scripts/

### DIFF
--- a/scripts/check-comment-only-assertions.py
+++ b/scripts/check-comment-only-assertions.py
@@ -196,8 +196,35 @@ PATH_LIT = re.compile(
 # that happens to read a file reported `expect(ctl.prevents).toContain('SEC-100')`
 # — an assertion about a parsed JSON array — against a workflow file. A guard
 # whose own first run produces false positives teaches people to ignore it.
+#
+# KAN-459: the declarator is OPTIONAL. The commonest shape in this repo splits
+# the declaration from the assignment —
+#
+#     let content;
+#     beforeAll(() => { content = fs.readFileSync(profilePath, 'utf8'); });
+#
+# so requiring `const|let|var` on the assignment line missed it entirely. The
+# `(?:^|[;{\n])\s*` prefix keeps this anchored to a statement start, so a
+# property write (`obj.src = readFileSync(...)`) still does not match — that
+# would attribute an assertion to a receiver nobody asserts on.
 RECEIVER = re.compile(
-    r"(?:const|let|var)\s+([A-Za-z_$][\w$]*)\s*=\s*[^;]*?readFileSync"
+    r"(?:^|[;{\n])\s*(?:(?:const|let|var)\s+)?([A-Za-z_$][\w$]*)\s*=\s*[^;]*?readFileSync",
+    re.M,
+)
+
+# A path held in a VARIABLE rather than passed inline:
+#
+#     const profilePath = path.join(root, SRC.slugPage);
+#     ... fs.readFileSync(profilePath, 'utf8')
+#
+# Without this, `resolve_subject` sees the identifier `profilePath`, finds
+# neither an `SRC.<key>` nor a path literal, and skips the block — which is how
+# KAN-459's instance went unreported. Every CTL-039 blind spot so far has been
+# attribution, never comment syntax; this closes the fourth.
+PATH_VAR = re.compile(
+    r"(?:const|let|var)\s+([A-Za-z_$][\w$]*)\s*=\s*"
+    r"([^;\n]*?(?:SRC\.[A-Za-z_$][\w$]*"
+    r"|['\"](?:\.{1,2}/)*(?:src|scripts|supabase|public|controls)/[^'\"]+['\"])[^;\n]*)"
 )
 
 
@@ -224,12 +251,33 @@ def _assert_re(var: str) -> re.Pattern:
 SCOPE = re.compile(r"\n\s*(?:test|it)\s*\(")
 
 
-def resolve_subject(expr: str, manifest: dict) -> str | None:
+def path_vars(text: str, manifest: dict) -> dict[str, str]:
+    """Map variables that hold a subject path to the subject they resolve to."""
+    out: dict[str, str] = {}
+    for m in PATH_VAR.finditer(text):
+        subject = _direct_subject(m.group(2), manifest)
+        if subject:
+            out[m.group(1)] = subject
+    return out
+
+
+def _direct_subject(expr: str, manifest: dict) -> str | None:
     m = SRC_KEY.search(expr)
     if m:
         return manifest.get(m.group(1))
     m = PATH_LIT.search(expr)
     return m.group(1) if m else None
+
+
+def resolve_subject(expr: str, manifest: dict, pvars: dict | None = None) -> str | None:
+    direct = _direct_subject(expr, manifest)
+    if direct:
+        return direct
+    # Fall back to a variable that holds the path (KAN-459).
+    for name, subject in (pvars or {}).items():
+        if re.search(rf"\b{re.escape(name)}\b", expr):
+            return subject
+    return None
 
 
 def scopes_of(text: str) -> tuple[str, list[str]]:
@@ -296,13 +344,17 @@ def analyse(root: Path, rel: str, manifest: dict) -> list[dict]:
         return []
 
     preamble, blocks = scopes_of(text)
+    # File-wide, because a path variable is declared once at describe level and
+    # used inside a beforeAll several blocks later (KAN-459).
+    pvars = path_vars(text, manifest)
 
     def subjects_in(chunk: str) -> list[str]:
         return sorted(
             {
                 x
                 for x in (
-                    resolve_subject(m.group(1), manifest) for m in READ.finditer(chunk)
+                    resolve_subject(m.group(1), manifest, pvars)
+                    for m in READ.finditer(chunk)
                 )
                 if x
             }
@@ -585,6 +637,53 @@ def self_test() -> int:
         if got:
             check("  ...and is comment-shadowed, not comment-only",
                   1 if got[0]["severity"] == "comment-shadowed" else 0, 1)
+
+    # --- KAN-459: indirected read (path in a var + bare assignment) ----------
+    with tempfile.TemporaryDirectory() as td:
+        r = Path(td)
+        (r / "src").mkdir(parents=True)
+        (r / "src" / "page.tsx").write_text(
+            "export default function P() {\n"
+            "  return (\n"
+            "    {/* A few of my favourite things */}\n"
+            "    <h2>Favourites</h2>\n"
+            "  );\n"
+            "}\n"
+        )
+        (r / "tests" / "unit").mkdir(parents=True)
+        (r / "tests" / "unit" / "t.test.js").write_text(
+            "const profilePath = path.join(root, 'src/page.tsx');\n"
+            "let content;\n"
+            "describe('d', () => {\n"
+            "  beforeAll(() => { content = fs.readFileSync(profilePath, 'utf8'); });\n"
+            "  test('t', () => {\n"
+            "    expect(content).toContain('A few of my favourite things');\n"
+            "  });\n"
+            "});\n"
+        )
+        got = scan(r, ["tests/unit/t.test.js"], {})
+        # Path held in a variable AND assigned without a declarator. Requiring
+        # either to be inline missed this, and it is the commonest shape in
+        # tests/scripts/ — the control was blind to that whole directory.
+        check("KAN-459: path-in-variable + bare assignment is seen", len(got), 1)
+
+    # A property write must still NOT be treated as a receiver — otherwise the
+    # optional declarator would attribute assertions to things nobody asserts on.
+    with tempfile.TemporaryDirectory() as td:
+        r = Path(td)
+        (r / "src").mkdir(parents=True)
+        (r / "src" / "a.ts").write_text("// marker text\nconst x = 1;\n")
+        (r / "tests" / "unit").mkdir(parents=True)
+        (r / "tests" / "unit" / "t.test.js").write_text(
+            "describe('d', () => {\n"
+            "  test('t', () => {\n"
+            "    obj.src = fs.readFileSync('src/a.ts', 'utf8');\n"
+            "    expect(unrelated).toContain('marker text');\n"
+            "  });\n"
+            "});\n"
+        )
+        got = scan(r, ["tests/unit/t.test.js"], {})
+        check("a property write is not a receiver", len(got), 0)
 
     # --- (2) scoped subject attribution --------------------------------------
     with tempfile.TemporaryDirectory() as td:

--- a/tests/support/comment-assertion-baseline.json
+++ b/tests/support/comment-assertion-baseline.json
@@ -3,6 +3,96 @@
   "ticket": "KAN-440",
   "findings": [
     {
+      "test": "tests/scripts/check-extraction-dod.test.js",
+      "subject": "scripts/check-extraction-dod.sh",
+      "assertion": "/EXTRACTION-DOD-OK/",
+      "severity": "comment-shadowed"
+    },
+    {
+      "test": "tests/scripts/check-extraction-dod.test.js",
+      "subject": "scripts/check-extraction-dod.sh",
+      "assertion": "/exit 2/",
+      "severity": "comment-shadowed"
+    },
+    {
+      "test": "tests/scripts/check-workflow-integrity.test.js",
+      "subject": "scripts/check-workflow-integrity.sh",
+      "assertion": "/LYRA_RELEASE_PAT/",
+      "severity": "comment-shadowed"
+    },
+    {
+      "test": "tests/scripts/check-workflow-integrity.test.js",
+      "subject": "scripts/check-workflow-integrity.sh",
+      "assertion": "/Pattern 5/",
+      "severity": "comment-shadowed"
+    },
+    {
+      "test": "tests/scripts/check-workflow-integrity.test.js",
+      "subject": "scripts/check-workflow-integrity.sh",
+      "assertion": "/Pattern 6/",
+      "severity": "comment-shadowed"
+    },
+    {
+      "test": "tests/scripts/check-workflow-integrity.test.js",
+      "subject": "scripts/check-workflow-integrity.sh",
+      "assertion": "/git push origin main/",
+      "severity": "comment-shadowed"
+    },
+    {
+      "test": "tests/scripts/check-workflow-integrity.test.js",
+      "subject": "scripts/check-workflow-integrity.sh",
+      "assertion": "/sec-66/",
+      "severity": "comment-shadowed"
+    },
+    {
+      "test": "tests/scripts/check-workflow-integrity.test.js",
+      "subject": "scripts/check-workflow-integrity.sh",
+      "assertion": "/sec-86/",
+      "severity": "comment-shadowed"
+    },
+    {
+      "test": "tests/scripts/daily-security-check.test.js",
+      "subject": "scripts/daily-security-check.sh",
+      "assertion": "/UNVERIFIED/",
+      "severity": "comment-shadowed"
+    },
+    {
+      "test": "tests/scripts/daily-security-check.test.js",
+      "subject": "scripts/daily-security-check.sh",
+      "assertion": "/\\bFAIL\\b/",
+      "severity": "comment-shadowed"
+    },
+    {
+      "test": "tests/scripts/daily-security-check.test.js",
+      "subject": "scripts/daily-security-check.sh",
+      "assertion": "/\\bPASS\\b/",
+      "severity": "comment-shadowed"
+    },
+    {
+      "test": "tests/scripts/weekly-health-regression.test.js",
+      "subject": "scripts/weekly-health-regression.sh",
+      "assertion": "/UNVERIFIED/",
+      "severity": "comment-shadowed"
+    },
+    {
+      "test": "tests/scripts/weekly-health-regression.test.js",
+      "subject": "scripts/weekly-health-regression.sh",
+      "assertion": "/exit 1/",
+      "severity": "comment-shadowed"
+    },
+    {
+      "test": "tests/unit/affiliate-badge.test.js",
+      "subject": "src/components/AffiliateBadge.tsx",
+      "assertion": "/no commission/",
+      "severity": "comment-shadowed"
+    },
+    {
+      "test": "tests/unit/affiliate-badge.test.js",
+      "subject": "src/components/AffiliateBadge.tsx",
+      "assertion": "commission",
+      "severity": "comment-shadowed"
+    },
+    {
       "test": "tests/unit/affiliations-and-autosave.test.ts",
       "subject": "src/app/dashboard/profile/page.tsx",
       "assertion": "/conversation_starter_prompts/",
@@ -33,10 +123,88 @@
       "severity": "comment-shadowed"
     },
     {
+      "test": "tests/unit/auth-confirm-route.test.ts",
+      "subject": "src/app/auth/confirm/route.ts",
+      "assertion": "/token_hash/",
+      "severity": "comment-shadowed"
+    },
+    {
+      "test": "tests/unit/auth-confirm-route.test.ts",
+      "subject": "src/app/auth/confirm/route.ts",
+      "assertion": "/verifyOtp/",
+      "severity": "comment-shadowed"
+    },
+    {
+      "test": "tests/unit/auth.test.js",
+      "subject": "src/app/(auth)/actions.ts",
+      "assertion": "// export async function signInWithApple",
+      "severity": "comment-only"
+    },
+    {
+      "test": "tests/unit/auth.test.js",
+      "subject": "src/app/(auth)/actions.ts",
+      "assertion": "KAN-37",
+      "severity": "comment-only"
+    },
+    {
+      "test": "tests/unit/auth.test.js",
+      "subject": "src/app/(auth)/actions.ts",
+      "assertion": "export async function signIn",
+      "severity": "comment-shadowed"
+    },
+    {
+      "test": "tests/unit/auth.test.js",
+      "subject": "src/middleware.ts",
+      "assertion": "/dashboard",
+      "severity": "comment-shadowed"
+    },
+    {
+      "test": "tests/unit/auth.test.js",
+      "subject": "src/middleware.ts",
+      "assertion": "/login",
+      "severity": "comment-shadowed"
+    },
+    {
+      "test": "tests/unit/backup.test.js",
+      "subject": ".github/workflows/backup-database.yml",
+      "assertion": "SUPABASE_DB_URL",
+      "severity": "comment-shadowed"
+    },
+    {
+      "test": "tests/unit/convene/connections-page.test.ts",
+      "subject": "src/app/api/convene/cron/token-health/route.ts",
+      "assertion": "/Bearer/",
+      "severity": "comment-shadowed"
+    },
+    {
+      "test": "tests/unit/convene/connections-page.test.ts",
+      "subject": "src/app/api/convene/cron/token-health/route.ts",
+      "assertion": "/CRON_SECRET/",
+      "severity": "comment-shadowed"
+    },
+    {
+      "test": "tests/unit/convene/connections-page.test.ts",
+      "subject": "src/app/dashboard/convene/connections/page.tsx",
+      "assertion": "/isConveneEnabled\\(\\)/",
+      "severity": "comment-only"
+    },
+    {
+      "test": "tests/unit/convene/dispatch.test.ts",
+      "subject": "src/app/api/convene/cron/send-invites/route.ts",
+      "assertion": "/CRON_SECRET/",
+      "severity": "comment-shadowed"
+    },
+    {
+      "test": "tests/unit/convene/gathering-ui.test.ts",
+      "subject": "src/app/dashboard/convene/gatherings/[id]/actions.ts",
+      "assertion": "/calendar_event_added/",
+      "severity": "comment-shadowed"
+    },
+    {
       "test": "tests/unit/conversation-starters.test.ts",
       "subject": "src/app/dashboard/profile/conversation-starters-actions.ts",
       "assertion": "/500/",
-      "severity": "comment-shadowed"
+      "severity": "comment-only"
     },
     {
       "test": "tests/unit/conversation-starters.test.ts",
@@ -63,15 +231,93 @@
       "severity": "comment-shadowed"
     },
     {
+      "test": "tests/unit/examples-page.test.js",
+      "subject": "src/app/examples/page.tsx",
+      "assertion": "LYRA_FORCE_WAITLIST",
+      "severity": "comment-shadowed"
+    },
+    {
+      "test": "tests/unit/examples-page.test.js",
+      "subject": "src/app/examples/page.tsx",
+      "assertion": "isProdDeploy",
+      "severity": "comment-shadowed"
+    },
+    {
+      "test": "tests/unit/examples-page.test.js",
+      "subject": "src/app/examples/page.tsx",
+      "assertion": "is_homepage_example",
+      "severity": "comment-shadowed"
+    },
+    {
+      "test": "tests/unit/examples-page.test.js",
+      "subject": "src/app/page.tsx",
+      "assertion": "See example profiles",
+      "severity": "comment-shadowed"
+    },
+    {
       "test": "tests/unit/forgot-reset-password.test.ts",
       "subject": "src/app/(auth)/actions.ts",
       "assertion": "/resetPasswordForEmail/",
       "severity": "comment-shadowed"
     },
     {
+      "test": "tests/unit/forgot-reset-password.test.ts",
+      "subject": "src/app/(auth)/reset-password/page.tsx",
+      "assertion": "/updateRecoveryPassword/",
+      "severity": "comment-shadowed"
+    },
+    {
+      "test": "tests/unit/gdpr-settings.test.js",
+      "subject": "src/app/dashboard/settings/actions.ts",
+      "assertion": "user.email",
+      "severity": "comment-shadowed"
+    },
+    {
       "test": "tests/unit/gdpr.test.js",
       "subject": "src/app/dashboard/settings/actions.ts",
       "assertion": "deleteAccount",
+      "severity": "comment-shadowed"
+    },
+    {
+      "test": "tests/unit/homepage-content.test.js",
+      "subject": "src/app/page.tsx",
+      "assertion": "A few people to meet",
+      "severity": "comment-shadowed"
+    },
+    {
+      "test": "tests/unit/homepage-content.test.js",
+      "subject": "src/app/page.tsx",
+      "assertion": "Be understood.",
+      "severity": "comment-shadowed"
+    },
+    {
+      "test": "tests/unit/homepage-content.test.js",
+      "subject": "src/app/page.tsx",
+      "assertion": "Find someone",
+      "severity": "comment-shadowed"
+    },
+    {
+      "test": "tests/unit/homepage-content.test.js",
+      "subject": "src/app/page.tsx",
+      "assertion": "See example profiles",
+      "severity": "comment-shadowed"
+    },
+    {
+      "test": "tests/unit/homepage-content.test.js",
+      "subject": "src/app/page.tsx",
+      "assertion": "is_homepage_example",
+      "severity": "comment-shadowed"
+    },
+    {
+      "test": "tests/unit/homepage-content.test.js",
+      "subject": "src/app/page.tsx",
+      "assertion": "is_published",
+      "severity": "comment-shadowed"
+    },
+    {
+      "test": "tests/unit/kan351-public-profile-data-integrity.test.ts",
+      "subject": "src/app/[slug]/page.tsx",
+      "assertion": "/sectionReadErrors/",
       "severity": "comment-shadowed"
     },
     {
@@ -99,9 +345,51 @@
       "severity": "comment-only"
     },
     {
+      "test": "tests/unit/photo-upload.test.js",
+      "subject": "src/app/dashboard/profile/steps/identity-step.tsx",
+      "assertion": "preview",
+      "severity": "comment-shadowed"
+    },
+    {
+      "test": "tests/unit/photo-upload.test.js",
+      "subject": "supabase/migrations/20260330120000_add_avatar_url_and_storage.sql",
+      "assertion": "avatar_url",
+      "severity": "comment-shadowed"
+    },
+    {
+      "test": "tests/unit/photo-upload.test.js",
+      "subject": "supabase/migrations/20260330120000_add_avatar_url_and_storage.sql",
+      "assertion": "profile-photos",
+      "severity": "comment-shadowed"
+    },
+    {
+      "test": "tests/unit/profile-items-visibility-migration.test.js",
+      "subject": "src/app/dashboard/profile/actions.ts",
+      "assertion": "coerceVisibility",
+      "severity": "comment-shadowed"
+    },
+    {
       "test": "tests/unit/public-profile.test.js",
       "subject": "src/app/[slug]/page.tsx",
       "assertion": "notFound",
+      "severity": "comment-shadowed"
+    },
+    {
+      "test": "tests/unit/pwa-manifest.test.ts",
+      "subject": "src/app/install-prompt.tsx",
+      "assertion": "/Share/",
+      "severity": "comment-shadowed"
+    },
+    {
+      "test": "tests/unit/pwa-manifest.test.ts",
+      "subject": "src/app/install-prompt.tsx",
+      "assertion": "beforeinstallprompt",
+      "severity": "comment-shadowed"
+    },
+    {
+      "test": "tests/unit/pwa-manifest.test.ts",
+      "subject": "src/app/install-prompt.tsx",
+      "assertion": "display-mode",
       "severity": "comment-shadowed"
     },
     {
@@ -132,6 +420,30 @@
       "test": "tests/unit/retention/gatherings-retention.test.ts",
       "subject": "supabase/migrations/20260717033000_sec74_gatherings_retention_purge.sql",
       "assertion": "/security definer/",
+      "severity": "comment-shadowed"
+    },
+    {
+      "test": "tests/unit/search-page.test.js",
+      "subject": "src/app/page.tsx",
+      "assertion": "Find someone",
+      "severity": "comment-shadowed"
+    },
+    {
+      "test": "tests/unit/search-page.test.js",
+      "subject": "src/app/search/page.tsx",
+      "assertion": "found",
+      "severity": "comment-shadowed"
+    },
+    {
+      "test": "tests/unit/search-page.test.js",
+      "subject": "src/app/search/page.tsx",
+      "assertion": "is_published",
+      "severity": "comment-shadowed"
+    },
+    {
+      "test": "tests/unit/search-page.test.js",
+      "subject": "src/app/search/page.tsx",
+      "assertion": "true",
       "severity": "comment-shadowed"
     },
     {


### PR DESCRIPTION
## The ticket's stated cause is wrong

KAN-459 attributes the miss to the JSX-comment form. `{/* … */}` in a `.tsx` file is **already stripped**, and a *direct* read of that exact shape **is** flagged — verified before changing anything.

## The real cause: attribution, in two independent places

```js
const profilePath = path.join(root, SRC.slugPage);   // path in a VARIABLE
let content;                                          // declared separately
beforeAll(() => {
  content = fs.readFileSync(profilePath, 'utf8');     // BARE assignment
});
```

- `resolve_subject()` looked for `SRC.<key>` or a path literal in the `readFileSync` argument, found the identifier `profilePath`, resolved nothing, and skipped the block.
- `RECEIVER` required `const|let|var` and found a bare `content = …`.

Either miss alone was sufficient. Reproduced both ways: **direct → flagged, indirected → missed → now flagged.**

## Scale of the miss

**Findings 26 → 77, across 35 test files.** Not noise: `tests/scripts/` almost universally uses `let source; … source = fs.readFileSync(SCRIPT, 'utf8')`, so **the control could not see that directory at all.**

Spot-verified before baselining — `check-workflow-integrity.test.js` asserts `/LYRA_RELEASE_PAT/` against `check-workflow-integrity.sh`, where the string sits in comments at lines 19/215/230 **and** code at 90/240. Genuinely comment-shadowed.

## The pattern worth naming

**Fourth attribution blind spot in this control, and every one has been attribution — never comment syntax.** So this fixes the axis rather than the case: it resolves *variables*, instead of requiring the read and the receiver to be syntactically adjacent.

Two new `--self-test` fixtures (SEC-101 §3a): the KAN-459 shape, and a **negative** one asserting a property write (`obj.src = readFileSync(...)`) is still not a receiver — without it, the now-optional declarator would attribute assertions to things nobody asserts on.

Docs / system map updated — N/A; CTL-039's registry entry is unchanged.
