### PR TITLE
fix(SEC-120): rate-limit bucket key is attacker-settable — confirmed LIVE, origin is directly reachable

### DIFF
--- a/src/lib/client-ip.ts
+++ b/src/lib/client-ip.ts
@@ -1,0 +1,114 @@
+/**
+ * SEC-120 — the single source of truth for "which IP do we rate-limit on".
+ *
+ * WHY THIS FILE EXISTS
+ * --------------------
+ * The precedence rule used to live in two places — `getClientIp` in
+ * `src/middleware.ts` and `clientIpFromHeaders` in `src/lib/rate-limit-shared.ts`
+ * — and both preferred `cf-connecting-ip`, a header any client can set:
+ *
+ *     cf-connecting-ip ?? x-forwarded-for ?? x-real-ip ?? 'unknown'
+ *
+ * CONFIRMED LIVE 2026-08-04, not theoretical. The Vercel origin answers
+ * directly, bypassing Cloudflare:
+ *
+ *     $ curl -sSI https://lyra-kohl.vercel.app/
+ *     HTTP/2 200 · server: Vercel · (no cf-ray)
+ *
+ * and Vercel Deployment Protection is entirely off — no password, no Vercel
+ * Authentication, no trusted IPs. So an actor reaching the origin rotates
+ * `cf-connecting-ip` per request and mints a fresh rate-limit bucket each time.
+ * Mutation-proven: 0 of 200 blocked with a rotating header, against 20 of 30
+ * with a stable one.
+ *
+ * The endpoint that matters is `/oauth/register` — its own header calls it
+ * INTENTIONALLY UNAUTHENTICATED and names "Capped per-IP rate limit" as a
+ * mitigation, and `sharedRateLimit` is genuinely cross-instance there, so the
+ * IP key is the ONLY thing making the 5-clients/hour cap bite.
+ *
+ * WHY NOT SIMPLY PREFER x-forwarded-for
+ * -------------------------------------
+ * Through Cloudflare, Vercel's `x-forwarded-for` is a Cloudflare EDGE ip. So
+ * preferring it would collapse all genuine traffic into a handful of buckets
+ * and rate-limit everybody — an outage, not a fix. This is a trusted-proxy
+ * configuration problem, not a careless `??` ordering.
+ *
+ * THE RULE
+ * --------
+ * Trust `cf-connecting-ip` only when the request PROVABLY transited Cloudflare,
+ * evidenced by a shared secret that a CF Transform Rule stamps on every request
+ * and that a direct-to-origin client cannot know.
+ *
+ * Note that `cf-ray` is NOT sufficient evidence: an attacker forging
+ * `cf-connecting-ip` can forge `cf-ray` in the same breath. Only a secret the
+ * attacker does not hold distinguishes the two paths.
+ */
+import { env } from '@/lib/env';
+
+/** Header a Cloudflare Transform Rule stamps with the shared secret. */
+export const CF_PROXY_HEADER = 'x-lyra-edge';
+
+function firstForwarded(headers: Headers): string | null {
+  return headers.get('x-forwarded-for')?.split(',')[0]?.trim() ?? null;
+}
+
+/**
+ * Did this request provably come through our Cloudflare edge?
+ *
+ * Returns false when the secret is not configured — callers then keep the
+ * legacy precedence (see `clientIp`). That is deliberate and temporary: see
+ * the rollout note there.
+ */
+export function transitedCloudflare(headers: Headers): boolean {
+  const expected = env.cfProxySecret();
+  if (!expected) return false;
+  const got = headers.get(CF_PROXY_HEADER);
+  return Boolean(got) && got === expected;
+}
+
+/**
+ * The IP to key rate-limit buckets on.
+ *
+ * ROLLOUT NOTE — read before changing the unconfigured branch.
+ *
+ * When `CF_PROXY_SECRET` is unset we fall back to the LEGACY precedence rather
+ * than to `x-forwarded-for`. Switching an unconfigured deployment to XFF would
+ * bucket every Cloudflare-fronted request by edge IP and rate-limit the whole
+ * user base — trading an abuse vector for an outage. So the secure behaviour
+ * activates when the founder configures the edge, and until then this is
+ * explicitly no worse than before, never worse.
+ *
+ * `isTrustedProxyConfigured()` is exported so the gap CAN be surfaced, but is
+ * not yet wired anywhere. It was going to go on `/api/health`, and that turned
+ * out to be the wrong place: `tests/unit/health-endpoint.test.ts` asserts the
+ * response shape with `toEqual` deep equality precisely so a field cannot be
+ * added to a PUBLIC endpoint silently. That test is correct and was left
+ * alone. Surfacing this belongs on an admin-only surface, as its own change.
+ */
+export function clientIp(headers: Headers): string {
+  if (transitedCloudflare(headers)) {
+    // Provably ours: CF overwrites cf-connecting-ip at its own edge, so this
+    // is the real client.
+    return headers.get('cf-connecting-ip') ?? firstForwarded(headers) ?? 'unknown';
+  }
+
+  if (env.cfProxySecret()) {
+    // Secret IS configured and this request did not present it, so it did not
+    // come through our edge. cf-connecting-ip is untrustworthy here — use the
+    // platform-set forwarded chain, which a client cannot overwrite.
+    return firstForwarded(headers) ?? headers.get('x-real-ip') ?? 'unknown';
+  }
+
+  // Not yet configured — legacy precedence, unchanged.
+  return (
+    headers.get('cf-connecting-ip') ??
+    firstForwarded(headers) ??
+    headers.get('x-real-ip') ??
+    'unknown'
+  );
+}
+
+/** Whether the trusted-proxy secret is configured. Not yet surfaced — see above. */
+export function isTrustedProxyConfigured(): boolean {
+  return Boolean(env.cfProxySecret());
+}

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -36,5 +36,10 @@ export const env = {
   // nothing and members type their school in themselves, so an unset value
   // degrades the feature rather than breaking it.
   placesApiKey: () => optionalEnv('GOOGLE_PLACES_API_KEY', '').trim(),
+  // SEC-120: shared secret a Cloudflare Transform Rule stamps on every request
+  // it proxies, proving the request came through our edge. Empty until the
+  // founder configures the rule — see src/lib/client-ip.ts for why the
+  // unconfigured branch keeps legacy behaviour rather than failing to XFF.
+  cfProxySecret: () => optionalEnv('CF_PROXY_SECRET', '').trim(),
 };
 // Force rebuild 20260329011858

--- a/src/lib/rate-limit-shared.ts
+++ b/src/lib/rate-limit-shared.ts
@@ -70,15 +70,14 @@ export async function sharedRateLimit(
   }
 }
 
+import { clientIp } from '@/lib/client-ip';
+
 /**
  * Extract the best-effort client IP from proxy headers (Cloudflare → Vercel).
  * Shared by the OAuth route handlers so they bucket consistently.
  */
 export function clientIpFromHeaders(headers: Headers): string {
-  return (
-    headers.get('cf-connecting-ip') ??
-    headers.get('x-forwarded-for')?.split(',')[0]?.trim() ??
-    headers.get('x-real-ip') ??
-    'unknown'
-  );
+  // SEC-120: delegates to the single shared implementation. Kept as a named
+  // export so the OAuth routes' import sites do not churn.
+  return clientIp(headers);
 }

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -4,14 +4,13 @@ import { rateLimit, RATE_LIMITS } from '@/lib/rate-limit';
 import { withParentCookieDomain } from '@/lib/cookie-domain';
 import { cfAccessEnabled, verifyCfAccessToken } from '@/lib/cf-access';
 import { buildCspReportOnly } from '@/lib/security-headers';
+import { clientIp } from '@/lib/client-ip';
 
+// SEC-120: the precedence rule lives in ONE place now — see
+// src/lib/client-ip.ts. It used to be duplicated here and in
+// rate-limit-shared.ts, and the duplication was the recurrence mechanism.
 function getClientIp(request: NextRequest): string {
-  return (
-    request.headers.get('cf-connecting-ip') ??
-    request.headers.get('x-forwarded-for')?.split(',')[0]?.trim() ??
-    request.headers.get('x-real-ip') ??
-    'unknown'
-  );
+  return clientIp(request.headers);
 }
 
 // SEC-63: per-request CSP nonce, base64 of 16 random bytes. Edge runtime

--- a/tests/unit/client-ip-trusted-proxy.test.ts
+++ b/tests/unit/client-ip-trusted-proxy.test.ts
@@ -1,0 +1,120 @@
+/**
+ * SEC-120 — the rate-limit bucket key must not be attacker-supplied.
+ *
+ * CONFIRMED LIVE 2026-08-04, which is what makes this more than hygiene:
+ *   * `curl -sSI https://lyra-kohl.vercel.app/` -> HTTP 200, `server: Vercel`,
+ *     **no `cf-ray`** — the origin answers directly, bypassing Cloudflare.
+ *   * Vercel Deployment Protection is entirely off — no password, no Vercel
+ *     Authentication, no trusted IPs.
+ *
+ * So an actor reaching the origin rotates `cf-connecting-ip` per request and
+ * mints a fresh bucket each time. Mutation-proven before the fix: 0 of 200
+ * blocked rotating, against 20 of 30 with a stable key.
+ *
+ * The endpoint that matters is `/oauth/register` — INTENTIONALLY UNAUTHENTICATED
+ * by its own header, naming "Capped per-IP rate limit" as a mitigation, and
+ * `sharedRateLimit` is genuinely cross-instance there, so the IP key is the
+ * ONLY thing making the 5-clients/hour cap bite.
+ *
+ * WHY THE UNCONFIGURED BRANCH KEEPS LEGACY BEHAVIOUR
+ * ---------------------------------------------------
+ * Through Cloudflare, Vercel's `x-forwarded-for` is a CF EDGE ip. Switching an
+ * unconfigured deployment to prefer it would bucket every real request by edge
+ * IP and rate-limit the entire user base — trading an abuse vector for an
+ * outage. So the hardening activates when the edge is configured, and until
+ * then this is explicitly no worse than before. Case 1 pins that promise.
+ */
+import { clientIp, transitedCloudflare, CF_PROXY_HEADER } from '@/lib/client-ip';
+
+const SECRET = 'edge-secret-abc';
+const REAL = '203.0.113.9';
+const SPOOF = '198.51.100.7';
+
+const ORIGINAL = process.env.CF_PROXY_SECRET;
+afterEach(() => {
+  if (ORIGINAL === undefined) delete process.env.CF_PROXY_SECRET;
+  else process.env.CF_PROXY_SECRET = ORIGINAL;
+});
+
+function headers(h: Record<string, string>): Headers {
+  return new Headers(h);
+}
+
+describe('clientIp — unconfigured edge (legacy behaviour preserved)', () => {
+  beforeEach(() => {
+    delete process.env.CF_PROXY_SECRET;
+  });
+
+  it('keeps the legacy precedence so an unconfigured deploy is unchanged', () => {
+    // The promise this file makes to the founder: shipping the fix before
+    // configuring the edge changes nothing.
+    expect(
+      clientIp(headers({ 'cf-connecting-ip': REAL, 'x-forwarded-for': '10.0.0.1' })),
+    ).toBe(REAL);
+  });
+
+  it('falls through to x-forwarded-for when no CF header is present', () => {
+    expect(clientIp(headers({ 'x-forwarded-for': `${REAL}, 10.0.0.1` }))).toBe(REAL);
+  });
+
+  it('reports the request as NOT provably via Cloudflare', () => {
+    expect(transitedCloudflare(headers({ 'cf-connecting-ip': REAL }))).toBe(false);
+  });
+});
+
+describe('clientIp — configured edge', () => {
+  beforeEach(() => {
+    process.env.CF_PROXY_SECRET = SECRET;
+  });
+
+  it('trusts cf-connecting-ip when the shared secret matches', () => {
+    const h = headers({ [CF_PROXY_HEADER]: SECRET, 'cf-connecting-ip': REAL });
+
+    expect(transitedCloudflare(h)).toBe(true);
+    expect(clientIp(h)).toBe(REAL);
+  });
+
+  it('IGNORES a spoofed cf-connecting-ip when the secret is absent', () => {
+    // The attack: direct to the Vercel origin, forging the CF header.
+    const h = headers({ 'cf-connecting-ip': SPOOF, 'x-forwarded-for': REAL });
+
+    expect(clientIp(h)).toBe(REAL);
+    expect(clientIp(h)).not.toBe(SPOOF);
+  });
+
+  it('IGNORES a spoofed cf-connecting-ip when the secret is WRONG', () => {
+    const h = headers({
+      [CF_PROXY_HEADER]: 'guessed-wrong',
+      'cf-connecting-ip': SPOOF,
+      'x-forwarded-for': REAL,
+    });
+
+    expect(clientIp(h)).toBe(REAL);
+  });
+
+  it('is not fooled by cf-ray alone — only the secret counts', () => {
+    // cf-ray is trivially forgeable by anyone already forging
+    // cf-connecting-ip, so it is deliberately not treated as evidence.
+    const h = headers({
+      'cf-ray': 'a25b7d890ce8edfa-LHR',
+      'cf-connecting-ip': SPOOF,
+      'x-forwarded-for': REAL,
+    });
+
+    expect(clientIp(h)).toBe(REAL);
+  });
+
+  it('defeats the rotation attack: many forged IPs collapse to one bucket', () => {
+    // Before the fix this produced 200 distinct buckets and the cap never
+    // fired. With the edge configured, every forged request keys on the
+    // platform-set forwarded address instead.
+    const keys = new Set(
+      Array.from({ length: 200 }, (_, i) =>
+        clientIp(headers({ 'cf-connecting-ip': `7.7.${i >> 8}.${i & 255}`, 'x-forwarded-for': REAL })),
+      ),
+    );
+
+    expect(keys.size).toBe(1);
+    expect([...keys][0]).toBe(REAL);
+  });
+});


### PR DESCRIPTION
## The open question is closed, and the answer is the bad one

SEC-120 was raised as *medium, contingent on one unverified deployment fact*. That fact is now verified:

```
$ curl -sSI https://lyra-kohl.vercel.app/
HTTP/2 200 · server: Vercel · (no cf-ray)
```

**Both Vercel origin aliases answer directly, bypassing Cloudflare.** And the project's Deployment Protection is entirely off — no password, no Vercel Authentication, no trusted IPs (read from the Vercel API, not inferred).

So the precondition holds: an actor reaching the origin rotates `cf-connecting-ip` and mints a fresh rate-limit bucket per request. Previously mutation-proven at **0 of 200 blocked** rotating, against 20 of 30 with a stable key.

The endpoint that matters is `/oauth/register` — **intentionally unauthenticated** by its own header, naming *"Capped per-IP rate limit"* as a mitigation, with `sharedRateLimit` genuinely cross-instance so the IP key is the **only** thing making the 5-clients/hour cap bite.

## The fix

One shared helper, `src/lib/client-ip.ts`. The rule was duplicated across `middleware.ts` and `rate-limit-shared.ts`, and that duplication was the recurrence mechanism named in the ticket — it now exists once.

`cf-connecting-ip` is trusted **only** when the request carries a shared secret that a Cloudflare Transform Rule stamps and a direct-to-origin client cannot know. `cf-ray` is deliberately **not** treated as evidence — anyone forging `cf-connecting-ip` forges `cf-ray` in the same breath.

**Not reordering the coalesce, on purpose.** Through Cloudflare, Vercel's `x-forwarded-for` is a CF *edge* IP, so preferring it would bucket all real traffic by edge IP and rate-limit the entire user base — an outage, not a fix.

## Rollout is safe by design

With `CF_PROXY_SECRET` unset, the legacy precedence is kept **exactly** — shipping this before the edge is configured changes nothing. The hardening activates when the secret is set. A test pins that promise so it cannot silently regress.

| Mutation | Result |
|---|---|
| always trust `cf-connecting-ip` (the pre-fix behaviour) | **5 of 8 failed** |
| accept any non-empty secret header without comparing | 1 failed |
| configured-but-untrusted falls back to `cf-connecting-ip` | 4 failed |

Full suite green: **225 suites / 2689 tests**.

## Founder action still required — the code alone does not close this

1. A **Cloudflare Transform Rule** stamping `x-lyra-edge: <secret>`, and `CF_PROXY_SECRET` set to the same value in Vercel.
2. Worth considering as well or instead: **restrict the Vercel origin** so only Cloudflare can reach it (Vercel Trusted IPs → CF ranges). That closes this *and* the premise behind SEC-37, rather than compensating at the app layer.

## One thing backed out

I tried surfacing the unconfigured state on `/api/health` and reverted it — `health-endpoint.test.ts` asserts the response with `toEqual` deep equality *precisely so a field cannot be added to a public endpoint silently*. That test is correct; it was left alone, and the code notes where this belongs instead.

Docs / system map updated — N/A; a new env var is documented in `src/lib/env.ts` and `src/lib/client-ip.ts`.
