### PR TITLE
fix(tests): the enforced test floor was 89% below reality — make it a ratchet

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "db:migrate": "echo 'No migrations configured yet'",
     "uptimerobot:bootstrap": "node scripts/uptimerobot/bootstrap.js",
     "gen:test-paths": "node scripts/gen-test-paths.mjs",
+    "gen:test-floor": "node scripts/gen-test-floor.mjs",
     "qa:preflight": "python3 qa-sweep/preflight.py",
     "qa:inventory": "python3 qa-sweep/inventory.py",
     "qa:coverage": "python3 qa-sweep/coverage.py"

--- a/scripts/gen-test-floor.mjs
+++ b/scripts/gen-test-floor.mjs
@@ -1,0 +1,74 @@
+#!/usr/bin/env node
+/**
+ * KAN-110 / KAN-168 successor — regenerate the test-floor baseline.
+ *
+ * WHY THIS SCRIPT EXISTS AT ALL
+ * -----------------------------
+ * The floor used to be two hand-typed constants inside the guard, with a
+ * comment saying "update the floors when consolidating tests intentionally".
+ * It was refreshed once, on 2026-05-05, and never again. By 2026-08-09 it
+ * enforced 29 files / 320 blocks against an actual 260 / 2,963 — so roughly
+ * 89% OF THE TEST ESTATE COULD HAVE BEEN DELETED WITHOUT TRIPPING CI.
+ *
+ * A number a human has to remember to raise is a number that goes stale, and a
+ * floor that far below reality is indistinguishable from no floor. It was
+ * independently flagged in four places (KAN-467, the modularisation plan twice,
+ * the plan revalidation) and fixed in none — the flagging was not the problem.
+ *
+ * So the floor is now a generated baseline and the guard fails in BOTH
+ * directions: too few tests means something was deleted, and too many means
+ * this file is stale and is quietly overstating the protection. The second
+ * half is the point. Same shape as the F4 raw-literal ratchet.
+ *
+ * USAGE
+ *   npm run gen:test-floor        # measure and write the baseline
+ *
+ * Run it in the SAME commit as any change to the test count. `git ls-files`
+ * is not involved here — jest --listTests walks the filesystem — so unstaged
+ * new files ARE counted, unlike the raw-literal ratchet.
+ */
+import { execSync } from 'node:child_process';
+import { readFileSync, writeFileSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
+const OUT = join(ROOT, 'tests/support/test-floor-baseline.json');
+
+/** The measurement the guard uses. Kept here so the two cannot disagree. */
+export function measure() {
+  const listed = execSync(
+    "npx jest --testPathPatterns='tests/(unit|scripts)' --listTests",
+    { cwd: ROOT, encoding: 'utf8' },
+  );
+  const files = listed.trim().split('\n').filter(Boolean);
+
+  let blocks = 0;
+  for (const f of files) {
+    const content = readFileSync(f, 'utf8');
+    // test()/it() at line start, allowing indentation. Approximate — does not
+    // expand `test.each([...])` — and deliberately matches the heuristic in
+    // weekly-report.yml so the two stay aligned.
+    blocks += (content.match(/^[ \t]*(test|it)\(/gm) || []).length;
+  }
+  return { files: files.length, blocks };
+}
+
+const { files, blocks } = measure();
+
+const baseline = {
+  $comment:
+    'GENERATED — regenerate with `npm run gen:test-floor`. The enforced test ' +
+    'floor. The guard fails if the counts DROP (a test was deleted) and also ' +
+    'if they RISE (this baseline is stale and is overstating how much of the ' +
+    'estate is actually protected). The rise case is the one that matters: ' +
+    'the previous hand-maintained floor sat at 29 files / 320 blocks against ' +
+    'an actual 260 / 2963, so ~89% of the tests could have been deleted ' +
+    'silently. Raise it in the SAME commit as any net-new test.',
+  measured_at: new Date().toISOString().slice(0, 10),
+  test_files: files,
+  test_blocks: blocks,
+};
+
+writeFileSync(OUT, JSON.stringify(baseline, null, 2) + '\n');
+console.log(`test-floor baseline: ${files} files, ${blocks} blocks -> ${OUT}`);

--- a/tests/support/test-floor-baseline.json
+++ b/tests/support/test-floor-baseline.json
@@ -1,0 +1,6 @@
+{
+  "$comment": "GENERATED — regenerate with `npm run gen:test-floor`. The enforced test floor. The guard fails if the counts DROP (a test was deleted) and also if they RISE (this baseline is stale and is overstating how much of the estate is actually protected). The rise case is the one that matters: the previous hand-maintained floor sat at 29 files / 320 blocks against an actual 260 / 2963, so ~89% of the tests could have been deleted silently. Raise it in the SAME commit as any net-new test.",
+  "measured_at": "2026-08-09",
+  "test_files": 260,
+  "test_blocks": 2965
+}

--- a/tests/unit/test-regression-guard.test.js
+++ b/tests/unit/test-regression-guard.test.js
@@ -18,49 +18,63 @@ const fs = require('fs');
 const REPO_ROOT = path.join(__dirname, '../..');
 
 describe('KAN-110 + KAN-168: Test count regression guard', () => {
-  test('test file count meets minimum floor', () => {
-    // KAN-168 refresh 2026-05-05: now 30 unit/script test files (was 22).
-    // Floor at 29 catches single-file deletion; raise this when adding
-    // new test files.
-    const TEST_FILE_FLOOR = 29;
+  // The floor is a GENERATED BASELINE, not two hand-typed constants.
+  //
+  // It used to be constants with a comment saying "update the floors when
+  // consolidating tests intentionally". That was done once, on 2026-05-05, and
+  // never again: by 2026-08-09 it enforced 29 files / 320 blocks against an
+  // actual 260 / 2963, so ~89% OF THE TEST ESTATE COULD HAVE BEEN DELETED
+  // WITHOUT TRIPPING CI. A floor that far below reality is indistinguishable
+  // from no floor.
+  //
+  // It was independently flagged in four places and fixed in none, so more
+  // flagging was never going to work — the number had to stop depending on
+  // someone remembering.
+  //
+  // Regenerate with: npm run gen:test-floor
+  const baseline = JSON.parse(
+    fs.readFileSync(path.join(REPO_ROOT, 'tests/support/test-floor-baseline.json'), 'utf8'),
+  );
 
-    const result = execSync(
+  /** Same measurement the generator uses, so the two cannot disagree. */
+  function measure() {
+    const listed = execSync(
       "npx jest --testPathPatterns='tests/(unit|scripts)' --listTests",
-      { cwd: REPO_ROOT, encoding: 'utf8' }
+      { cwd: REPO_ROOT, encoding: 'utf8' },
     );
+    const files = listed.trim().split('\n').filter(Boolean);
+    let blocks = 0;
+    for (const f of files) {
+      const content = fs.readFileSync(f, 'utf8');
+      blocks += (content.match(/^[ \t]*(test|it)\(/gm) || []).length;
+    }
+    return { files: files.length, blocks };
+  }
 
-    const testFiles = result.trim().split('\n').filter(Boolean);
-    expect(testFiles.length).toBeGreaterThanOrEqual(TEST_FILE_FLOOR);
+  test('the baseline is not vacuous', () => {
+    // If the baseline were ever regenerated against an empty or broken jest
+    // run, every assertion below would pass over nothing — which is precisely
+    // the failure this whole guard exists to prevent, one level up.
+    expect(baseline.test_files).toBeGreaterThan(100);
+    expect(baseline.test_blocks).toBeGreaterThan(1000);
   });
 
-  test('total test count meets minimum floor', () => {
-    // KAN-168 refresh 2026-05-05: now 327 test()/it() blocks at line starts
-    // across tests/unit + tests/scripts (Jest reports 319 unit + scripts,
-    // 330 incl. e2e). Floor at 320 leaves a small headroom for legitimate
-    // refactors but catches large deletions. Increase this floor in the
-    // same PR as any net-new-test addition.
-    const TEST_COUNT_FLOOR = 320;
+  test('no test FILE was deleted', () => {
+    expect(measure().files).toBeGreaterThanOrEqual(baseline.test_files);
+  });
 
-    // KAN-168: include tests/scripts (uptimerobot bootstrap test) which
-    // is now part of the test:unit run via the broadened jest pattern in
-    // package.json.
-    const listOutput = execSync(
-      "npx jest --testPathPatterns='tests/(unit|scripts)' --listTests",
-      { cwd: REPO_ROOT, encoding: 'utf8' }
-    );
-    const testFiles = listOutput.trim().split('\n').filter(Boolean);
+  test('no test BLOCK was deleted', () => {
+    expect(measure().blocks).toBeGreaterThanOrEqual(baseline.test_blocks);
+  });
 
-    let totalTests = 0;
-    for (const file of testFiles) {
-      const content = fs.readFileSync(file, 'utf8');
-      // Count test()/it() blocks at line starts (allows for indentation).
-      // Approximate — doesn't expand `test.each([...])`. Matches Section 6
-      // of weekly-report.yml's test-count heuristic so the two stay aligned.
-      const matches = content.match(/^[ \t]*(test|it)\(/gm) || [];
-      totalTests += matches.length;
-    }
-
-    expect(totalTests).toBeGreaterThanOrEqual(TEST_COUNT_FLOOR);
+  test('the baseline is not STALE — it must rise when tests are added', () => {
+    // The half that actually fixes the 50-day drift. Without it the baseline
+    // silently falls behind again and quietly overstates how much of the
+    // estate is protected, which is exactly how it reached 89% headroom.
+    // Adding a test means running `npm run gen:test-floor` in the same commit.
+    const now = measure();
+    expect(now.files).toBe(baseline.test_files);
+    expect(now.blocks).toBe(baseline.test_blocks);
   });
 
   test('jest config has coverage collection configured', () => {


### PR DESCRIPTION
tests/unit/test-regression-guard.test.js enforced 29 files / 320 blocks.
Actual: 260 files / 2,963 blocks. About 89% OF THE TEST ESTATE COULD HAVE BEEN
DELETED WITHOUT TRIPPING CI — on the guard whose own header says "a
quietly-deleted test would otherwise pass CI silently".

The cause is in its design, not anyone's diligence: two hand-typed constants
with a comment saying "update the floors when consolidating tests
intentionally". That was done once, on 2026-05-05, and never again. A number a
human must remember to raise is a number that goes stale, and a floor that far
below reality is indistinguishable from no floor.

It was independently flagged in FOUR places (KAN-467, the modularisation plan
twice, the plan revalidation) and fixed in none. More flagging was never going
to work — the number had to stop depending on memory.

WHAT CHANGES
  scripts/gen-test-floor.mjs        measures and writes the baseline
  tests/support/test-floor-baseline.json  generated, committed
  npm run gen:test-floor            regenerate

The guard now fails in BOTH directions:
  counts DROP  -> a test was deleted
  counts RISE  -> this baseline is stale and is overstating the protection

The second half is the point, and it is what fixes the 50-day drift. Same shape
as the F4 raw-literal ratchet, which fails on a rise for the same reason.

It proved itself immediately: rewriting this file added 2 test blocks, the
staleness check went red at 2963 vs 2965, and the baseline had to be
regenerated in the same commit. That friction IS the mechanism.

Mutation-proven: deleting one test file takes 260 -> 259 files and 2965 -> 2953
blocks, and all three assertions fire. Under the old floor that file, and 230
more, would have gone silently.

Also pins the baseline as non-vacuous (>100 files, >1000 blocks), so a
regeneration against a broken jest run cannot quietly zero the floor — the same
failure this guard exists to prevent, one level up.

WHY NOW: this is the gate for the modularisation restart. Extraction moves
files; a floor at 11% of reality means a botched move is invisible.

NOT DONE HERE — mutation testing. It is `disabled_manually`, i.e. someone
turned it off deliberately (last green run 2026-06-14), along with five other
workflows. Re-enabling is a founder decision, not a repair, so it is flagged
rather than flipped.

3163/3163.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

## Verification

- `npm run test:unit` — **3163/3163** ✓
- Mutation proof: deleting one test file fires all three assertions (260→259 files, 2965→2953 blocks)
- Self-demonstrated: rewriting the guard added 2 blocks and the staleness check went red until the baseline was regenerated

## Why this is step 0 of the modularisation restart

The §2.2 re-decision re-opened the extraction programme on evidence (vertical coupling flat-or-worse under Phase 0 alone). Extraction **moves files**. A floor at 11% of reality means a botched move is invisible — so this lands before sequencing D1 (`platform` + `guards` + `observability`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)