### PR TITLE
fix(SEC-36): beta has no OAuth authorization server — turn it off, don't key it

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -35,8 +35,53 @@ function stampCspReportOnly(res: NextResponse, csp: string): NextResponse {
   return res;
 }
 
+/**
+ * Paths that make up the OAuth authorization server surface (SEC-36).
+ *
+ * Both the public `/.well-known/*` paths and the internal `/api/well-known/*`
+ * they rewrite to are listed. Middleware sees the public path, but the rewrite
+ * targets are directly addressable too, so gating only one half would leave a
+ * back door.
+ */
+function isOauthServerPath(pathname: string): boolean {
+  return (
+    pathname.startsWith('/oauth/') ||
+    pathname === '/.well-known/oauth-authorization-server' ||
+    pathname === '/.well-known/jwks.json' ||
+    pathname.startsWith('/api/well-known/')
+  );
+}
+
 export async function middleware(request: NextRequest) {
   const pathname = request.nextUrl.pathname;
+
+  // ---------------------------------------------------------------------
+  // SEC-36: beta has no OAuth authorization server. Turn it OFF, don't key it.
+  //
+  // Beta advertised ITSELF as the issuer and answered on /oauth/token,
+  // /register and /revoke, while /.well-known/jwks.json returned 500 — it has
+  // no RS256 keypair on the beta scope and never has. Verified 2026-08-09:
+  // NOTHING points at it. Both resource servers derive the AS from
+  // LYRA_SITE_URL — prod MCP leaves it unset (defaults to checklyra.com) and
+  // dev MCP sets dev.checklyra.com. That is the "confirm unused" question
+  // SEC-36 asked in June, answered with evidence.
+  //
+  // Giving beta a keypair would have been the WRONG fix. Beta runs on the
+  // PRODUCTION Supabase project (gotcha #19), so a working beta AS would mint
+  // tokens whose `sub` is a real production user and write jti rows into
+  // production's oauth_access_tokens — a token factory for production
+  // identities in the deliberately less-hardened environment, separated from
+  // prod only by an `iss` string comparison in the verifier.
+  //
+  // 404, not 403: beta genuinely has no authorization server, and that is what
+  // a client should discover. It also closes the unauthenticated DCR write
+  // into production's oauth_clients via /oauth/register, which the beta gate
+  // further down CANNOT reach because that one only runs for authenticated
+  // requests.
+  // ---------------------------------------------------------------------
+  if (process.env.IS_BETA_DEPLOY === 'true' && isOauthServerPath(pathname)) {
+    return new NextResponse(null, { status: 404 });
+  }
 
   // SEC-63: derive a per-request nonce + the Report-Only nonce CSP once, then
   // stamp it on each document-serving response before it returns.

--- a/tests/unit/sec36-beta-oauth-disabled.test.ts
+++ b/tests/unit/sec36-beta-oauth-disabled.test.ts
@@ -1,0 +1,102 @@
+/**
+ * SEC-36: beta has no OAuth authorization server, so it must not answer as one.
+ *
+ * WHY OFF RATHER THAN KEYED
+ * -------------------------
+ * Beta advertised ITSELF as the issuer and answered on /oauth/token, /register
+ * and /revoke, while /.well-known/jwks.json returned 500 — beta has no RS256
+ * keypair and never has. The obvious remedy is to give it one. That is the
+ * wrong remedy.
+ *
+ * Beta runs on the PRODUCTION Supabase project (CLAUDE.md gotcha #19). A
+ * working beta AS would mint tokens whose `sub` is a real production user and
+ * write jti rows into production's `oauth_access_tokens` — a token factory for
+ * production identities in the deliberately less-hardened environment,
+ * separated from production by a single `iss` string comparison in the
+ * verifier. Turning it off costs nothing and removes the whole class.
+ *
+ * Verified 2026-08-09 that nothing points at beta: both resource servers derive
+ * the AS from LYRA_SITE_URL — prod MCP leaves it unset (defaults to
+ * checklyra.com), dev MCP sets dev.checklyra.com. That is the "confirm unused"
+ * question SEC-36 asked in June, answered.
+ *
+ * The load-bearing case below is /oauth/register while SIGNED OUT. The existing
+ * beta gate further down middleware.ts only runs `if (deployTier && user)`, so
+ * an unauthenticated Dynamic Client Registration call sailed past it and wrote
+ * into PRODUCTION's oauth_clients.
+ */
+process.env.NEXT_PUBLIC_SUPABASE_URL = 'https://test.supabase.co';
+process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY = 'anon-key';
+
+// Signed OUT on purpose — the DCR path is reachable without a session, which is
+// exactly why the existing authenticated-only gate could not cover it.
+jest.mock('@supabase/ssr', () => ({
+  createServerClient: () => ({
+    auth: { getUser: async () => ({ data: { user: null } }) },
+    from: () => ({
+      select: () => ({ eq: () => ({ maybeSingle: async () => ({ data: null }) }) }),
+    }),
+  }),
+}));
+
+import { NextRequest } from 'next/server';
+import { middleware } from '@/middleware';
+
+const AS_PATHS = [
+  '/oauth/authorize',
+  '/oauth/token',
+  '/oauth/register',
+  '/oauth/revoke',
+  '/.well-known/oauth-authorization-server',
+  '/.well-known/jwks.json',
+  // The internal rewrite targets are directly addressable, so gating only the
+  // public half would leave a back door.
+  '/api/well-known/jwks',
+  '/api/well-known/oauth-authorization-server',
+];
+
+function req(path: string, host: string): NextRequest {
+  return new NextRequest(new URL(`https://${host}${path}`), { headers: { host } });
+}
+
+describe('SEC-36: beta does not answer as an OAuth authorization server', () => {
+  const original = process.env.IS_BETA_DEPLOY;
+  afterEach(() => {
+    if (original === undefined) delete process.env.IS_BETA_DEPLOY;
+    else process.env.IS_BETA_DEPLOY = original;
+  });
+
+  it.each(AS_PATHS)('404s %s on beta', async (path) => {
+    process.env.IS_BETA_DEPLOY = 'true';
+    const res = await middleware(req(path, 'beta.checklyra.com'));
+    expect(res.status).toBe(404);
+  });
+
+  it('404s /oauth/register on beta while SIGNED OUT — the DCR write into prod', async () => {
+    // The case the pre-existing beta gate could not reach: it runs only
+    // `if (deployTier && user)`. An unauthenticated registration call therefore
+    // reached the route and inserted into PRODUCTION's oauth_clients, because
+    // beta shares the production database.
+    process.env.IS_BETA_DEPLOY = 'true';
+    const res = await middleware(req('/oauth/register', 'beta.checklyra.com'));
+    expect(res.status).toBe(404);
+  });
+
+  it('does NOT gate these paths when the deploy is not beta', async () => {
+    // The inverse. A gate that fired everywhere would take production's real
+    // authorization server offline — far worse than the problem it fixes.
+    delete process.env.IS_BETA_DEPLOY;
+    for (const path of AS_PATHS) {
+      const res = await middleware(req(path, 'checklyra.com'));
+      expect(res.status).not.toBe(404);
+    }
+  });
+
+  it('does not gate unrelated paths on beta', async () => {
+    process.env.IS_BETA_DEPLOY = 'true';
+    for (const path of ['/', '/search', '/login', '/api/health']) {
+      const res = await middleware(req(path, 'beta.checklyra.com'));
+      expect(res.status).not.toBe(404);
+    }
+  });
+});


### PR DESCRIPTION
Beta advertised ITSELF as the issuer and answered on /oauth/token, /register
and /revoke, while /.well-known/jwks.json returned 500 — beta has no RS256
keypair on its scope and never has. SEC-36 flagged this in June and asked
someone to "confirm unused". That is now answered with evidence.

NOTHING POINTS AT BETA (verified 2026-08-09, live)
Both resource servers derive the AS from LYRA_SITE_URL:
  prod MCP (elegant-tranquility)  — unset, defaults to https://checklyra.com
  dev  MCP (overflowing-laughter) — https://dev.checklyra.com
Neither expects a beta issuer, and no reference to beta as an OAuth issuer
exists in any of the three repos.

WHY OFF AND NOT KEYED — the obvious fix is the wrong one
Beta runs on the PRODUCTION Supabase project (gotcha #19). Giving it a keypair
would convert a broken issuer into a WORKING second issuer minting tokens whose
`sub` is a real production user, writing jti rows into production's
oauth_access_tokens — a token factory for production identities in the
deliberately less-hardened environment, separated from production by a single
`iss` string comparison in the verifier. Disabling costs nothing, needs no
founder-generated secret material, and removes the class rather than the
symptom.

IT ALSO CLOSES AN UNAUTHENTICATED WRITE INTO PRODUCTION
The pre-existing beta gate runs `if (deployTier && user && !exempt)` — only for
AUTHENTICATED requests. So an unauthenticated Dynamic Client Registration call
to /oauth/register sailed straight past it and inserted into PRODUCTION's
oauth_clients, because beta shares the production database. The new gate is
unconditional and sits before any auth work, so it covers that path. That case
is pinned by its own test.

404, not 403: beta genuinely has no authorization server, and that is what a
client should discover.

Gates both the public /.well-known/* paths and the /api/well-known/* rewrite
targets — the latter are directly addressable, so covering only one half would
leave a back door.

Mutation-proven: disabling the condition fails 9 of the 11 tests. The inverse is
pinned too — the gate must NOT fire when the deploy is not beta, because a gate
that fired everywhere would take production's real authorization server offline,
which is far worse than the problem it fixes.

3147/3147, tsc clean.

Does NOT close SEC-36 — the HS256 teardown (steps 2-5) remains, and dev MCP
still carries the now-inert OAUTH_JWT_SIGNING_SECRET. Evidence for step 1 is
recorded on the ticket.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

## The question SEC-36 asked in June, answered

> "Beta's own AS is moot (beta rides on the prod AS), but its `/oauth/token` would 500 without the secret — **confirm unused**."

Measured live 2026-08-09. That assumption was also **wrong** in one respect: beta does *not* ride on the prod AS. Its discovery document advertises **beta** as the issuer and its endpoints answer directly. But nothing consumes them.

## Verification

- `tests/unit/sec36-beta-oauth-disabled.test.ts` — **11/11** ✓
- Mutation proof: disabling the condition fails **9 of 11**; restoring gives 11/11
- Full suite **3147/3147**, tsc clean ✓

## Deliberately still open

This does **not** close SEC-36. Steps 2–5 (the HS256 teardown) remain, and dev MCP still carries the now-inert `OAUTH_JWT_SIGNING_SECRET`. Evidence for step 1 — all four Railway services confirmed at `OAUTH_ALLOW_HS256_FALLBACK=0` — is recorded on the ticket.

Worth finishing: that flag **defaults to the insecure value**, is set in no committed config, and the only test mentioning it greps the source for the string rather than asserting the value. RS256-only currently holds because four env vars were set in June, with nothing that would notice if one lapsed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)