### PR TITLE
fix(BUGS-91): no backup we take has ever contained the migration lineage

### DIFF
--- a/scripts/backup-database-complete.sh
+++ b/scripts/backup-database-complete.sh
@@ -42,7 +42,16 @@ TIMESTAMP="$(date -u +%Y%m%dT%H%M%SZ)"
 # Schemas that together make a restorable platform. Internal/replication
 # schemas (pg_catalog, information_schema, pgbouncer, realtime, vault internals)
 # are deliberately excluded — they are recreated by the target Postgres/Supabase.
-SCHEMAS=(public auth storage)
+# BUGS-91 (2026-08-09): `supabase_migrations` added. This script exists because
+# public-only dumps "CANNOT reconstruct a working platform" (see the header) —
+# and it had the same shape of hole it was written to fix. It captured auth and
+# storage but not the migration LINEAGE, so a restore produced a database with
+# no migration history: `supabase db push` afterwards treats every migration as
+# unapplied and replays the whole lineage against restored data.
+#
+# On production that was 75 rows / 133 KB of recorded `statements` held nowhere
+# else. Verified 2026-08-09 against both backup paths.
+SCHEMAS=(public auth storage supabase_migrations)
 
 ROLES_FILE="${OUTPUT_DIR}/roles_${TIMESTAMP}.sql"
 DUMP_FILE="${OUTPUT_DIR}/lyra_complete_${TIMESTAMP}.dump"

--- a/scripts/backup-database.sh
+++ b/scripts/backup-database.sh
@@ -36,10 +36,26 @@ echo "Output: $BACKUP_FILE"
 echo ""
 
 # Run pg_dump (schema + data, excluding auth schema which is managed by Supabase)
+#
+# BUGS-91 (2026-08-09): `supabase_migrations` added. It was NOT here, so no
+# backup we take has ever contained the migration lineage — 75 rows and 133 KB
+# of recorded `statements` on production at the time this was found.
+#
+# That is not a completeness nicety. A restore from a public-only dump produces
+# a database with NO migration history, so `supabase db push` afterwards
+# considers every migration unapplied and tries to replay the entire lineage
+# against the restored data. The backup that exists to prove DR could not, on
+# its own, reconstitute a database anyone could safely continue to migrate —
+# which is the substance of SEC-23's restore drill and BUGS-75.
+#
+# It also means the BUGS-91 reconciliation had no safety net: `supabase
+# migration repair --status reverted` DELETEs these rows, and nothing anywhere
+# held a copy.
 pg_dump "$SUPABASE_DB_URL" \
   --no-owner \
   --no-privileges \
   --schema=public \
+  --schema=supabase_migrations \
   --format=plain \
   --file="$BACKUP_FILE" \
   2>&1

--- a/scripts/check-complete-backup.sh
+++ b/scripts/check-complete-backup.sh
@@ -47,7 +47,12 @@ except Exception as e:
     print(f"FAIL:invalid JSON ({e})"); sys.exit(0)
 schemas = m.get("schemas", [])
 # auth is the schema whose absence makes a backup non-restorable (no users).
-for required in ("public", "auth", "storage"):
+# supabase_migrations added BUGS-91 (2026-08-09): without it a restore yields a
+# database with no migration history, so `supabase db push` afterwards treats
+# every migration as unapplied and replays the whole lineage over restored
+# data. Enforced here rather than trusted, because it went missing from BOTH
+# backup paths for months while every check stayed green.
+for required in ("public", "auth", "storage", "supabase_migrations"):
     if required not in schemas:
         print(f"FAIL:manifest missing required schema '{required}' (schemas={schemas})")
         sys.exit(0)

--- a/scripts/restore-database.sh
+++ b/scripts/restore-database.sh
@@ -44,11 +44,22 @@ echo "Resetting the public schema..."
 # recreate the whole public schema instead, so the restore is clean regardless
 # of how the schema has grown. (The dump itself recreates public via CREATE
 # SCHEMA; we DROP it first so that statement succeeds.)
+#
+# BUGS-91 (2026-08-09): `supabase_migrations` is reset here too, because the
+# dump now CONTAINS it. Leaving it in place would make the restore collide on
+# the existing schema_migrations rows — so this must move in lockstep with
+# backup-database.sh. Backup and restore drifting apart is how a restore that
+# "succeeds" produces a database nobody can migrate afterwards.
+#
+# Dropping it is safe *in a restore*, which is already destructive by design
+# (see the warning above), and the dump recreates it with the lineage that
+# matches the data being restored — which is the entire point.
 psql "$SUPABASE_DB_URL" -v ON_ERROR_STOP=1 -c "
   DROP SCHEMA IF EXISTS public CASCADE;
   CREATE SCHEMA public;
   GRANT ALL ON SCHEMA public TO postgres;
   GRANT USAGE ON SCHEMA public TO anon, authenticated, service_role;
+  DROP SCHEMA IF EXISTS supabase_migrations CASCADE;
 " 2>&1
 
 echo "Restoring from backup..."

--- a/tests/fixtures/complete-backup/valid/MANIFEST_20260623T010000Z.json
+++ b/tests/fixtures/complete-backup/valid/MANIFEST_20260623T010000Z.json
@@ -5,7 +5,8 @@
   "schemas": [
     "public",
     "auth",
-    "storage"
+    "storage",
+    "supabase_migrations"
   ],
   "roles_status": "captured",
   "dump_file": "lyra_complete_20260623T010000Z.dump",
@@ -14,7 +15,8 @@
   "row_counts": {
     "public.profiles": 10,
     "auth.users": 6,
-    "storage.objects": 0
+    "storage.objects": 0,
+    "supabase_migrations.schema_migrations": 75
   },
   "critical_row_counts": {
     "auth_users": 6,

--- a/tests/unit/backup.test.js
+++ b/tests/unit/backup.test.js
@@ -65,7 +65,11 @@ describe('SEC-23 — DR/backup coverage hardening', () => {
     expect(executable(SRC.backupDatabaseComplete)).toBe(true);
     const s = read(SRC.backupDatabaseComplete);
     // The whole point: it must NOT be public-only like backup-database.sh.
-    expect(s).toMatch(/SCHEMAS=\(public auth storage\)/);
+    // BUGS-91: supabase_migrations added. This script exists because
+    // public-only dumps cannot reconstruct a working platform — and it had the
+    // same shape of hole it was written to fix, capturing auth and storage but
+    // not the migration lineage.
+    expect(s).toMatch(/SCHEMAS=\(public auth storage supabase_migrations\)/);
     expect(s).toContain('pg_dumpall --roles-only');
   });
 
@@ -104,6 +108,33 @@ describe('SEC-23 — DR/backup coverage hardening', () => {
   test('restore script resets the whole public schema, not a hardcoded table list', () => {
     const s = read(SRC.restoreDatabase);
     expect(s).toContain('DROP SCHEMA IF EXISTS public CASCADE');
+  });
+
+  /**
+   * BUGS-91 (2026-08-09). The dump was `--schema=public` only, so NO backup we
+   * had ever taken contained the migration lineage — 75 rows and 133 KB of
+   * recorded `statements` on production when this was found.
+   *
+   * That is not a completeness nicety. A restore from a public-only dump gives
+   * a database with no migration history, so `supabase db push` afterwards
+   * considers every migration unapplied and replays the whole lineage against
+   * the restored data. The backup that exists to prove DR could not, alone,
+   * produce a database anyone could safely continue to migrate.
+   *
+   * Both halves are asserted because they must move together: a dump that
+   * carries the schema and a restore that does not reset it would collide on
+   * the existing rows, and a "successful" restore would leave a database
+   * nobody can migrate. Backup and restore drifting apart is the failure mode.
+   */
+  test('backup captures the migration lineage, not just public', () => {
+    const s = read(SRC.scriptsBackupDatabase);
+    expect(s).toContain('--schema=public');
+    expect(s).toContain('--schema=supabase_migrations');
+  });
+
+  test('restore resets the migration lineage too, so the two stay symmetric', () => {
+    const s = read(SRC.restoreDatabase);
+    expect(s).toContain('DROP SCHEMA IF EXISTS supabase_migrations CASCADE');
   });
 
   test('disaster recovery doc exists with a clean-room compromise procedure', () => {

--- a/tests/unit/check-complete-backup.test.js
+++ b/tests/unit/check-complete-backup.test.js
@@ -29,8 +29,8 @@ describe('check-complete-backup.sh', () => {
       expect(result.status).toBe(0);
     });
 
-    test('manifest reports public + auth + storage schemas', () => {
-      expect(result.stdout).toMatch(/✅ manifest:.*public,auth,storage/);
+    test('manifest reports public + auth + storage + supabase_migrations schemas', () => {
+      expect(result.stdout).toMatch(/✅ manifest:.*public,auth,storage,supabase_migrations/);
     });
 
     test('dump reported as a valid PGDMP archive', () => {


### PR DESCRIPTION
Found while establishing the prerequisites for the BUGS-91 reconciliation:
`supabase migration repair --status reverted` DELETEs rows from
supabase_migrations.schema_migrations, so the plan called for a snapshot first.
Checking whether the daily backup already covered it turned up something worse
— nothing does.

  scripts/backup-database.sh          --schema=public                only
  scripts/backup-database-complete.sh SCHEMAS=(public auth storage)  only

Neither captures supabase_migrations. On production that is 75 rows and 133 KB
of recorded `statements`, held nowhere else. Measured 2026-08-09.

THIS IS A DR FINDING, NOT ONLY A BUGS-91 PREREQUISITE
A restore from either backup produces a database with NO migration history. Run
`supabase db push` afterwards and it considers every migration unapplied and
replays the entire lineage against the restored data. The backup that exists to
prove DR could not, alone, produce a database anyone could safely continue to
migrate. Bears directly on SEC-23's restore drill and BUGS-75.

The irony is instructive: backup-database-complete.sh was WRITTEN because
public-only dumps "CANNOT reconstruct a working platform" — and it shipped with
the same shape of hole, capturing auth and storage but not the lineage.

CHANGES
  backup-database.sh          + --schema=supabase_migrations
  backup-database-complete.sh + supabase_migrations in SCHEMAS
  restore-database.sh         + DROP SCHEMA supabase_migrations CASCADE
  check-complete-backup.sh    + supabase_migrations in the REQUIRED list

The restore change is not optional. A dump that carries the schema and a
restore that does not reset it would collide on the existing rows — backup and
restore drifting apart is precisely how a "successful" restore leaves a
database nobody can migrate.

Enforced rather than trusted: the required-schema list is the control, because
this went missing from BOTH paths for months while every check stayed green.
Mutation-proven — a manifest listing only public/auth/storage is now REJECTED
("manifest missing required schema 'supabase_migrations'").

Tests updated where they pinned the old, incomplete behaviour: the
SCHEMAS= assertion, the checker's expected schema line, and the valid fixture
manifest.

3138/3138, tsc clean.

Does NOT perform the BUGS-91 reconciliation. No migration marker has been
touched. This makes the snapshot possible, which was prerequisite 1.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

## Verification

- `npm run test:unit` — **3138/3138** ✓
- `tsc --noEmit` — 0 errors ✓
- `check-workflow-integrity`, `check-guard-path-drift` ✓
- Mutation proof: a manifest listing only `public/auth/storage` is now **rejected**

🤖 Generated with [Claude Code](https://claude.com/claude-code)