### PR TITLE
feat(profile): remove "A couple of extras" section (KAN-469)

### DIFF
--- a/src/app/[slug]/page.tsx
+++ b/src/app/[slug]/page.tsx
@@ -632,17 +632,12 @@ export default async function PublicProfilePage({ params }: Props) {
             </section>
           )}
 
-          {/* Billboard */}
-          {(groupedItems['billboard']?.length ?? 0) > 0 && (
-            <section className="mt-11">
-              <div className="bg-[var(--color-sage)] rounded-[12px] p-8 text-center">
-                <p className="text-xs uppercase tracking-wide text-white/70 mb-3">If I had a giant billboard, it would say&hellip;</p>
-                <p className="text-xl sm:text-2xl font-[family-name:var(--font-serif)] text-white leading-relaxed">
-                  &ldquo;{groupedItems['billboard']?.[0]?.title}&rdquo;
-                </p>
-              </div>
-            </section>
-          )}
+          {/* KAN-469: the standalone sage-green quote section that used to sit
+              here is gone. The prompt it rendered is now an ordinary
+              conversation starter, so its answer appears in the Q&A section
+              above with everything else. The wording it used is not repeated
+              in this comment on purpose — CTL-039: a removed string that
+              survives in prose keeps every text-scan assertion green. */}
 
           {/* Links */}
           {typedLinks.length > 0 && (

--- a/src/app/dashboard/profile/edit-profile-form.tsx
+++ b/src/app/dashboard/profile/edit-profile-form.tsx
@@ -171,14 +171,12 @@ const SECTIONS: SectionDef[] = [
     kind: 'starters',
     description: 'Random things about you — answer any that take your fancy, or write your own.',
   },
-  {
-    id: 'extras',
-    label: 'A couple of extras',
-    icon: '✨',
-    kind: 'items',
-    categories: ['billboard', 'questions'],
-    description: "Your billboard message, and any other questions you'd love to be asked.",
-  },
+  // KAN-469: the 'extras' section is deliberately absent. It held two item
+  // categories that no longer need a section of their own — the prompt it
+  // existed for now lives in 'starters' above, written by hand rather than in
+  // code, and 'questions' items already surface in the same place on the
+  // public profile. Both categories stay valid in the schema; nothing was
+  // migrated or deleted.
   { id: 'links', label: 'Links', icon: '🔗', kind: 'links' },
 ];
 

--- a/tests/unit/kan469-extras-section-removed.test.ts
+++ b/tests/unit/kan469-extras-section-removed.test.ts
@@ -1,0 +1,151 @@
+/**
+ * KAN-469 — "A couple of extras" is gone from the profile editor, and the
+ * standalone billboard block is gone from the public profile.
+ *
+ * WHAT THIS SUITE IS FOR
+ * ----------------------
+ * A removal is the hardest kind of change to guard. Adding a feature leaves
+ * something to assert on; removing one leaves an absence, and an absence is
+ * exactly what a careless `toContain` cannot distinguish from a rename, a
+ * reorder, or a merge conflict resolved the wrong way. Both halves of this
+ * change are one line of a literal away from silently coming back:
+ *
+ *   - the editor's `SECTIONS` array is a list of object literals, so a revert
+ *     or a bad merge reinstates the section with no type error and no other
+ *     test noticing;
+ *   - the public page's block was a plain `{cond && <section/>}`, likewise.
+ *
+ * So this suite ENUMERATES the editor's section ids rather than sampling them
+ * (gotcha #29 — only classifying every entry finds the one that came back),
+ * and asserts the public page reaches `groupedItems['billboard']` nowhere at
+ * all.
+ *
+ * WHY A SOURCE PARSE AND NOT A RENDER
+ * -----------------------------------
+ * `SECTIONS` is module-private to a `'use client'` component that pulls in the
+ * router, ten server actions and the whole item/link/starter data shape.
+ * Rendering it to read back a list of headings would test the mocks. Parsing
+ * the array literal reads the same declaration the component maps over, and
+ * every assertion below runs against COMMENT-STRIPPED source — CTL-039 /
+ * SEC-100 is the failure where a removed string survives in the prose
+ * documenting its removal, and the scan asserting it is gone keeps matching
+ * the comment.
+ *
+ * MUTATION PROOF (2026-08-06). Each mutation was applied to the real source,
+ * this suite re-run, and the source restored from a /tmp copy and confirmed
+ * byte-identical by shasum. Baseline: 8 passed, 0 failed.
+ *
+ *   mutation                                              failures it causes
+ *   --------------------------------------------------------------------------
+ *   re-add the `extras` entry to SECTIONS                          3
+ *   re-add the public billboard block to [slug]/page.tsx           1
+ *   replace stripComments with the identity function               0
+ *
+ * READ THAT LAST ROW HONESTLY. The strip is currently defence-in-depth, NOT
+ * load-bearing, and the first draft of this header claimed the opposite —
+ * asserting the suite would go green-for-the-wrong-reason without it. The
+ * experiment says otherwise, and the reason is worth keeping: the two comments
+ * this change added to `edit-profile-form.tsx` and `[slug]/page.tsx` were
+ * written to avoid naming the strings they removed, so an un-stripped scan has
+ * nothing to match on. That is a property of today's prose, not of the guard.
+ * Add one comment mentioning `'billboard'` or "A couple of extras" near either
+ * site and the strip becomes the only thing standing between this suite and a
+ * vacuous pass — which is precisely why it stays, and why the row above says 0
+ * rather than pretending otherwise.
+ */
+
+import fs from 'fs';
+import path from 'path';
+
+const { SRC } = require('../support/source-paths.json');
+
+const root = path.join(__dirname, '../..');
+
+/**
+ * Strip block and line comments. Mirrors the helper in
+ * profile-sections.test.js — the `(^|[^:])` guard keeps `https://` intact.
+ */
+const stripComments = (s: string): string =>
+  s.replace(/\/\*[\s\S]*?\*\//g, '').replace(/(^|[^:])\/\/.*$/gm, '$1');
+
+const read = (rel: string): string =>
+  stripComments(fs.readFileSync(path.join(root, rel), 'utf8'));
+
+describe('KAN-469: the editor no longer offers "A couple of extras"', () => {
+  let sectionsLiteral: string;
+  let ids: string[];
+
+  beforeAll(() => {
+    const src = read(SRC.editProfileForm);
+
+    // Slice out the SECTIONS array literal itself, so a stray `id:` elsewhere
+    // in a 500-line component cannot join the enumeration.
+    const start = src.indexOf('const SECTIONS: SectionDef[] = [');
+    expect(start).toBeGreaterThan(-1);
+    const end = src.indexOf('\n];', start);
+    expect(end).toBeGreaterThan(start);
+    sectionsLiteral = src.slice(start, end);
+
+    ids = Array.from(sectionsLiteral.matchAll(/\bid:\s*'([^']+)'/g)).map((m) => m[1]);
+  });
+
+  test('the section list is non-trivial — the parse actually found sections', () => {
+    // Guards the enumeration itself: if the slice above ever stops matching,
+    // `ids` becomes [] and every "does not contain" assertion below passes
+    // vacuously. This is the one assertion that fails loudly in that case.
+    expect(ids.length).toBeGreaterThanOrEqual(10);
+    expect(new Set(ids).size).toBe(ids.length); // no duplicate ids
+  });
+
+  test('no section has the id "extras"', () => {
+    expect(ids).not.toContain('extras');
+  });
+
+  test('no section is labelled "A couple of extras"', () => {
+    const labels = Array.from(sectionsLiteral.matchAll(/\blabel:\s*(['"])(.*?)\1/g)).map(
+      (m) => m[2],
+    );
+    expect(labels.length).toBeGreaterThanOrEqual(10);
+    expect(labels.some((l) => /couple of extras/i.test(l))).toBe(false);
+  });
+
+  test('the editor declares no section carrying the billboard category', () => {
+    // The categories array is what wired the removed section to item rows.
+    // A section re-added under a different id or label would still need this.
+    expect(sectionsLiteral).not.toContain("'billboard'");
+  });
+
+  test('the sections the prompt moved to and from are both still there', () => {
+    // 'starters' is "A bit more about me" — where the billboard prompt now
+    // lives, added as a conversation starter rather than in code. 'links'
+    // stayed last when the removed section was spliced out from above it.
+    expect(ids).toContain('starters');
+    expect(ids[ids.length - 1]).toBe('links');
+  });
+});
+
+describe('KAN-469: the public profile no longer renders a standalone billboard', () => {
+  let page: string;
+
+  beforeAll(() => {
+    page = read(SRC.slugPage);
+  });
+
+  test('the public page source is non-trivial — the read actually found it', () => {
+    expect(page.length).toBeGreaterThan(1000);
+    expect(page).toContain('groupedItems');
+  });
+
+  test('nothing on the public page reads the billboard category', () => {
+    expect(page).not.toContain("groupedItems['billboard']");
+    expect(page).not.toContain('billboard');
+  });
+
+  test('the Q&A section that absorbs the prompt is untouched', () => {
+    // The billboard block sat between the Q&A section and Links. Removing it
+    // must not have taken either neighbour with it.
+    expect(page).toContain("groupedItems['questions']");
+    expect(page).toContain('A bit more about me');
+    expect(page).toContain('typedLinks');
+  });
+});

--- a/tests/unit/profile-sections.test.js
+++ b/tests/unit/profile-sections.test.js
@@ -14,6 +14,19 @@ const NEW_CATEGORIES = [
   'proud_of', 'life_hacks', 'questions', 'billboard',
 ];
 
+// KAN-469: the public profile no longer renders 'billboard' — the prompt it
+// existed for is now an ordinary conversation starter, so its answer appears
+// in the Q&A section with everything else.
+//
+// This is a SEPARATE list rather than a deletion from NEW_CATEGORIES, and the
+// distinction is the whole point: NEW_CATEGORIES also drives the items-step
+// label check above, which is still correct — the legacy wizard continues to
+// offer a Billboard label (retiring it is KAN-453). Removing the entry from
+// the shared list would have quietly weakened that assertion too, which is
+// the failure mode this repo keeps re-learning: a list edited to make one
+// caller green stops guarding its other callers without saying so.
+const PUBLIC_PAGE_CATEGORIES = NEW_CATEGORIES.filter((c) => c !== 'billboard');
+
 describe('KAN-137: Wizard supports new section categories', () => {
   const wizardPath = path.join(root, SRC.wizard);
   let wizardContent;
@@ -124,7 +137,7 @@ describe('KAN-137 / KAN-265: Public profile renders all categories (redesign)', 
     expect(pageContent).toContain('groupFavourites(typedItems)');
   });
 
-  test.each(NEW_CATEGORIES)('page renders category: %s', (cat) => {
+  test.each(PUBLIC_PAGE_CATEGORIES)('page renders category: %s', (cat) => {
     expect(content).toContain(`'${cat}'`);
   });
 
@@ -141,18 +154,14 @@ describe('KAN-137 / KAN-265: Public profile renders all categories (redesign)', 
     expect(content).toContain('A bit more about me');
   });
 
-  test('billboard has special large-quote rendering', () => {
-    expect(content).toContain("groupedItems['billboard']");
-    expect(content).toContain('giant billboard');
-  });
-
-  test('billboard renders with sage green background', () => {
-    const billboardSection = content.slice(
-      content.indexOf("groupedItems['billboard']"),
-      content.indexOf('Links */')
-    );
-    expect(billboardSection).toContain('bg-[var(--color-sage)]');
-  });
+  // KAN-469: two tests stood here — one asserting the standalone billboard
+  // block existed, one asserting its sage background. Both are gone with the
+  // block, and the guard that replaced them is the stronger direction:
+  // tests/unit/kan469-extras-section-removed.test.ts asserts the public page
+  // reaches `groupedItems['billboard']` NOWHERE, so it goes red if the block
+  // ever returns rather than red because it left. Sage-on-this-page coverage
+  // is unaffected — see the left-rule test immediately below, which is
+  // untouched. Founder-signed-off 2026-08-06.
 
   test('section headings use the sage left-rule (border-l-[3px])', () => {
     expect(content).toContain('border-l-[3px]');


### PR DESCRIPTION
Closes work for [KAN-469](https://checklyra.atlassian.net/browse/KAN-469). Founder-initiated design change, entered through the KAN-441 design loop.

**Design card:** [KAN-469.dc.html](https://claude.ai/design/p/c179aa52-22a7-4dd2-bd9d-682f21d2a76c?file=KAN-469.dc.html) — approved 2026-08-06, **scope option B**. Manifest state `DESIGN_APPROVED` → `DEV_IMPL`.

## What changes

The profile editor's **"A couple of extras"** section is removed. It carried two item categories and, in practice, only the giant billboard message — which becomes an ordinary prompt under **"A bit more about me"**, added by hand as a conversation starter rather than in code.

Option B also removes the standalone sage-green quote block from the public profile, so no render path is left that nothing can fill. `questions` items are unaffected: they already render in the public Q&A section, which is where the new prompt's answer will land too.

| File | Change |
|---|---|
| `src/app/dashboard/profile/edit-profile-form.tsx` | `extras` entry dropped from `SECTIONS` |
| `src/app/[slug]/page.tsx` | standalone billboard block removed |
| `tests/unit/kan469-extras-section-removed.test.ts` | **new** — 8 cases |
| `tests/unit/profile-sections.test.js` | 3 assertions, founder-signed-off (below) |

## Data

**Nothing is touched.** No migration, no backfill, no deletion. Both categories stay valid in the schema and in `ITEM_CATEGORY_TO_SECTION`.

| Environment | `billboard` items | `questions` items |
|---|---|---|
| `prod-lyra` (production + beta) | **0** | **0** |
| `dev-lyra` | 2 (seed) | 1 (seed) |

Verified 2026-08-06 by direct query. No member data is stranded.

## Tests

**New guard, mutation-verified.** A removal leaves an absence, and an absence is what a careless `toContain` cannot tell apart from a rename or a bad merge. The new suite *enumerates* the editor's section ids rather than sampling them, and asserts the public page reaches `groupedItems['billboard']` nowhere at all.

| mutation | failures |
|---|---|
| re-add the `extras` entry to `SECTIONS` | 3 |
| re-add the public billboard block | 1 |
| replace this suite's `stripComments` with identity | **0** |

That last row is reported as measured, not as hoped. The strip is currently **defence-in-depth, not load-bearing** — the two comments this change adds were written to avoid naming the strings they remove, so an un-stripped scan has nothing to match. The suite header says exactly that instead of claiming otherwise; the first draft claimed the opposite and the experiment disproved it. Each mutation was restored from a `/tmp` copy and confirmed byte-identical by `shasum`.

**Three existing assertions changed — founder-signed-off 2026-08-06:**

- **line 127** now iterates a new `PUBLIC_PAGE_CATEGORIES`. `NEW_CATEGORIES` is deliberately left whole, because it also drives the `items-step` label check, which is still correct — the legacy wizard genuinely offers a Billboard label (KAN-453 retires it). Deleting the entry from the shared list would have quietly weakened that second caller.
- **lines 145 + 154** (`billboard has special large-quote rendering`, `billboard renders with sage green background`) deleted as superseded by the inverted assertion above, which fails if the block *returns* rather than because it left.
- **line 157** (sage left-rule) untouched — sage coverage on that page is unaffected.

## Verification

- `npm run test:unit` → **3001 passed / 251 suites**; the only 18 failures are `guard-fail-closed.test.js` + `check-extraction-dod.test.js`, the two macOS-only suites CLAUDE.md documents as pre-existing (green on ubuntu-latest, unrelated to this diff).
- `npm run lint` → 0 errors · `npm run type-check` → clean · `npm run build` → success
- `check-ui-copy-ownership.sh` → OK (`UI-Change-Approved: KAN-469`)
- `check-test-reimplementation.py` (CTL-038) → no new findings · `check-comment-only-assertions.py` (CTL-039) → no new findings · `check-guard-path-drift.py` (CTL-035) → 0 dead

## Checklist

- [x] Docs / system map updated — **N/A**: no service, table, env var, route, scheduled job or security boundary changes. The design baseline is this ticket's doc footprint.
- [x] MCP coverage — **not applicable**: pure UI removal, no data-model change. `lyra_add_item` still accepts both categories.
- [x] Security review — no auth, RLS or input-validation surface touched; one public read path renders less.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[KAN-469]: https://checklyra.atlassian.net/browse/KAN-469?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ