### PR TITLE
docs(runbook): stop pointing at `supabase db push` — it would re-run every migration

### DIFF
--- a/docs/RUNBOOK.md
+++ b/docs/RUNBOOK.md
@@ -472,8 +472,35 @@ WARNING: This drops all existing tables before restoring.
 
 1. Run `./scripts/backup-database.sh` to create a backup
 2. Review the SQL in `supabase/migrations/`
-3. Test on dev environment first
-4. Apply with `supabase db push`
+3. Test on **dev** first, then **staging**, then **production**
+4. Apply with the Supabase MCP `apply_migration` tool — **not `supabase db push`**
+
+> ### ⛔ DO NOT run `supabase db push` on this project (verified 2026-08-09)
+>
+> It would attempt to **re-run every migration in the repo**, including old DDL.
+>
+> Migrations here are applied with the MCP `apply_migration` tool, which stamps
+> the row in `supabase_migrations.schema_migrations` with a **fresh timestamp**
+> rather than the version in the filename. So the repo's versions and the
+> database's recorded versions have never matched, and the CLI sees every local
+> migration as unapplied. Check for yourself with `supabase migration list
+> --linked`: the local and remote columns barely overlap. Example — repo
+> `20260727120000_security_invariants_report_v2.sql`, database
+> `20260727123637 security_invariants_report_v2`: same migration, same name,
+> different version.
+>
+> Consequences beyond the footgun: migration parity cannot be checked by
+> version, and DR restore-from-lineage cannot be proven (BUGS-75, SEC-23).
+> Reconciling this needs a decision — **do not hand-edit
+> `supabase_migrations.schema_migrations`.**
+
+> ### ⚠️ `beta` runs on the PRODUCTION database
+>
+> There are three Supabase projects for four environments. A migration must
+> reach **production before the `staging → beta` promote**, not before
+> `beta → main` — schedule it against `beta → main` and you are one promote too
+> late, and beta serves new code against a production database missing the
+> column. See CLAUDE.md "Deployment Pipeline" and gotcha #19.
 
 ### Rolling back a migration
 


### PR DESCRIPTION
RUNBOOK step 4 said "Apply with `supabase db push`". On this project that would
attempt to RE-RUN EVERY MIGRATION IN THE REPO, including old DDL.

Verified 2026-08-09 with `supabase migration list --linked`: the local and
remote columns barely overlap. Migrations here are applied with the Supabase MCP
`apply_migration` tool, which stamps `supabase_migrations.schema_migrations`
with a fresh timestamp rather than the version in the filename — so the repo's
versions and the database's have never matched, and the CLI sees every local
migration as unapplied. Example: repo
`20260727120000_security_invariants_report_v2.sql` vs database
`20260727123637 security_invariants_report_v2` — same migration, same name,
different version.

The instruction was not merely stale, it was actively dangerous, and it sat in
the runbook someone would reach for during an incident.

Also records the two things that bite hardest here and were only in CLAUDE.md:
migrations must reach PRODUCTION before the staging→beta promote (beta runs on
the production database — three projects, four environments), and the
version-divergence blocks proving DR restore-from-lineage (BUGS-75, SEC-23).

Does NOT hand-fix the divergence: that needs a decision, and editing
schema_migrations by hand is exactly how a lineage becomes unprovable twice.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

## Why this matters more than a doc tidy

This is the runbook someone reaches for **during an incident**. Step 4 told them to run a command that, on this project, would attempt to replay every migration in the repo against a live database.

## Verification

```
supabase migration list --linked
```

Local (repo) and remote (DB) columns barely overlap — nearly every repo version appears with no remote counterpart, and the DB carries a different auto-generated timestamp for the same migration *name*.

Also folds in two facts that were only in CLAUDE.md and belong in the runbook:
- **beta runs on the production database** — three Supabase projects, four environments — so migrations land on prod *before* `staging → beta`
- the version divergence blocks proving DR restore-from-lineage (BUGS-75, SEC-23)

Deliberately does **not** hand-fix the divergence. That needs a decision, and editing `schema_migrations` by hand is how a lineage becomes unprovable twice.

EXTRACTION-DOD-DESIGN-SYSTEM: n/a — no file moved.
EXTRACTION-DOD-ROUTINE-PROMPTS: n/a — no script renamed, no protected-surface list changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)