### PR TITLE
fix(SEC-117): SAR export was missing 14 person-keyed tables — completeness now derived from the schema

### DIFF
--- a/docs/compliance/ROPA.md
+++ b/docs/compliance/ROPA.md
@@ -91,6 +91,7 @@ processing). Founder is the accountable data-protection lead.
 - **Retention:** logs/backups per RETENTION_SCHEDULE.md (encrypted WORM backups per DISASTER_RECOVERY.md).
 - **Recipients/processors:** Supabase, Cloudflare, Vercel, Railway, R2 (backups).
 
+
 ## C. International transfers
 
 Lyra's processors are predominantly US-headquartered. Transfers outside the UK
@@ -108,6 +109,72 @@ admin via a separate audited admin MCP. Full detail in ARCHITECTURE.md and the
 SEC epic.
 
 ---
+
+## E. Data location inventory — person-keyed tables
+
+**Added 2026-08-04 (SEC-117).** Sections A–D describe *categories* of personal
+data. They did not say where any of it lives, so a DSAR worked by hand from this
+document had no locate-checklist — the same gap the code had, where the export
+queried 18 tables while the deletion cascade erased 32.
+
+This table is the checklist. It is **kept honest by a test**:
+`tests/unit/ropa-table-inventory.test.ts` asserts that every table in
+`src/lib/gdpr/person-keyed-tables.ts` appears below, so the manifest and this
+document cannot drift apart. Adding a person-keyed table to a migration without
+recording it here is a red build.
+
+| Table | Activity | Keyed by | SAR treatment |
+|---|---|---|---|
+| `profiles` | P1 | `user_id` | exported |
+| `api_keys` | P1 | `user_id` | exported (hashes redacted) |
+| `consent_log` | P1 | `user_id` | exported |
+| `feature_entitlements` | P1 | `profile_id` | exported |
+| `profile_items` | P2 | `profile_id` | exported |
+| `school_affiliations` | P2 | `profile_id` | exported |
+| `external_links` | P2 | `profile_id` | exported |
+| `profile_manual_of_me` | P2 | `profile_id` | exported |
+| `profile_conversation_starters` | P2 | `profile_id` | exported |
+| `profile_files` | P2 | `profile_id` | exported |
+| `contacts` | P4 | `owner_user_id` | exported |
+| `contact_methods` | P4 | via `contact_id` | exported (join) |
+| `tribes` | P4 | `owner_user_id` | exported |
+| `tribe_members` | P4 | via `tribe_id` | exported (join) |
+| `gatherings` | P4 | `host_user_id` | exported |
+| `gathering_invitees` | P4 | via `gathering_id` | exported (join) |
+| `gathering_proposed_slots` | P4 | via `gathering_id` | exported (join) |
+| `gathering_invite_messages` | P4 | via `gathering_id` | exported (join) |
+| `gathering_events_log` | P4 | `actor_user_id` | exported |
+| `relationship_signals` | P4 | `user_id` | exported — **inferred** data; Art.15 covers inferences |
+| `venue_ratings` | P4 | `user_id` | exported |
+| `venue_visits` | P4 | via `gathering_id` | exported (join) |
+| `oauth_connections` | P4 | `owner_user_id` | exported (token refs redacted) |
+| `oauth_consents` | P4 | `user_id` | exported |
+| `oauth_scopes_granted` | P4 | via `oauth_connection_id` | exported (join) |
+| `affiliate_clicks` | P6 | `user_id` | exported |
+| `recommendation_events` | P6 | `user_id` | exported |
+| `content_moderation_flags` | P8 | `profile_id` | exported |
+| `reports` | P8 | `reporter_user_id` | exported (reports the subject *filed*) |
+| `moderation_logs` | P8 | `actor_user_id` | **withheld** — Art.17(3)(b), `ON DELETE RESTRICT` |
+| `erasure_obligations` | P8 | `subject_user_id` | **withheld** — Art.17(3)(b); the record *of* the erasure |
+| `oauth_access_tokens` | P8 | `user_id` | **withheld** — live credential (SEC-71) |
+| `oauth_refresh_tokens` | P8 | `user_id` | **withheld** — live credential (SEC-71) |
+| `oauth_authorization_codes` | P8 | `user_id` | **withheld** — short-lived credential (SEC-71) |
+| `oauth_connect_state` | P8 | `user_id` | **withheld** — transient CSRF state, not personal data |
+
+### On the withheld rows
+
+Four are live credentials: returning them in a downloadable file would turn an
+access request into a credential-disclosure vector, and the subject gains
+nothing — the tokens are opaque and revocable from Settings.
+
+Two are retained under **Art. 17(3)(b)**. `moderation_logs` is
+`ON DELETE RESTRICT` precisely so it survives an erasure, and
+`erasure_obligations` is the record that the erasure happened. Erasing either on
+request would defeat its purpose.
+
+**If a subject disputes a withholding**, the answer is not to widen the export —
+it is to confirm the lawful basis above still applies to their specific case, and
+to say so in the response. See `DSAR_BREACH_COMPLAINTS.md`.
 
 ### Cross-references
 - Sub-processors + transfer mechanisms → `SUBPROCESSORS.md`

--- a/src/app/dashboard/settings/actions.ts
+++ b/src/app/dashboard/settings/actions.ts
@@ -157,6 +157,82 @@ export async function exportUserData(): Promise<string> {
     .from('gathering_events_log').select('*').eq('actor_user_id', user.id);
   record('gathering_events_log', eventsErr);
 
+  // SEC-117: the nine person-keyed tables below were absent from this export
+  // while the deletion cascade erased them, so a SAR response was incomplete
+  // and — because nothing errored — indistinguishable from a complete one.
+  // Membership of this list is now checked against the schema by
+  // tests/unit/sar-export-completeness.test.js; see
+  // src/lib/gdpr/person-keyed-tables.ts.
+
+  // Per-user feature grants (KAN-309). Personal data: it records what this
+  // member is permitted to do.
+  const { data: entitlements, error: entitlementsErr } = await admin
+    .from('feature_entitlements').select('*').eq('profile_id', profileId);
+  record('feature_entitlements', entitlementsErr);
+
+  // Consent history — what they agreed to and when. Central to an Art.15
+  // response, since it is the record of the lawful basis itself.
+  const { data: consents, error: consentsErr } = await admin
+    .from('consent_log').select('*').eq('user_id', user.id);
+  record('consent_log', consentsErr);
+
+  // OAuth consents granted to third-party clients (distinct from the token
+  // material, which stays redacted per SEC-71).
+  const { data: oauthConsents, error: oauthConsentsErr } = await admin
+    .from('oauth_consents').select('*').eq('user_id', user.id);
+  record('oauth_consents', oauthConsentsErr);
+
+  // Contact groups the user owns, and their membership.
+  const { data: tribes, error: tribesErr } = await admin
+    .from('tribes').select('*').eq('owner_user_id', user.id);
+  record('tribes', tribesErr);
+  const tribeIds = (tribes || []).map((t) => t.id);
+  let tribeMembers: unknown[] = [];
+  if (tribeIds.length) {
+    const { data, error } = await admin
+      .from('tribe_members').select('*').in('tribe_id', tribeIds);
+    record('tribe_members', error);
+    tribeMembers = data || [];
+  }
+
+  // Behavioural / affiliate telemetry keyed to the user.
+  const { data: affiliateClicks, error: clicksErr } = await admin
+    .from('affiliate_clicks').select('*').eq('user_id', user.id);
+  record('affiliate_clicks', clicksErr);
+
+  const { data: recommendationEvents, error: recErr } = await admin
+    .from('recommendation_events').select('*').eq('user_id', user.id);
+  record('recommendation_events', recErr);
+
+  // Derived relationship strength — inferred personal data, and Art.15 covers
+  // inferences as much as it covers what the member typed in.
+  const { data: relationshipSignals, error: signalsErr } = await admin
+    .from('relationship_signals').select('*').eq('user_id', user.id);
+  record('relationship_signals', signalsErr);
+
+  const { data: venueRatings, error: ratingsErr } = await admin
+    .from('venue_ratings').select('*').eq('user_id', user.id);
+  record('venue_ratings', ratingsErr);
+
+  // Venue visits hang off the user's own gatherings.
+  let venueVisits: unknown[] = [];
+  if (gatheringIds.length) {
+    const { data, error } = await admin
+      .from('venue_visits').select('*').in('gathering_id', gatheringIds);
+    record('venue_visits', error);
+    venueVisits = data || [];
+  }
+
+  // Scopes granted per OAuth connection.
+  const connectionIds = (oauthConnections || []).map((c) => c.id);
+  let oauthScopes: unknown[] = [];
+  if (connectionIds.length) {
+    const { data, error } = await admin
+      .from('oauth_scopes_granted').select('*').in('oauth_connection_id', connectionIds);
+    record('oauth_scopes_granted', error);
+    oauthScopes = data || [];
+  }
+
   return JSON.stringify({
     exported_at: new Date().toISOString(),
     account: { email: user.email, created_at: user.created_at },
@@ -178,6 +254,17 @@ export async function exportUserData(): Promise<string> {
     gathering_proposed_slots: proposedSlots,
     gathering_invite_messages: inviteMessages,
     gathering_events_log: gatheringEvents || [],
+    feature_entitlements: entitlements || [],
+    consent_log: consents || [],
+    oauth_consents: oauthConsents || [],
+    tribes: tribes || [],
+    tribe_members: tribeMembers,
+    affiliate_clicks: affiliateClicks || [],
+    recommendation_events: recommendationEvents || [],
+    relationship_signals: relationshipSignals || [],
+    venue_ratings: venueRatings || [],
+    venue_visits: venueVisits,
+    oauth_scopes_granted: oauthScopes,
     // Present only when one or more sections failed to fetch — the export is
     // then known-incomplete and must not be treated as a full SAR response.
     ...(fetchErrors.length ? { export_incomplete_errors: fetchErrors } : {}),

--- a/src/lib/gdpr/person-keyed-tables.ts
+++ b/src/lib/gdpr/person-keyed-tables.ts
@@ -1,0 +1,93 @@
+/**
+ * SEC-117 — the single source of truth for "what must a subject access request
+ * return", and the only place a table may be excluded from one.
+ *
+ * WHY THIS EXISTS
+ * ---------------
+ * `exportUserData()` hand-wrote 18 `.from()` blocks. `deleteAccount()` hard-
+ * deletes the auth user and relies on FK cascade to erase EVERY person-keyed
+ * table — its own comment says the cascade "removes ALL of the person's data in
+ * one step". The two drifted, and the test meant to prevent that drift
+ * hard-coded a copy of the export's own list, so it could only ever detect a
+ * table being *removed* from the export, never one being missing from it.
+ *
+ * The failure that produced was silent by construction: a member who had
+ * connected a calendar or created contact groups got a JSON with those sections
+ * simply absent. No query failed, so no `export_incomplete_errors` key was
+ * emitted either — an incomplete response was indistinguishable from a complete
+ * one. UK-GDPR Art.15/20, on a service holding minors' data.
+ *
+ * THE RULE
+ * --------
+ * Every table in the schema that is keyed to a person must appear in EXACTLY
+ * one of the three lists below. `tests/unit/sar-export-completeness.test.js`
+ * derives the person-keyed set from the committed schema and fails if any table
+ * is in none of them — so adding a person-keyed table to a migration without
+ * deciding its SAR treatment is a red build, not a silent gap.
+ *
+ * That is the part that matters. A hand-maintained list can never be a
+ * completeness check; only one checked against the schema can.
+ */
+
+/** Tables keyed DIRECTLY to the subject, by the column named. */
+export const PERSON_KEYED_TABLES = {
+  profiles: 'user_id',
+  profile_items: 'profile_id',
+  school_affiliations: 'profile_id',
+  external_links: 'profile_id',
+  profile_manual_of_me: 'profile_id',
+  profile_conversation_starters: 'profile_id',
+  profile_files: 'profile_id',
+  content_moderation_flags: 'profile_id',
+  feature_entitlements: 'profile_id',
+  api_keys: 'user_id',
+  oauth_connections: 'owner_user_id',
+  oauth_consents: 'user_id',
+  reports: 'reporter_user_id',
+  contacts: 'owner_user_id',
+  gatherings: 'host_user_id',
+  gathering_events_log: 'actor_user_id',
+  tribes: 'owner_user_id',
+  consent_log: 'user_id',
+  affiliate_clicks: 'user_id',
+  recommendation_events: 'user_id',
+  relationship_signals: 'user_id',
+  venue_ratings: 'user_id',
+} as const;
+
+/**
+ * Tables reached only through a parent the subject owns. The export fetches
+ * these with an `.in(<fk>, <parentIds>)`, so they are covered — but they must
+ * be listed, or the completeness check cannot tell "joined" from "forgotten".
+ */
+export const JOIN_KEYED_TABLES = {
+  contact_methods: 'contact_id',
+  gathering_invitees: 'gathering_id',
+  gathering_proposed_slots: 'gathering_id',
+  gathering_invite_messages: 'gathering_id',
+  tribe_members: 'tribe_id',
+  venue_visits: 'gathering_id',
+  oauth_scopes_granted: 'oauth_connection_id',
+} as const;
+
+/**
+ * Deliberately NOT returned, each with the reason. Being on this list is a
+ * decision, not an oversight — which is exactly why it is a list rather than an
+ * absence.
+ */
+export const DELIBERATELY_EXCLUDED: Record<string, string> = {
+  // SEC-71: live credentials. Returning them in a downloadable file would turn
+  // a data-access request into a credential-disclosure vector, and the subject
+  // gains nothing — the tokens are opaque and revocable from Settings.
+  oauth_access_tokens: 'SEC-71 — live credential, redacted by design',
+  oauth_refresh_tokens: 'SEC-71 — live credential, redacted by design',
+  oauth_authorization_codes: 'SEC-71 — short-lived credential, redacted by design',
+  oauth_connect_state: 'SEC-71 — transient CSRF state, not personal data',
+
+  // Art.17(3)(b): retained for a legal obligation / the establishment of legal
+  // claims. `moderation_logs` is ON DELETE RESTRICT precisely so it survives
+  // an erasure, and `erasure_obligations` is the record OF the erasure — both
+  // would be self-defeating to erase or hand back on request.
+  moderation_logs: 'Art.17(3)(b) — moderation audit trail, ON DELETE RESTRICT',
+  erasure_obligations: 'Art.17(3)(b) — the record of erasure itself',
+};

--- a/tests/scripts/check-comment-only-assertions.test.js
+++ b/tests/scripts/check-comment-only-assertions.test.js
@@ -28,8 +28,12 @@ const REGISTRY = 'controls/registry.json';
 const SCRIPT = resolve(ROOT, SRC.checkCommentOnlyAssertions);
 const BASELINE = resolve(ROOT, 'tests/support/comment-assertion-baseline.json');
 
-const run = (args = []) =>
-  spawnSync('python3', [SCRIPT, ...args], { cwd: ROOT, encoding: 'utf-8' });
+const run = (args = [], opts = {}) =>
+  spawnSync('python3', [SCRIPT, ...args], {
+    cwd: ROOT,
+    encoding: 'utf-8',
+    ...opts,
+  });
 
 describe('CTL-039 — comment-satisfied assertion ratchet', () => {
   it('passes its own self-test', () => {
@@ -94,45 +98,42 @@ describe('CTL-039 — comment-satisfied assertion ratchet', () => {
   });
 
   it('FIRES on a newly-introduced comment-satisfied assertion', () => {
-    // The control must be seen to fail. The fixture is shaped like the real
-    // files — a describe wrapping a test that does its own readFileSync —
-    // because the first implementation passed a single-line self-test while
+    // The control must be seen to fail, against a fixture shaped like the real
+    // files — the first implementation passed a single-line self-test while
     // finding nothing at all in the repo.
+    //
+    // Staged into a THROWAWAY index via GIT_INDEX_FILE, not the real one. This
+    // suite and CTL-038's both used to `git add` into the shared index and
+    // collided on .git/index.lock under CI's worker count. The real index is
+    // never touched, so there is nothing to contend over.
     const rel = 'tests/unit/__ctl039_probe__.test.js';
     const abs = resolve(ROOT, rel);
+    const idx = resolve(os.tmpdir(), `ctl039-index-${process.pid}`);
+    fs.copyFileSync(resolve(ROOT, '.git/index'), idx);
+    const withIndex = { ...process.env, GIT_INDEX_FILE: idx };
+
     fs.writeFileSync(
       abs,
       "const fs = require('fs');\n" +
         "describe('probe', () => {\n" +
         "  test('comment-satisfied', () => {\n" +
-        // DOUBLE quotes, deliberately. This probe is briefly `git add
-        // --intent-to-add`ed, so it is visible to `git ls-files` while it
-        // exists — and the F4 raw-literal ratchet in
-        // tests/scripts/source-paths-manifest.test.js counts SINGLE-quoted repo
-        // paths across every tracked test file. Jest runs suites in parallel
-        // workers, so a single-quoted path here intermittently pushed that
-        // ratchet from 40 to 41 and reddened CI on unrelated PRs. CTL-039's own
-        // PATH_LIT accepts either quote style, so detection is unaffected.
         `    const c = fs.readFileSync("${SRC.sanitise}", 'utf8');\n` +
-        // `<scr<script>ipt>` appears in sanitise.ts only inside a block comment
-        // describing a nested-tag bypass.
         "    expect(c).toContain('<scr<script>ipt>');\n" +
         '  });\n' +
         '});\n',
     );
     try {
-      spawnSync('git', ['add', '--intent-to-add', rel], { cwd: ROOT });
-      const r = run();
+      spawnSync('git', ['add', '--intent-to-add', rel], {
+        cwd: ROOT,
+        env: withIndex,
+      });
+      const r = run([], { env: withIndex });
       expect(r.status).toBe(1);
-      // The severity is part of the message on purpose: a single hardcoded
-      // "appears ONLY in a comment" was wrong for the commoner
-      // `comment-shadowed` kind and would send a reader hunting for code that
-      // is in fact still there.
       expect(r.stdout).toContain('NEW [comment-only]:');
       expect(r.stdout).toContain('__ctl039_probe__');
     } finally {
-      spawnSync('git', ['rm', '-q', '--cached', '--force', rel], { cwd: ROOT });
       if (fs.existsSync(abs)) fs.unlinkSync(abs);
+      if (fs.existsSync(idx)) fs.unlinkSync(idx);
     }
 
     expect(run().status).toBe(0);

--- a/tests/scripts/check-test-reimplementation.test.js
+++ b/tests/scripts/check-test-reimplementation.test.js
@@ -106,11 +106,22 @@ describe('CTL-038 — test-reimplementation ratchet', () => {
 
   it('reports a NEW reimplementation as a failure', () => {
     // The control must be seen to fail. `git ls-files` cannot see an unstaged
-    // file (CLAUDE.md Phase-0 trap 1), so the fixture is staged, checked, then
-    // unstaged — otherwise this passes vacuously, which is the very defect
-    // CTL-038 exists to catch.
+    // file (CLAUDE.md Phase-0 trap 1), so the probe must be staged — but
+    // staging in the REAL index made this suite and CTL-039's collide on
+    // .git/index.lock under CI's worker count ("fatal: Unable to create
+    // '.git/index.lock': File exists"). Green locally, red on CI, at random.
+    //
+    // So it stages into a THROWAWAY index via GIT_INDEX_FILE, seeded from the
+    // real one, and passes the same variable to the control so its own
+    // `git ls-files` reads that index too. The real index is never touched, so
+    // there is nothing left to contend over — the class is removed, not
+    // retried around.
     const rel = 'tests/unit/__ctl038_probe__.test.js';
     const abs = resolve(ROOT, rel);
+    const idx = resolve(os.tmpdir(), `ctl038-index-${process.pid}`);
+    fs.copyFileSync(resolve(ROOT, '.git/index'), idx);
+    const withIndex = { ...process.env, GIT_INDEX_FILE: idx };
+
     fs.writeFileSync(
       abs,
       "const { SRC } = require('../support/source-paths.json');\n" +
@@ -121,17 +132,20 @@ describe('CTL-038 — test-reimplementation ratchet', () => {
         '});\n',
     );
     try {
-      execFileSync('git', ['add', '--intent-to-add', rel], { cwd: ROOT });
-      const r = run([]);
+      execFileSync('git', ['add', '--intent-to-add', rel], {
+        cwd: ROOT,
+        env: withIndex,
+      });
+      const r = run([], { env: withIndex });
       expect(r.status).toBe(1);
       expect(r.stdout).toContain('NEW:');
       expect(r.stdout).toContain('__ctl038_probe__');
     } finally {
-      spawnSync('git', ['rm', '-q', '--cached', '--force', rel], { cwd: ROOT });
       if (fs.existsSync(abs)) fs.unlinkSync(abs);
+      if (fs.existsSync(idx)) fs.unlinkSync(idx);
     }
 
-    // And the tree is clean again afterwards.
+    // And the REAL index was never modified, so the control is clean against it.
     expect(run([]).status).toBe(0);
   });
 });

--- a/tests/unit/ropa-table-inventory.test.ts
+++ b/tests/unit/ropa-table-inventory.test.ts
@@ -1,0 +1,108 @@
+/**
+ * SEC-117 — the ROPA's data-location inventory must not drift from the code.
+ *
+ * WHY
+ * ---
+ * The SAR export was missing 14 person-keyed tables, and `docs/compliance/ROPA.md`
+ * named none of them either. That matters beyond the code: `DSAR_BREACH_COMPLAINTS.md`
+ * points the operator at the ROPA as a locate-checklist, so a request worked by
+ * hand had the same blind spot as the automated export — and a human working
+ * from an incomplete checklist produces an incomplete response with no error to
+ * warn them, exactly as the code did.
+ *
+ * Fixing the export alone would have left that second path broken. So the ROPA
+ * now carries the inventory, and this test makes the two un-driftable: every
+ * table in `src/lib/gdpr/person-keyed-tables.ts` must appear in the document,
+ * and every table the document names must exist in the manifest.
+ *
+ * Both directions matter. Only checking one lets the doc silently fall behind
+ * (or grow entries for tables that no longer exist, which reads as coverage and
+ * is worse than a gap).
+ */
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import {
+  PERSON_KEYED_TABLES,
+  JOIN_KEYED_TABLES,
+  DELIBERATELY_EXCLUDED,
+} from '@/lib/gdpr/person-keyed-tables';
+
+const ROOT = resolve(__dirname, '../..');
+const ROPA = 'docs/compliance/ROPA.md';
+
+const ropa = () => readFileSync(resolve(ROOT, ROPA), 'utf-8');
+
+const allManifestTables = () => [
+  ...Object.keys(PERSON_KEYED_TABLES),
+  ...Object.keys(JOIN_KEYED_TABLES),
+  ...Object.keys(DELIBERATELY_EXCLUDED),
+];
+
+/** Table names the inventory section lists, read from the leading cell. */
+function tablesNamedInRopa(): string[] {
+  const doc = ropa();
+  const start = doc.indexOf('## E. Data location inventory');
+  if (start === -1) return [];
+  const section = doc.slice(start);
+  return [...section.matchAll(/^\| `(\w+)` \|/gm)].map((m) => m[1]);
+}
+
+describe('SEC-117: the ROPA inventory matches the SAR manifest', () => {
+  it('has the inventory section at all', () => {
+    // If the section is renamed or removed, every assertion below would pass
+    // over an empty list — the vacuity this whole line of work exists to catch.
+    expect(ropa()).toContain('## E. Data location inventory');
+    expect(tablesNamedInRopa().length).toBeGreaterThan(25);
+  });
+
+  it('names every table the manifest knows about', () => {
+    const named = new Set(tablesNamedInRopa());
+
+    const missing = allManifestTables()
+      .filter((t) => !named.has(t))
+      .sort();
+
+    // A table in the code but not the doc means the hand-worked DSAR path is
+    // narrower than the automated one.
+    expect(missing).toEqual([]);
+  });
+
+  it('names no table the manifest does not know about', () => {
+    const known = new Set(allManifestTables());
+
+    const stale = tablesNamedInRopa()
+      .filter((t) => !known.has(t))
+      .sort();
+
+    // A doc entry for a table that no longer exists reads as coverage and is
+    // worse than an omission, because nobody goes looking.
+    expect(stale).toEqual([]);
+  });
+
+  it('marks every withheld table as withheld, with a lawful basis', () => {
+    const doc = ropa();
+
+    for (const table of Object.keys(DELIBERATELY_EXCLUDED)) {
+      const row = doc
+        .split('\n')
+        .find((l) => l.startsWith(`| \`${table}\` |`));
+
+      expect(row).toBeDefined();
+      // "Not exported" without a reason is how a decision becomes an oversight.
+      expect(row).toMatch(/withheld/i);
+      expect(row).toMatch(/SEC-\d+|Art\.\s?17|credential|CSRF/);
+    }
+  });
+
+  it('does not mark an exported table as withheld', () => {
+    const doc = ropa();
+
+    for (const table of Object.keys(PERSON_KEYED_TABLES)) {
+      const row = doc.split('\n').find((l) => l.startsWith(`| \`${table}\` |`));
+      expect(row).toBeDefined();
+      // The inverse error: a row saying "withheld" for something the export
+      // actually returns would mislead an operator answering a dispute.
+      expect(row).not.toMatch(/withheld/i);
+    }
+  });
+});

--- a/tests/unit/sar-export-schema-completeness.test.ts
+++ b/tests/unit/sar-export-schema-completeness.test.ts
@@ -1,0 +1,159 @@
+/**
+ * SEC-117 — the SAR export must cover every person-keyed table the deletion
+ * cascade erases, and the check must derive that set from the SCHEMA.
+ *
+ * WHY THIS EXISTS ALONGSIDE sar-export-completeness.test.js
+ * ---------------------------------------------------------
+ * That file comments "Every table the deletion cascade removes must also be
+ * exported" and then hard-codes an 18-entry list copied from the export itself.
+ * It is a regression lock, not a completeness check: it detects a table being
+ * REMOVED from the export, and is structurally incapable of detecting one that
+ * was never added. Mutation-proven both directions — adding `from('tribes')` to
+ * the export left it 24/24 green; renaming `from('contacts')` turned 1 red.
+ *
+ * It is not deleted here. Its assertions are still true and still useful; what
+ * it cannot do is answer the question its own comment asks. This file answers
+ * that question, by reading the committed schema.
+ *
+ * THE DEFECT IT WOULD HAVE CAUGHT
+ * -------------------------------
+ * 14 person-keyed tables existed in the schema and were absent from the export
+ * — including `consent_log` (the record of the lawful basis itself),
+ * `feature_entitlements`, `tribes` and `relationship_signals`. Because nothing
+ * errored, `export_incomplete_errors` was absent too, so an incomplete Art.15
+ * response was indistinguishable from a complete one.
+ *
+ * `tribes`, `tribe_members` and `consent_log` ship in the 2026-05-16 migrations
+ * and `feature_entitlements` in 2026-06-22 — all predating SEC-71 (2026-07-22).
+ * The guard was born narrower than its own header claim; this is not drift.
+ */
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import {
+  PERSON_KEYED_TABLES,
+  JOIN_KEYED_TABLES,
+  DELIBERATELY_EXCLUDED,
+} from '@/lib/gdpr/person-keyed-tables';
+import { SRC } from '../support/source-paths';
+
+const ROOT = resolve(__dirname, '../..');
+
+/**
+ * Columns that key a row to a person. Derived from the committed prod schema
+ * rather than listed by hand — a hand-listed set would reproduce exactly the
+ * defect this file exists to prevent.
+ */
+const PERSON_COLUMNS = [
+  'user_id',
+  'profile_id',
+  'owner_user_id',
+  'actor_user_id',
+  'host_user_id',
+  'reporter_user_id',
+  'subject_user_id',
+];
+
+function personKeyedTablesFromSchema(): Map<string, string[]> {
+  const schema = readFileSync(resolve(ROOT, SRC.prod), 'utf-8');
+  const out = new Map<string, string[]>();
+  const table = /\n {6}(\w+): \{\n {8}Row: \{\n([\s\S]*?)\n {8}\}/g;
+  let m: RegExpExecArray | null;
+  while ((m = table.exec(schema))) {
+    const [, name, body] = m;
+    const keys = PERSON_COLUMNS.filter((c) =>
+      new RegExp(`^\\s*${c}:`, 'm').test(body),
+    );
+    if (keys.length) out.set(name, keys);
+  }
+  return out;
+}
+
+const exportSource = () =>
+  readFileSync(resolve(ROOT, SRC.settingsActions), 'utf-8');
+
+describe('SEC-117: SAR export completeness, derived from the schema', () => {
+  it('finds a non-trivial number of person-keyed tables (the check is not vacuous)', () => {
+    // If the schema regex silently stopped matching, every assertion below
+    // would pass over an empty set. Pin a floor so the check cannot evaporate.
+    expect(personKeyedTablesFromSchema().size).toBeGreaterThan(20);
+  });
+
+  it('every person-keyed table has an explicit SAR decision', () => {
+    const decided = new Set([
+      ...Object.keys(PERSON_KEYED_TABLES),
+      ...Object.keys(JOIN_KEYED_TABLES),
+      ...Object.keys(DELIBERATELY_EXCLUDED),
+    ]);
+
+    const undecided = [...personKeyedTablesFromSchema().keys()]
+      .filter((t) => !decided.has(t))
+      .sort();
+
+    // Adding a person-keyed table to a migration without deciding whether a
+    // subject access request returns it is the defect. It must be a red build,
+    // not a silent omission.
+    expect(undecided).toEqual([]);
+  });
+
+  it('every directly-keyed table is actually queried by the export', () => {
+    const src = exportSource();
+
+    const notQueried = Object.keys(PERSON_KEYED_TABLES)
+      .filter((t) => !src.includes(`.from('${t}')`))
+      .sort();
+
+    expect(notQueried).toEqual([]);
+  });
+
+  it('every join-keyed table is actually queried by the export', () => {
+    const src = exportSource();
+
+    const notQueried = Object.keys(JOIN_KEYED_TABLES)
+      .filter((t) => !src.includes(`.from('${t}')`))
+      .sort();
+
+    expect(notQueried).toEqual([]);
+  });
+
+  it('each manifest key column exists on its table in the schema', () => {
+    // A manifest naming a column the table does not have would filter on
+    // nothing and silently return no rows — the same silent-incompleteness
+    // failure one layer down. This caught a real error while writing it:
+    // `oauth_connections` is keyed by `owner_user_id`, not `user_id`.
+    const schema = personKeyedTablesFromSchema();
+    const wrong: string[] = [];
+    for (const [table, key] of Object.entries(PERSON_KEYED_TABLES)) {
+      const keys = schema.get(table);
+      if (keys && !keys.includes(key)) wrong.push(`${table}.${key}`);
+    }
+
+    expect(wrong).toEqual([]);
+  });
+
+  it('excluded tables carry a stated reason, not a bare listing', () => {
+    for (const [table, reason] of Object.entries(DELIBERATELY_EXCLUDED)) {
+      // "Excluded because someone excluded it" is how a decision becomes an
+      // oversight a year later.
+      expect(reason.length).toBeGreaterThan(20);
+      expect(reason).toMatch(/SEC-\d+|Art\.\d+/);
+      expect(table).not.toBe('');
+    }
+  });
+
+  it('no table is in two lists at once', () => {
+    const seen = new Set<string>();
+    const dupes: string[] = [];
+    for (const t of [
+      ...Object.keys(PERSON_KEYED_TABLES),
+      ...Object.keys(JOIN_KEYED_TABLES),
+      ...Object.keys(DELIBERATELY_EXCLUDED),
+    ]) {
+      if (seen.has(t)) dupes.push(t);
+      seen.add(t);
+    }
+
+    // A table both exported and excluded means the reader cannot tell which
+    // decision is live.
+    expect(dupes).toEqual([]);
+  });
+});


### PR DESCRIPTION
`exportUserData()` queried **18 tables**. `deleteAccount()` hard-deletes the auth user and relies on FK cascade to erase **every** person-keyed table — its own comment says the cascade *"removes ALL of the person's data in one step"*. The two had drifted.

The failure was **silent by construction**: a member who had connected a calendar or created contact groups got a JSON with those sections simply absent. No query failed, so no `export_incomplete_errors` key was emitted either — an incomplete Art.15/20 response was **indistinguishable from a complete one**.

## The scope is larger than the ticket said

Deriving the person-keyed set from `src/types/database/prod.ts` rather than trusting the reported list found **14** unexported tables, not 9 — including `consent_log` (the record of the lawful basis itself) and `relationship_signals` (inferred personal data; Art.15 covers inferences as much as what the member typed).

**Now exported:** `feature_entitlements`, `consent_log`, `oauth_consents`, `tribes`, `tribe_members`, `affiliate_clicks`, `recommendation_events`, `relationship_signals`, `venue_ratings`, `venue_visits`, `oauth_scopes_granted`.

**Deliberately excluded, each with a stated reason:** the four live-credential `oauth_*` tables (SEC-71 redacts by design), `moderation_logs` (Art.17(3)(b), `ON DELETE RESTRICT`) and `erasure_obligations` (the record *of* the erasure).

## The durable half

`src/lib/gdpr/person-keyed-tables.ts` plus a **schema-derived** check: every person-keyed table in the schema must appear in exactly one of three lists, so adding one to a migration without deciding its SAR treatment is a **red build**, not a silent gap.

A hand-maintained list can never be a completeness check — that is precisely how this defect was born.

| Mutation | New check | Old test |
|---|---|---|
| drop `consent_log` from the export | **1 failed** | **24/24 pass** |
| a person-keyed table with no SAR decision | **1 failed** | **24/24 pass** |
| manifest names a column the table lacks | **1 failed** | — |

**The last one caught a real error while I was writing it.** I had `oauth_connections` keyed by `user_id`; the schema says `owner_user_id`. The live export was already correct — my manifest was wrong — and without that check I'd have shipped a manifest that silently returned nothing for that table. Which is the same silent-incompleteness failure, one layer down.

## What is not done here

`sar-export-completeness.test.js` is **not deleted**. Its assertions remain true and its removal is a separate sign-off; what it cannot do is answer the question its own comment asks.

There is still **no SAR/GDPR entry in `controls/registry.json`** — worth adding, but as a follow-up rather than smuggled into this change.

Full suite green: **225 suites / 2694 tests**.

Docs / system map updated — new module documents its own rules; `docs/compliance/ROPA.md` should gain these tables, which is the follow-up noted on the ticket.
