### PR TITLE
feat(SEC-120): monitor mode, so the trusted-proxy rollout is observable

### DIFF
--- a/src/lib/client-ip.ts
+++ b/src/lib/client-ip.ts
@@ -86,20 +86,48 @@ export function transitedCloudflare(headers: Headers): boolean {
  * alone. Surfacing this belongs on an admin-only surface, as its own change.
  */
 export function clientIp(headers: Headers): string {
-  if (transitedCloudflare(headers)) {
+  // MONITOR MODE (SEC-120). Enforcement is gated behind a SECOND variable on
+  // purpose. There is no way to observe, from outside, whether the Cloudflare
+  // Transform Rule is actually stamping the header — so flipping straight to
+  // enforcement means the first symptom of a mis-built rule is the entire user
+  // base rate-limited into a handful of Cloudflare edge-IP buckets.
+  //
+  // With the secret set but CF_PROXY_ENFORCE unset, behaviour is unchanged and
+  // any request arriving WITHOUT a valid secret is logged. Once the logs show
+  // that only direct-to-origin traffic is missing it, set CF_PROXY_ENFORCE=1.
+  //
+  // Rollout order matters and is the reverse of the obvious one:
+  //   1. add the CF Transform Rule
+  //   2. set CF_PROXY_SECRET        (monitor — safe, observable)
+  //   3. confirm the logs are quiet
+  //   4. set CF_PROXY_ENFORCE=1     (enforce)
+  const trusted = transitedCloudflare(headers);
+
+  if (env.cfProxySecret() && !trusted) {
+    // Deliberately not rate-limited or sampled: after step 1 this should be
+    // near-silent, and a flood IS the signal that the rule is not working.
+    console.warn(
+      '[SEC-120] request without a valid edge secret — ' +
+        (env.cfProxyEnforce()
+          ? 'cf-connecting-ip IGNORED'
+          : 'monitor mode, cf-connecting-ip still trusted'),
+    );
+  }
+
+  if (trusted) {
     // Provably ours: CF overwrites cf-connecting-ip at its own edge, so this
     // is the real client.
     return headers.get('cf-connecting-ip') ?? firstForwarded(headers) ?? 'unknown';
   }
 
-  if (env.cfProxySecret()) {
-    // Secret IS configured and this request did not present it, so it did not
+  if (env.cfProxySecret() && env.cfProxyEnforce()) {
+    // Enforcing, and this request did not present the secret, so it did not
     // come through our edge. cf-connecting-ip is untrustworthy here — use the
     // platform-set forwarded chain, which a client cannot overwrite.
     return firstForwarded(headers) ?? headers.get('x-real-ip') ?? 'unknown';
   }
 
-  // Not yet configured — legacy precedence, unchanged.
+  // Unconfigured, or configured-but-monitoring — legacy precedence, unchanged.
   return (
     headers.get('cf-connecting-ip') ??
     firstForwarded(headers) ??
@@ -111,4 +139,10 @@ export function clientIp(headers: Headers): string {
 /** Whether the trusted-proxy secret is configured. Not yet surfaced — see above. */
 export function isTrustedProxyConfigured(): boolean {
   return Boolean(env.cfProxySecret());
+}
+
+/** 'off' | 'monitor' | 'enforce' — the current trusted-proxy posture. */
+export function trustedProxyMode(): 'off' | 'monitor' | 'enforce' {
+  if (!env.cfProxySecret()) return 'off';
+  return env.cfProxyEnforce() ? 'enforce' : 'monitor';
 }

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -41,5 +41,8 @@ export const env = {
   // founder configures the rule — see src/lib/client-ip.ts for why the
   // unconfigured branch keeps legacy behaviour rather than failing to XFF.
   cfProxySecret: () => optionalEnv('CF_PROXY_SECRET', '').trim(),
+  // SEC-120: enforcement is a SECOND switch so the secret can be rolled out in
+  // monitor mode first. See the rollout order in src/lib/client-ip.ts.
+  cfProxyEnforce: () => optionalEnv('CF_PROXY_ENFORCE', '').trim() === '1',
 };
 // Force rebuild 20260329011858

--- a/tests/unit/client-ip-trusted-proxy.test.ts
+++ b/tests/unit/client-ip-trusted-proxy.test.ts
@@ -24,16 +24,24 @@
  * outage. So the hardening activates when the edge is configured, and until
  * then this is explicitly no worse than before. Case 1 pins that promise.
  */
-import { clientIp, transitedCloudflare, CF_PROXY_HEADER } from '@/lib/client-ip';
+import {
+  clientIp,
+  transitedCloudflare,
+  trustedProxyMode,
+  CF_PROXY_HEADER,
+} from '@/lib/client-ip';
 
 const SECRET = 'edge-secret-abc';
 const REAL = '203.0.113.9';
 const SPOOF = '198.51.100.7';
 
 const ORIGINAL = process.env.CF_PROXY_SECRET;
+const ORIGINAL_ENFORCE = process.env.CF_PROXY_ENFORCE;
 afterEach(() => {
   if (ORIGINAL === undefined) delete process.env.CF_PROXY_SECRET;
   else process.env.CF_PROXY_SECRET = ORIGINAL;
+  if (ORIGINAL_ENFORCE === undefined) delete process.env.CF_PROXY_ENFORCE;
+  else process.env.CF_PROXY_ENFORCE = ORIGINAL_ENFORCE;
 });
 
 function headers(h: Record<string, string>): Headers {
@@ -62,9 +70,10 @@ describe('clientIp — unconfigured edge (legacy behaviour preserved)', () => {
   });
 });
 
-describe('clientIp — configured edge', () => {
+describe('clientIp — configured edge, ENFORCING', () => {
   beforeEach(() => {
     process.env.CF_PROXY_SECRET = SECRET;
+    process.env.CF_PROXY_ENFORCE = '1';
   });
 
   it('trusts cf-connecting-ip when the shared secret matches', () => {
@@ -116,5 +125,59 @@ describe('clientIp — configured edge', () => {
 
     expect(keys.size).toBe(1);
     expect([...keys][0]).toBe(REAL);
+  });
+});
+
+describe('clientIp — MONITOR mode (secret set, enforcement off)', () => {
+  beforeEach(() => {
+    process.env.CF_PROXY_SECRET = SECRET;
+    delete process.env.CF_PROXY_ENFORCE;
+  });
+
+  it('does NOT change behaviour — a spoofed header is still trusted', () => {
+    // This is the whole point of monitor mode. Setting the secret must be a
+    // no-op for traffic, so a mis-built Transform Rule cannot take the site
+    // down before anyone has seen a log line.
+    const h = headers({ 'cf-connecting-ip': SPOOF, 'x-forwarded-for': REAL });
+
+    expect(clientIp(h)).toBe(SPOOF);
+  });
+
+  it('warns when a request arrives without a valid secret', () => {
+    const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      clientIp(headers({ 'cf-connecting-ip': SPOOF }));
+
+      // The signal the operator watches before flipping enforcement on.
+      expect(warn).toHaveBeenCalledWith(expect.stringContaining('SEC-120'));
+      expect(warn).toHaveBeenCalledWith(expect.stringContaining('monitor mode'));
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
+  it('is silent when the request DOES carry the secret', () => {
+    const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      clientIp(headers({ [CF_PROXY_HEADER]: SECRET, 'cf-connecting-ip': REAL }));
+
+      // A monitor that logs on every request teaches people to ignore it.
+      expect(warn).not.toHaveBeenCalled();
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
+  it('reports its posture as monitor, not enforce', () => {
+    expect(trustedProxyMode()).toBe('monitor');
+  });
+
+  it('reports off when no secret is set, and enforce when both are', () => {
+    delete process.env.CF_PROXY_SECRET;
+    expect(trustedProxyMode()).toBe('off');
+
+    process.env.CF_PROXY_SECRET = SECRET;
+    process.env.CF_PROXY_ENFORCE = '1';
+    expect(trustedProxyMode()).toBe('enforce');
   });
 });


### PR DESCRIPTION
## What

Follow-up to #692. Enforcement of the trusted-proxy rule is now gated behind a **second** variable, `CF_PROXY_ENFORCE`, so the rollout has an observable middle step.

## Why the obvious rollout order is the dangerous one

Nothing observable from outside tells you whether the Cloudflare Transform Rule is actually stamping `x-lyra-edge`. Flipping straight from off to enforcing means **the first symptom of a mis-built rule is the entire user base rate-limited into a handful of Cloudflare edge-IP buckets** — an outage caused by the fix.

## Rollout order — this is the reverse of the intuitive one

| # | Step | Effect |
|---|---|---|
| 1 | Add the CF Transform Rule | no app change |
| 2 | Set `CF_PROXY_SECRET` | **monitor**: behaviour unchanged; requests lacking a valid secret are logged |
| 3 | Confirm the logs are quiet | the rule is proven, from the inside |
| 4 | Set `CF_PROXY_ENFORCE=1` | **enforce** |

**Setting the secret before the rule is the outage.** Monitor mode is what makes step 2 safe and step 3 possible at all.

## Verification

`tests/unit/client-ip-trusted-proxy.test.ts` — **13/13** ✓

## For Luisa — the two env changes this is waiting on

Nothing here takes effect until both are set, and **order matters**: Transform Rule first, secret second.

1. **Cloudflare Transform Rule** — add a request-header rule setting `x-lyra-edge` to the shared secret on requests to the app origin.
2. **Vercel env `CF_PROXY_SECRET`** — the same value, on the environments you want monitored.
3. Later, once logs are quiet: **`CF_PROXY_ENFORCE=1`**.

EXTRACTION-DOD-DESIGN-SYSTEM: n/a — no file moved.
EXTRACTION-DOD-ROUTINE-PROMPTS: n/a — no script renamed, no protected-surface list changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
