### PR TITLE
fix(BUGS-87): stop showing members raw Postgres errors, without losing the diagnostic

### DIFF
--- a/src/app/dashboard/profile/actions.ts
+++ b/src/app/dashboard/profile/actions.ts
@@ -18,6 +18,7 @@ import {
 } from './section-visibility';
 import { preflightUpload } from '@/lib/file-magic-bytes';
 import { MAX_SUGGESTION_KEY_LENGTH } from '@/lib/recommend/dismissals';
+import { dbErrorFor } from '@/lib/db-error-copy';
 
 async function getAuthenticatedUser() {
   const supabase = await createClient();
@@ -134,7 +135,7 @@ export async function updateProfileFields(data: Record<string, string | boolean 
     .update(sanitised)
     .eq('user_id', user!.id);
 
-  if (error) return { success: false, error: error.message };
+  if (error) return { success: false, error: dbErrorFor('update-profile-fields', error) };
   revalidatePath('/dashboard/profile');
   return { success: true };
 }
@@ -240,7 +241,7 @@ export async function addProfileItem(data: {
       ...(sanitisedGroupLabel ? { group_label: sanitisedGroupLabel } : {}),
     });
 
-  if (error) return { success: false, error: error.message };
+  if (error) return { success: false, error: dbErrorFor('add-profile-item', error) };
   revalidatePath('/dashboard/profile');
   return { success: true };
 }
@@ -270,7 +271,7 @@ export async function updateProfileItemVisibility(
     .eq('id', itemId)
     .eq('profile_id', profile.id);
 
-  if (error) return { success: false, error: error.message };
+  if (error) return { success: false, error: dbErrorFor('update-profile-item-visibility', error) };
   revalidatePath('/dashboard/profile');
   return { success: true };
 }
@@ -380,7 +381,7 @@ export async function updateProfileItem(
     .select('id, category, title, description, url, visibility')
     .single();
 
-  if (error) return { success: false, error: error.message };
+  if (error) return { success: false, error: dbErrorFor('update-profile-item', error) };
   if (!row) return { success: false, error: 'Item not found' };
   revalidatePath('/dashboard/profile');
   return { success: true, item: row as WizardItem };
@@ -400,7 +401,7 @@ export async function removeProfileItem(itemId: string): Promise<ActionResult> {
     .eq('id', itemId)
     .eq('profile_id', profile.id);
 
-  if (error) return { success: false, error: error.message };
+  if (error) return { success: false, error: dbErrorFor('remove-profile-item', error) };
   revalidatePath('/dashboard/profile');
   return { success: true };
 }
@@ -448,7 +449,7 @@ export async function dismissGiftSuggestion(suggestionKey: string): Promise<Acti
       { onConflict: 'profile_id,suggestion_key', ignoreDuplicates: true },
     );
 
-  if (error) return { success: false, error: error.message };
+  if (error) return { success: false, error: dbErrorFor('dismiss-gift-suggestion', error) };
   revalidatePath('/dashboard/profile');
   return { success: true };
 }
@@ -478,7 +479,7 @@ export async function restoreGiftSuggestion(suggestionKey: string): Promise<Acti
     .eq('profile_id', profile.id)
     .eq('suggestion_key', key);
 
-  if (error) return { success: false, error: error.message };
+  if (error) return { success: false, error: dbErrorFor('restore-gift-suggestion', error) };
   revalidatePath('/dashboard/profile');
   return { success: true };
 }
@@ -572,7 +573,7 @@ export async function addSchoolAffiliation(data: {
       affiliation_type: affiliationType,
     });
 
-  if (error) return { success: false, error: error.message };
+  if (error) return { success: false, error: dbErrorFor('add-school-affiliation', error) };
   revalidatePath('/dashboard/profile');
   return { success: true };
 }
@@ -694,7 +695,7 @@ export async function updateSchoolAffiliation(
     .eq('id', affiliationId)
     .eq('profile_id', profile.id);
 
-  if (error) return { success: false, error: error.message };
+  if (error) return { success: false, error: dbErrorFor('update-school-affiliation', error) };
   revalidatePath('/dashboard/profile');
   return { success: true };
 }
@@ -713,7 +714,7 @@ export async function removeSchoolAffiliation(affiliationId: string): Promise<Ac
     .eq('id', affiliationId)
     .eq('profile_id', profile.id);
 
-  if (error) return { success: false, error: error.message };
+  if (error) return { success: false, error: dbErrorFor('remove-school-affiliation', error) };
   revalidatePath('/dashboard/profile');
   return { success: true };
 }
@@ -737,7 +738,7 @@ export async function updateAffiliationVisibility(
     .eq('id', affiliationId)
     .eq('profile_id', profile.id);
 
-  if (error) return { success: false, error: error.message };
+  if (error) return { success: false, error: dbErrorFor('update-affiliation-visibility', error) };
   revalidatePath('/dashboard/profile');
   return { success: true };
 }
@@ -801,7 +802,7 @@ export async function addExternalLink(data: {
       description: sanitisedDesc,
     });
 
-  if (error) return { success: false, error: error.message };
+  if (error) return { success: false, error: dbErrorFor('add-external-link', error) };
   revalidatePath('/dashboard/profile');
   return { success: true };
 }
@@ -881,7 +882,7 @@ export async function updateExternalLink(
     .eq('id', linkId)
     .eq('profile_id', profile.id);
 
-  if (error) return { success: false, error: error.message };
+  if (error) return { success: false, error: dbErrorFor('update-external-link', error) };
   revalidatePath('/dashboard/profile');
   return { success: true };
 }
@@ -900,7 +901,7 @@ export async function removeExternalLink(linkId: string): Promise<ActionResult> 
     .eq('id', linkId)
     .eq('profile_id', profile.id);
 
-  if (error) return { success: false, error: error.message };
+  if (error) return { success: false, error: dbErrorFor('remove-external-link', error) };
   revalidatePath('/dashboard/profile');
   return { success: true };
 }
@@ -958,7 +959,7 @@ export async function updateSectionVisibility(
     .update({ section_visibility: nextSV })
     .eq('user_id', user!.id);
 
-  if (error) return { success: false, error: error.message };
+  if (error) return { success: false, error: dbErrorFor('update-section-visibility', error) };
   revalidatePath('/dashboard/profile');
   // Also revalidate the public profile path so the change shows up
   // immediately on the next visit.
@@ -993,7 +994,7 @@ export async function publishProfile(): Promise<ActionResult> {
     .update({ is_published: true, onboarding_complete: true })
     .eq('user_id', user!.id);
 
-  if (error) return { success: false, error: error.message };
+  if (error) return { success: false, error: dbErrorFor('publish-profile', error) };
   revalidatePath('/dashboard/profile');
   revalidatePath('/dashboard');
   return { success: true };

--- a/src/app/dashboard/profile/conversation-starters-actions.ts
+++ b/src/app/dashboard/profile/conversation-starters-actions.ts
@@ -6,6 +6,7 @@ import { sanitiseText, type ActionResult } from '@/lib/sanitise';
 import { moderateAndAudit } from '@/lib/moderation-audit';
 import { checkProfileWriteRateLimit } from '@/lib/profile-rate-limit';
 import { ANSWER_MAX, CUSTOM_PROMPT_MAX } from './conversation-starters-fields';
+import { dbErrorFor } from '@/lib/db-error-copy';
 
 /**
  * KAN-181: server actions for `profile_conversation_starters`.
@@ -62,26 +63,13 @@ async function getAuthedRequest(): Promise<AuthedRequest | { error: string }> {
   return { supabase, profileId: profile.id as string, userId: user.id };
 }
 
-/**
- * Map a Postgres error from either cap trigger onto member-facing copy.
- *
- * Order matters: the custom-cap message ('Custom question limit (3) reached')
- * also matches the generic `limit (\d+) reached` pattern, so it has to be
- * tested first or a member who filled their three own questions would be told
- * to remove one of their ten answers.
+/*
+ * `capErrorCopy` lived here until BUGS-87. It moved to
+ * src/lib/db-error-copy.ts, where its matchers were ANCHORED per trigger.
+ * The generic `/limit \(\d+\) reached/` it used was safe while it was
+ * local to this file and became a bug the moment it was shared: it also
+ * matches 'Profile file limit (10) reached'. See that module's header.
  */
-function capErrorCopy(message: string): string | null {
-  if (/custom question limit \(\d+\) reached/i.test(message)) {
-    return 'You can write up to 3 of your own questions. Remove one to add another.';
-  }
-  // The DB trigger raises a custom message for the answer cap; surface
-  // it as a clean toast. Match the limit generically (any digits) so the
-  // copy survives future cap changes without a code edit.
-  if (/limit \(\d+\) reached/.test(message)) {
-    return 'You can answer up to 10 prompts. Remove one to add another.';
-  }
-  return null;
-}
 
 /**
  * Validate + clean the question a member wrote themselves.
@@ -161,13 +149,11 @@ export async function addConversationStarter(input: {
     });
 
   if (error) {
-    const capCopy = capErrorCopy(error.message);
-    if (capCopy) return { success: false, error: capCopy };
-    // 23505 = unique_violation on (profile_id, prompt_id)
-    if (error.code === '23505') {
-      return { success: false, error: 'You already answered this prompt — edit your existing answer instead.' };
-    }
-    return { success: false, error: error.message };
+    // BUGS-87: the cap messages and 23505 (unique_violation on
+    // profile_id+prompt_id) both live in src/lib/db-error-copy.ts now, so the
+    // add and update paths cannot drift apart — the sibling-drift shape this
+    // module's header warns about, previously reproduced right here.
+    return { success: false, error: dbErrorFor('add-conversation-starter', error) };
   }
 
   revalidatePath('/dashboard/profile');
@@ -225,9 +211,7 @@ export async function updateConversationStarter(
     .eq('profile_id', profileId);
 
   if (error) {
-    const capCopy = capErrorCopy(error.message);
-    if (capCopy) return { success: false, error: capCopy };
-    return { success: false, error: error.message };
+    return { success: false, error: dbErrorFor('update-conversation-starter', error) };
   }
 
   revalidatePath('/dashboard/profile');
@@ -246,7 +230,7 @@ export async function removeConversationStarter(id: string): Promise<ActionResul
     .eq('profile_id', profileId);
 
   if (error) {
-    return { success: false, error: error.message };
+    return { success: false, error: dbErrorFor('remove-conversation-starter', error) };
   }
 
   revalidatePath('/dashboard/profile');

--- a/src/app/dashboard/profile/delivery-country-actions.ts
+++ b/src/app/dashboard/profile/delivery-country-actions.ts
@@ -26,6 +26,7 @@ import { revalidatePath } from 'next/cache';
 import { type ActionResult } from '@/lib/sanitise';
 import { checkProfileWriteRateLimit } from '@/lib/profile-rate-limit';
 import { normaliseDeliveryCountry } from '@/lib/affiliate/country-codes';
+import { dbErrorFor } from '@/lib/db-error-copy';
 
 export async function updateDeliveryCountry(
   input: string | null
@@ -59,7 +60,7 @@ export async function updateDeliveryCountry(
     .update({ delivery_country_code: normalised })
     .eq('user_id', user.id);
 
-  if (error) return { success: false, error: error.message };
+  if (error) return { success: false, error: dbErrorFor('update-delivery-country', error) };
   revalidatePath('/dashboard/profile');
   return { success: true };
 }

--- a/src/app/dashboard/profile/files-actions.ts
+++ b/src/app/dashboard/profile/files-actions.ts
@@ -12,6 +12,7 @@ import {
   type AllowedMime,
 } from '@/lib/file-magic-bytes';
 import { getMyFeatureEntitlements } from '@/lib/features/entitlements';
+import { dbErrorFor } from '@/lib/db-error-copy';
 
 /**
  * KAN-142: server actions for the profile_files surface.
@@ -194,7 +195,7 @@ export async function updateProfileFileVisibility(
     .eq('id', id)
     .eq('profile_id', profileId);
   if (error) {
-    return { success: false, error: error.message };
+    return { success: false, error: dbErrorFor('update-profile-file-visibility', error) };
   }
 
   revalidatePath('/dashboard/profile');

--- a/src/app/dashboard/profile/manual-of-me-actions.ts
+++ b/src/app/dashboard/profile/manual-of-me-actions.ts
@@ -22,6 +22,7 @@ import { revalidatePath } from 'next/cache';
 import { sanitiseText, type ActionResult } from '@/lib/sanitise';
 import { moderateAndAudit } from '@/lib/moderation-audit';
 import { checkProfileWriteRateLimit } from '@/lib/profile-rate-limit';
+import { dbErrorFor } from '@/lib/db-error-copy';
 import {
   MANUAL_OF_ME_FIELDS,
   MANUAL_OF_ME_MAX_LENGTHS,
@@ -134,7 +135,7 @@ export async function updateManualOfMe(
       { onConflict: 'profile_id' }
     );
 
-  if (error) return { success: false, error: error.message };
+  if (error) return { success: false, error: dbErrorFor('update-manual-of-me', error) };
 
   revalidatePath('/dashboard/profile');
   return { success: true };

--- a/src/lib/db-error-copy.ts
+++ b/src/lib/db-error-copy.ts
@@ -1,0 +1,133 @@
+/**
+ * BUGS-87 — one place that turns a database error into something a member
+ * should read, and records the real one where an engineer can find it.
+ *
+ * WHY THIS EXISTS
+ * ---------------
+ * 33 sites across 12 server-action files returned a raw Supabase/Postgres
+ * `error.message` straight to the caller. 11 of those reach a member's screen
+ * — `gift-extras-section.tsx` renders the string verbatim inside a
+ * `role="alert"` paragraph — so a member could be shown
+ * `relation "public.gift_suggestion_dismissals" does not exist`, or an
+ * internal constraint name like `pcs_prompt_source_xor`.
+ *
+ * NOT A PLAIN SWEEP: the diagnostic matters more than the leak
+ * ------------------------------------------------------------
+ * Those files had ZERO logging. The leaked string was the only record the
+ * failure had happened anywhere. Replacing it with a generic sentence and
+ * stopping there would be a net loss — a silent failure is worse than an ugly
+ * one. So `dbErrorFor` does both halves in one call: it reports the real error
+ * to Sentry and returns the member-facing copy.
+ *
+ * ⚠️ WHY THE MATCHERS ARE ANCHORED, NOT GENERIC
+ * ---------------------------------------------
+ * The mapper this replaces (`capErrorCopy`) used
+ *     /limit \(\d+\) reached/
+ * deliberately, so "the copy survives future cap changes without a code edit".
+ * That generality is a trap the moment the function is shared: it also matches
+ * `Profile file limit (10) reached` (20260516180000_profile_files.sql:46).
+ * Lifting it verbatim into a shared helper would tell a member who exceeded
+ * the TEN-FILE UPLOAD CAP: "You can answer up to 10 prompts. Remove one to add
+ * another."
+ *
+ * That would have landed invisibly — `wizard.tsx` discards the file-upload
+ * result today, so no screen or test exercises it — and surfaced later, with
+ * no code change, the moment file errors get wired to the UI (which
+ * `files-step.tsx` says is the intent).
+ *
+ * So every matcher below is anchored to its OWN trigger message. Adding a new
+ * cap means adding a line here, which is the correct amount of friction for a
+ * string a member reads.
+ */
+import * as Sentry from '@sentry/nextjs';
+
+/** The shape both `supabase-js` errors and thrown Postgres errors satisfy. */
+export type DbErrorLike = {
+  message?: string | null;
+  code?: string | null;
+} | null | undefined;
+
+/**
+ * What a member sees when we have nothing specific and useful to tell them.
+ * Deliberately actionable and free of internal vocabulary.
+ */
+export const GENERIC_DB_ERROR = 'Something went wrong saving that. Please try again.';
+
+/**
+ * Anchored, per-trigger copy. Order still matters for the two
+ * conversation-starter caps: `Custom question limit` must be tested before any
+ * looser sibling, which is why each entry is anchored at the start of the
+ * message rather than searched for anywhere within it.
+ *
+ * Every message here is quoted verbatim from the migration that raises it, so
+ * a `grep` from either direction finds the pair.
+ */
+const TRIGGER_COPY: ReadonlyArray<readonly [RegExp, string]> = [
+  // 20260803160000_kan445_custom_conversation_prompts.sql:248
+  [
+    /^custom question limit \(\d+\) reached/i,
+    'You can write up to 3 of your own questions. Remove one to add another.',
+  ],
+  // 20260516200200_conversation_starters.sql:31 and its later 5-cap sibling
+  [
+    /^conversation-starter answer limit \(\d+\) reached/i,
+    'You can answer up to 10 prompts. Remove one to add another.',
+  ],
+  // 20260516180000_profile_files.sql:46 — NOT previously mapped anywhere.
+  // Its absence is exactly the collision described in the header: without its
+  // own entry it would fall into the conversation-starter copy.
+  [
+    /^profile file limit \(\d+\) reached/i,
+    'You can upload up to 10 files. Remove one to add another.',
+  ],
+];
+
+/** Postgres SQLSTATEs with copy that is genuinely more useful than the generic. */
+const CODE_COPY: Readonly<Record<string, string>> = {
+  // unique_violation. The only current use is (profile_id, prompt_id) on
+  // profile_conversation_starters — see conversation-starters-actions.ts.
+  '23505': 'You already answered this prompt — edit your existing answer instead.',
+};
+
+/**
+ * Member-facing copy for a database error. PURE — no logging, no side effects,
+ * so it can be unit-tested directly. Prefer `dbErrorFor` at call sites, which
+ * also records the real error.
+ */
+export function memberFacingDbError(error: DbErrorLike): string {
+  if (!error) return GENERIC_DB_ERROR;
+
+  const message = (error.message ?? '').trim();
+  for (const [pattern, copy] of TRIGGER_COPY) {
+    if (pattern.test(message)) return copy;
+  }
+
+  const code = (error.code ?? '').trim();
+  if (code && code in CODE_COPY) return CODE_COPY[code];
+
+  return GENERIC_DB_ERROR;
+}
+
+/**
+ * Record the real error, return what the member should read.
+ *
+ * `area` is a short, stable identifier for the call site (e.g.
+ * 'gift-dismissals'). It is the thing an engineer greps for when a member says
+ * "it just said something went wrong", so make it specific.
+ *
+ * A recognised trigger message is NOT reported to Sentry: hitting a documented
+ * cap is the product working, not a fault, and paging on it would train people
+ * to ignore the channel.
+ */
+export function dbErrorFor(area: string, error: DbErrorLike): string {
+  const copy = memberFacingDbError(error);
+
+  if (error && copy === GENERIC_DB_ERROR) {
+    Sentry.captureException(
+      new Error(`${area}: ${error.message ?? 'unknown database error'}`),
+      { tags: { area, ticket: 'BUGS-87' }, extra: { code: error.code ?? null } },
+    );
+  }
+
+  return copy;
+}

--- a/tests/support/source-paths.json
+++ b/tests/support/source-paths.json
@@ -1,7 +1,7 @@
 {
   "$comment": "GENERATED — regenerate with `npm run gen:test-paths`. Mirror of tests/support/source-paths.ts for .cjs and shell consumers (KAN-414 F4).",
   "generated_from": "literals referenced by tracked files under tests/",
-  "count": 180,
+  "count": 181,
   "SRC": {
     "codeowners": ".github/CODEOWNERS",
     "pullRequestTemplate": ".github/PULL_REQUEST_TEMPLATE.md",
@@ -153,6 +153,7 @@
     "oauthConnections": "src/lib/convene/oauth-connections.ts",
     "postEvent": "src/lib/convene/post-event.ts",
     "resolveWidgets": "src/lib/dashboard/resolve-widgets.ts",
+    "dbErrorCopy": "src/lib/db-error-copy.ts",
     "libEnv": "src/lib/env.ts",
     "entitlementsService": "src/lib/features/entitlements-service.ts",
     "fileMagicBytes": "src/lib/file-magic-bytes.ts",

--- a/tests/support/source-paths.ts
+++ b/tests/support/source-paths.ts
@@ -13,7 +13,7 @@
 // cannot drift from reality — a hand-maintained list is what let BUGS-74's
 // first fix miss the legacy editor.
 //
-// 180 entries.
+// 181 entries.
 
 export const SRC = {
   codeowners: '.github/CODEOWNERS',
@@ -166,6 +166,7 @@ export const SRC = {
   oauthConnections: 'src/lib/convene/oauth-connections.ts',
   postEvent: 'src/lib/convene/post-event.ts',
   resolveWidgets: 'src/lib/dashboard/resolve-widgets.ts',
+  dbErrorCopy: 'src/lib/db-error-copy.ts',
   libEnv: 'src/lib/env.ts',
   entitlementsService: 'src/lib/features/entitlements-service.ts',
   fileMagicBytes: 'src/lib/file-magic-bytes.ts',

--- a/tests/unit/bugs70-manual-of-me-persist.test.ts
+++ b/tests/unit/bugs70-manual-of-me-persist.test.ts
@@ -99,7 +99,12 @@ describe('BUGS-70: updateManualOfMe persistence', () => {
 
     expect(result.success).toBe(false);
     if (!result.success) {
-      expect(result.error).toMatch(/row-level security/i);
+      // BUGS-87: this asserted the member is shown 'row-level security policy
+      // for table "profile_manual_of_me"'. This test's stated intent is that a
+      // failed write is surfaced and NOT revalidated — that is untouched. What
+      // changes is that the member no longer reads the database's internals.
+      expect(result.error).toBe('Something went wrong saving that. Please try again.');
+      expect(result.error).not.toMatch(/row-level security/i);
     }
     // No false "Saved": the save path never claims success on a failed write,
     // and it must not revalidate a page whose data did not change.

--- a/tests/unit/conversation-starters.test.ts
+++ b/tests/unit/conversation-starters.test.ts
@@ -17,6 +17,7 @@
 import { readFileSync, existsSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { SRC } from '../support/source-paths';
+import { memberFacingDbError } from '@/lib/db-error-copy';
 
 const ROOT = resolve(__dirname, '../..');
 
@@ -87,15 +88,24 @@ describe('KAN-181 conversation starters — surface-area regression guards', () 
   });
 
   test('server-actions file surfaces the answer cap as a clean error', () => {
-    const src = readFileSync(
-      resolve(ROOT, SRC.conversationStartersActions),
-      'utf-8',
-    );
-    // KAN-404 #14: the actions file now matches the trigger message with a
-    // robust regex (any digit count) rather than a hard-coded "limit (5)",
-    // and the friendly copy advertises the raised cap of 10.
-    expect(src).toMatch(/limit \\\(\\d\+\\\) reached/);
-    expect(src).toMatch(/up to 10/);
+    // BUGS-87: was a source-text scan of the actions file. The cap copy moved
+    // to src/lib/db-error-copy.ts, and CTL-039 immediately flagged the
+    // relocated scan as comment-shadowed — the copy appears in that module's
+    // header AND in its code, so deleting the code would have left the
+    // assertion green. So this is now BEHAVIOURAL: it calls the mapper.
+    //
+    // It also drops the old `limit (\d+) reached` assertion. That pattern was
+    // the defect, not the guarantee: it matches 'Profile file limit (10)
+    // reached' too, so sharing it would have told a member who hit the
+    // ten-FILE cap that they could answer ten prompts. The anchored behaviour
+    // below is what actually matters.
+    expect(
+      memberFacingDbError({ message: 'Conversation-starter answer limit (10) reached' }),
+    ).toMatch(/up to 10 prompts/);
+    // Anchored, not generic: the file cap must NOT get this copy.
+    expect(
+      memberFacingDbError({ message: 'Profile file limit (10) reached' }),
+    ).not.toMatch(/prompts/);
 
     // Coverage not weakened: the robust regex the actions file uses must
     // still map the LEGACY 'limit (5) reached' message (e.g. a stale DB

--- a/tests/unit/db-error-copy.test.ts
+++ b/tests/unit/db-error-copy.test.ts
@@ -1,0 +1,136 @@
+/**
+ * BUGS-87 — the shared database-error mapper.
+ *
+ * The load-bearing test here is "does NOT collide with the file cap". The
+ * obvious implementation of this module — lift `capErrorCopy` out of
+ * conversation-starters-actions.ts verbatim — passes every other assertion in
+ * this file and still ships a real bug, because that function matches
+ * `/limit \(\d+\) reached/` anywhere in the message and
+ * `Profile file limit (10) reached` satisfies it.
+ *
+ * A member who exceeded the ten-FILE upload cap would have been told
+ * "You can answer up to 10 prompts." It would have landed invisibly, because
+ * the file-upload result is discarded at the call site today — so no screen
+ * and no other test exercises it — and surfaced later with no code change at
+ * all, the moment file errors get wired to the UI.
+ */
+import {
+  memberFacingDbError,
+  dbErrorFor,
+  GENERIC_DB_ERROR,
+} from '@/lib/db-error-copy';
+
+jest.mock('@sentry/nextjs', () => ({ captureException: jest.fn() }));
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const Sentry = require('@sentry/nextjs');
+
+/** Quoted verbatim from the migrations that raise them. */
+const TRIGGER_MESSAGES = {
+  customQuestion: 'Custom question limit (3) reached',
+  answers10: 'Conversation-starter answer limit (10) reached',
+  answers5: 'Conversation-starter answer limit (5) reached',
+  files: 'Profile file limit (10) reached',
+};
+
+beforeEach(() => jest.clearAllMocks());
+
+describe('BUGS-87: memberFacingDbError', () => {
+  it('maps the custom-question cap to its own copy', () => {
+    expect(memberFacingDbError({ message: TRIGGER_MESSAGES.customQuestion })).toMatch(
+      /up to 3 of your own questions/,
+    );
+  });
+
+  it('maps both answer-cap variants to the answers copy', () => {
+    for (const m of [TRIGGER_MESSAGES.answers10, TRIGGER_MESSAGES.answers5]) {
+      expect(memberFacingDbError({ message: m })).toMatch(/answer up to 10 prompts/);
+    }
+  });
+
+  it('does NOT collide the FILE cap with the prompt cap', () => {
+    // The whole reason the matchers are anchored per-trigger instead of the
+    // generic /limit \(\d+\) reached/ the old mapper used.
+    const copy = memberFacingDbError({ message: TRIGGER_MESSAGES.files });
+    expect(copy).toMatch(/upload up to 10 files/);
+    expect(copy).not.toMatch(/prompts/);
+    expect(copy).not.toMatch(/questions/);
+  });
+
+  it('proves the naive implementation WOULD have collided', () => {
+    // Pins the reason this module is not a verbatim lift. If someone later
+    // "simplifies" the matchers back to the generic pattern, the assertion
+    // above breaks — and this one explains why.
+    const naive = /limit \(\d+\) reached/;
+    expect(naive.test(TRIGGER_MESSAGES.files)).toBe(true);
+    expect(naive.test(TRIGGER_MESSAGES.customQuestion)).toBe(true);
+  });
+
+  it('keeps the custom-question cap ahead of the answer cap', () => {
+    // Ordering was documented as load-bearing in the original mapper: a member
+    // who filled their three own questions must not be told to remove one of
+    // their ten answers.
+    expect(memberFacingDbError({ message: TRIGGER_MESSAGES.customQuestion })).not.toMatch(
+      /answer up to 10 prompts/,
+    );
+  });
+
+  it('maps 23505 to the already-answered copy', () => {
+    expect(memberFacingDbError({ message: 'duplicate key value', code: '23505' })).toMatch(
+      /already answered this prompt/,
+    );
+  });
+
+  it('returns the generic sentence for anything unrecognised', () => {
+    for (const m of [
+      'relation "public.gift_suggestion_dismissals" does not exist',
+      'new row for relation "profile_conversation_starters" violates check constraint "pcs_prompt_source_xor"',
+      'permission denied for table profiles',
+    ]) {
+      expect(memberFacingDbError({ message: m })).toBe(GENERIC_DB_ERROR);
+    }
+  });
+
+  it('never leaks internal vocabulary in the generic copy', () => {
+    // The specific strings BUGS-87 is about.
+    expect(GENERIC_DB_ERROR).not.toMatch(/relation|constraint|pcs_|public\.|permission denied/i);
+  });
+
+  it('handles null/undefined/empty without throwing', () => {
+    expect(memberFacingDbError(null)).toBe(GENERIC_DB_ERROR);
+    expect(memberFacingDbError(undefined)).toBe(GENERIC_DB_ERROR);
+    expect(memberFacingDbError({})).toBe(GENERIC_DB_ERROR);
+    expect(memberFacingDbError({ message: null, code: null })).toBe(GENERIC_DB_ERROR);
+  });
+});
+
+describe('BUGS-87: dbErrorFor also preserves the diagnostic', () => {
+  it('reports the REAL error to Sentry when the copy is generic', () => {
+    // Removing error.message from the return value without this is a net loss:
+    // these files had no logging at all, so the leaked string was the only
+    // record the failure ever happened.
+    const raw = 'relation "public.gift_suggestion_dismissals" does not exist';
+    const copy = dbErrorFor('gift-dismissals', { message: raw, code: '42P01' });
+
+    expect(copy).toBe(GENERIC_DB_ERROR);
+    expect(Sentry.captureException).toHaveBeenCalledTimes(1);
+
+    const [err, ctx] = Sentry.captureException.mock.calls[0];
+    expect(err.message).toContain(raw);
+    expect(err.message).toContain('gift-dismissals');
+    expect(ctx.tags).toMatchObject({ area: 'gift-dismissals', ticket: 'BUGS-87' });
+    expect(ctx.extra).toMatchObject({ code: '42P01' });
+  });
+
+  it('does NOT page on a recognised cap — that is the product working', () => {
+    const copy = dbErrorFor('conversation-starters', {
+      message: TRIGGER_MESSAGES.customQuestion,
+    });
+    expect(copy).toMatch(/up to 3 of your own questions/);
+    expect(Sentry.captureException).not.toHaveBeenCalled();
+  });
+
+  it('does not report when there is no error at all', () => {
+    expect(dbErrorFor('anything', null)).toBe(GENERIC_DB_ERROR);
+    expect(Sentry.captureException).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/kan443-gift-suggestion-dismissals.test.ts
+++ b/tests/unit/kan443-gift-suggestion-dismissals.test.ts
@@ -299,9 +299,18 @@ describe('dismissGiftSuggestion', () => {
   });
 
   test('a database error is surfaced, not swallowed', async () => {
+    // BUGS-87 (founder-approved 2026-08-09): this asserted the RAW Postgres
+    // string reached the caller — and `gift-extras-section.tsx` renders it
+    // verbatim in a role="alert", so it reached the MEMBER. The test's real
+    // intent is "the failure is surfaced, not swallowed"; that is preserved,
+    // and strengthened by asserting the raw text is now absent.
     mockUpsertError = { message: 'relation does not exist' };
     const result = await dismissGiftSuggestion('books_reading:something to read');
-    expect(result).toEqual({ success: false, error: 'relation does not exist' });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error).toBe('Something went wrong saving that. Please try again.');
+      expect(result.error).not.toMatch(/relation does not exist/);
+    }
     expect(mockRevalidatePath).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
BUGS-87 said "two unguarded lines in profile/actions.ts". It is 22 sites across
five files — `return { success: false, error: error.message }` was the
convention, not an oversight. `gift-extras-section.tsx` renders that string
verbatim inside a role="alert", so a member could read
`relation "public.gift_suggestion_dismissals" does not exist` or an internal
constraint name like `pcs_prompt_source_xor`.

THE HARDER HALF: those files had ZERO logging. The leaked string was the only
record the failure had happened anywhere, so genericising it and stopping would
have been a net loss — a silent failure is worse than an ugly one. `dbErrorFor`
does both in one call: reports the real error to Sentry, returns the copy.

ANCHORED MATCHERS, NOT A VERBATIM LIFT
The obvious implementation is to move `capErrorCopy` into src/lib and share it.
That ships a real bug. Its second matcher is deliberately generic —

    /limit \(\d+\) reached/

"so the copy survives future cap changes without a code edit". Safe while local;
a defect the moment it is shared, because
`20260516180000_profile_files.sql:46` raises 'Profile file limit (10) reached'.
A member who exceeded the TEN-FILE upload cap would have been told "You can
answer up to 10 prompts. Remove one to add another."

It would have landed invisibly — wizard.tsx discards the file-upload result, so
no screen or test exercises it — and surfaced later with no code change at all,
the moment file errors get wired to the UI, which files-step.tsx says is the
intent. Every matcher is now anchored to its own trigger message, and the file
cap gained the copy it never had.

Mutation-proven: reverting one matcher to the generic form fires the collision
test; restoring gives 12/12.

TESTS THAT PINNED THE BUG (Test Integrity Policy — all three listed)
1. kan443-gift-suggestion-dismissals.test.ts:301 — FOUNDER-APPROVED 2026-08-09.
   was: expect(result).toEqual({ success: false, error: 'relation does not exist' })
   now: asserts success===false, the generic copy, AND that the raw text is absent.
2. bugs70-manual-of-me-persist.test.ts:102 — same class, found during execution.
   was: expect(result.error).toMatch(/row-level security/i)
   now: asserts the generic copy and that 'row-level security' is absent.
   Its stated intent (surfaced, not revalidated) is untouched.
3. conversation-starters.test.ts:97 — was a source-text scan asserting the
   actions file contains `limit (\d+) reached` and 'up to 10'. The copy moved,
   and CTL-039 immediately flagged the relocated scan as comment-shadowed. It is
   now BEHAVIOURAL: it calls the mapper, and additionally asserts the file cap
   does NOT get the prompt copy.

(2) and (3) were not covered by the original sign-off — flagged explicitly.

ALSO: deletes the local capErrorCopy, so the add and update paths can no longer
drift — the sibling-drift shape that module's own header warns about, which it
was reproducing.

DELIBERATELY EXCLUDED, so the sweep does not break real copy: settings/actions.ts
Art.15 fetch-failure records (they must distinguish "0 rows" from "fetch
failed"), GoTrue auth messages like 'Invalid login credentials', moderation and
rate-limit strings, and admin throw sites.

3148/3148, tsc clean, CTL-039 clean, env-access exact.

UI-Bugfix-Only: BUGS-87

The KAN-411 guard does NOT fire — the change is confined to .ts action files
plus a new src/lib module, which is invisible to its path list. The trailer is
here anyway because this unquestionably changes what a member reads, and a gate
not firing is not the same as a change not needing sign-off.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

## Verification

- `npm run test:unit` — **3148/3148, 259 suites** ✓
- `tsc --noEmit` — 0 real-source errors ✓
- CTL-039 — 77 known, none new, none stale ✓
- `check-env-access`, `check-server-action-exports`, `check-guard-path-drift` ✓
- Mutation proof: reverting one matcher to the generic form fires the collision test; restoring gives 12/12

## Still open, raised not fixed

`updateConversationStarter` has no `pcs_prompt_source_xor` re-check, unlike the add path — so a direct action call can still reach the raw 23514 the module header says it exists to prevent. Out of scope here; worth its own ticket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)