### PR TITLE
fix(release): unblock the stalled promotion chain — soak gate, paused-promote, rollback 409, SAR staleness

### DIFF
--- a/.github/workflows/promote-staging-to-beta.yml
+++ b/.github/workflows/promote-staging-to-beta.yml
@@ -19,7 +19,10 @@ on:
 
 permissions:
   contents: write
-  actions: read
+  # `write` (was `read`) so this workflow can DISPATCH soak-journey against the
+  # staging ref when no soak exists for the SHA being promoted. See the
+  # "post-deploy soak" gate below for why that is necessary rather than nice.
+  actions: write
 
 env:
   VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
@@ -125,6 +128,46 @@ jobs:
           set -euo pipefail
           STAGING_SHA="${{ steps.check.outputs.staging_sha }}"
           echo "Looking for a soak result for ${STAGING_SHA:0:8}"
+
+          # ------------------------------------------------------------------
+          # 2026-08-09: this gate was UNSATISFIABLE exactly when it mattered.
+          #
+          # soak-journey fires on `schedule` and `workflow_run`, and GitHub runs
+          # BOTH of those from the DEFAULT branch — so every automatic soak run
+          # is attributed headSha = main's HEAD, never staging's. This gate
+          # matches on headSha == staging HEAD.
+          #
+          # The result is perverse rather than merely broken: those two SHAs are
+          # equal only when staging and main are already in sync, i.e. when
+          # there is nothing to promote. The moment staging advances — the only
+          # time anyone promotes — no matching soak can exist and the gate
+          # refuses forever. That is why staging sat 34 commits ahead of beta,
+          # with run 30741750933 failing on exactly this.
+          #
+          # Failing closed was RIGHT. What was wrong was leaving no way to
+          # satisfy it. So: if no soak exists for this SHA, dispatch one against
+          # the staging ref (which attributes headSha to staging HEAD) and then
+          # wait for it exactly as before. The gate keeps its teeth; it stops
+          # demanding something nothing could produce.
+          # ------------------------------------------------------------------
+          EXISTING=$(gh run list \
+            --repo "${{ github.repository }}" \
+            --workflow soak-journey.yml \
+            --limit 20 \
+            --json headSha \
+            --jq "[.[] | select(.headSha == \"$STAGING_SHA\")] | length")
+
+          if [ "$EXISTING" = "0" ]; then
+            echo "::notice::No soak-journey run exists for ${STAGING_SHA:0:8} — dispatching one against the staging ref."
+            gh workflow run soak-journey.yml \
+              --repo "${{ github.repository }}" \
+              --ref staging
+            # Let GitHub register the run before the poll loop starts, so the
+            # first attempt is not a guaranteed miss.
+            sleep 15
+          else
+            echo "Found $EXISTING existing soak-journey run(s) for ${STAGING_SHA:0:8}."
+          fi
 
           # The soak takes ~5-10 min and starts only after deploy-staging
           # finishes, so allow a generous budget. 40 x 20s = ~13 min.

--- a/.github/workflows/promote-to-production.yml
+++ b/.github/workflows/promote-to-production.yml
@@ -253,8 +253,19 @@ jobs:
     name: Wait for production deploy (SHA-matched)
     needs: merge-and-push
     runs-on: ubuntu-latest
+    outputs:
+      # SEC-106 follow-up (2026-08-09): 'deployed' or 'awaiting-approval'.
+      # Exiting 0 on `waiting` stopped THIS job failing, but smoke-tests only
+      # `needs:` it — so smoke-tests still ran, its Vercel SHA check could not
+      # possibly pass against a deployment that had not happened, and
+      # auto-rollback fired on `if: failure()`. The spurious rollback was not
+      # removed, it moved one job downstream. That is why the last three
+      # promotes each ended in a rollback attempt that then died on a 409.
+      # Downstream jobs must gate on this VALUE, not merely on this job.
+      deploy_state: ${{ steps.wait.outputs.deploy_state }}
     steps:
       - name: Wait for deploy-production.yml run for our SHA
+        id: wait
         env:
           GH_TOKEN: ${{ github.token }}
           EXPECTED_SHA: ${{ needs.merge-and-push.outputs.merge_sha }}
@@ -319,12 +330,23 @@ jobs:
             if [ "$STATUS" = "waiting" ]; then
               echo "::notice::deploy-production run $RUN_ID is WAITING for environment approval (SEC-106 required reviewer). main is merged at ${EXPECTED_SHA:0:8}; the deploy runs on approval."
               echo "::notice::Approve it at ${{ github.server_url }}/${{ github.repository }}/actions/runs/$RUN_ID — this promote is not failing and no rollback is warranted."
+              echo "deploy_state=awaiting-approval" >> "$GITHUB_OUTPUT"
+              {
+                echo "### ⏸ Production deploy awaiting approval"
+                echo ""
+                echo "\`main\` is merged at \`${EXPECTED_SHA:0:8}\` and is CORRECT."
+                echo "Smoke tests and the release tag are **skipped, not passed** —"
+                echo "they cannot verify a deployment that has not run yet."
+                echo ""
+                echo "Approve run \`$RUN_ID\`, then re-run this workflow to smoke-test and tag."
+              } >> "$GITHUB_STEP_SUMMARY"
               exit 0
             fi
 
             if [ "$STATUS" = "completed" ]; then
               if [ "$CONCLUSION" = "success" ]; then
                 echo "::notice::deploy-production run $RUN_ID succeeded for SHA ${EXPECTED_SHA:0:8}"
+                echo "deploy_state=deployed" >> "$GITHUB_OUTPUT"
                 exit 0
               else
                 echo "::error::deploy-production run $RUN_ID FAILED ($CONCLUSION) for SHA ${EXPECTED_SHA:0:8}"
@@ -350,6 +372,13 @@ jobs:
   smoke-tests:
     name: Production smoke tests + SHA verification
     needs: [merge-and-push, wait-for-deploy]
+    # SEC-106 follow-up (2026-08-09): only run when the deploy ACTUALLY ran.
+    # `needs: wait-for-deploy` alone is not enough — that job exits 0 while the
+    # deploy sits awaiting a reviewer, and these tests then fail against a
+    # production that was never updated, firing auto-rollback on a promote that
+    # is perfectly healthy. Skipping here is deliberate and LOUD (see the job
+    # summary written by wait-for-deploy); it is not a silent pass.
+    if: needs.wait-for-deploy.outputs.deploy_state == 'deployed'
     runs-on: ubuntu-latest
     steps:
       # BUGS-4: verify Vercel actually deployed our SHA to production.
@@ -487,7 +516,7 @@ jobs:
 
   summary:
     name: Production promotion summary
-    needs: [merge-and-push, smoke-tests, release-tag]
+    needs: [merge-and-push, wait-for-deploy, smoke-tests, release-tag]
     if: always()
     runs-on: ubuntu-latest
     steps:
@@ -497,6 +526,7 @@ jobs:
           RELEASE_TAG: ${{ needs.release-tag.outputs.release_tag }}
           SMOKE_RESULT: ${{ needs.smoke-tests.result }}
           TAG_RESULT: ${{ needs.release-tag.result }}
+          DEPLOY_STATE: ${{ needs.wait-for-deploy.outputs.deploy_state }}
         run: |
           set -euo pipefail
           if [ "$SMOKE_RESULT" = "success" ] && [ "$TAG_RESULT" = "success" ]; then
@@ -511,12 +541,31 @@ jobs:
               echo "- All 9 smoke tests passed"
               echo "- BUGS-11 / BUGS-16: direct-merge flow worked, no admin intervention"
             } >> "$GITHUB_STEP_SUMMARY"
+          elif [ "$DEPLOY_STATE" = "awaiting-approval" ]; then
+            # SEC-106 follow-up (2026-08-09): a promote paused on the required
+            # reviewer is HEALTHY, not failed. Reporting it as "❌ Failed" is the
+            # same misleading alert wait-for-deploy was fixed to stop emitting —
+            # it just reappeared here, one job later. main is merged and correct;
+            # nothing is broken and no rollback is warranted.
+            {
+              echo "## ⏸ Production Promotion Paused — awaiting approval"
+              echo ""
+              echo "\`main\` is merged at \`${MERGE_SHA:0:8}\` and is CORRECT."
+              echo ""
+              echo "The production deploy is waiting on the required reviewer (SEC-106)."
+              echo "Smoke tests and the release tag were **skipped, not failed** — they"
+              echo "cannot verify a deployment that has not happened yet."
+              echo ""
+              echo "**Next:** approve the deploy-production run, then re-run this"
+              echo "workflow to smoke-test and tag."
+            } >> "$GITHUB_STEP_SUMMARY"
           else
             {
               echo "## ❌ Production Promotion Failed"
               echo ""
               echo "- Smoke tests: $SMOKE_RESULT"
               echo "- Release tag: $TAG_RESULT"
+              echo "- Deploy state: ${DEPLOY_STATE:-unknown}"
               echo "- Merge SHA: \`${MERGE_SHA:0:8}\`"
               echo ""
               echo "Investigate via Actions tab. Auto-rollback may have triggered."

--- a/docs/compliance/ROPA.md
+++ b/docs/compliance/ROPA.md
@@ -146,6 +146,7 @@ recording it here is a red build.
 | `gathering_events_log` | P4 | `actor_user_id` | exported |
 | `relationship_signals` | P4 | `user_id` | exported — **inferred** data; Art.15 covers inferences |
 | `venue_ratings` | P4 | `user_id` | exported |
+| `gift_suggestion_dismissals` | P4 | `profile_id` | exported — the member's own editorial decisions about their profile (KAN-443) |
 | `venue_visits` | P4 | via `gathering_id` | exported (join) |
 | `oauth_connections` | P4 | `owner_user_id` | exported (token refs redacted) |
 | `oauth_consents` | P4 | `user_id` | exported |

--- a/scripts/rollback-to-sha.py
+++ b/scripts/rollback-to-sha.py
@@ -168,6 +168,64 @@ def main() -> int:
             promote_deployment(token, team_id, uid)
         except urllib.error.HTTPError as e:
             body = e.read().decode("utf-8", errors="replace")
+
+            # 409 is the case this script kept dying on (3/3 recent promotes).
+            # Vercel refuses to promote a deployment that is ALREADY the live
+            # production deployment. That happens whenever the rollback fires on
+            # a promote whose deploy never ran — e.g. it was sitting at
+            # `waiting` for the SEC-106 required reviewer, so production never
+            # moved off the pre-merge SHA in the first place.
+            #
+            # Rolling back to where production already is, is a NO-OP, and a
+            # no-op is not a failure. Reporting it as one produced a red
+            # "rollback failed" alert on a production that was never at risk —
+            # and taught everyone to distrust the rollback alert, which is the
+            # expensive part.
+            #
+            # This is verified, not assumed: we re-read the live deployment and
+            # only treat the 409 as benign when production genuinely already
+            # serves TARGET_SHA. Any other 409 is still a real failure.
+            if e.code == 409:
+                try:
+                    live_sha = parse_current_sha(
+                        list_production_deployments(token, project_id, team_id, limit=5)
+                    )
+                except urllib.error.HTTPError as verify_err:
+                    print(
+                        f"::error::Vercel returned 409 on promote and the follow-up "
+                        f"verification ALSO failed ({verify_err.code} {verify_err.reason}) "
+                        f"— cannot tell 'already rolled back' from 'rollback broken'."
+                    )
+                    print(body)
+                    return 1
+
+                if live_sha == target_sha:
+                    print(
+                        f"::notice::Vercel returned 409 because deployment {uid} is "
+                        f"already the live production deployment. Production serves "
+                        f"{target_sha[:8]} — the rollback target — so there is nothing "
+                        f"to undo. Treating as success."
+                    )
+                    summary = os.environ.get("GITHUB_STEP_SUMMARY")
+                    if summary:
+                        with open(summary, "a") as fh:
+                            fh.write(
+                                "## ✅ Auto-Rollback: nothing to undo\n\n"
+                                f"Production already serves the rollback target "
+                                f"`{target_sha[:8]}`.\n\n"
+                                "Vercel returned 409 because the target deployment is "
+                                "already live — most commonly because the promote's "
+                                "deploy never ran (awaiting the required reviewer), so "
+                                "production never moved.\n"
+                            )
+                    return 0
+
+                print(
+                    f"::error::Vercel returned 409 on promote, but production serves "
+                    f"{(live_sha or 'unknown')[:8]}, NOT the rollback target "
+                    f"{target_sha[:8]}. This is a real rollback failure."
+                )
+
             print(f"::error::Vercel promote API call failed: {e.code} {e.reason}")
             print(body)
             return 1

--- a/src/app/dashboard/settings/actions.ts
+++ b/src/app/dashboard/settings/actions.ts
@@ -214,6 +214,12 @@ export async function exportUserData(): Promise<string> {
     .from('venue_ratings').select('*').eq('user_id', user.id);
   record('venue_ratings', ratingsErr);
 
+  // KAN-443: the gift suggestions the member dismissed. Their own editorial
+  // decisions about their own profile — Art.15 data, keyed by profile_id.
+  const { data: giftDismissals, error: dismissalsErr } = await admin
+    .from('gift_suggestion_dismissals').select('*').eq('profile_id', profileId);
+  record('gift_suggestion_dismissals', dismissalsErr);
+
   // Venue visits hang off the user's own gatherings.
   let venueVisits: unknown[] = [];
   if (gatheringIds.length) {
@@ -265,6 +271,7 @@ export async function exportUserData(): Promise<string> {
     venue_ratings: venueRatings || [],
     venue_visits: venueVisits,
     oauth_scopes_granted: oauthScopes,
+    gift_suggestion_dismissals: giftDismissals || [],
     // Present only when one or more sections failed to fetch — the export is
     // then known-incomplete and must not be treated as a full SAR response.
     ...(fetchErrors.length ? { export_incomplete_errors: fetchErrors } : {}),

--- a/src/lib/gdpr/person-keyed-tables.ts
+++ b/src/lib/gdpr/person-keyed-tables.ts
@@ -53,6 +53,12 @@ export const PERSON_KEYED_TABLES = {
   recommendation_events: 'user_id',
   relationship_signals: 'user_id',
   venue_ratings: 'user_id',
+  // KAN-443. A member's own editorial decisions about their own profile —
+  // which auto-generated gift suggestions they said "not for me" to. Personal
+  // data about them, and something they would expect to see in an Art.15
+  // response. Added 2026-08-09, at the same time as its migration, precisely
+  // so it never exists in the schema without a SAR decision attached.
+  gift_suggestion_dismissals: 'profile_id',
 } as const;
 
 /**

--- a/tests/unit/rollback-to-sha.test.js
+++ b/tests/unit/rollback-to-sha.test.js
@@ -139,3 +139,92 @@ describe('rollback-to-sha.py — format_summary', () => {
     expect(summary).toContain('Verified');
   });
 });
+
+/**
+ * The 409 branch (2026-08-09).
+ *
+ * Auto-rollback failed 3/3 recent production promotes with a Vercel 409, and
+ * the reason was not a rollback bug: the rollback was firing on promotes whose
+ * deploy never ran (sitting at `waiting` for the SEC-106 required reviewer), so
+ * production had never moved off the pre-merge SHA. "Roll back" then meant
+ * "promote the deployment that is already live", which Vercel rejects.
+ *
+ * Rolling back to where production already is, is a NO-OP — and a no-op
+ * reported as a failure produced a red rollback alert on a production that was
+ * never at risk. The expensive part is not the red tick; it is that it teaches
+ * everyone to distrust the rollback alert.
+ *
+ * Both directions are pinned below, because "treat 409 as success" on its own
+ * would be exactly the false-green this repo keeps finding: a 409 while
+ * production serves something OTHER than the target is a REAL rollback failure
+ * and must stay red.
+ */
+function runMainWithStubbedHttp({ promoteStatus, liveSha, targetSha }) {
+  const script = `
+import importlib.util, json, os, sys, urllib.error, io
+spec = importlib.util.spec_from_file_location("rollback_to_sha", "${SCRIPT}")
+mod = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(mod)
+
+TARGET = ${JSON.stringify(targetSha)}
+LIVE   = ${JSON.stringify(liveSha)}
+
+def fake_list(token, project_id, team_id, limit=20):
+    return {"deployments": [
+        {"uid": "dpl_live", "url": "live.vercel.app", "readyState": "READY",
+         "meta": {"githubCommitSha": LIVE}},
+        {"uid": "dpl_target", "url": "target.vercel.app", "readyState": "READY",
+         "meta": {"githubCommitSha": TARGET}},
+    ]}
+
+def fake_promote(token, team_id, uid):
+    raise urllib.error.HTTPError(
+        "https://api.vercel.com/promote", ${promoteStatus}, "Conflict", {},
+        io.BytesIO(b'{"error":{"code":"conflict"}}'))
+
+mod.list_production_deployments = fake_list
+mod.promote_deployment = fake_promote
+
+os.environ.update(TARGET_SHA=TARGET, VERCEL_TOKEN="t",
+                  VERCEL_ORG_ID="team", VERCEL_PROJECT_ID="prj")
+sys.exit(mod.main())
+`;
+  return spawnSync('python3', ['-c', script], { encoding: 'utf8' });
+}
+
+describe('rollback-to-sha.py — 409 handling', () => {
+  const TARGET = 'a'.repeat(40);
+
+  test('409 while production ALREADY serves the target exits 0 — nothing to undo', () => {
+    const r = runMainWithStubbedHttp({
+      promoteStatus: 409,
+      liveSha: TARGET, // production never moved
+      targetSha: TARGET,
+    });
+    expect(r.status).toBe(0);
+    expect(r.stdout).toMatch(/already the live production deployment/);
+    expect(r.stdout).toMatch(/nothing\s+to\s+undo|nothing to undo/i);
+  });
+
+  test('409 while production serves something ELSE stays a REAL failure', () => {
+    // The inverse. Without this, "treat 409 as success" would silently swallow
+    // a genuine inability to roll production back — the worst possible
+    // false-green, on the one control that exists for when things go wrong.
+    const r = runMainWithStubbedHttp({
+      promoteStatus: 409,
+      liveSha: 'b'.repeat(40), // production is on a DIFFERENT sha
+      targetSha: TARGET,
+    });
+    expect(r.status).toBe(1);
+    expect(r.stdout).toMatch(/real rollback failure/i);
+  });
+
+  test('a non-409 promote error is still a failure', () => {
+    const r = runMainWithStubbedHttp({
+      promoteStatus: 500,
+      liveSha: TARGET,
+      targetSha: TARGET,
+    });
+    expect(r.status).toBe(1);
+  });
+});

--- a/tests/unit/sar-export-schema-completeness.test.ts
+++ b/tests/unit/sar-export-schema-completeness.test.ts
@@ -27,7 +27,7 @@
  * and `feature_entitlements` in 2026-06-22 — all predating SEC-71 (2026-07-22).
  * The guard was born narrower than its own header claim; this is not drift.
  */
-import { readFileSync } from 'node:fs';
+import { readFileSync, readdirSync } from 'node:fs';
 import { resolve } from 'node:path';
 import {
   PERSON_KEYED_TABLES,
@@ -155,5 +155,107 @@ describe('SEC-117: SAR export completeness, derived from the schema', () => {
     // A table both exported and excluded means the reader cannot tell which
     // decision is live.
     expect(dupes).toEqual([]);
+  });
+});
+
+/**
+ * SEC-117 follow-up (2026-08-09) — the guard above had the defect it exists to
+ * catch, one level up.
+ *
+ * It derives the person-keyed set from `src/types/database/prod.ts`, a COMMITTED
+ * SNAPSHOT of the production schema. A snapshot is only as current as its last
+ * regeneration. So a migration that adds a person-keyed table is invisible to it
+ * until someone remembers to regenerate — and `gift_suggestion_dismissals`
+ * (KAN-443, `profile_id`) proved it: the table existed in a migration and on two
+ * live databases while that suite sat 7/7 green and said nothing.
+ *
+ * A completeness check whose INPUT can silently go stale is not a completeness
+ * check. This reads the migrations instead. They cannot lag, because they ARE
+ * the change.
+ *
+ * Drop-aware on purpose: `convene_spike_oauth_connections` is created by
+ * 20260516200100 and dropped by 20260516240000. Demanding a SAR decision for a
+ * table that no longer exists would be noise, and noise is what teaches people
+ * to wave a gate through.
+ */
+const MIGRATIONS = SRC.migrations;
+
+/** Tables that still exist after replaying every migration's create/drop. */
+function personKeyedTablesFromMigrations(): Map<string, string[]> {
+  const dir = resolve(ROOT, MIGRATIONS);
+  const files = readdirSync(dir).filter((f) => f.endsWith('.sql')).sort();
+  const live = new Map<string, string[]>();
+
+  for (const f of files) {
+    // Strip `--` line comments FIRST. Every well-written migration here
+    // documents its own rollback in a comment, e.g.
+    //     --   drop table if exists public.gift_suggestion_dismissals;
+    // and the first cut of this parser matched that prose, deleted the table
+    // from the map, and reported 19 tables instead of 28 — missing the very
+    // table it was written to catch. That is the comment-satisfied-assertion
+    // defect (CTL-039) reappearing inside the fix for it: a check reading
+    // prose as if it were code.
+    const sql = readFileSync(resolve(dir, f), 'utf-8')
+      .split('\n')
+      .map((line) => line.replace(/--.*$/, ''))
+      .join('\n');
+
+    const createRe =
+      /create table (?:if not exists )?(?:public\.)?(\w+)\s*\(([\s\S]*?)\n\);/gi;
+    let m: RegExpExecArray | null;
+    while ((m = createRe.exec(sql))) {
+      const [, name, body] = m;
+      const keys = PERSON_COLUMNS.filter((c) =>
+        new RegExp(`^\\s*${c}\\b`, 'm').test(body),
+      );
+      if (keys.length) live.set(name, keys);
+    }
+
+    const dropRe = /drop table (?:if exists )?(?:public\.)?(\w+)/gi;
+    while ((m = dropRe.exec(sql))) live.delete(m[1]);
+  }
+  return live;
+}
+
+describe('SEC-117 follow-up: person-keyed tables derived from MIGRATIONS', () => {
+  it('finds a non-trivial number (the derivation is not vacuous)', () => {
+    // If the create-table regex stopped matching, every assertion below would
+    // pass over an empty map — the exact failure this file exists to prevent,
+    // reproduced in the fix for it.
+    expect(personKeyedTablesFromMigrations().size).toBeGreaterThan(20);
+  });
+
+  it('every person-keyed table a migration creates has an explicit SAR decision', () => {
+    const decided = new Set([
+      ...Object.keys(PERSON_KEYED_TABLES),
+      ...Object.keys(JOIN_KEYED_TABLES),
+      ...Object.keys(DELIBERATELY_EXCLUDED),
+    ]);
+
+    const undecided = [...personKeyedTablesFromMigrations().keys()]
+      .filter((t) => !decided.has(t))
+      .sort();
+
+    // Adding a person-keyed table in a migration without deciding whether a
+    // subject access request returns it must be a RED BUILD at the moment the
+    // migration lands — not whenever prod.ts is next regenerated.
+    expect(undecided).toEqual([]);
+  });
+
+  it('drops are honoured — a dropped table needs no SAR decision', () => {
+    const live = personKeyedTablesFromMigrations();
+    // Created by 20260516200100, dropped by 20260516240000. Verified absent
+    // from production 2026-08-09.
+    expect(live.has('convene_spike_oauth_connections')).toBe(false);
+    // Sanity: the drop logic must not be deleting everything.
+    expect(live.has('profiles')).toBe(true);
+  });
+
+  it('catches what the snapshot missed: gift_suggestion_dismissals', () => {
+    // The concrete case. Pinned by name so a future refactor that reintroduces
+    // snapshot-only derivation fails here rather than silently.
+    const live = personKeyedTablesFromMigrations();
+    expect(live.get('gift_suggestion_dismissals')).toEqual(['profile_id']);
+    expect(Object.keys(PERSON_KEYED_TABLES)).toContain('gift_suggestion_dismissals');
   });
 });


### PR DESCRIPTION
## What

Four fixes that together unblock the stalled `staging → beta → main` chain, plus a real UK-GDPR Art.15 gap found on the way.

Raised from an adversarial pre-flight audit of the 34-commit promotion payload, which returned **NO-GO**. This PR clears four of the blockers; the migrations remain outstanding.

## 1. The soak gate was unsatisfiable exactly when it mattered

`staging` has sat 34 commits ahead of `beta` with promotes failing. This is why.

`soak-journey` fires on `schedule` and `workflow_run`. GitHub runs **both from the default branch**, so every automatic soak run is attributed `headSha = main's HEAD`. The promote gate matches on `headSha == staging HEAD`. Measured live:

| | matching soak runs |
|---|---|
| staging HEAD `0bae0467` | **0** |
| main HEAD `5b174a2d` | **14** |

So the gate is not merely broken, it is **perverse**: those SHAs are equal only when staging and main are already level — i.e. when there is nothing to promote. The moment staging advances, no matching soak can exist and it refuses forever. It last passed 2026-08-02 when the branches happened to be level.

Failing closed was **right**. What was wrong was leaving no way to satisfy it. The gate now dispatches a soak against the staging ref when none exists, then waits as before. It keeps its teeth.

## 2. A promote paused on the reviewer was reported as a failure

SEC-106 added a required reviewer, so a deploy legitimately sits at `waiting`. `wait-for-deploy` was fixed to exit 0 rather than fire a spurious rollback — but `smoke-tests` only `needs:` that job, so it still ran, and its Vercel SHA check **cannot pass against a deployment that has not happened**. It failed, and auto-rollback fired.

The spurious rollback was never removed. It **moved one job downstream**. `wait-for-deploy` now emits `deploy_state`, and `smoke-tests` gates on the value. `release-tag` and `auto-rollback` both depend on `smoke-tests`, so both skip cleanly — a skipped job is not a failure.

The summary job gained a third state; it previously printed "❌ Production Promotion Failed" for a healthy paused promote.

## 3. The rollback died on a 409 that meant "nothing to undo"

Auto-rollback failed 3/3 recent promotes with a Vercel 409. Not a rollback bug — a consequence of #2. When the deploy never ran, production never moved off the pre-merge SHA, so "roll back" meant "promote the deployment that is already live", which Vercel rejects.

Now **verified, not assumed benign**: the script re-reads the live deployment and exits 0 only when production genuinely already serves the target. A 409 while production serves anything else stays a loud failure — "treat 409 as success" alone would be a false-green on the one control that exists for when things have already gone wrong.

## 4. The SAR guard's own input could go stale

The completeness guard added 2026-08-08 derives person-keyed tables from `src/types/database/prod.ts` — a **committed snapshot**. A snapshot is only as current as its last regeneration.

`gift_suggestion_dismissals` (KAN-443, `profile_id`) exists in a migration and now on two live databases, and that suite sat **7/7 green** throughout. A person-keyed table could have shipped with no Art.15 coverage and the check would have said nothing.

Now derives from the **migrations**, which cannot lag because they *are* the change. Drop-aware, so a created-then-dropped table doesn't demand a decision it doesn't need.

> The first cut of the parser matched the `drop table` statements inside migrations' own **rollback comments**, deleted those tables, and reported 19 instead of 28 — missing the very table it was written to catch. The comment-satisfied-assertion defect (CTL-039) reappearing inside the fix for it. Comments are stripped before parsing now.

The gap it found is closed too: the table is in the manifest, queried by the export, and in the ROPA.

## Verification

- `npm run test:unit` — **3136/3136, 258 suites** ✓
- `tsc --noEmit` — **0** real-source errors ✓
- `check-workflow-integrity`, `check-action-pinning`, `check-routine-ownership`, `check-doc-mirror-manifest` ✓
- `check-ui-copy-ownership` — no founder-owned paths changed ✓
- Mutation proofs: the 409 branch (2 tests redden), the SAR migration check (reddens while the snapshot check stays green)

## Still outstanding for the promotion

1. **Three migrations** — rehearsed and verified on **dev**; staging is **3 of 4** (KAN-443 blocked by the permissions classifier); prod not started. Beta runs on the **production** database, so these land on prod *before* `staging → beta`.
2. **Stuck production deployment** — run 30749235408 has been `waiting` since 2026-08-02; prod still serves `5c698be9`.
3. **Migration lineage divergence** — `supabase db push` is unusable here; recorded separately.

EXTRACTION-DOD-DESIGN-SYSTEM: n/a — no file moved.
EXTRACTION-DOD-ROUTINE-PROMPTS: n/a — no script renamed, no protected-surface list changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
