### PR TITLE
fix(tests): unblock 5 PRs, and restore two security guards that were silently green on macOS

### DIFF
--- a/scripts/check-extraction-dod.sh
+++ b/scripts/check-extraction-dod.sh
@@ -179,7 +179,12 @@ is_valid_check() {
 }
 
 HATCH_BAD=0
-for line in "${HATCH_LINES[@]}"; do
+# bash 3.2 (macOS) errors on expanding an EMPTY array under `set -u`; bash 4.4+
+# does not. Every run with no escape hatch therefore died here on a developer
+# machine while passing in CI — 18 permanently-red tests that trained everyone
+# to stop reading this suite (gotcha #28). The `+` form expands to nothing when
+# the array is empty and is identical on both.
+for line in ${HATCH_LINES[@]+"${HATCH_LINES[@]}"}; do
   # strip trailing CR / whitespace
   line="${line%$'\r'}"
   if ! grep -Eq "$HATCH_RE" <<<"$line"; then

--- a/scripts/check-server-action-exports.sh
+++ b/scripts/check-server-action-exports.sh
@@ -43,6 +43,20 @@ search_or_die() {
 # (Some `'use server'` directives appear inline in client files for actions —
 # we restrict to module-level by checking the first ~5 lines.)
 # Written portably for bash 3.2 (macOS) and bash 5.x (Ubuntu CI).
+# ---------------------------------------------------------------------------
+# Portability precondition (SEC-109). The exit-code check below cannot carry
+# this on its own: GNU grep (Linux/CI) returns 2 when a search path does not
+# exist, but BSD grep (macOS) returns 1 — indistinguishable from "no match".
+# So on a developer Mac an absent src/ read as a CLEAN SCAN and this control
+# reported green while searching nothing: exactly the SEC-79 false-green it
+# exists to prevent. Verified 2026-08-08 against /usr/bin/grep. Testing the
+# path directly is dialect-independent and true on both platforms.
+if [ ! -d src ] || [ ! -r src ]; then
+  echo "::error::check-server-action-exports: src/ is missing or unreadable, so the search command failed to run."
+  echo "::error::  Failing closed (exit 2) rather than reporting a clean scan that never ran."
+  exit 2
+fi
+
 search_or_die "listing 'use server' files under src/" \
   grep -rl --include='*.ts' --include='*.tsx' "'use server'" src/
 CANDIDATE_FILES="$SEARCH_OUT"

--- a/scripts/check-service-role-client.sh
+++ b/scripts/check-service-role-client.sh
@@ -29,6 +29,20 @@ FACTORY='src/lib/supabase-service.ts'
 # print "All service-role clients go through the factory" and pass a
 # security gate that never ran. That is the KAN-167 false-green class (and the
 # SEC-79 shape: a control reporting green while disabled). Exit 2 = unverified.
+# ---------------------------------------------------------------------------
+# Portability precondition (SEC-109). The exit-code check below cannot carry
+# this on its own: GNU grep (Linux/CI) returns 2 when a search path does not
+# exist, but BSD grep (macOS) returns 1 — indistinguishable from "no match".
+# So on a developer Mac an absent src/ read as a CLEAN SCAN and this control
+# reported green while searching nothing: exactly the SEC-79 false-green it
+# exists to prevent. Verified 2026-08-08 against /usr/bin/grep. Testing the
+# path directly is dialect-independent and true on both platforms.
+if [ ! -d src ] || [ ! -r src ]; then
+  echo "::error::check-service-role-client: src/ is missing or unreadable, so the search command failed to run."
+  echo "::error::  Failing closed (exit 2) rather than reporting a clean scan that never ran."
+  exit 2
+fi
+
 if MATCHES="$(grep -rnE '\.supabaseServiceRoleKey\(\)' --include='*.ts' --include='*.tsx' src/ 2>&1)"; then
   GREP_RC=0
 else

--- a/tests/scripts/check-comment-only-assertions.test.js
+++ b/tests/scripts/check-comment-only-assertions.test.js
@@ -17,7 +17,7 @@
  * real finding. Exempting the file is correct; exempting a file that genuinely
  * scans source would not be.
  */
-const { spawnSync } = require('node:child_process');
+const { spawnSync, execFileSync } = require('node:child_process');
 const { resolve } = require('node:path');
 const fs = require('node:fs');
 const os = require('node:os');
@@ -109,7 +109,16 @@ describe('CTL-039 — comment-satisfied assertion ratchet', () => {
     const rel = 'tests/unit/__ctl039_probe__.test.js';
     const abs = resolve(ROOT, rel);
     const idx = resolve(os.tmpdir(), `ctl039-index-${process.pid}`);
-    fs.copyFileSync(resolve(ROOT, '.git/index'), idx);
+    // `.git` is a DIRECTORY in a normal clone but a FILE in a git worktree,
+    // so resolve(ROOT, '.git/index') is ENOTDIR there. CLAUDE.md *mandates*
+    // worktrees for parallel sessions, so hardcoding the path meant this guard
+    // could not run for anyone following the house rule — green in CI, absent
+    // where the work actually happens. Ask git for the real git dir instead.
+    const gitDir = execFileSync('git', ['rev-parse', '--git-dir'], {
+      cwd: ROOT,
+      encoding: 'utf8',
+    }).trim();
+    fs.copyFileSync(resolve(ROOT, gitDir, 'index'), idx);
     const withIndex = { ...process.env, GIT_INDEX_FILE: idx };
 
     fs.writeFileSync(

--- a/tests/scripts/check-test-reimplementation.test.js
+++ b/tests/scripts/check-test-reimplementation.test.js
@@ -119,7 +119,16 @@ describe('CTL-038 — test-reimplementation ratchet', () => {
     const rel = 'tests/unit/__ctl038_probe__.test.js';
     const abs = resolve(ROOT, rel);
     const idx = resolve(os.tmpdir(), `ctl038-index-${process.pid}`);
-    fs.copyFileSync(resolve(ROOT, '.git/index'), idx);
+    // `.git` is a DIRECTORY in a normal clone but a FILE in a git worktree,
+    // so resolve(ROOT, '.git/index') is ENOTDIR there. CLAUDE.md *mandates*
+    // worktrees for parallel sessions, so hardcoding the path meant this guard
+    // could not run for anyone following the house rule — green in CI, absent
+    // where the work actually happens. Ask git for the real git dir instead.
+    const gitDir = execFileSync('git', ['rev-parse', '--git-dir'], {
+      cwd: ROOT,
+      encoding: 'utf8',
+    }).trim();
+    fs.copyFileSync(resolve(ROOT, gitDir, 'index'), idx);
     const withIndex = { ...process.env, GIT_INDEX_FILE: idx };
 
     fs.writeFileSync(

--- a/tests/unit/test-meta-integrity.test.js
+++ b/tests/unit/test-meta-integrity.test.js
@@ -104,6 +104,15 @@ const EXEMPT_BLOCKS = new Set([
 // meta-check doesn't flag its own documentation.
 const SELF_FILENAME = path.basename(__filename);
 
+// The CTL-038 and CTL-039 guard suites each prove their checker detects a NEW
+// finding by writing a probe file into tests/unit/, running the checker, then
+// deleting it. Jest runs suites in parallel, so `--listTests` above can observe
+// a probe that is gone by the time we read it — an ENOENT that has nothing to
+// do with what this file asserts, and which failed five unrelated PRs in a row.
+// Excluding the naming convention is the fix; the readFileSync guard below
+// closes the remaining window between listing and reading.
+const TRANSIENT_PROBE_RE = /^__.*_probe__.*\.test\.js$/;
+
 describe('KAN-168: every test block must make at least one assertion', () => {
   // Discover all unit test files (excluding self — see SELF_FILENAME above).
   const listOutput = execSync('npx jest --testPathPatterns=tests/unit --listTests', {
@@ -114,16 +123,38 @@ describe('KAN-168: every test block must make at least one assertion', () => {
     .trim()
     .split('\n')
     .filter(Boolean)
-    .filter((f) => path.basename(f) !== SELF_FILENAME);
+    .filter((f) => path.basename(f) !== SELF_FILENAME)
+    .filter((f) => !TRANSIENT_PROBE_RE.test(path.basename(f)));
 
   test('discovered at least one test file to scan', () => {
     expect(testFiles.length).toBeGreaterThan(0);
   });
 
+  // Pins the exclusion by NAME against the two suites that actually create
+  // probes, so renaming a probe without updating this pattern fails here rather
+  // than resurfacing as an intermittent ENOENT on an unrelated PR. Asserted both
+  // ways: a real test filename must NOT be excluded, or a too-greedy pattern
+  // could quietly drop the whole suite and this file would still pass.
+  test('transient guard probes are excluded, real test files are not', () => {
+    expect(TRANSIENT_PROBE_RE.test('__ctl038_probe__.test.js')).toBe(true);
+    expect(TRANSIENT_PROBE_RE.test('__ctl039_probe__.test.js')).toBe(true);
+    expect(TRANSIENT_PROBE_RE.test('test-meta-integrity.test.js')).toBe(false);
+    expect(TRANSIENT_PROBE_RE.test('rate-limit.test.js')).toBe(false);
+    expect(testFiles.some((f) => TRANSIENT_PROBE_RE.test(path.basename(f)))).toBe(false);
+  });
+
   test('every test() / it() block contains expect(', () => {
     const violations = [];
     for (const file of testFiles) {
-      const source = fs.readFileSync(file, 'utf8');
+      let source;
+      try {
+        source = fs.readFileSync(file, 'utf8');
+      } catch (err) {
+        // Narrow on purpose: a file that no longer exists cannot be a committed
+        // test, so skipping it hides nothing. Any other error still throws.
+        if (err.code === 'ENOENT') continue;
+        throw err;
+      }
       const blocks = extractTestBlocks(source);
       const fileName = path.basename(file);
       for (const block of blocks) {


### PR DESCRIPTION
Started as *"why is PR Quality Gate failing on five docs PRs"*. Ended up finding the local suite has **never been green on macOS**, and that **two fail-closed security guards do not fail closed** on the platform where releases are prepared.

## 1 — The flake blocking #710, #707, #703, #689, #685
`test-meta-integrity.test.js` lists `tests/unit/` then reads each file. The CTL-038 and CTL-039 guard suites each prove their checker detects a *new* finding by **writing a probe into `tests/unit/`**, running the checker, then deleting it. Jest runs suites in parallel — so the probe gets listed, then vanishes before it's read. `ENOENT`, on a suite unrelated to either.

Excluded by naming convention, plus a narrow ENOENT skip for the remaining window. Pinned by a test asserting **both** directions — a too-greedy pattern would silently drop the whole suite and still pass.

## 2 — Two CTL suites couldn't run in a worktree at all
Both copied `.git/index` by joining the repo root. **In a git worktree `.git` is a file, not a directory** → `ENOTDIR`. CLAUDE.md *mandates* worktrees for parallel sessions, so anyone following the house rule lost both guards locally while CI stayed green.

## 3 — `check-extraction-dod.sh` died on every run with no escape hatch
Expanding an **empty array under `set -u`** errors in bash 3.2 (macOS), fine in 4.4+. One line — that suite goes from 18 permanently-red tests to **27/27**. CLAUDE.md itself warns a standing red *"trains you to stop reading it"*.

## 4 — The one that matters
CLAUDE.md left this open: *"either that fix is Linux-only or the test's PATH shim is."* **It's the fix.**

**GNU grep returns 2 when a search path doesn't exist. BSD grep returns 1 — indistinguishable from "no match."** So `if [ "$RC" -gt 1 ]` never fires on macOS, and `check-service-role-client.sh` printed **"All service-role clients go through the factory ✓" and exited 0 while searching nothing.**

Verified against `/usr/bin/grep`. That's exactly the SEC-79 false-green both guards were written to prevent — reintroduced by a grep dialect. Fixed with a dialect-independent precondition on both.

## Test integrity
**No existing assertion was changed.** The new guard message was worded to satisfy the contract `guard-fail-closed.test.js` already asserts, rather than editing the test to fit the code — **that file is untouched.**

## Verification
Mutation-verified throughout. Removing the probe exclusion turns the suite red. The service-role guard still exits **1** on a real violation (flagged with file+line), **2** when `src/` is absent, **0** when clean.

**macOS: 256 suites / 3103 tests, all passing.** Was 4 failed suites / 20 failed tests.

## Follow-up
The CLAUDE.md note documenting *"18 expected macOS failures"* is **now stale** and should be updated once this lands — I've left it rather than editing the operating manual in a test-fix PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)