### PR TITLE
fix(version): resync package.json to latest tag, harden drift guard

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lyra",
-  "version": "0.1.37",
+  "version": "0.1.94",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lyra",
-      "version": "0.1.37",
+      "version": "0.1.94",
       "dependencies": {
         "@sentry/nextjs": "^10.68.0",
         "@supabase/ssr": "^0.12.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lyra",
-  "version": "0.1.37",
+  "version": "0.1.94",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/tests/unit/version-drift.test.js
+++ b/tests/unit/version-drift.test.js
@@ -67,4 +67,41 @@ describe('KAN-166: package.json version aligns with git tags', () => {
     const expectedTag = `v${pkgVersion}`;
     expect(allTags).toContain(expectedTag);
   });
+
+  // Regression guard: the test above is deliberately tolerant of pkgVersion
+  // matching ANY existing tag, not just the latest, so a release-in-progress
+  // doesn't break CI. But because old tags are never deleted, that tolerance
+  // means once pkgVersion matches a tag once, this file can never re-detect
+  // further drift — which is exactly how develop's package.json sat at
+  // 0.1.37 while tags advanced to v0.1.94 (57 releases) with this suite
+  // green the entire time. This test bounds how far pkgVersion may lag the
+  // latest tag, so that class of drift fails loud again.
+  test('package.json version is not more than 20 releases behind the latest git tag', () => {
+    if (allTags.length === 0) {
+      return;
+    }
+
+    const parseSemver = (v) => {
+      const m = /^v?(\d+)\.(\d+)\.(\d+)$/.exec(v);
+      return m ? [Number(m[1]), Number(m[2]), Number(m[3])] : null;
+    };
+
+    const parsedTags = allTags.map(parseSemver).filter(Boolean);
+    if (parsedTags.length === 0) {
+      return;
+    }
+
+    const compare = (a, b) => a[0] - b[0] || a[1] - b[1] || a[2] - b[2];
+    const latest = parsedTags.reduce((best, t) => (compare(t, best) > 0 ? t : best));
+
+    const pkg = parseSemver(pkgVersion);
+    expect(pkg).not.toBeNull();
+
+    // Only bound drift within the same major.minor line — a deliberate
+    // major/minor bump is not drift and shouldn't fail this guard.
+    if (pkg[0] === latest[0] && pkg[1] === latest[1]) {
+      const releasesBehind = latest[2] - pkg[2];
+      expect(releasesBehind).toBeLessThanOrEqual(20);
+    }
+  });
 });


### PR DESCRIPTION
## Summary

`tests/unit/version-drift.test.js` failed the 2026-08-09 weekly health+regression run: `package.json` (`0.1.37`) had drifted **57 releases** behind the latest git tag (`v0.1.94`) — a recurrence of KAN-166 (closed 2026-05, then `0.1.0` vs `v0.1.35`).

Root cause: the existing assertion only checks that `pkgVersion` matches **some** existing tag, not the latest. Since tags are never deleted, that's satisfied forever once matched once, so it can never re-detect *further* drift after the initial fix. Combined with version bumps apparently happening on release/promotion branches rather than consistently landing back on `develop`, the file drifted silently across ~57 production releases while this exact suite stayed green.

This PR:
- Bumps `package.json` + `package-lock.json` to `0.1.94` (current latest tag).
- Adds a new test to `tests/unit/version-drift.test.js` (existing assertion untouched, per Test Integrity Policy) bounding how far `pkgVersion` may lag the latest tag's patch number (within the same major.minor line) to 20 releases.
- Mutation-proves the new guard: reverted `package.json` to `0.1.37` locally, reran — failed (`57 > 20`); restored — green. (Detail in BUGS-89.)

**Not fully fixed by this PR:** the deeper process gap (why the bump doesn't land on `develop` on every release) needs an owner decision — flagged in BUGS-89's `Prevention:` line for follow-up, not resolved here.

## Jira Ticket

BUGS-89

## Checklist

- [x] Unit tests added/updated for new/changed functionality
- [x] All existing tests pass (`npm run test:unit` — 256/256 suites, 3104/3104 tests)
- [x] Lint passes (`npm run lint`)
- [x] Type check passes (`npm run type-check`)
- [x] Build succeeds (`npm run build`)
- [x] Coverage has not decreased (net +1 test, no source lines removed)
- [x] No eslint-disable or ts-ignore without KAN-XX reference (none added)
- [x] Dependency-rule gate reviewed — no import changes, N/A
- [ ] ARCHITECTURE.md updated if architectural changes were made — N/A, no architectural change
- [ ] Ops routine / Control-Room registry updated — N/A, no scheduled-routine behaviour changed
- [ ] Docs / system map updated — N/A, pure version-string + test-coverage change, no service/table/env var/route/job/security-boundary change
- [ ] Design loop (KAN-441) — N/A, no user-facing look/text changed (`package.json`, `package-lock.json`, and a `tests/` file are all outside the founder-owned UI/copy surface)

This PR does not move, delete, or rename any file under `src/`, so the Extraction Definition-of-Done section is inert and omitted per the template's own instruction.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GbP7Ln3RtqcRgHwwoTNZRW)_