### PR TITLE
feat(oauth): pin the external HTTP contract; re-open the extraction programme (KAN-415)

### DIFF
--- a/docs/modularisation/RE-DECISION-2026-08-09.md
+++ b/docs/modularisation/RE-DECISION-2026-08-09.md
@@ -1,0 +1,152 @@
+# Extraction re-decision (KAN-432 §2.2 trigger) — 2026-08-09
+
+**Instrument:** `docs/modularisation/kan432-revalidate.py`, the same script that
+produced the 2026-07-28 re-validation. Raw output:
+`docs/modularisation/data/kan432-revalidation.json`.
+
+**Ruling: the extraction programme is RE-OPENED.**
+
+---
+
+## 1. What the trigger actually says
+
+From §2.2, quoted rather than paraphrased because the wording is the whole test:
+
+> **Re-decision trigger — this is binding, so that "deferred" cannot decay into
+> "abandoned".** When Phase 0 closes, re-derive §1.1 and §1.2 against a
+> decoupled test estate and a generated `Database` type, and re-take this
+> decision on that evidence. Extraction should be re-opened **if the vertical
+> coupling has *not* materially improved under Phase 0 alone**.
+
+Note the polarity. The trigger does **not** ask "did Phase 0 work?" — it asks
+whether Phase 0 *by itself* closed the vertical-coupling gap. A **negative**
+result re-opens extraction. This is deliberately the opposite of the usual
+reading, and getting it backwards would invert the decision.
+
+## 2. Preconditions
+
+| Precondition | State | Evidence |
+|---|---|---|
+| Generated `Database` type | **MET** | `src/types/database/{dev,staging,prod}.ts` exist and are load-bearing — `tests/unit/sar-export-schema-completeness.test.ts` derives the person-keyed table set from `prod.ts`, which is what caught SEC-117's 14 missing SAR tables. |
+| Decoupled test estate | **PARTIAL** | See §4. The path-literal half landed decisively; the behavioural-conversion half did not. |
+| Phase 0 closed | **NO — partial** | F4 is materially advanced but not closed; pure source-text scans **rose** 70 → 110. |
+
+Phase 0 is not closed, so this is a re-decision taken **early**, and that is
+stated rather than glossed. It is taken now because the substantive question the
+trigger poses is already answerable with high confidence, and because the answer
+does not depend on the unfinished part — see §5.
+
+## 3. The measurement — vertical coupling (§1.2)
+
+| Measure | Plan (2026-07-26) | Re-val (2026-07-28) | **Now (2026-08-09)** | Direction |
+|---|---|---|---|---|
+| `.from()` sites | 280 | 277 | **296** | ↑ worse |
+| distinct tables touched | 33 | 33 | **41** | ↑ wider surface |
+| `.from()` inside route/page/action | 199 | — | **213** | ↑ worse |
+| service-role importers | 40 | 39 | **39** | flat |
+| `profiles` call sites | 75 | 77 | **77** | flat, above plan |
+| `profiles` module groups | 15 | 17 | **17** | flat, above plan |
+| `auth.getUser()` files | 37 | 41 | **42** | ↑ worse |
+
+**Every vertical measure is flat or worse than the July baseline.** Not one
+improved. `.from()` sites are up 16 on the plan figure and up 19 on the
+re-validation figure, and the growth is concentrated in exactly the wrong place
+— inside routes, pages and server actions (199 → 213), which is the coupling
+C3 exists to remove.
+
+Some of that growth is honest and mine: SEC-117 added 11 `.from()` blocks to the
+SAR export because the export was incomplete under UK-GDPR Art.15. That is a
+defect fixed, not debt added — **and it is also the point**. The correct fix for
+a compliance gap currently *requires* adding eleven more direct table reads to a
+server action, because there is no data layer to add them to. The metric
+worsening as a direct consequence of doing the right thing is the strongest
+possible evidence that the structure, not the discipline, is the constraint.
+
+## 4. The measurement — horizontal structure and Phase 0 (§1.1)
+
+Phase 0 and the control programme delivered, and the numbers say so plainly:
+
+| Measure | Plan | **Now** | |
+|---|---|---|---|
+| import cycles | 1 | **0** | fixed |
+| `lib` → `app` edges | 1 | **0** | fixed |
+| app-segment → app-segment edges | 5 | **3** | improved |
+| distinct `src` path literals in tests | 112 | **21** | **−81%** — F4's manifest working |
+| registered controls | 11 | **39** | control estate transformed |
+
+But two Phase 0 measures moved the wrong way:
+
+| Measure | Plan | **Now** | |
+|---|---|---|---|
+| pure source-text scans in tests | 70 | **110** | ↑ — F4's *behavioural* half unfinished |
+| `readFileSync` test files | 98 | **136** | ↑ (against 213 → 259 test files) |
+| cross-group edges | 328 | **349** | ↑ |
+| deep imports | 145 | **149** | ↑ |
+
+The estate also simply grew: 213 → 259 test files, 2,401 → 2,963 test blocks,
+273 → 289 graph nodes. Growth is not by itself a regression, but it does mean
+the per-file ratios matter more than the totals, and the ratio that matters —
+scans per test file — went from 0.33 to 0.42.
+
+## 5. Why the ruling does not wait for Phase 0 to close
+
+The unfinished part of Phase 0 is the conversion of source-text scans into
+behavioural tests. That work makes the *test estate* survive a file move. It has
+no mechanism by which it could reduce `.from()` sites, `auth.getUser()` fan-out,
+or `profiles` fan-in — those are properties of application code, not of tests.
+
+So finishing it cannot change this ruling's input. Waiting would delay the
+decision without improving the evidence, which is the failure mode the trigger's
+own "deferred must not decay into abandoned" clause was written to prevent.
+
+**What finishing Phase 0 *does* still gate is the extraction's safety, not its
+justification.** 110 pure source-text scans and 136 `readFileSync` test files
+are exactly what turns a file move into a wall of information-free failures.
+That is a sequencing constraint on *how* to extract, recorded in §7 below — not
+a reason to keep the programme deferred.
+
+## 6. ⚠️ Naming collision — "D1" means two different things
+
+This must be settled before anyone acts on a ticket that says "do D1", because
+the two readings produce different work:
+
+| Table | ID | Meaning |
+|---|---|---|
+| §3 "Layer 2 — Domains" (the **module inventory**) | **D1** | the `oauth-as` **module** |
+| §8 sequencing (the **story order**) | **D1** | extract **`platform` + `guards` + `observability`** |
+| §8 sequencing | **D2** | extract **`oauth-as`** — "the pilot", *depends on D1* |
+
+So **"the D1 oauth extraction" conflates an inventory ID with a sequencing ID.**
+In sequencing terms the oauth work is **D2**, and the plan puts the kernel
+(`platform`/`guards`/`observability`) ahead of it on the grounds that "naming the
+kernel is what makes every later rule expressible".
+
+**Recommendation:** retire the inventory-side D-numbers in favour of module
+names, and let D1–D15 mean sequencing only. Until that is done, always write
+`oauth-as` rather than a D-number.
+
+## 7. Sequencing constraints that survive this ruling
+
+Carried forward from §8 and confirmed against the current tree:
+
+1. **`oauth-as` must pin its external HTTP contract with tests FIRST.** Its
+   consumers — claude.ai, Claude Desktop, `lyra-mcp-server` and
+   `lyra-admin-mcp-server` — are all outside this repo's CI. A move that changes
+   a route path, status code, header or error body breaks live integrations with
+   no failing test anywhere in this repo.
+2. **D9 (`public-profile`) remains gated on SEC-104.**
+3. **D8 absorbs the two residual `app/[slug]` → `app/dashboard/profile` edges**
+   (the D-4 privacy finding).
+4. **The 110 remaining source-text scans are a live hazard to any move.** Each
+   is a test that asserts on file *contents* and will either fail
+   uninformatively or — worse — keep passing while asserting nothing.
+
+## 8. Provenance
+
+- Trigger: §2.2 of `LYRA_MODULARISATION_PLAN_2026-07-26.md` (KAN-432 option A,
+  founder decision 2026-07-28).
+- Founder direction, 2026-08-04, in session: extraction may proceed now; the
+  deferral was not the founder's preference.
+- Evidence: `kan432-revalidate.py` run 2026-08-09 against
+  `feat/kan-457-design-baseline-gate` (tree equal to `develop` for all measured
+  paths).

--- a/docs/modularisation/data/kan432-revalidation.json
+++ b/docs/modularisation/data/kan432-revalidation.json
@@ -1,5 +1,5 @@
 {
- "generatedFrom": "674f0a7f47c73d5673f2550f589b7f3fc4d086e0",
+ "generatedFrom": "81f44c3b824024fc288e172c4e68679cf1db478c",
  "methodNotes": [
   "Import graph built by regex scan of src/**, resolving the tsconfig alias '@/* -> ./src/*', relative specifiers and directory index files. Static import, re-export, bare side-effect import and dynamic import()/require() all count as edges. Bare package specifiers are excluded (the plan counted the internal src/ graph).",
   "'Group' = src/<area>/<first-segment> (e.g. src/lib/convene, src/app/dashboard). 'App segment' = top-level route segment under src/app, with a Next route group '(x)' collapsed onto its child so '(legal)/about' is one segment.",
@@ -7,9 +7,9 @@
   "dependency-cruiser was unavailable (node_modules absent), so these figures are an independent derivation rather than a re-run of the plan's tool. Deltas of +/-1 on graph counts may be method, not drift; deltas larger than that are drift."
  ],
  "graph": {
-  "plan_nodes_273": 274,
-  "plan_nodesWithAtLeastOneEdge": 251,
-  "plan_edges_525": 527,
+  "plan_nodes_273": 289,
+  "plan_nodesWithAtLeastOneEdge": 262,
+  "plan_edges_525": 555,
   "plan_libToApp_1": 0,
   "libToApp_detail": [],
   "plan_appSegToAppSeg_5": 3,
@@ -20,45 +20,38 @@
   ],
   "appSegments_total": 19,
   "appSegments_zeroFanIn": 16,
-  "plan_cycles_1": 1,
-  "cycles_detail": [
-   {
-    "files": [
-     "src/app/dashboard/convene/organise/organise-wizard.tsx",
-     "src/app/dashboard/convene/organise/page.tsx"
-    ],
-    "allTypeOnly": false
-   }
-  ],
-  "plan_crossGroupEdges_328": 336,
-  "plan_deepImports_145": 142,
-  "deepImportPct": 42.3,
-  "crossGroupEdgesNotViaBarrel": 326,
-  "plan_barrels_4": 5,
+  "plan_cycles_1": 0,
+  "cycles_detail": [],
+  "plan_crossGroupEdges_328": 349,
+  "plan_deepImports_145": 149,
+  "deepImportPct": 42.7,
+  "crossGroupEdgesNotViaBarrel": 338,
+  "plan_barrels_4": 6,
   "barrels_detail": [
    "src/app/dashboard/profile/sections/index.ts",
    "src/app/dashboard/profile/steps/index.ts",
    "src/lib/access-model/index.ts",
    "src/lib/convene/calendar/index.ts",
-   "src/lib/recommend/index.ts"
+   "src/lib/recommend/index.ts",
+   "src/types/database/index.ts"
   ],
-  "plan_crossGroupViaBarrel_9": 10
+  "plan_crossGroupViaBarrel_9": 11
  },
  "kernel": {
   "src/lib/supabase-server.ts": {
    "planFanIn": 46,
-   "actualFanIn": 46,
-   "actualTransitiveDependants": 89
+   "actualFanIn": 47,
+   "actualTransitiveDependants": 92
   },
   "src/lib/supabase-service.ts": {
    "planFanIn": 39,
    "actualFanIn": 39,
-   "actualTransitiveDependants": 114
+   "actualTransitiveDependants": 115
   },
   "src/lib/env.ts": {
    "planFanIn": 17,
-   "actualFanIn": 17,
-   "actualTransitiveDependants": 142
+   "actualFanIn": 19,
+   "actualTransitiveDependants": 148
   },
   "src/lib/admin.ts": {
    "planFanIn": 17,
@@ -72,10 +65,10 @@
   }
  },
  "dataBoundary": {
-  "plan_fromSites_280": 277,
-  "plan_tables_33": 33,
-  "plan_inRoutePageAction_199": 194,
-  "inRoutePageActionPct": 70.0,
+  "plan_fromSites_280": 296,
+  "plan_tables_33": 41,
+  "plan_inRoutePageAction_199": 213,
+  "inRoutePageActionPct": 72.0,
   "plan_serviceRoleImporters_40": 39,
   "serviceRoleImporters_detail": [
    "src/app/[slug]/page.tsx",
@@ -142,20 +135,20 @@
   "generatedDatabaseType_present": false
  },
  "duplicatedRules": {
-  "plan_authGetUserFiles_37": 41,
-  "authGetUser_totalCallSites": 49,
+  "plan_authGetUserFiles_37": 42,
+  "authGetUser_totalCallSites": 50,
   "plan_redirectLoginFiles_8": 8,
   "plan_conveneGateCallSites_16": 58,
   "conveneGate_files": 24
  },
  "testEstate": {
-  "plan_testFiles_213": 220,
-  "unitFiles": 203,
-  "scriptsFiles": 17,
-  "plan_readFileSyncFiles_98": 116,
-  "plan_distinctSrcPathLiterals_112": 125,
-  "plan_pureSourceTextScans_70": 92,
-  "plan_testBlocks_2401": 2439,
+  "plan_testFiles_213": 259,
+  "unitFiles": 229,
+  "scriptsFiles": 30,
+  "plan_readFileSyncFiles_98": 136,
+  "plan_distinctSrcPathLiterals_112": 21,
+  "plan_pureSourceTextScans_70": 110,
+  "plan_testBlocks_2401": 2963,
   "regressionGuardFloors": {
    "files": 29,
    "allNumericConstants": [
@@ -174,12 +167,12 @@
    "stryker.config.mjs": true
   },
   "plan_blockingStaticGuards_11": null,
-  "controlsRegistered_now": 32,
+  "controlsRegistered_now": 39,
   "ticketAssumed_31": 31,
   "controlsAdvisoryVsBlocking": {
    "registrySchemaHasBlockingField": false,
    "byKind": {
-    "ci-gate": 22,
+    "ci-gate": 29,
     "scheduled": 6,
     "test": 4
    },
@@ -206,7 +199,13 @@
     "CTL-019",
     "CTL-020",
     "CTL-022",
-    "CTL-032"
+    "CTL-032",
+    "CTL-033",
+    "CTL-035",
+    "CTL-037",
+    "CTL-036",
+    "CTL-038",
+    "CTL-039"
    ],
    "schemaKeys": [
     "added",

--- a/tests/support/source-paths.json
+++ b/tests/support/source-paths.json
@@ -1,7 +1,7 @@
 {
   "$comment": "GENERATED — regenerate with `npm run gen:test-paths`. Mirror of tests/support/source-paths.ts for .cjs and shell consumers (KAN-414 F4).",
   "generated_from": "literals referenced by tracked files under tests/",
-  "count": 175,
+  "count": 176,
   "SRC": {
     "codeowners": ".github/CODEOWNERS",
     "pullRequestTemplate": ".github/PULL_REQUEST_TEMPLATE.md",
@@ -47,6 +47,7 @@
     "routineWatchdog": "scripts/routine-watchdog.sh",
     "securityAlertEmail": "scripts/security-alert-email.sh",
     "weeklyHealthRegression": "scripts/weekly-health-regression.sh",
+    "app": "src/app",
     "actions": "src/app/(auth)/actions.ts",
     "authErrors": "src/app/(auth)/auth-errors.ts",
     "page": "src/app/(auth)/forgot-password/page.tsx",

--- a/tests/support/source-paths.ts
+++ b/tests/support/source-paths.ts
@@ -13,7 +13,7 @@
 // cannot drift from reality — a hand-maintained list is what let BUGS-74's
 // first fix miss the legacy editor.
 //
-// 175 entries.
+// 176 entries.
 
 export const SRC = {
   codeowners: '.github/CODEOWNERS',
@@ -60,6 +60,7 @@ export const SRC = {
   routineWatchdog: 'scripts/routine-watchdog.sh',
   securityAlertEmail: 'scripts/security-alert-email.sh',
   weeklyHealthRegression: 'scripts/weekly-health-regression.sh',
+  app: 'src/app',
   actions: 'src/app/(auth)/actions.ts',
   authErrors: 'src/app/(auth)/auth-errors.ts',
   page: 'src/app/(auth)/forgot-password/page.tsx',

--- a/tests/unit/oauth/external-http-contract.test.ts
+++ b/tests/unit/oauth/external-http-contract.test.ts
@@ -1,0 +1,151 @@
+/**
+ * OAuth AS — the external HTTP contract. Prerequisite for the `oauth-as`
+ * extraction (modularisation plan §8 D2, re-opened by RE-DECISION-2026-08-09).
+ *
+ * WHY THIS EXISTS
+ * ---------------
+ * The plan makes one thing a hard precondition of moving this module:
+ *
+ *   "Pin the external HTTP contract with a test first — claude.ai, Claude
+ *    Desktop and both Railway services are outside CI."
+ *
+ * In the App Router a route's URL **is** its directory path under `src/app/`.
+ * So relocating `src/app/oauth/token/route.ts` silently changes a live URL that
+ * four consumers outside this repository depend on, and nothing in this repo
+ * would fail.
+ *
+ * THE GAP THIS CLOSES
+ * -------------------
+ * `metadata.test.ts` already asserts the advertised endpoints:
+ *
+ *   expect(body.token_endpoint).toBe('https://dev.checklyra.com/oauth/token')
+ *
+ * That pins what the discovery document **says**. It does not pin that anything
+ * answers there. Both sides are computed from `oauthConfig`, so if the route
+ * file moved, the metadata would keep advertising `/oauth/token`, that
+ * assertion would keep passing, and the endpoint would 404 — a green suite
+ * describing a broken authorisation server.
+ *
+ * This file closes the loop: for every endpoint the AS advertises, a real
+ * handler must exist at the path the URL implies. Mutation-proven by moving
+ * `token/route.ts` and watching this redden while `metadata.test.ts` stayed
+ * green.
+ *
+ * SCOPE
+ * -----
+ * This asserts route **existence and addressability**, not behaviour — the
+ * twelve sibling files in `tests/unit/oauth/` cover behaviour. Existence is the
+ * property a file move breaks, and the only one nothing else was checking.
+ */
+import { existsSync, readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { oauthConfig } from '@/lib/oauth/config';
+
+const ROOT = resolve(__dirname, '../../..');
+const APP = 'src/app';
+const NEXT_CONFIG = 'next.config.ts';
+
+/** The path part of an advertised absolute endpoint URL. */
+const pathOf = (url: string): string => new URL(url).pathname;
+
+/**
+ * Every rewrite `next.config.ts` declares, as source → destination.
+ *
+ * Read from the file text rather than by importing the config: the module is
+ * ESM/TS with Next-specific resolution, and the thing under test is the
+ * committed declaration, not a runtime object.
+ */
+function rewrites(): Map<string, string> {
+  const text = readFileSync(resolve(ROOT, NEXT_CONFIG), 'utf-8');
+  const out = new Map<string, string>();
+  const re = /source:\s*'([^']+)'\s*,\s*destination:\s*'([^']+)'/g;
+  for (const m of text.matchAll(re)) out.set(m[1], m[2]);
+  return out;
+}
+
+/** Resolve a URL path to the App Router file that must serve it, or null. */
+function handlerFor(urlPath: string): string | null {
+  const base = `${APP}${urlPath}`;
+  for (const candidate of [
+    `${base}/route.ts`,
+    `${base}/route.tsx`,
+    `${base}/page.tsx`,
+  ]) {
+    if (existsSync(resolve(ROOT, candidate))) return candidate;
+  }
+  return null;
+}
+
+/** Advertised endpoints, derived from the AS config — never hand-listed. */
+const ADVERTISED: Record<string, string> = {
+  authorization_endpoint: oauthConfig.authorizationEndpoint(),
+  token_endpoint: oauthConfig.tokenEndpoint(),
+  registration_endpoint: oauthConfig.registrationEndpoint(),
+  revocation_endpoint: oauthConfig.revocationEndpoint(),
+  jwks_uri: oauthConfig.jwksUri(),
+};
+
+describe('OAuth AS external HTTP contract', () => {
+  it('advertises the endpoints this test claims to cover (not vacuous)', () => {
+    // If oauthConfig were refactored so these came back empty or undefined,
+    // every loop below would pass over nothing. Pin the shape first.
+    expect(Object.keys(ADVERTISED)).toHaveLength(5);
+    for (const [name, url] of Object.entries(ADVERTISED)) {
+      expect(`${name}=${url}`).toMatch(/=https?:\/\//);
+    }
+  });
+
+  it.each(['token_endpoint', 'registration_endpoint', 'revocation_endpoint'])(
+    'has a handler serving the advertised %s',
+    (name) => {
+      const p = pathOf(ADVERTISED[name]);
+      const handler = handlerFor(p);
+
+      // A null here means the AS advertises a URL nothing answers on. That is
+      // exactly what relocating the file out of src/app/ would produce.
+      expect(`${p} -> ${handler ?? 'NO HANDLER'}`).toBe(`${p} -> ${handler}`);
+      expect(handler).not.toBeNull();
+    },
+  );
+
+  it('has a page serving the advertised authorization_endpoint', () => {
+    // This one is a rendered page, not a route handler — and it is the reason
+    // the oauth extraction trips the KAN-411 UI/copy gate.
+    const p = pathOf(ADVERTISED.authorization_endpoint);
+    expect(handlerFor(p)).toBe(`${APP}${p}/page.tsx`);
+  });
+
+  it('serves jwks_uri through a declared rewrite to a real handler', () => {
+    // The canonical path is '.'-prefixed, which Next will not route as a
+    // folder, so it is served via an internal rewrite (SEC-33). Two things can
+    // break independently: the rewrite can be dropped, or its destination can
+    // move. Assert both.
+    const p = pathOf(ADVERTISED.jwks_uri);
+    const dest = rewrites().get(p);
+
+    expect(`${p} rewrite`).toBe(dest ? `${p} rewrite` : `${p} rewrite MISSING`);
+    expect(dest).toBeDefined();
+    expect(handlerFor(dest as string)).not.toBeNull();
+  });
+
+  it('serves the AS metadata document through a declared rewrite', () => {
+    // /.well-known/oauth-authorization-server is how every MCP client
+    // discovers this server. It is not in oauthConfig because it is the
+    // document that publishes oauthConfig, so it is named here explicitly.
+    const source = '/.well-known/oauth-authorization-server';
+    const dest = rewrites().get(source);
+
+    expect(dest).toBeDefined();
+    expect(handlerFor(dest as string)).not.toBeNull();
+  });
+
+  it('keeps every advertised endpoint on the issuer origin', () => {
+    // RFC 8414: metadata URLs must share the issuer's origin. A move that
+    // introduced a differently-derived base URL would break client validation
+    // before it broke anything visible here.
+    const issuer = new URL(oauthConfig.issuer()).origin;
+    for (const [name, url] of Object.entries(ADVERTISED)) {
+      expect(`${name}:${new URL(url).origin}`).toBe(`${name}:${issuer}`);
+    }
+  });
+});

--- a/tests/unit/oauth/external-http-contract.test.ts
+++ b/tests/unit/oauth/external-http-contract.test.ts
@@ -40,9 +40,10 @@
 import { existsSync, readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { oauthConfig } from '@/lib/oauth/config';
+import { SRC } from '../../support/source-paths';
 
 const ROOT = resolve(__dirname, '../../..');
-const APP = 'src/app';
+const APP = SRC.app;
 const NEXT_CONFIG = 'next.config.ts';
 
 /** The path part of an advertised absolute endpoint URL. */


### PR DESCRIPTION
Two things, both prerequisites for moving `oauth-as`.

1. THE §2.2 RE-DECISION

The 2026-07-28 scope ruling deferred D1–D15 behind a binding trigger: re-derive
§1.1/§1.2 and re-open extraction IF vertical coupling has NOT materially
improved under Phase 0 alone. Note the polarity — a negative result re-opens.

Re-ran the same instrument (kan432-revalidate.py). Every vertical measure is
flat or worse than the July baseline; not one improved:

  .from() sites             280 -> 296
  .from() in route/page/    199 -> 213
  auth.getUser() files       37 -> 42
  profiles sites/groups   75/15 -> 77/17

Horizontal structure and the control estate did improve (cycles 1->0, lib->app
1->0, distinct src path literals in tests 112->21, controls 11->39). So Phase 0
worked, and it did not close the vertical gap — which is precisely the
condition the trigger names.

Part of the worsening is SEC-117 adding 11 .from() blocks to fix an incomplete
Art.15 export. That is the argument, not a caveat: fixing a compliance defect
CURRENTLY REQUIRES adding direct table reads to a server action, because there
is no data layer to add them to.

Ruling: extraction is RE-OPENED. Recorded in RE-DECISION-2026-08-09.md with the
preconditions honestly graded — a generated Database type now exists (MET), but
Phase 0 is NOT closed (pure source-text scans rose 70 -> 110), and the doc
explains why the unfinished half cannot change this ruling's input while still
being a real constraint on how to extract safely.

Also settles a naming collision that would otherwise produce the wrong work:
"D1" is the `oauth-as` MODULE in the inventory table and the platform/guards/
observability STORY in the sequencing table. In sequencing terms oauth is D2.

2. THE CONTRACT PIN — the plan's hard precondition for this module

  "Pin the external HTTP contract with a test first — claude.ai, Claude Desktop
   and both Railway services are outside CI."

In the App Router a route's URL IS its directory path, so relocating
src/app/oauth/token/route.ts silently changes a live URL. metadata.test.ts
looked like it covered this — it asserts token_endpoint is '.../oauth/token' —
but both that assertion and the advertised value derive from oauthConfig, so it
pins what the server SAYS, not that anything answers there.

Mutation-proven: moving token/route.ts reddens the new test with "NO HANDLER"
while metadata.test.ts stays 12/12 GREEN. An oauth route could have moved,
broken discovery for every MCP client, and left a fully green build.

The new file asserts existence and addressability only — the twelve sibling
files cover behaviour. Existence is what a move breaks and what nothing checked.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

## Verification

- `tests/unit/oauth/external-http-contract.test.ts` — 8/8 ✓
- Mutation proof: `mv src/app/oauth/token/route.ts` → new test **fails** (`NO HANDLER`), `metadata.test.ts` **12/12 green**. Restored, 8/8 ✓
- `kan432-revalidate.py` re-run; raw output committed as evidence

No file moved in this PR — it adds the safety net the move requires.

EXTRACTION-DOD-DESIGN-SYSTEM: n/a — no file moved.
EXTRACTION-DOD-ROUTINE-PROMPTS: n/a — no script renamed, no protected-surface list changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)