### PR TITLE
chore(SEC-125): E2E Cloudflare bypass secrets provisioned

### DIFF
--- a/.github/absent-secrets.txt
+++ b/.github/absent-secrets.txt
@@ -35,5 +35,3 @@ ATLASSIAN_DOMAIN              # explicit -z guard -> DATA UNAVAILABLE with reaso
 # (CLAUDE.md gotcha #7), so the authed E2E journey cannot run from CI at all
 # until the founder adds a CF WAF skip rule and provisions this header/secret
 # pair. Until then that coverage is UNVERIFIED, not passing.
-E2E_CF_BYPASS_HEADER        # open blocker: needs CF WAF skip rule, founder-provisioned (SEC-102)
-E2E_CF_BYPASS_SECRET        # open blocker: needs CF WAF skip rule, founder-provisioned (SEC-102)

--- a/.github/known-secrets.txt
+++ b/.github/known-secrets.txt
@@ -1,6 +1,7 @@
 # Secrets known to exist on luisa-sys/lyra (SEC-101).
 #
 # Regenerate with:  gh secret list --json name --jq '.[].name' | sort
+#                   ...then re-add this header — the command does not preserve it.
 # Then re-run:      python3 scripts/check-workflow-secret-refs.py
 #
 # GITHUB_TOKEN is minted per-run by Actions and is exempt, so it is not listed.
@@ -15,6 +16,8 @@ CLOUDFLARE_API_TOKEN
 CLOUDFLARE_KV_API_TOKEN
 CLOUDFLARE_KV_NAMESPACE_ID
 CLOUDFLARE_ZONE_ID
+E2E_CF_BYPASS_HEADER
+E2E_CF_BYPASS_SECRET
 E2E_SUPABASE_SERVICE_ROLE_KEY
 E2E_SUPABASE_SERVICE_ROLE_KEY_STAGING
 E2E_SUPABASE_URL


### PR DESCRIPTION
**[SEC-125](https://checklyra.atlassian.net/browse/SEC-125)** — both secrets now exist on the repo, so they move `absent-secrets.txt` → `known-secrets.txt`. CTL-029 green.

## The ticket was half stale
It was written as *"founder must add a CF WAF rule **and** provision the secrets"*. Opening the dashboard showed **the rule already existed and was Active** — *"E2E authed harness bypass (KAN-348)"*, hostname in `dev`/`stage` **and** header `x-lyra-e2e-bypass` equals a secret value.

So only the GitHub half was missing. Worth noting the consequence: **the header name isn't a free choice** — it's fixed by that rule, and a mismatch wouldn't error, it would silently send nothing.

## Small thing worth fixing in passing
The file's own regenerate instruction (`gh secret list ... | sort`) **does not preserve the header** — following it verbatim deletes the block explaining how to regenerate the file. Added a line saying so.

## Raised separately — [SEC-129](https://checklyra.atlassian.net/browse/SEC-129)
Custom rule **"GitHub Runner"** skips bot protection for any request whose User-Agent merely *contains* `github-actions`. A User-Agent is client-chosen, so that's an **open bypass needing no secret**, sitting in front of the properly secret-gated one. Almost certainly redundant now, but shouldn't be deleted blind.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[SEC-125]: https://checklyra.atlassian.net/browse/SEC-125?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SEC-129]: https://checklyra.atlassian.net/browse/SEC-129?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ