### PR TITLE
fix(deps): override nanoid to ^3.3.17 to clear HIGH audit finding

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13564,9 +13564,9 @@
       "license": "ISC"
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
   },
   "overrides": {
     "postcss": "^8.5.18",
+    "nanoid": "^3.3.17",
     "tmp": "^0.2.7",
     "brace-expansion": "5.0.9",
     "@eslint/config-array": {


### PR DESCRIPTION
## Summary

`npm audit --audit-level=high` was failing on `develop` — `nanoid <3.3.17` (transitive via `@tailwindcss/postcss` → `postcss@8.5.23` [already overridden per SEC-94] → `nanoid@3.3.16`) carries a HIGH advisory: custom generators can loop indefinitely when `size=0` (GHSA-2v37-7h3g-55p8). This blocks the `audit` gate in `pr-checks.yml` and every `deploy-*.yml`.

Fix: add a scoped `"nanoid": "^3.3.17"` entry to `package.json` `overrides`, following the same pattern as the existing SEC-94 `postcss`/`brace-expansion`/`minimatch` overrides. Resolves to `nanoid@3.3.18`.

A second, unrelated MODERATE finding (`uuid <11.1.1` via dev-only `@lhci/cli`) remains in the audit but does not trip the HIGH-only gate — same precedent as SEC-97, not chased here.

## Jira Ticket

SEC-128

## Verification (clean `npm ci`)

- [x] `npm run lint` — pass, no new warnings
- [x] `npm run type-check` — pass
- [x] `npm run build` — pass
- [x] `npm run test:unit` — 2996/2996 tests, 250/250 suites pass
- [x] `npm audit --audit-level=high` — clean (0 high/critical; 2 pre-existing dev-only moderate findings remain, same as base)

## Checklist

- [x] Unit tests added/updated for new/changed functionality — n/a, dependency-version bump only, no code path changed
- [x] All existing tests pass (`npm run test:unit`)
- [x] Lint passes (`npm run lint`)
- [x] Type check passes (`npm run type-check`)
- [x] Build succeeds (`npm run build`)
- [x] Coverage has not decreased — no source files touched
- [x] No eslint-disable or ts-ignore without KAN-XX reference — n/a
- [x] Dependency-rule gate reviewed — n/a, no import changes
- [x] ARCHITECTURE.md updated if architectural changes were made — n/a, no architectural change
- [x] Ops routine / Control-Room registry updated if scheduled-routine behaviour changed — n/a
- [x] Docs / system map updated — N/A, pure dependency-security patch, no architecture/data-model/env-var change (KAN-359)

## Extraction Definition-of-Done (KAN-428)

N/A — this PR does not move, delete, or rename any file under `src/`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01X6F46NMQsGYCS5gf69rdMC)_