### PR TITLE
feat(controls): CTL-040 — make the design attestation load-bearing (KAN-457)

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -117,6 +117,26 @@ jobs:
         env:
           PR_BODY: ${{ github.event.pull_request.body }}
         run: BASE_REF="origin/${{ github.base_ref }}" bash scripts/check-extraction-dod.sh
+      - name: Design re-baseline gate (CTL-040, KAN-457)
+        # Makes the DoD's design-system attestation load-bearing. That
+        # attestation is prose — a human types `done` — because the Claude
+        # Design source is in a different, PRIVATE repo this CI cannot read.
+        # An attestation satisfied by typing a word is indistinguishable from
+        # no control: the comment-satisfied-assertion shape (CTL-039) one layer
+        # up. So when a PR MOVES a design-bearing file, design/BASELINE.json's
+        # `baseline_ref` must change in the same PR — the claim then rests on a
+        # diff rather than a promise.
+        #
+        # Deliberately narrow: it cannot prove the design system was really
+        # re-pointed (CI still cannot read that repo), only that someone opened
+        # it and recorded its head. Stating that limit is the point; a control
+        # read as broader than it is gets mistaken for coverage.
+        # Escape hatch: `Design-Baseline-Ok: <JIRA-KEY> <reason>` — key AND
+        # reason both required, printed on every run.
+        run: |
+          set -euo pipefail
+          python3 scripts/check-design-baseline.py --self-test
+          BASE_REF="origin/${{ github.base_ref }}" python3 scripts/check-design-baseline.py
       - name: Guard-path-drift check (KAN-414 F1)
         # Guard #12, and the companion to #13 above. Where the DoD gate looks at
         # THIS PR's diff, this one audits the WHOLE registry on every run: every

--- a/controls/registry.json
+++ b/controls/registry.json
@@ -698,6 +698,26 @@
       ],
       "escape_hatch": "// comment-assertion-ok: <JIRA-KEY> <reason>",
       "added": "2026-08-02"
+    },
+    {
+      "id": "CTL-040",
+      "name": "Design re-baseline gate",
+      "defect_class": "self-certified-attestation",
+      "summary": "Requires design/BASELINE.json's baseline_ref to change in the SAME PR that moves a design-bearing file (src/app/globals.css, src/components/**, or any src/app/**/*.tsx). Exists because the Claude Design build loop's source lives in a different, PRIVATE repo (github.com/luisa-sys/lyra-design-system) that this CI cannot read, so the extraction DoD could only ask a human to attest 'EXTRACTION-DOD-DESIGN-SYSTEM: done' - and an attestation satisfied by typing a word is indistinguishable from no control, the same defect shape as a comment-satisfied assertion (CTL-039) one layer up. The concrete failure it covers is KAN-419 5.1: build.py reads globals.css and reconstructs 21 @dsCard previews from page sources, so a move breaks its source pointer loudly but on the founder's machine, hours later, with nothing warning the agent that moved it. SCOPE LIMIT, stated deliberately: this does NOT prove the design system was re-pointed or regenerated - CI cannot read that repo. It proves someone opened it, took its head and recorded it here, raising a false attestation's cost from 'type a word' to 'go and look'. Fires only on relocation (D/R), not edits, because an edit leaves the pointer resolving; widening it would make every extraction PR demand a meaningless re-baseline and drive people to the hatch by reflex.",
+      "implementation": "scripts/check-design-baseline.py",
+      "kind": "ci-gate",
+      "wired_in": [
+        ".github/workflows/pr-checks.yml"
+      ],
+      "prevents": [
+        "KAN-457",
+        "KAN-441",
+        "KAN-419",
+        "KAN-415"
+      ],
+      "escape_hatch": "Design-Baseline-Ok: <JIRA-KEY> <reason>  (commit trailer; key AND reason both required)",
+      "self_test": "scripts/check-design-baseline.py --self-test",
+      "added": "2026-08-08"
     }
   ]
 }

--- a/design/BASELINE.json
+++ b/design/BASELINE.json
@@ -1,0 +1,24 @@
+{
+  "_why": [
+    "KAN-457. This file is the app repo's record of which Claude Design commit the",
+    "rendered UI was last reconciled against. It exists because the design system",
+    "lives in a DIFFERENT, PRIVATE repo (github.com/luisa-sys/lyra-design-system)",
+    "that this repo's CI cannot read, so the extraction DoD could only ever ask a",
+    "human to attest 'done' — and an attestation satisfied by typing a word is",
+    "indistinguishable from no control at all.",
+    "",
+    "CTL-040 (scripts/check-design-baseline.py) makes that attestation load-bearing:",
+    "when a PR MOVES a file on a design-bearing surface, `baseline_ref` below must",
+    "change in the SAME PR. The claim is then backed by a diff, not a promise.",
+    "",
+    "This does NOT prove the design system was actually re-pointed — CI still cannot",
+    "read that repo. It proves someone opened it, took its head, and recorded it",
+    "here. That is a deliberate, stated limit; see docs/MODULARISATION_EXTRACTION_DOD.md",
+    "section 2.2 and the CTL-040 registry entry."
+  ],
+  "design_repo": "https://github.com/luisa-sys/lyra-design-system",
+  "baseline_ref": "70c583093955aa76b7d59e83606a9b516cd8581b",
+  "reconciled_on": "2026-08-08",
+  "reconciled_for": "KAN-457",
+  "note": "Initial baseline. Design head at the time CTL-040 was introduced: 'chore(design): KAN-469 -> DEV_IMPL (PR #702)'."
+}

--- a/docs/DESIGN_CHANGE_WORKFLOW.md
+++ b/docs/DESIGN_CHANGE_WORKFLOW.md
@@ -5,8 +5,8 @@
 > **repo mirror**, so the process is readable from the app repo, in CI and
 > offline. **If the two differ, `BUILD-LOOP.md` wins and this mirror is
 > regenerated.** Registered in `docs/DOC_SOURCE_OF_TRUTH.md`. Epic **KAN-441**;
-> loop enforcement **KAN-456**; the canonical-home question is **open** — see
-> "Still open" below.
+> loop enforcement **KAN-456**; the canonical-home question is **open but no
+> longer blocking** — see "Still open" below and the CTL-040 note beneath it.
 
 Lyra's UI changes go through **Claude Design** before they reach code. A change
 is designed, approved by Luisa, then implemented, promoted, re-imported and
@@ -247,11 +247,41 @@ One trap this makes concrete:
 
 | Question | Ticket | Status |
 |---|---|---|
-| **Canonical home.** Should `lyra-design-system` fold into the `lyra` monorepo, so CI can diff design against `src/` directly instead of relying on a human attestation? | **KAN-427**, **KAN-457** | **Open.** Until it is decided, the two checkers cannot run in this repo's CI. |
+| **Canonical home.** Should `lyra-design-system` fold into the `lyra` monorepo, so CI can diff design against `src/` directly instead of relying on a human attestation? | **KAN-427** | **Open — but no longer blocking.** The two checkers still cannot run in this repo's CI, and that is unchanged. What changed (2026-08-08, KAN-457) is that it is no longer a prerequisite for having *any* control here: **CTL-040** gates the app side from inside this repo. Folding the repos would buy a genuinely stronger check; it is now an improvement rather than an unblock. |
 | **Documentation class.** This doc is registered in `docs/DOC_SOURCE_OF_TRUTH.md` as its own class (canonical = the `lyra-design-system` spec). The alternative is to treat it as an Ops/runbook narrative with a Confluence page as canonical — which would make `BUILD-LOOP.md` a *second* mirror, i.e. three surfaces for one process. | **Unspecified — needs a ticket.** Surfaced by epic KAN-441, but no ticket tracks the decision. | **Open.** The table currently records what is true today. |
 | **Which surface performs the `DesignSync` writes.** `docs/CLAUDE_SURFACE_POLICY.md` is a strict binary — Claude Code is the auditable surface, chat is the discussion surface — and its "What requires Claude Code" table has no row for Claude Design. Writing a card is a persisted state change. `DesignSync` **is** available in Claude Code, so routing writes through it would satisfy the policy, but the rule is not written down. | **Unspecified — needs a ticket.** KAN-456 tracks loop *enforcement*, not this question; `docs/ADR.md` (ADR-009) raises it with no key attached either. | **Open** — needs a row in that table. |
 
-**CTL-040** (registering `check-design-sync.py` as a control) is **pending on
-KAN-457** and is deliberately *not* in `controls/registry.json`:
+### CTL-040 — what shipped, and what it is not
+
+**Updated 2026-08-08 (KAN-457).** The paragraph that stood here said CTL-040 was
+pending, because registering `check-design-sync.py` is impossible from this repo:
 `scripts/check-control-registry.py` fails when a registered control's
-implementation file is missing, and that file lives in the other repo.
+implementation file is missing, and that file lives in the other repo. **That
+constraint is real and has not gone away.**
+
+So **CTL-040 as shipped is a different control**, and the distinction matters
+enough to state rather than let the ID paper over:
+
+| | `check-design-sync.py` | **CTL-040** (`scripts/check-design-baseline.py`) |
+|---|---|---|
+| Repo | `lyra-design-system` | **this one** |
+| Checks | the loop's G0–G4 gates across both repos and all four envs | that a PR moving a design-bearing file also moves `design/BASELINE.json`'s `baseline_ref` |
+| Registered | no — cannot be | **yes** |
+| Runs in this CI | no | **yes, on every PR** |
+
+CTL-040 does **not** verify the design system was re-pointed or regenerated —
+this CI still cannot read that repo. It verifies that whoever moved the file
+opened it, took its head commit, and recorded it. That raises the cost of a
+false `EXTRACTION-DOD-DESIGN-SYSTEM: done` from *typing a word* to *going and
+looking*, which is the most an in-repo check can do across a boundary it cannot
+cross.
+
+The human attestation therefore **still stands**. CTL-040 backs it; it does not
+replace it, and it does not close the canonical-home question — it removes that
+question as a *blocker* for having any control at all. Registering
+`check-design-sync.py` itself remains available only if the repos ever fold
+together.
+
+> The `lyra-design-system` side of this — running `check-design-sync.py` in that
+> repo's own CI, which currently has **no workflows at all** — is the other half
+> and is not done. Tracked on KAN-457.

--- a/docs/MODULARISATION_EXTRACTION_DOD.md
+++ b/docs/MODULARISATION_EXTRACTION_DOD.md
@@ -64,6 +64,7 @@ the KAN-419 register; the section reference points at the evidence.
 | `tests/**` | The module's tests. A test left behind is a test that no longer covers the module it names. | §1 D, KAN-417 |
 | `.github/workflows/*.yml` | 30 `bash scripts/X` literals + Actions `paths:` filters + one anchored `grep -E` on changed paths in `pr-checks.yml`. | §1 D |
 | `tsconfig.json`, `jest.config.js`, `package.json`, `eslint.config.mjs`, `playwright.config.ts` | TS path mapping, `collectCoverageFrom`, `--testPathPatterns`, flat-config globs, `testDir` / `testMatch` / `testIgnore`. | §1 D |
+| `design/BASELINE.json` | The app-side record of which Claude Design commit the UI was last reconciled against. Moving a design-bearing file breaks a pointer held in a **different, private repo** — so CTL-040 requires `baseline_ref` to change in the same PR. This is the checkable half of the §2.2 design attestation; see the note there for what it deliberately does **not** prove. | §2.2, KAN-457 |
 
 ### 2.2 Human-attested — CI can never check these
 
@@ -71,6 +72,37 @@ Two couplings live outside every repository this CI can read. **No grep will
 ever find them.** A ticked box is a weaker control than a machine check, and
 this document is not going to pretend otherwise — it is simply the only control
 available for these two.
+
+> **⚠️ Updated 2026-08-08 (KAN-457) — the design attestation is now half
+> machine-checked.** The sentence above was true and remains true about the
+> *design system's contents*. But it was hiding something: an attestation a
+> developer satisfies by **typing `done`** is indistinguishable from no control
+> at all. That is the comment-satisfied-assertion defect (CTL-039) one layer up
+> — a gate that passes for a reason unrelated to what it claims.
+>
+> **CTL-040** (`scripts/check-design-baseline.py`) closes the checkable half.
+> When a PR **moves** a design-bearing file — `src/app/globals.css`,
+> `src/components/**`, or any `src/app/**/*.tsx` — `design/BASELINE.json`'s
+> `baseline_ref` must change **in the same PR**. The claim then rests on a diff
+> instead of a promise.
+>
+> **What it still cannot do**, stated plainly rather than left to be assumed:
+> it cannot prove the design system was actually re-pointed and regenerated,
+> because CI still cannot read that repo. It proves someone opened it, took its
+> head commit, and recorded it here. That raises the cost of a false
+> attestation from *type a word* to *go and look* — the most any in-repo check
+> can do across a boundary it cannot cross. The `EXTRACTION-DOD-DESIGN-SYSTEM:`
+> line below therefore **still stands**; CTL-040 backs it, it does not replace
+> it.
+>
+> It fires on **relocation only** (`D`/`R`), never a plain edit: an edit leaves
+> the generator's pointer resolving. Widening it would make every extraction PR
+> demand a meaningless re-baseline and train people to reach for the escape
+> hatch by reflex, which is how a gate becomes noise and then gets ignored.
+>
+> Escape hatch: `Design-Baseline-Ok: <JIRA-KEY> <reason>` — **both** a key and
+> a reason are required, and a bare key does not suppress (pinned by a test,
+> because that bypass would degrade the gate back into the prose it replaced).
 
 | Coupling | What breaks | PR-body line |
 |---|---|---|

--- a/scripts/check-design-baseline.py
+++ b/scripts/check-design-baseline.py
@@ -1,0 +1,346 @@
+#!/usr/bin/env python3
+"""
+CTL-040 — a move on a design-bearing surface must carry a recorded re-baseline.
+
+WHY THIS EXISTS
+---------------
+The Claude Design -> dev build loop (KAN-441) keeps its source in a DIFFERENT,
+PRIVATE repo: github.com/luisa-sys/lyra-design-system. This repo's CI cannot
+read it. So the extraction DoD (docs/MODULARISATION_EXTRACTION_DOD.md section
+2.2) could only ask a human to attest `EXTRACTION-DOD-DESIGN-SYSTEM: done`.
+
+An attestation that is satisfied by typing a word is indistinguishable from no
+control. That is the same defect class this programme has been chasing all
+along — a comment-satisfied assertion (CTL-039) is a scan the prose satisfies;
+a prose-only attestation is a gate the typist satisfies. One layer up, same
+shape, same consequence: it passes for a reason unrelated to the thing it
+claims to check.
+
+The concrete failure it leaves open is recorded in KAN-419 section 5.1 and
+restated in the DoD: `build.py` reads `src/app/globals.css` and reconstructs 21
+`@dsCard` previews from page sources. Move one of those files and the
+generator's source pointer breaks — loudly, but on the founder's machine, hours
+later, with nothing warning the agent that moved it.
+
+WHAT THIS ACTUALLY PROVES — AND WHAT IT DOES NOT
+------------------------------------------------
+It proves that whoever moved a design-bearing file opened the design repo, took
+its head commit, and recorded it in `design/BASELINE.json` in the same PR. The
+claim is then backed by a diff instead of a promise.
+
+It does NOT prove the design system was really re-pointed and regenerated. CI
+still cannot read that repo, so nothing here can. That limit is deliberate and
+stated rather than papered over: this control raises the cost of a false
+attestation from "type a word" to "go and look", which is the most any in-repo
+check can do across a repo boundary it cannot cross.
+
+Registering this as a control with an honest, narrow claim is the point. A
+control whose stated scope exceeds what it verifies is worse than none, because
+it is read as coverage.
+
+EXIT CODES
+  0  pass (including: no design-bearing move in this range)
+  1  a design-bearing file moved and the baseline did not change
+  2  cannot verify — fail closed
+
+ENV
+  BASE_REF   default origin/develop
+  HEAD_REF   default HEAD
+
+ESCAPE HATCH
+  A commit trailer in the range:
+      Design-Baseline-Ok: <JIRA-KEY> <reason>
+  Requires a Jira key and a reason, and every active exception is printed on
+  every run — the `UI-Change-Approved` loudness standard.
+"""
+from __future__ import annotations
+
+import json
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+BASELINE_PATH = "design/BASELINE.json"
+
+# Surfaces the design system is generated FROM. `build.py` reads globals.css for
+# tokens and reconstructs page previews; components are the ui-kit. A move of
+# anything at or under these breaks a pointer that lives outside this repo.
+DESIGN_SURFACES = (
+    "src/app/globals.css",
+    "src/components/",
+)
+# Page/layout sources carry `@dsCard` previews. Matched by suffix so a move of
+# any rendered route is caught, not just the ones that have a card today —
+# a card added later must not silently fall outside the gate.
+DESIGN_SUFFIXES = (".tsx",)
+DESIGN_PREFIX_FOR_SUFFIX = "src/app/"
+
+HATCH_RE = re.compile(
+    r"^Design-Baseline-Ok:\s*([A-Z][A-Z0-9]+-\d+)\s+(\S.*)$",
+    re.M,
+)
+
+
+class Unverifiable(Exception):
+    """Raised when the check cannot reach a verdict. Always exit 2."""
+
+
+def die_unverifiable(msg: str) -> None:
+    print(f"::error::check-design-baseline: {msg}")
+    print(
+        "::error::  Failing closed (exit 2): a gate that cannot verify must "
+        "never read as a pass."
+    )
+    sys.exit(2)
+
+
+def git(*args: str) -> str:
+    """Run git; anything but exit 0 is unverifiable, never a silent empty result."""
+    try:
+        out = subprocess.run(
+            ["git", "-C", str(REPO_ROOT), *args],
+            capture_output=True,
+            text=True,
+            timeout=60,
+        )
+    except Exception as exc:  # noqa: BLE001 - surfaced as unverifiable, not swallowed
+        raise Unverifiable(f"`git {' '.join(args)}` could not run: {exc}") from exc
+    if out.returncode != 0:
+        raise Unverifiable(
+            f"`git {' '.join(args)}` failed (exit {out.returncode}): "
+            f"{(out.stderr or out.stdout).strip()}"
+        )
+    return out.stdout
+
+
+# --------------------------------------------------------------- pure logic
+# Split out so the decision is testable without a git fixture. The guard test
+# in tests/scripts/ drives the real git path end to end.
+
+
+def is_design_bearing(path: str) -> bool:
+    """Does a move of `path` invalidate something the design system points at?"""
+    if any(
+        path == s or path.startswith(s)
+        for s in DESIGN_SURFACES
+    ):
+        return True
+    return path.startswith(DESIGN_PREFIX_FOR_SUFFIX) and path.endswith(DESIGN_SUFFIXES)
+
+
+def moved_design_paths(name_status: str) -> list[str]:
+    """Moved-FROM paths (D deleted, R renamed) that are design-bearing.
+
+    A pure edit is not a move and is out of scope: the design system's pointer
+    still resolves. It is relocation that breaks it.
+    """
+    found: list[str] = []
+    for line in name_status.splitlines():
+        if not line.strip():
+            continue
+        parts = line.split("\t")
+        status, old = parts[0], parts[1] if len(parts) > 1 else ""
+        if not status or status[0] not in ("D", "R"):
+            continue
+        if old and is_design_bearing(old):
+            found.append(old)
+    return found
+
+
+def read_baseline_ref(blob: str, where: str) -> str:
+    """Parse a baseline_ref out of BASELINE.json content, or fail closed."""
+    try:
+        data = json.loads(blob)
+    except json.JSONDecodeError as exc:
+        raise Unverifiable(f"{BASELINE_PATH} at {where} is not valid JSON: {exc}") from exc
+    ref = data.get("baseline_ref")
+    if not isinstance(ref, str) or not ref.strip():
+        raise Unverifiable(
+            f"{BASELINE_PATH} at {where} has no non-empty string `baseline_ref`."
+        )
+    return ref.strip()
+
+
+def hatches(commit_msgs: str) -> list[tuple[str, str]]:
+    return [(m.group(1), m.group(2).strip()) for m in HATCH_RE.finditer(commit_msgs)]
+
+
+# ------------------------------------------------------------------- driver
+
+
+def main() -> int:
+    if "--self-test" in sys.argv:
+        return self_test()
+
+    base_ref = os.environ.get("BASE_REF", "origin/develop")
+    head_ref = os.environ.get("HEAD_REF", "HEAD")
+
+    try:
+        git("rev-parse", "--verify", "--quiet", base_ref)
+    except Unverifiable:
+        die_unverifiable(
+            f"base ref '{base_ref}' not found — cannot compute the change range."
+        )
+
+    try:
+        merge_base = git("merge-base", base_ref, head_ref).strip()
+        if not merge_base:
+            raise Unverifiable(f"no merge-base for {base_ref}..{head_ref}.")
+
+        name_status = git("diff", "--name-status", "-M", merge_base, head_ref)
+        moved = moved_design_paths(name_status)
+
+        if not moved:
+            print(
+                "check-design-baseline: no design-bearing file was moved in this "
+                "range — not a re-baseline PR. OK."
+            )
+            return 0
+
+        print(
+            f"check-design-baseline: {len(moved)} design-bearing move(s) detected:"
+        )
+        for p in moved:
+            print(f"  moved: {p}")
+
+        # Escape hatch, printed loudly whether or not it is needed.
+        msgs = git("log", f"{merge_base}..{head_ref}", "--format=%B")
+        active = hatches(msgs)
+        if active:
+            for key, reason in active:
+                print(
+                    f"::warning::check-design-baseline: EXCEPTION in force — "
+                    f"{key}: {reason}"
+                )
+            print(
+                "check-design-baseline: suppressed by an explicit, attributed "
+                "exception. OK."
+            )
+            return 0
+
+        head_blob = git("show", f"{head_ref}:{BASELINE_PATH}")
+        head_ref_val = read_baseline_ref(head_blob, head_ref)
+
+        try:
+            base_blob = git("show", f"{merge_base}:{BASELINE_PATH}")
+        except Unverifiable:
+            # The baseline did not exist at the merge-base: this PR introduces
+            # it. That IS a re-baseline, so it satisfies the gate.
+            print(
+                f"check-design-baseline: {BASELINE_PATH} is introduced by this "
+                f"PR (ref {head_ref_val[:12]}). OK."
+            )
+            return 0
+
+        base_ref_val = read_baseline_ref(base_blob, merge_base[:12])
+
+        if head_ref_val == base_ref_val:
+            print(
+                f"::error::check-design-baseline: a design-bearing file moved, but "
+                f"{BASELINE_PATH} still points at {base_ref_val[:12]}."
+            )
+            print(
+                "::error::  Moving one of these files breaks a pointer held in a "
+                "repo this CI cannot read (github.com/luisa-sys/lyra-design-system)."
+            )
+            print(
+                "::error::  Re-point the design system, then record its new head "
+                f"as `baseline_ref` in {BASELINE_PATH} in THIS PR."
+            )
+            print(
+                "::error::  If the move genuinely cannot affect the design source, "
+                "say so explicitly with a commit trailer:"
+            )
+            print("::error::      Design-Baseline-Ok: <JIRA-KEY> <reason>")
+            return 1
+
+        print(
+            f"check-design-baseline: baseline moved {base_ref_val[:12]} -> "
+            f"{head_ref_val[:12]}. OK."
+        )
+        return 0
+
+    except Unverifiable as exc:
+        die_unverifiable(str(exc))
+        return 2  # unreachable; die_unverifiable exits
+
+
+# --------------------------------------------------------------- self-test
+
+
+def self_test() -> int:
+    """Pin the decision logic against fixtures, including the cases that would
+    make the gate vacuous if they regressed."""
+    failures: list[str] = []
+
+    def check(label: str, got, want) -> None:
+        if got != want:
+            failures.append(f"{label}: got {got!r}, want {want!r}")
+
+    # Surfaces in scope.
+    check("globals.css", is_design_bearing("src/app/globals.css"), True)
+    check("component", is_design_bearing("src/components/ui/button.tsx"), True)
+    check("page tsx", is_design_bearing("src/app/oauth/authorize/page.tsx"), True)
+    check("nested page", is_design_bearing("src/app/dashboard/profile/page.tsx"), True)
+
+    # Out of scope — a lib move does not break a design pointer, and treating
+    # it as one would make every extraction PR demand a meaningless re-baseline
+    # until people reached for the hatch by reflex.
+    check("lib ts", is_design_bearing("src/lib/oauth/jwt.ts"), False)
+    check("route ts", is_design_bearing("src/app/oauth/token/route.ts"), False)
+    check("test", is_design_bearing("tests/unit/foo.test.ts"), False)
+    # A prefix that merely *starts* like a surface must not match.
+    check("near-miss", is_design_bearing("src/components-legacy/x.tsx"), False)
+
+    # Move detection: only D and R count; a pure edit (M) does not.
+    ns = (
+        "M\tsrc/app/dashboard/page.tsx\n"
+        "R100\tsrc/components/card.tsx\tsrc/ui/card.tsx\n"
+        "D\tsrc/app/globals.css\n"
+        "A\tsrc/app/new/page.tsx\n"
+        "M\tsrc/lib/oauth/jwt.ts\n"
+    )
+    check(
+        "moved set",
+        moved_design_paths(ns),
+        ["src/components/card.tsx", "src/app/globals.css"],
+    )
+    # The vacuity case: if this returned [] for a real move set the whole gate
+    # would silently pass forever.
+    check("moved non-empty", len(moved_design_paths(ns)) > 0, True)
+
+    # Baseline parsing.
+    check("ref parse", read_baseline_ref('{"baseline_ref":"abc123"}', "x"), "abc123")
+    for bad, why in (
+        ('{"baseline_ref":""}', "empty"),
+        ('{"baseline_ref":null}', "null"),
+        ("{}", "absent"),
+        ("not json", "unparseable"),
+    ):
+        try:
+            read_baseline_ref(bad, "x")
+            failures.append(f"baseline {why}: should have raised Unverifiable")
+        except Unverifiable:
+            pass
+
+    # Escape hatch must require BOTH a key and a reason.
+    check("hatch ok", hatches("Design-Baseline-Ok: KAN-457 moved a test helper"),
+          [("KAN-457", "moved a test helper")])
+    check("hatch no reason", hatches("Design-Baseline-Ok: KAN-457"), [])
+    check("hatch no key", hatches("Design-Baseline-Ok: because"), [])
+
+    if failures:
+        for f in failures:
+            print(f"::error::self-test: {f}")
+        print(f"check-design-baseline self-test: FAILED ({len(failures)})")
+        return 1
+
+    print("check-design-baseline self-test: OK")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/gen-test-paths.mjs
+++ b/scripts/gen-test-paths.mjs
@@ -68,7 +68,10 @@ const OUT_JSON = join(ROOT, 'tests/support/source-paths.json');
 // Repo roots a test may legitimately reference by path, encoded in the regex
 // below. `tests/` itself is deliberately absent: a test referencing another
 // test is test-estate coupling, which KAN-429 owns, not this manifest.
-const LITERAL_RE = /'((?:src|supabase|scripts|public|\.github)\/[A-Za-z0-9_./[\]()@-]+)'/g;
+// `design/` added 2026-08-08 (KAN-457): design/BASELINE.json is the app-side
+// design re-baseline pointer CTL-040 gates on, and a root the manifest cannot
+// name is a root whose tests must hard-code it.
+const LITERAL_RE = /'((?:src|supabase|scripts|public|design|\.github)\/[A-Za-z0-9_./[\]()@-]+)'/g;
 
 function trackedTestFiles() {
   const out = execFileSync('git', ['-C', ROOT, 'ls-files', 'tests'], {

--- a/tests/scripts/check-design-baseline.test.js
+++ b/tests/scripts/check-design-baseline.test.js
@@ -33,6 +33,12 @@ const BASELINE = SRC.baseline;
 // `src/components/**` is design-bearing, so if that path ever moves, this file
 // must be revisited. Naming them through the manifest is what makes that true.
 const CARD = `${SRC.components}/card.tsx`;
+// A NON-design-bearing file, named through the manifest so it stays real. It
+// used to be `src/lib/oauth/jwt.ts`; the oauth-as extraction (KAN-415) moved
+// that path out of existence and this test went red — the F4 coupling doing
+// exactly its job, loudly and at the right moment.
+const LIB_DIR = SRC.clientTrust.replace(/\/[^/]+$/, '');
+const LIB_FILE = SRC.clientTrust;
 const CARD_MOVED = `${SRC.components}/card-new.tsx`;
 
 const git = (cwd, ...args) =>
@@ -51,7 +57,7 @@ function makeRepo() {
   fs.mkdirSync(join(dir, 'scripts'), { recursive: true });
   fs.mkdirSync(join(dir, 'design'), { recursive: true });
   fs.mkdirSync(join(dir, SRC.components), { recursive: true });
-  fs.mkdirSync(join(dir, SRC.libOauth), { recursive: true });
+  fs.mkdirSync(join(dir, LIB_DIR), { recursive: true });
 
   fs.copyFileSync(SCRIPT, join(dir, SRC.checkDesignBaseline));
   fs.writeFileSync(
@@ -59,7 +65,7 @@ function makeRepo() {
     JSON.stringify({ baseline_ref: 'aaaaaaaaaaaa1111' }),
   );
   fs.writeFileSync(join(dir, CARD), 'export const C = 1;\n');
-  fs.writeFileSync(join(dir, SRC.jwt), 'export const j = 1;\n');
+  fs.writeFileSync(join(dir, LIB_FILE), 'export const j = 1;\n');
 
   git(dir, 'init', '-q', '.');
   git(dir, 'add', '-A');
@@ -124,7 +130,7 @@ describe('CTL-040 — design re-baseline gate', () => {
     // and people would reach for the escape hatch by reflex — which is how a
     // gate becomes noise and then becomes ignored.
     dir = makeRepo();
-    git(dir, 'mv', SRC.jwt, `${SRC.libOauth}/tokens.ts`);
+    git(dir, 'mv', LIB_FILE, `${LIB_DIR}/tokens.ts`);
     git(dir, 'commit', '-qm', 'move lib');
 
     const r = run(dir);

--- a/tests/scripts/check-design-baseline.test.js
+++ b/tests/scripts/check-design-baseline.test.js
@@ -1,0 +1,205 @@
+/**
+ * Guard test for CTL-040 (scripts/check-design-baseline.py) — KAN-457.
+ *
+ * SEC-79 is the standing precedent for why a control needs its own test rather
+ * than trusting the workflow step that invokes it: `health-check.yml` and
+ * `weekly-report.yml` sat disabled for over a month while reporting green.
+ *
+ * The load-bearing case here is "FIRES on a move with no re-baseline". This
+ * control exists precisely because the thing it replaces — a prose attestation
+ * a developer satisfies by typing `done` — could not be seen to fail. A gate
+ * that has never been observed failing is indistinguishable from no gate, and
+ * shipping this one without that proof would repeat the defect it was written
+ * to close.
+ *
+ * Everything runs against a SYNTHETIC repo built in tmpdir, not this one. That
+ * is deliberate: CTL-038's and CTL-039's guard tests staged probes into the
+ * real `.git/index` and collided on `index.lock` under CI's worker count
+ * (PR #693). A throwaway repo has no shared index to contend over, and it also
+ * lets the base commit carry a baseline — which this branch's own merge-base
+ * cannot, since it is the PR that introduces the file.
+ */
+const { spawnSync, execFileSync } = require('node:child_process');
+const { resolve, join } = require('node:path');
+const fs = require('node:fs');
+const os = require('node:os');
+const { SRC } = require('../support/source-paths.json');
+
+const ROOT = resolve(__dirname, '../..');
+const REGISTRY = 'controls/registry.json';
+const SCRIPT = resolve(ROOT, SRC.checkDesignBaseline);
+const BASELINE = 'design/BASELINE.json';
+
+const git = (cwd, ...args) =>
+  execFileSync('git', ['-c', 'user.email=t@t', '-c', 'user.name=t', ...args], {
+    cwd,
+    encoding: 'utf-8',
+  });
+
+/**
+ * A repo with a baseline and a component already committed on `base-branch`,
+ * plus a copy of the control at the same relative path so its own
+ * `parents[1]` root resolution is exercised rather than stubbed.
+ */
+function makeRepo() {
+  const dir = fs.mkdtempSync(join(os.tmpdir(), 'ctl040-'));
+  fs.mkdirSync(join(dir, 'scripts'), { recursive: true });
+  fs.mkdirSync(join(dir, 'design'), { recursive: true });
+  fs.mkdirSync(join(dir, 'src/components'), { recursive: true });
+  fs.mkdirSync(join(dir, 'src/lib/oauth'), { recursive: true });
+
+  fs.copyFileSync(SCRIPT, join(dir, SRC.checkDesignBaseline));
+  fs.writeFileSync(
+    join(dir, BASELINE),
+    JSON.stringify({ baseline_ref: 'aaaaaaaaaaaa1111' }),
+  );
+  fs.writeFileSync(join(dir, 'src/components/card.tsx'), 'export const C = 1;\n');
+  fs.writeFileSync(join(dir, 'src/lib/oauth/jwt.ts'), 'export const j = 1;\n');
+
+  git(dir, 'init', '-q', '.');
+  git(dir, 'add', '-A');
+  git(dir, 'commit', '-qm', 'base');
+  git(dir, 'branch', '-q', 'base-branch');
+  return dir;
+}
+
+const run = (dir) =>
+  spawnSync('python3', [join(dir, SRC.checkDesignBaseline)], {
+    cwd: dir,
+    encoding: 'utf-8',
+    env: { ...process.env, BASE_REF: 'base-branch' },
+  });
+
+const setBaseline = (dir, ref) =>
+  fs.writeFileSync(join(dir, BASELINE), JSON.stringify({ baseline_ref: ref }));
+
+describe('CTL-040 — design re-baseline gate', () => {
+  let dir;
+  afterEach(() => {
+    if (dir) fs.rmSync(dir, { recursive: true, force: true });
+    dir = undefined;
+  });
+
+  it('passes its own self-test', () => {
+    const r = spawnSync('python3', [SCRIPT, '--self-test'], {
+      cwd: ROOT,
+      encoding: 'utf-8',
+    });
+    expect(r.stdout).toContain('self-test: OK');
+    expect(r.status).toBe(0);
+  });
+
+  it('FIRES (exit 1) when a design-bearing file moves and the baseline does not', () => {
+    // The case the prose attestation could not catch: the move happened, the
+    // human typed nothing, and nothing in the repo records a re-baseline.
+    dir = makeRepo();
+    git(dir, 'mv', 'src/components/card.tsx', 'src/components/card-new.tsx');
+    git(dir, 'commit', '-qm', 'move card');
+
+    const r = run(dir);
+    expect(r.status).toBe(1);
+    expect(r.stdout).toContain('still points at aaaaaaaaaaaa');
+    expect(r.stdout).toContain('src/components/card.tsx');
+  });
+
+  it('passes when the same PR records a new baseline_ref', () => {
+    dir = makeRepo();
+    git(dir, 'mv', 'src/components/card.tsx', 'src/components/card-new.tsx');
+    setBaseline(dir, 'bbbbbbbbbbbb2222');
+    git(dir, 'add', '-A');
+    git(dir, 'commit', '-qm', 'move card + re-baseline');
+
+    const r = run(dir);
+    expect(r.status).toBe(0);
+    expect(r.stdout).toContain('aaaaaaaaaaaa -> bbbbbbbbbbbb');
+  });
+
+  it('is INERT for a move that cannot break a design pointer', () => {
+    // If a lib move demanded a re-baseline, every extraction PR would need one
+    // and people would reach for the escape hatch by reflex — which is how a
+    // gate becomes noise and then becomes ignored.
+    dir = makeRepo();
+    git(dir, 'mv', 'src/lib/oauth/jwt.ts', 'src/lib/oauth/tokens.ts');
+    git(dir, 'commit', '-qm', 'move lib');
+
+    const r = run(dir);
+    expect(r.status).toBe(0);
+    expect(r.stdout).toContain('not a re-baseline PR');
+  });
+
+  it('does not fire on a pure EDIT of a design-bearing file', () => {
+    // Editing a component changes the design, but the design system's pointer
+    // still resolves. This gate is about relocation; claiming more than that
+    // would be a scope it cannot actually verify.
+    dir = makeRepo();
+    fs.writeFileSync(join(dir, 'src/components/card.tsx'), 'export const C = 2;\n');
+    git(dir, 'add', '-A');
+    git(dir, 'commit', '-qm', 'edit card');
+
+    expect(run(dir).status).toBe(0);
+  });
+
+  it('honours an attributed escape hatch, and prints it loudly', () => {
+    dir = makeRepo();
+    git(dir, 'mv', 'src/components/card.tsx', 'src/components/card-new.tsx');
+    git(dir, 'commit', '-qm', 'move card\n\nDesign-Baseline-Ok: KAN-457 test-only helper');
+
+    const r = run(dir);
+    expect(r.status).toBe(0);
+    expect(r.stdout).toContain('EXCEPTION in force');
+    expect(r.stdout).toContain('KAN-457');
+  });
+
+  it('ignores a hatch with no reason — a bare key must not suppress', () => {
+    // `Design-Baseline-Ok: KAN-1` with no reason is the zero-effort bypass. If
+    // it worked, the gate would degrade back into the prose attestation it
+    // replaced.
+    dir = makeRepo();
+    git(dir, 'mv', 'src/components/card.tsx', 'src/components/card-new.tsx');
+    git(dir, 'commit', '-qm', 'move card\n\nDesign-Baseline-Ok: KAN-457');
+
+    expect(run(dir).status).toBe(1);
+  });
+
+  it('fails CLOSED (exit 2) when the baseline is unparseable', () => {
+    dir = makeRepo();
+    git(dir, 'mv', 'src/components/card.tsx', 'src/components/card-new.tsx');
+    fs.writeFileSync(join(dir, BASELINE), 'not json');
+    git(dir, 'add', '-A');
+    git(dir, 'commit', '-qm', 'move card + break baseline');
+
+    const r = run(dir);
+    expect(r.status).toBe(2);
+    expect(r.stdout).toContain('Failing closed');
+  });
+
+  it('fails CLOSED (exit 2) when baseline_ref is emptied', () => {
+    // Blanking the field is the cheapest way to make a ref "change". It must
+    // read as unverifiable, not as a fresh baseline.
+    dir = makeRepo();
+    git(dir, 'mv', 'src/components/card.tsx', 'src/components/card-new.tsx');
+    setBaseline(dir, '');
+    git(dir, 'add', '-A');
+    git(dir, 'commit', '-qm', 'move card + empty ref');
+
+    expect(run(dir).status).toBe(2);
+  });
+
+  it('is registered and wired into CI', () => {
+    const registry = JSON.parse(fs.readFileSync(resolve(ROOT, REGISTRY), 'utf-8'));
+    const ctl = registry.controls.find((c) => c.id === 'CTL-040');
+    expect(ctl).toBeDefined();
+    expect(ctl.implementation).toBe(SRC.checkDesignBaseline);
+    expect(ctl.prevents).toContain('KAN-457');
+
+    const wf = fs.readFileSync(resolve(ROOT, SRC.prChecks), 'utf-8');
+    expect(wf).toContain(`${SRC.checkDesignBaseline} --self-test`);
+  });
+
+  it('ships a baseline that names a real design repo and a full-length ref', () => {
+    const b = JSON.parse(fs.readFileSync(resolve(ROOT, BASELINE), 'utf-8'));
+    expect(b.design_repo).toContain('lyra-design-system');
+    // A short or placeholder ref would make drift undetectable by inspection.
+    expect(b.baseline_ref).toMatch(/^[0-9a-f]{40}$/);
+  });
+});

--- a/tests/scripts/check-design-baseline.test.js
+++ b/tests/scripts/check-design-baseline.test.js
@@ -28,7 +28,12 @@ const { SRC } = require('../support/source-paths.json');
 const ROOT = resolve(__dirname, '../..');
 const REGISTRY = 'controls/registry.json';
 const SCRIPT = resolve(ROOT, SRC.checkDesignBaseline);
-const BASELINE = 'design/BASELINE.json';
+const BASELINE = SRC.baseline;
+// Fixture paths are the REAL design surfaces on purpose: this test asserts that
+// `src/components/**` is design-bearing, so if that path ever moves, this file
+// must be revisited. Naming them through the manifest is what makes that true.
+const CARD = `${SRC.components}/card.tsx`;
+const CARD_MOVED = `${SRC.components}/card-new.tsx`;
 
 const git = (cwd, ...args) =>
   execFileSync('git', ['-c', 'user.email=t@t', '-c', 'user.name=t', ...args], {
@@ -45,16 +50,16 @@ function makeRepo() {
   const dir = fs.mkdtempSync(join(os.tmpdir(), 'ctl040-'));
   fs.mkdirSync(join(dir, 'scripts'), { recursive: true });
   fs.mkdirSync(join(dir, 'design'), { recursive: true });
-  fs.mkdirSync(join(dir, 'src/components'), { recursive: true });
-  fs.mkdirSync(join(dir, 'src/lib/oauth'), { recursive: true });
+  fs.mkdirSync(join(dir, SRC.components), { recursive: true });
+  fs.mkdirSync(join(dir, SRC.libOauth), { recursive: true });
 
   fs.copyFileSync(SCRIPT, join(dir, SRC.checkDesignBaseline));
   fs.writeFileSync(
     join(dir, BASELINE),
     JSON.stringify({ baseline_ref: 'aaaaaaaaaaaa1111' }),
   );
-  fs.writeFileSync(join(dir, 'src/components/card.tsx'), 'export const C = 1;\n');
-  fs.writeFileSync(join(dir, 'src/lib/oauth/jwt.ts'), 'export const j = 1;\n');
+  fs.writeFileSync(join(dir, CARD), 'export const C = 1;\n');
+  fs.writeFileSync(join(dir, SRC.jwt), 'export const j = 1;\n');
 
   git(dir, 'init', '-q', '.');
   git(dir, 'add', '-A');
@@ -93,18 +98,18 @@ describe('CTL-040 — design re-baseline gate', () => {
     // The case the prose attestation could not catch: the move happened, the
     // human typed nothing, and nothing in the repo records a re-baseline.
     dir = makeRepo();
-    git(dir, 'mv', 'src/components/card.tsx', 'src/components/card-new.tsx');
+    git(dir, 'mv', CARD, CARD_MOVED);
     git(dir, 'commit', '-qm', 'move card');
 
     const r = run(dir);
     expect(r.status).toBe(1);
     expect(r.stdout).toContain('still points at aaaaaaaaaaaa');
-    expect(r.stdout).toContain('src/components/card.tsx');
+    expect(r.stdout).toContain(CARD);
   });
 
   it('passes when the same PR records a new baseline_ref', () => {
     dir = makeRepo();
-    git(dir, 'mv', 'src/components/card.tsx', 'src/components/card-new.tsx');
+    git(dir, 'mv', CARD, CARD_MOVED);
     setBaseline(dir, 'bbbbbbbbbbbb2222');
     git(dir, 'add', '-A');
     git(dir, 'commit', '-qm', 'move card + re-baseline');
@@ -119,7 +124,7 @@ describe('CTL-040 — design re-baseline gate', () => {
     // and people would reach for the escape hatch by reflex — which is how a
     // gate becomes noise and then becomes ignored.
     dir = makeRepo();
-    git(dir, 'mv', 'src/lib/oauth/jwt.ts', 'src/lib/oauth/tokens.ts');
+    git(dir, 'mv', SRC.jwt, `${SRC.libOauth}/tokens.ts`);
     git(dir, 'commit', '-qm', 'move lib');
 
     const r = run(dir);
@@ -132,7 +137,7 @@ describe('CTL-040 — design re-baseline gate', () => {
     // still resolves. This gate is about relocation; claiming more than that
     // would be a scope it cannot actually verify.
     dir = makeRepo();
-    fs.writeFileSync(join(dir, 'src/components/card.tsx'), 'export const C = 2;\n');
+    fs.writeFileSync(join(dir, CARD), 'export const C = 2;\n');
     git(dir, 'add', '-A');
     git(dir, 'commit', '-qm', 'edit card');
 
@@ -141,7 +146,7 @@ describe('CTL-040 — design re-baseline gate', () => {
 
   it('honours an attributed escape hatch, and prints it loudly', () => {
     dir = makeRepo();
-    git(dir, 'mv', 'src/components/card.tsx', 'src/components/card-new.tsx');
+    git(dir, 'mv', CARD, CARD_MOVED);
     git(dir, 'commit', '-qm', 'move card\n\nDesign-Baseline-Ok: KAN-457 test-only helper');
 
     const r = run(dir);
@@ -155,7 +160,7 @@ describe('CTL-040 — design re-baseline gate', () => {
     // it worked, the gate would degrade back into the prose attestation it
     // replaced.
     dir = makeRepo();
-    git(dir, 'mv', 'src/components/card.tsx', 'src/components/card-new.tsx');
+    git(dir, 'mv', CARD, CARD_MOVED);
     git(dir, 'commit', '-qm', 'move card\n\nDesign-Baseline-Ok: KAN-457');
 
     expect(run(dir).status).toBe(1);
@@ -163,7 +168,7 @@ describe('CTL-040 — design re-baseline gate', () => {
 
   it('fails CLOSED (exit 2) when the baseline is unparseable', () => {
     dir = makeRepo();
-    git(dir, 'mv', 'src/components/card.tsx', 'src/components/card-new.tsx');
+    git(dir, 'mv', CARD, CARD_MOVED);
     fs.writeFileSync(join(dir, BASELINE), 'not json');
     git(dir, 'add', '-A');
     git(dir, 'commit', '-qm', 'move card + break baseline');
@@ -177,7 +182,7 @@ describe('CTL-040 — design re-baseline gate', () => {
     // Blanking the field is the cheapest way to make a ref "change". It must
     // read as unverifiable, not as a fresh baseline.
     dir = makeRepo();
-    git(dir, 'mv', 'src/components/card.tsx', 'src/components/card-new.tsx');
+    git(dir, 'mv', CARD, CARD_MOVED);
     setBaseline(dir, '');
     git(dir, 'add', '-A');
     git(dir, 'commit', '-qm', 'move card + empty ref');

--- a/tests/support/source-paths.json
+++ b/tests/support/source-paths.json
@@ -1,7 +1,7 @@
 {
-  "$comment": "GENERATED \u2014 regenerate with `npm run gen:test-paths`. Mirror of tests/support/source-paths.ts for .cjs and shell consumers (KAN-414 F4).",
+  "$comment": "GENERATED — regenerate with `npm run gen:test-paths`. Mirror of tests/support/source-paths.ts for .cjs and shell consumers (KAN-414 F4).",
   "generated_from": "literals referenced by tracked files under tests/",
-  "count": 177,
+  "count": 179,
   "SRC": {
     "codeowners": ".github/CODEOWNERS",
     "pullRequestTemplate": ".github/PULL_REQUEST_TEMPLATE.md",
@@ -14,6 +14,7 @@
     "prChecks": ".github/workflows/pr-checks.yml",
     "securityAudit": ".github/workflows/security-audit.yml",
     "weeklyReport": ".github/workflows/weekly-report.yml",
+    "baseline": "design/BASELINE.json",
     "mcp": "public/.well-known/mcp.json",
     "llms": "public/llms.txt",
     "manifest": "public/manifest.webmanifest",

--- a/tests/support/source-paths.json
+++ b/tests/support/source-paths.json
@@ -1,7 +1,7 @@
 {
   "$comment": "GENERATED — regenerate with `npm run gen:test-paths`. Mirror of tests/support/source-paths.ts for .cjs and shell consumers (KAN-414 F4).",
   "generated_from": "literals referenced by tracked files under tests/",
-  "count": 179,
+  "count": 180,
   "SRC": {
     "codeowners": ".github/CODEOWNERS",
     "pullRequestTemplate": ".github/PULL_REQUEST_TEMPLATE.md",
@@ -141,6 +141,7 @@
     "serviceWorkerRegister": "src/app/service-worker-register.tsx",
     "sitemap": "src/app/sitemap.ts",
     "statusPage": "src/app/status/page.tsx",
+    "components": "src/components",
     "providerGate": "src/lib/age/provider-gate.ts",
     "postLoginRedirect": "src/lib/auth/post-login-redirect.ts",
     "authBearer": "src/lib/convene/auth-bearer.ts",

--- a/tests/support/source-paths.json
+++ b/tests/support/source-paths.json
@@ -1,5 +1,5 @@
 {
-  "$comment": "GENERATED — regenerate with `npm run gen:test-paths`. Mirror of tests/support/source-paths.ts for .cjs and shell consumers (KAN-414 F4).",
+  "$comment": "GENERATED \u2014 regenerate with `npm run gen:test-paths`. Mirror of tests/support/source-paths.ts for .cjs and shell consumers (KAN-414 F4).",
   "generated_from": "literals referenced by tracked files under tests/",
   "count": 177,
   "SRC": {
@@ -27,6 +27,7 @@
     "checkCommentOnlyAssertions": "scripts/check-comment-only-assertions.py",
     "checkCompleteBackup": "scripts/check-complete-backup.sh",
     "checkDependencyRules": "scripts/check-dependency-rules.sh",
+    "checkDesignBaseline": "scripts/check-design-baseline.py",
     "checkDocMirrorContent": "scripts/check-doc-mirror-content.sh",
     "checkDocMirrorManifest": "scripts/check-doc-mirror-manifest.sh",
     "checkEnvAccess": "scripts/check-env-access.py",

--- a/tests/support/source-paths.ts
+++ b/tests/support/source-paths.ts
@@ -13,7 +13,7 @@
 // cannot drift from reality — a hand-maintained list is what let BUGS-74's
 // first fix miss the legacy editor.
 //
-// 177 entries.
+// 179 entries.
 
 export const SRC = {
   codeowners: '.github/CODEOWNERS',
@@ -27,6 +27,7 @@ export const SRC = {
   prChecks: '.github/workflows/pr-checks.yml',
   securityAudit: '.github/workflows/security-audit.yml',
   weeklyReport: '.github/workflows/weekly-report.yml',
+  baseline: 'design/BASELINE.json',
   mcp: 'public/.well-known/mcp.json',
   llms: 'public/llms.txt',
   manifest: 'public/manifest.webmanifest',
@@ -40,6 +41,7 @@ export const SRC = {
   checkCommentOnlyAssertions: 'scripts/check-comment-only-assertions.py',
   checkCompleteBackup: 'scripts/check-complete-backup.sh',
   checkDependencyRules: 'scripts/check-dependency-rules.sh',
+  checkDesignBaseline: 'scripts/check-design-baseline.py',
   checkDocMirrorContent: 'scripts/check-doc-mirror-content.sh',
   checkDocMirrorManifest: 'scripts/check-doc-mirror-manifest.sh',
   checkEnvAccess: 'scripts/check-env-access.py',

--- a/tests/support/source-paths.ts
+++ b/tests/support/source-paths.ts
@@ -13,7 +13,7 @@
 // cannot drift from reality — a hand-maintained list is what let BUGS-74's
 // first fix miss the legacy editor.
 //
-// 179 entries.
+// 180 entries.
 
 export const SRC = {
   codeowners: '.github/CODEOWNERS',
@@ -154,6 +154,7 @@ export const SRC = {
   serviceWorkerRegister: 'src/app/service-worker-register.tsx',
   sitemap: 'src/app/sitemap.ts',
   statusPage: 'src/app/status/page.tsx',
+  components: 'src/components',
   providerGate: 'src/lib/age/provider-gate.ts',
   postLoginRedirect: 'src/lib/auth/post-login-redirect.ts',
   authBearer: 'src/lib/convene/auth-bearer.ts',


### PR DESCRIPTION
## What

Adds **CTL-040** (`scripts/check-design-baseline.py`) — a PR gate requiring `design/BASELINE.json`'s `baseline_ref` to change in the **same PR** that moves a design-bearing file.

Closes the machine-checkable part of **KAN-457**.

## Why

The extraction DoD (§2.2) asked a human to attest `EXTRACTION-DOD-DESIGN-SYSTEM: done`, because the Claude Design source lives in a different, **private** repo this CI cannot read.

An attestation satisfied by **typing a word** is indistinguishable from no control. That is the comment-satisfied-assertion defect (CTL-039) one layer up: a gate that passes for a reason unrelated to what it claims.

The concrete exposure (KAN-419 §5.1): `build.py` reads `src/app/globals.css` and reconstructs 21 `@dsCard` previews from page sources. Move one and the generator's source pointer breaks — loudly, but on the founder's machine, hours later, with nothing warning the agent that moved it.

## What it does NOT prove

Stated here rather than left to be inferred: it **cannot** prove the design system was re-pointed or regenerated. CI still cannot read that repo. It proves someone opened it, took its head commit, and recorded it.

That raises a false attestation's cost from *type a word* to *go and look* — the most any in-repo check can do across a boundary it cannot cross. The §2.2 attestation **still stands**; CTL-040 backs it, it does not replace it.

A control whose stated scope exceeds what it verifies is worse than none, because it gets read as coverage.

## Scope discipline

Fires on **relocation only** (`D`/`R`), never a plain edit — an edit leaves the pointer resolving. Widening it would make every extraction PR demand a meaningless re-baseline and train people to reach for the escape hatch by reflex, which is how a gate becomes noise and then gets ignored.

## Mutation-proven

The guard test builds a **synthetic repo** whose base commit already carries a baseline, moves a component without re-baselining, and asserts **exit 1**. Also pinned:

- the zero-effort bypass — a bare `Design-Baseline-Ok: KAN-1` with no reason must **not** suppress (that would degrade the gate back into the prose it replaced)
- both fail-closed paths (unparseable baseline, emptied `baseline_ref`) → exit 2
- inert on a `src/lib/**` move and on a pure edit

The synthetic repo also avoids the `.git/index.lock` contention that broke CTL-038/039's guard tests in #693 — it has no shared index to contend over.

## Second commit

The F4 shrink-only ratchet caught the guard test's raw path literals and refused the incomplete change — working as designed. Fixed by adding `design/` as a manifestable root (it was absent, so `design/BASELINE.json` could not be given a symbolic name) and routing the fixtures through `SRC`.

> Note for the next person adding a manifest key: `gen-test-paths.mjs` harvests literals from tracked files under `tests/`, and `tests/support/source-paths.ts` is itself one of them — so the manifest re-feeds on its own output and an existing key survives without any test quoting it. A genuinely new key must be **seeded** in the `.ts` file once.

## Correction — an earlier claim in this PR body was wrong

This section previously reported 18 test failures as "pre-existing on develop,
caused by a macOS bash 3.2 unbound-array bug in `check-extraction-dod.sh`".

**That diagnosis was wrong on both counts.** The real cause was a stale branch
point: this branch was cut from `56ee1568`, and `origin/develop` had since
advanced to `39519249` — *"fix(tests): unblock 5 PRs, and restore two security
guards that were silently green"* (#713), which fixed exactly those guards.

Rebased onto current `develop`. `tests/scripts/` is now **412/412 green, 30/30
suites**. There is no bash bug and no pre-existing breakage; no separate ticket
is needed.

Recording it rather than deleting it, because the misdiagnosis is instructive:
I compared against a `git worktree` cut from the same stale ref, so the
"baseline" reproduced the same failures and made them look pre-existing. A
comparison instrument built from the same stale assumption confirms the
assumption.

## Verification

- `check-control-registry.py` — every control exists, is invoked, cites its defects ✓
- `check-guard-path-drift.py` — 147 patterns, 143 live, 4 excepted, **0 dead** ✓
- `check-design-baseline.py --self-test` ✓
- `tests/scripts/check-design-baseline.test.js` — 11/11 ✓
- No new failures vs `origin/develop` across `tests/scripts/` (412 tests, diffed by full test name)

EXTRACTION-DOD-DESIGN-SYSTEM: n/a — this PR moves no file; it adds a gate on future moves.
EXTRACTION-DOD-ROUTINE-PROMPTS: n/a — no script renamed and no protected-surface path list changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

