### PR TITLE
chore(weekly-health-regression): surface the failing suite name, not just tail boilerplate

### DIFF
--- a/scripts/weekly-health-regression.sh
+++ b/scripts/weekly-health-regression.sh
@@ -59,6 +59,20 @@ echo "# weekly-health-regression $(date -u +%Y-%m-%dT%H:%M:%SZ)  phases: $PHASES
 [ -f package.json ] || record UNVERIFIED repo "no package.json in $(pwd) — wrong dir/branch? (did you checkout develop?)"
 [ -d node_modules ] || record UNVERIFIED deps "node_modules missing — run 'npm ci' (and 'npx playwright install' for E2E) in the setup script first"
 
+fail_detail() { # $1=logfile — richer than a bare tail: names the failing
+  # jest suite(s) + summary counts when present. A bare `tail -n 3` can land
+  # entirely inside jest's Snapshots/Time/"Ran all test suites" boilerplate
+  # and never show WHICH test failed, forcing a manual re-run to find out —
+  # hit for real on the 2026-08-08 and 2026-08-09 runs.
+  local f="$1" jest_bits
+  jest_bits="$(grep -E '^FAIL |^(Tests:|Test Suites:)' "$f" 2>/dev/null)"
+  if [ -n "$jest_bits" ]; then
+    printf '%s\n' "$jest_bits" | tr '\n' ' ' | cut -c1-500
+  else
+    tail -n 3 "$f" | tr '\n' ' ' | cut -c1-300
+  fi
+}
+
 run_phase() { # $1 label
   local label="$1" c rc log; c="$(cmd_for "$label")"
   [ -z "$c" ] && { record UNVERIFIED "$label" "no command mapped"; return; }
@@ -85,7 +99,7 @@ run_phase() { # $1 label
       # the audit report (no network error) and still FAILs below.
       record UNVERIFIED "$label" "npm registry unreachable — audit gate could not run (env gap, not a vuln): $(tail -n 1 "$log" | cut -c1-160)"
     else
-      record FAIL "$label" "exit $rc — $(tail -n 3 "$log" | tr '\n' ' ' | cut -c1-300)"
+      record FAIL "$label" "exit $rc — $(fail_detail "$log")"
     fi
   fi
   rm -f "$log"

--- a/tests/scripts/weekly-health-regression.test.js
+++ b/tests/scripts/weekly-health-regression.test.js
@@ -117,6 +117,54 @@ describe(SRC.weeklyHealthRegression, () => {
     });
   });
 
+  // Regression guard for a rough edge hit for real on the 2026-08-08 and
+  // 2026-08-09 routine runs: a bare `tail -n 3` on a FAILed jest phase can
+  // land entirely inside the Snapshots/Time/"Ran all test suites"
+  // boilerplate and never show WHICH suite failed, forcing a manual re-run
+  // to find out. The FAIL detail should surface the `FAIL <path>` line and
+  // the `Tests:`/`Test Suites:` summary when the log looks like jest output.
+  describe('FAIL detail names the failing suite, not just boilerplate tail (jest-output case)', () => {
+    let dir = '';
+    let res3;
+    const stub = (d, name, body) => {
+      const p = path.join(d, name);
+      fs.writeFileSync(p, `#!/usr/bin/env bash\n${body}\n`, { mode: 0o755 });
+      return p;
+    };
+
+    beforeAll(() => {
+      dir = fs.mkdtempSync(path.join(os.tmpdir(), 'whr-jestfail-'));
+      fs.writeFileSync(path.join(dir, 'package.json'), '{"name":"stub"}');
+      fs.mkdirSync(path.join(dir, 'node_modules'));
+      const env = {
+        ...process.env,
+        PHASES: 'jestfail',
+        RUN_E2E: '0',
+        CMD_jestfail: stub(dir, 'jestfail.sh', [
+          'echo "FAIL tests/unit/version-drift.test.js"',
+          'echo "  ● some test name"',
+          'echo "Test Suites: 1 failed, 255 passed, 256 total"',
+          'echo "Tests:       1 failed, 3102 passed, 3103 total"',
+          'echo "Snapshots:   0 total"',
+          'echo "Time:        26.438 s"',
+          'echo "Ran all test suites matching tests/(unit|scripts)."',
+          'exit 1',
+        ].join('\n')),
+      };
+      res3 = spawnSync('bash', [SCRIPT], { cwd: dir, env, encoding: 'utf8' });
+    });
+
+    afterAll(() => { if (dir) fs.rmSync(dir, { recursive: true, force: true }); });
+
+    it('includes the FAIL <path> line and the Tests: summary, not just the tail boilerplate', () => {
+      const line = res3.stdout.split('\n').find((l) => l.split('\t')[1] === 'jestfail') || '';
+      expect(line.startsWith('FAIL')).toBe(true);
+      expect(line).toContain('FAIL tests/unit/version-drift.test.js');
+      expect(line).toContain('Tests:');
+      expect(line).not.toContain('Ran all test suites matching');
+    });
+  });
+
   // SEC-91 (2026-07-22): the runner now runs the SAME npm-audit gate as
   // pr-checks.yml + every deploy-*.yml, so a RED dependency gate (which blocks
   // all PRs + the deploy chain) is surfaced by the runner, not found by hand.


### PR DESCRIPTION
## Summary

Self-update proposal (routine step 6 — proposing via PR, not silently changing behaviour).

`scripts/weekly-health-regression.sh`'s FAIL detail used a bare `tail -n 3` on the phase log. For a jest phase, that can land entirely inside the `Snapshots:`/`Time:`/`Ran all test suites` boilerplate and never show WHICH suite failed. This happened for real on both the 2026-08-08 run log (noted explicitly: *"the script's own `tail -3` log capture only retained the `Snapshots`/`Time`/`Ran all test suites` lines, not the `Tests:`/`Test Suites:` failure counts, so the exact failing test was never identified"*) and again on this 2026-08-09 run — I had to manually re-run `npm run test:unit` to find the actual failing test (the version-drift drift, BUGS-89 / #719).

This PR adds a `fail_detail()` helper that greps the log for jest's own `FAIL <path>` and `Tests:`/`Test Suites:` lines when present, falling back to the previous tail-based behaviour for non-jest phases (lint/build/audit) where those patterns don't apply.

Mutation-proven: reverted the script locally, confirmed the new test (`FAIL detail names the failing suite...`) failed exactly as expected against the old behaviour; restored, confirmed green.

## Jira Ticket

None — small script-robustness fix discovered while running the scheduled Weekly Health + Regression routine on 2026-08-09; no separate ticket filed as this is routine-infrastructure housekeeping, not a product defect. Happy to file one if preferred.

## Checklist

- [x] Unit tests added/updated for new/changed functionality (new test in `tests/scripts/weekly-health-regression.test.js`, existing assertions untouched)
- [x] All existing tests pass (`npm run test:unit` — only pre-existing, unrelated failure is the KAN-166 version-drift recurrence tracked separately in BUGS-89/#719; this branch's own tests are 14/14 green)
- [x] Lint passes (`npm run lint`)
- [x] Type check passes (`npm run type-check`) — no `.ts`/`.tsx` touched
- [x] Build succeeds (`npm run build`) — no app code touched
- [x] Coverage has not decreased (net +1 test)
- [x] No eslint-disable or ts-ignore without KAN-XX reference (none added)
- [x] Dependency-rule gate reviewed — no import changes, N/A
- [ ] ARCHITECTURE.md updated — N/A, no architectural change
- [ ] Ops routine / Control-Room registry updated — N/A, this changes only the runner script's internal FAIL-detail formatting, not the routine's cadence, ownership, or behaviour contract (still PASS/FAIL/UNVERIFIED, still exit 0/1/2, still read-only)
- [ ] Docs / system map updated — N/A, no service/table/env var/route/job/security-boundary change
- [ ] Design loop (KAN-441) — N/A, `scripts/` and `tests/` are outside the founder-owned UI/copy surface

This PR does not move, delete, or rename any file under `src/`, so the Extraction Definition-of-Done section is inert and omitted per the template's own instruction.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GbP7Ln3RtqcRgHwwoTNZRW)_