### PR TITLE
feat(CTL-042): assert scheduled workflows are ACTIVE, not merely present (SEC-79 family)

### DIFF
--- a/.github/scheduled-workflow-exceptions.json
+++ b/.github/scheduled-workflow-exceptions.json
@@ -1,0 +1,25 @@
+{
+  "$comment": [
+    "CTL-042 — scheduled workflows that are deliberately NOT active.",
+    "",
+    "Read by scripts/check-scheduled-workflows-active.py. Every entry needs a",
+    "Jira key AND a reason; a bare marker is itself a failure, and an entry for",
+    "a workflow that has since been re-enabled is a STALE exception and fails",
+    "the check outright — a list containing things that no longer apply is a",
+    "list nobody reads.",
+    "",
+    "DELIBERATELY EMPTY as of 2026-08-09. Four scheduled workflows were found",
+    "inactive that day (anomaly-detect */15, affiliate-link-smoke hourly,",
+    "mutation-testing weekly, auto-promote-to-staging weekly), all dark since",
+    "mid-June. None of them is listed here, because nobody has yet said which",
+    "were switched off on purpose — and writing an exception on that guess is",
+    "how a finding becomes a permanent silence. They surface as warnings on",
+    "every run until a human decides: re-enable, or except with a reason.",
+    "",
+    "Note that CLAUDE.md currently documents at least two of them as live",
+    "cadences ('Sunday 04:00 - Stryker mutation testing', and staging promotion",
+    "'also auto-runs Sunday 23:00 UTC'). Whichever way each decision goes, the",
+    "docs move with it."
+  ],
+  "exceptions": {}
+}

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -16,6 +16,9 @@ defaults:
 
 permissions:
   contents: read
+  # CTL-042 reads /actions/workflows to learn each workflow's STATE, which is
+  # the one fact about a workflow that does not live in the repository. Read-only.
+  actions: read
 
 jobs:
   checks:
@@ -290,6 +293,30 @@ jobs:
           set -euo pipefail
           python3 scripts/check-control-registry.py --self-test
           python3 scripts/check-control-registry.py
+      - name: Scheduled workflows are actually ACTIVE (CTL-042, SEC-79 family)
+        # A DISABLED workflow still has a perfect file on disk. Every other
+        # check in this repo reasons about .github/workflows/*.yml as TEXT -
+        # the step above confirms a control's file exists and that something
+        # invokes it - and all of them pass for a workflow GitHub will never
+        # run again, because `state: disabled_manually` lives in the API and
+        # nowhere in the repository.
+        #
+        # Found 2026-08-09: 4 of the 20 workflows declaring a cron schedule
+        # were inactive and had been since mid-June, including anomaly-detect
+        # on */15. Dependabot kept bumping all four (#474), so they kept
+        # appearing in diffs looking maintained.
+        #
+        # WARN-ONLY until the four are re-enabled or excepted - same warn->block
+        # path as the KAN-413 signup gate. Blocking now would fail every
+        # unrelated PR pending a founder-only decision, and a gate that blocks
+        # work nobody can unblock is a gate that gets switched off. Flip via
+        # SCHEDULED_WORKFLOW_GATE_ENFORCE=1.
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          python3 scripts/check-scheduled-workflows-active.py --self-test
+          python3 scripts/check-scheduled-workflows-active.py
       - name: Auto-heal pattern catalogue self-test (KAN-63 Tier 4)
         # Verify every entry in scripts/auto-fix-patterns.json still
         # matches its fixture under tests/fixtures/auto-fix-logs/, and

--- a/controls/registry.json
+++ b/controls/registry.json
@@ -735,6 +735,23 @@
       "escape_hatch": "Add the path to UNOWNED_BY_DESIGN in the test, with a comment arguing why it belongs to no module. Deliberately a literal list, never a glob - a pattern would silently adopt whatever lands next to it.",
       "self_test": "Mutation-proven 2026-08-09, all four directions: removing client-ip from guards' paths, overstating profile's owns.files, declaring a path that does not exist, and deleting convene's more specific nested path each turn the suite red; the clean manifest is green.",
       "added": "2026-08-09"
+    },
+    {
+      "id": "CTL-042",
+      "name": "Scheduled workflows are actually active",
+      "defect_class": "disabled-but-looks-configured",
+      "summary": "Queries the GitHub API for every workflow's state and fails when one that declares a cron schedule is not active. A DISABLED workflow still has a perfect file on disk, and every other check in this repo reasons about .github/workflows/*.yml as TEXT - check-workflow-integrity.sh greps it, CTL-023 confirms the file exists and that something invokes it, CTL-035 confirms its path literals still match - so all of them pass for a workflow GitHub will never run again, because `state: disabled_manually` lives in the API and nowhere in the repository. Found 2026-08-09: 4 of the 20 workflows declaring a cron schedule were inactive and had been since mid-June, including anomaly-detect on */15. Two things hid it - CLAUDE.md still documented 'Sunday 04:00 Stryker mutation testing' and a Sunday 23:00 staging auto-promote as live cadences, and Dependabot kept bumping all four files (#474), so they kept appearing in diffs looking maintained. This is SEC-79 exactly, and the lesson taken from SEC-79 does not cover it, because existence and invocation were never what broke.",
+      "implementation": "scripts/check-scheduled-workflows-active.py",
+      "kind": "ci-gate",
+      "wired_in": [
+        ".github/workflows/pr-checks.yml"
+      ],
+      "prevents": [
+        "SEC-79"
+      ],
+      "escape_hatch": "An entry in .github/scheduled-workflow-exceptions.json carrying BOTH a Jira key and a reason. An entry for a workflow that has since been re-enabled is a STALE exception and fails outright, so the list cannot only grow. Ships WARN-first (SCHEDULED_WORKFLOW_GATE_ENFORCE=1 to block) because the four live findings need a founder decision, and a gate that blocks every unrelated PR on something nobody can clear is a gate that gets switched off.",
+      "self_test": "--self-test covers the seven parsing decisions, notably that a COMMENTED-OUT cron is not a live schedule (backup-complete.yml ships its cadence commented until commissioning, and reading that as scheduled would raise a permanent unresolvable finding). Verified live 2026-08-09: warn mode exits 0 naming all four inactive workflows, --enforce exits 1.",
+      "added": "2026-08-09"
     }
   ]
 }

--- a/scripts/check-scheduled-workflows-active.py
+++ b/scripts/check-scheduled-workflows-active.py
@@ -1,0 +1,246 @@
+#!/usr/bin/env python3
+"""scripts/check-scheduled-workflows-active.py — CTL-042 (SEC-79 family).
+
+A workflow that is DISABLED still has a perfect file on disk.
+
+That sentence is the whole control. Every existing check in this repo reasons
+about `.github/workflows/*.yml` as text: check-workflow-integrity.sh greps it,
+check-control-registry.py confirms the file exists and something invokes it,
+check-guard-path-drift.py confirms its path literals still match. All of them
+pass for a workflow that GitHub will never run again, because `state:
+disabled_manually` lives in the GitHub API and nowhere in the repository.
+
+Measured on 2026-08-09, 4 of the 20 workflows that declare a cron schedule were
+not active, and had not run since mid-June:
+
+    anomaly-detect.yml          */15 * * * *   ~8 weeks dark
+    affiliate-link-smoke.yml    17 * * * *     ~8 weeks dark
+    mutation-testing.yml        0 4 * * 0      ~8 weeks dark
+    auto-promote-to-staging.yml 0 23 * * 0     ~8 weeks dark
+
+Two things made that invisible for two months rather than two days:
+
+  * CLAUDE.md's "Scheduled Workflows" section still documents "Sunday 04:00 —
+    Stryker mutation testing" as a live cadence. Documentation describing a
+    schedule is indistinguishable from a schedule.
+  * Dependabot kept bumping all four files (#474, 2026-07-22), so they kept
+    appearing in PR diffs looking actively maintained.
+
+This is SEC-79 exactly — health-check.yml and weekly-report.yml sat disabled
+for over a month while everything reported green — and the lesson taken from
+SEC-79 (register controls, assert they exist and are invoked) does not cover
+it, because existence and invocation were never the thing that broke.
+
+USAGE
+    check-scheduled-workflows-active.py            warn (default)
+    check-scheduled-workflows-active.py --enforce  block
+    check-scheduled-workflows-active.py --self-test
+
+Ships WARN-first on purpose, the same warn->block path as the KAN-413 signup
+gate: turning it straight to blocking would fail every unrelated PR until a
+founder-only decision is made about four workflows, and a gate that blocks work
+nobody can unblock gets switched off. Flip with SCHEDULED_WORKFLOW_GATE_ENFORCE=1
+(or --enforce) once the four are re-enabled or consciously excepted.
+
+EXCEPTIONS  .github/scheduled-workflow-exceptions.json
+    Each needs a Jira key AND a reason. An entry for a workflow that is actually
+    active is itself an error — a stale exception is how a list stops being read.
+
+EXIT
+    0  every scheduled workflow is active (or excepted); or findings in warn mode
+    1  a scheduled workflow is inactive, in --enforce mode
+    2  cannot verify — fail closed
+"""
+from __future__ import annotations
+
+import json
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+WF_DIR = ROOT / ".github" / "workflows"
+EXCEPTIONS = ROOT / ".github" / "scheduled-workflow-exceptions.json"
+REPO = os.environ.get("GITHUB_REPOSITORY", "luisa-sys/lyra")
+
+KEY_RE = re.compile(r"^[A-Z][A-Z0-9]+-[0-9]+$")
+
+
+class Unverifiable(Exception):
+    """Raised when we cannot establish the truth. Never downgraded to a pass."""
+
+
+def die_unverifiable(msg: str) -> None:
+    print(f"::error::check-scheduled-workflows-active: {msg}")
+    print(
+        "::error::  Failing closed (exit 2): this control exists because "
+        "'looks fine' and 'is running' are different things, so 'cannot tell' "
+        "must never read as 'fine'."
+    )
+    sys.exit(2)
+
+
+def declares_cron(text: str) -> list[str]:
+    """Return the cron expressions a workflow actually schedules.
+
+    Comment-stripped first. A commented-out cron is the deliberate pattern used
+    by backup-complete.yml — the cadence is documented but not armed until the
+    backup is commissioned — and treating that as a live schedule would produce
+    a permanent false finding, which is how a gate teaches people to ignore it.
+    """
+    live = "\n".join(re.sub(r"#.*$", "", ln) for ln in text.splitlines())
+    if not re.search(r"^\s*schedule:", live, re.M):
+        return []
+    return re.findall(r"cron:\s*['\"]([^'\"]+)['\"]", live)
+
+
+def load_exceptions() -> dict[str, dict]:
+    if not EXCEPTIONS.exists():
+        return {}
+    try:
+        raw = json.loads(EXCEPTIONS.read_text())
+    except (OSError, json.JSONDecodeError) as exc:
+        raise Unverifiable(f"{EXCEPTIONS.name} is present but unreadable: {exc}")
+    out = {}
+    for path, meta in (raw.get("exceptions") or {}).items():
+        if not isinstance(meta, dict):
+            raise Unverifiable(f"exception for '{path}' is not an object")
+        key, reason = meta.get("key"), meta.get("reason")
+        if not key or not KEY_RE.match(str(key)):
+            raise Unverifiable(
+                f"exception for '{path}' has no valid Jira key (got {key!r}). "
+                "A bare marker is itself a failure."
+            )
+        if not reason or not str(reason).strip():
+            raise Unverifiable(f"exception for '{path}' has a key but no reason")
+        out[path] = meta
+    return out
+
+
+def live_states() -> dict[str, str]:
+    """workflow path -> state, from the GitHub API. The only source of truth."""
+    try:
+        res = subprocess.run(
+            ["gh", "api", f"/repos/{REPO}/actions/workflows", "--paginate", "-q", ".workflows"],
+            capture_output=True, text=True, timeout=60,
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        raise Unverifiable(f"could not call the GitHub API: {exc}")
+    if res.returncode != 0:
+        raise Unverifiable(f"gh api failed (exit {res.returncode}): {res.stderr.strip()[:300]}")
+
+    entries = []
+    for chunk in res.stdout.strip().split("\n"):
+        if not chunk.strip():
+            continue
+        try:
+            parsed = json.loads(chunk)
+        except json.JSONDecodeError:
+            continue
+        entries.extend(parsed if isinstance(parsed, list) else [parsed])
+    if not entries:
+        raise Unverifiable("the GitHub API returned no workflows — refusing to pass vacuously")
+    return {w["path"]: w.get("state", "unknown") for w in entries if "path" in w}
+
+
+def main() -> int:
+    enforce = "--enforce" in sys.argv or os.environ.get("SCHEDULED_WORKFLOW_GATE_ENFORCE") == "1"
+
+    if not WF_DIR.is_dir():
+        die_unverifiable(f"{WF_DIR} does not exist — nothing could be scanned.")
+
+    try:
+        exceptions = load_exceptions()
+        states = live_states()
+    except Unverifiable as exc:
+        die_unverifiable(str(exc))
+        return 2  # unreachable; keeps type-checkers and readers honest
+
+    scheduled: list[tuple[str, list[str]]] = []
+    for f in sorted(list(WF_DIR.glob("*.yml")) + list(WF_DIR.glob("*.yaml"))):
+        crons = declares_cron(f.read_text(encoding="utf-8", errors="ignore"))
+        if crons:
+            scheduled.append((str(f.relative_to(ROOT)), crons))
+
+    if not scheduled:
+        die_unverifiable("no workflow declares a cron schedule — that is not credible for this repo; the scan did not work.")
+
+    problems, stale_exceptions = [], []
+    for path, crons in scheduled:
+        state = states.get(path)
+        if state is None:
+            # On disk with a schedule, absent from the API: unregistered, so it
+            # cannot run and cannot be seen to be not running.
+            problems.append((path, "NOT-REGISTERED-WITH-GITHUB", crons))
+            continue
+        if state != "active":
+            if path in exceptions:
+                e = exceptions[path]
+                print(f"  excepted  {path}  [{e['key']}] {e['reason']}")
+            else:
+                problems.append((path, state, crons))
+        elif path in exceptions:
+            stale_exceptions.append(path)
+
+    print(f"check-scheduled-workflows-active: {len(scheduled)} workflow(s) declare a cron schedule.")
+
+    for path in stale_exceptions:
+        print(f"::error::  STALE exception: {path} is ACTIVE but still listed in {EXCEPTIONS.name}.")
+        print("::error::    Remove it. An exception list containing entries that no longer apply is a list nobody reads.")
+
+    for path, state, crons in problems:
+        print(f"::{'error' if enforce else 'warning'}::  {path} declares cron '{', '.join(crons)}' but its state is '{state}'.")
+        print(f"::{'error' if enforce else 'warning'}::    It will NOT run. The file on disk is not evidence that it does.")
+
+    if not problems and not stale_exceptions:
+        print("Every scheduled workflow is active. ✓")
+        return 0
+
+    if stale_exceptions:
+        return 1  # always blocking: a stale exception is unambiguous
+
+    if enforce:
+        print("::error::Re-enable the workflow, or add it to "
+              f"{EXCEPTIONS.name} with a Jira key and a reason.")
+        return 1
+
+    print(f"::warning::check-scheduled-workflows-active: {len(problems)} inactive scheduled workflow(s). "
+          "Warn-only; set SCHEDULED_WORKFLOW_GATE_ENFORCE=1 to block.")
+    return 0
+
+
+def self_test() -> int:
+    """Fixtures for the parsing decisions that are easy to get wrong."""
+    cases = [
+        ("plain cron detected",
+         declares_cron("on:\n  schedule:\n    - cron: '0 4 * * 0'\n") == ["0 4 * * 0"]),
+        ("double-quoted cron detected",
+         declares_cron('on:\n  schedule:\n    - cron: "0 4 * * 0"\n') == ["0 4 * * 0"]),
+        # backup-complete.yml ships its cadence commented until commissioning.
+        # Reading that as a live schedule would raise a finding that can never
+        # be resolved, and an unresolvable finding is how a gate gets ignored.
+        ("commented-out cron is NOT a schedule",
+         declares_cron("on:\n  schedule:\n    # - cron: '0 1 * * *'\n") == []),
+        ("cron mentioned in prose without a schedule block is not one",
+         declares_cron("# runs on cron: '0 4 * * 0' historically\non:\n  push:\n") == []),
+        ("workflow_dispatch only is not scheduled",
+         declares_cron("on:\n  workflow_dispatch:\n") == []),
+        ("multiple crons all captured",
+         declares_cron("on:\n  schedule:\n    - cron: '0 1 * * *'\n    - cron: '0 5 * * 0'\n")
+         == ["0 1 * * *", "0 5 * * 0"]),
+        ("jira key shape enforced", bool(KEY_RE.match("SEC-79")) and not KEY_RE.match("SEC-xxx")),
+    ]
+    failed = [n for n, ok in cases if not ok]
+    for name, ok in cases:
+        print(f"  {'ok  ' if ok else 'FAIL'} {name}")
+    if failed:
+        print(f"::error::self-test: {len(failed)} case(s) failed: {', '.join(failed)}")
+        return 1
+    print(f"self-test: {len(cases)}/{len(cases)} passed")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(self_test() if "--self-test" in sys.argv else main())

--- a/tests/scripts/check-scheduled-workflows-active.test.js
+++ b/tests/scripts/check-scheduled-workflows-active.test.js
@@ -1,0 +1,157 @@
+/**
+ * CTL-042 — scheduled workflows must actually be ACTIVE.
+ *
+ * The control's whole premise is that a DISABLED workflow has a perfect file on
+ * disk, so these tests are careful to exercise the two halves that can rot
+ * independently: the PARSING (which workflows claim a schedule) and the
+ * POLICY (what happens when one of them is not active).
+ *
+ * The GitHub API is not reachable from a unit test, so the parsing half is
+ * covered through the script's own --self-test fixtures, and the policy half by
+ * asserting the source contract. That is a real limitation and is stated rather
+ * than papered over: the end-to-end path is exercised for real on every CI run
+ * of pr-checks.yml, where the token exists.
+ */
+const { execFileSync, execSync } = require('child_process');
+const fs = require('fs');
+const path = require('path');
+
+const ROOT = path.resolve(__dirname, '../../');
+const { SRC } = require('../support/source-paths.json');
+// Both taken from the manifest rather than written out — the KAN-414 F4
+// ratchet counts raw path literals in tests, and a test about a guard is
+// exactly the kind that hardcodes its subject's path and then breaks on a move.
+const SCRIPT = path.join(ROOT, SRC.checkScheduledWorkflowsActive);
+const EXCEPTIONS = path.join(ROOT, SRC.scheduledWorkflowExceptions);
+
+function run(args = [], env = {}) {
+  try {
+    return {
+      exitCode: 0,
+      stdout: execFileSync('python3', [SCRIPT, ...args], {
+        cwd: ROOT, encoding: 'utf8', env: { ...process.env, ...env },
+      }),
+    };
+  } catch (err) {
+    return { exitCode: err.status ?? 1, stdout: `${err.stdout || ''}${err.stderr || ''}` };
+  }
+}
+
+describe('check-scheduled-workflows-active.py (CTL-042)', () => {
+  const source = fs.readFileSync(SCRIPT, 'utf8');
+
+  test('the script exists and is executable', () => {
+    expect(fs.existsSync(SCRIPT)).toBe(true);
+    expect(fs.statSync(SCRIPT).mode & 0o111).toBeTruthy();
+  });
+
+  test('self-test passes in full', () => {
+    const r = run(['--self-test']);
+    expect(r.exitCode).toBe(0);
+    expect(r.stdout).toMatch(/self-test: \d+\/\d+ passed/);
+  });
+
+  test('a commented-out cron is not treated as a live schedule', () => {
+    // backup-complete.yml ships its cadence commented until the backup is
+    // commissioned, so reading that as scheduled would raise a finding nobody
+    // can ever resolve — and an unresolvable finding is how a gate gets waved
+    // through. Pinned here as well as in --self-test because it is the one
+    // parsing decision that produces a PERMANENT false positive if wrong.
+    const r = run(['--self-test']);
+    expect(r.stdout).toMatch(/ok\s+commented-out cron is NOT a schedule/);
+  });
+
+  test('it fails CLOSED when the truth cannot be established', () => {
+    // The failure this control guards against is "looks fine but is not
+    // running". If the check itself cannot run, reporting a pass would be the
+    // same class of lie.
+    expect(source).toMatch(/def die_unverifiable/);
+    expect(source).toMatch(/sys\.exit\(2\)/);
+    expect(source).toMatch(/refusing to pass vacuously/);
+    // An empty API response must be unverifiable, never "nothing wrong".
+    expect(source).toMatch(/the GitHub API returned no workflows/);
+  });
+
+  test('it refuses to pass when the scan finds no scheduled workflows at all', () => {
+    // A scan that silently matches nothing is the SEC-79 shape this whole
+    // control exists to close, so the script must not accept its own zero.
+    expect(source).toMatch(/no workflow declares a cron schedule/);
+    expect(source).toMatch(/not credible for this repo/);
+  });
+
+  test('an exception requires BOTH a Jira key and a reason', () => {
+    expect(source).toMatch(/has no valid Jira key/);
+    expect(source).toMatch(/has a key but no reason/);
+    expect(source).toMatch(/A bare marker is itself a failure/);
+  });
+
+  test('a STALE exception — for a workflow that is active again — is an error', () => {
+    // Without this, the list only ever grows, and a list that only grows is a
+    // suppression list. Note it returns 1 even in warn mode, deliberately:
+    // a stale entry is unambiguous and needs no founder decision.
+    expect(source).toMatch(/STALE exception/);
+    expect(source).toMatch(/stale_exceptions/);
+  });
+
+  test('the exceptions file is valid JSON with an exceptions object', () => {
+    const raw = JSON.parse(fs.readFileSync(EXCEPTIONS, 'utf8'));
+    expect(typeof raw.exceptions).toBe('object');
+    for (const [wf, meta] of Object.entries(raw.exceptions)) {
+      expect(typeof wf).toBe('string');
+      expect(meta.key).toMatch(/^[A-Z][A-Z0-9]+-[0-9]+$/);
+      expect(String(meta.reason || '').trim().length).toBeGreaterThan(0);
+    }
+  });
+
+  test('every workflow named in the exceptions file actually exists', () => {
+    // An exception for a workflow that has been deleted is dead weight that
+    // reads as active cover.
+    const raw = JSON.parse(fs.readFileSync(EXCEPTIONS, 'utf8'));
+    for (const wf of Object.keys(raw.exceptions)) {
+      expect(fs.existsSync(path.join(ROOT, wf))).toBe(true);
+    }
+  });
+
+  test('it is wired into pr-checks.yml, with the actions:read it needs', () => {
+    const wf = fs.readFileSync(path.join(ROOT, SRC.prChecks), 'utf8');
+    expect(wf).toContain('check-scheduled-workflows-active.py');
+    // Reading workflow STATE needs actions:read. Without it the gh call fails,
+    // the script exits 2, and the step goes red — loudly, not silently, which
+    // is the intended direction. Asserted anyway so the permission is not
+    // dropped by a future least-privilege sweep without someone noticing.
+    expect(wf).toMatch(/actions:\s*read/);
+    expect(wf).toMatch(/GH_TOKEN:\s*\$\{\{\s*secrets\.GITHUB_TOKEN\s*\}\}/);
+  });
+
+  test('it ships warn-first, with an explicit escalation switch', () => {
+    // Four workflows are inactive pending a founder decision. Blocking now
+    // would fail every unrelated PR on something nobody but the founder can
+    // clear, and that is how gates get switched off for good.
+    expect(source).toMatch(/SCHEDULED_WORKFLOW_GATE_ENFORCE/);
+    expect(source).toMatch(/--enforce/);
+  });
+
+  test('is registered in the control registry', () => {
+    const reg = JSON.parse(fs.readFileSync(path.join(ROOT, 'controls/registry.json'), 'utf8'));
+    const controls = reg.controls || reg;
+    const entry = controls.find((c) => c.id === 'CTL-042');
+    expect(entry).toBeDefined();
+    expect(entry.implementation).toContain('check-scheduled-workflows-active.py');
+  });
+});
+
+describe('CTL-042 — the finding it was built from is real', () => {
+  test('the repo has scheduled workflows to check', () => {
+    const out = execSync('git ls-files .github/workflows/', { cwd: ROOT, encoding: 'utf8' });
+    const files = out.split('\n').filter((f) => f.endsWith('.yml') || f.endsWith('.yaml'));
+    expect(files.length).toBeGreaterThan(10);
+    const scheduled = files.filter((f) => {
+      const text = fs.readFileSync(path.join(ROOT, f), 'utf8');
+      const live = text.split('\n').map((l) => l.replace(/#.*$/, '')).join('\n');
+      return /^\s*schedule:/m.test(live) && /cron:\s*['"]/.test(live);
+    });
+    // If this ever reaches zero the control above would pass vacuously, so the
+    // premise is asserted rather than assumed.
+    expect(scheduled.length).toBeGreaterThan(5);
+  });
+});

--- a/tests/support/source-paths.json
+++ b/tests/support/source-paths.json
@@ -1,11 +1,12 @@
 {
   "$comment": "GENERATED — regenerate with `npm run gen:test-paths`. Mirror of tests/support/source-paths.ts for .cjs and shell consumers (KAN-414 F4).",
   "generated_from": "literals referenced by tracked files under tests/",
-  "count": 181,
+  "count": 183,
   "SRC": {
     "codeowners": ".github/CODEOWNERS",
     "pullRequestTemplate": ".github/PULL_REQUEST_TEMPLATE.md",
     "dependabot": ".github/dependabot.yml",
+    "scheduledWorkflowExceptions": ".github/scheduled-workflow-exceptions.json",
     "signupSurface": ".github/signup-surface.paths",
     "workflows": ".github/workflows",
     "backupComplete": ".github/workflows/backup-complete.yml",
@@ -36,6 +37,7 @@
     "checkFixOnlyPromote": "scripts/check-fix-only-promote.sh",
     "checkGuardPathDrift": "scripts/check-guard-path-drift.py",
     "checkRoutineOwnership": "scripts/check-routine-ownership.sh",
+    "checkScheduledWorkflowsActive": "scripts/check-scheduled-workflows-active.py",
     "checkSchemaTypeParity": "scripts/check-schema-type-parity.py",
     "checkTestReimplementation": "scripts/check-test-reimplementation.py",
     "checkUiCopyOwnership": "scripts/check-ui-copy-ownership.sh",

--- a/tests/support/source-paths.ts
+++ b/tests/support/source-paths.ts
@@ -13,12 +13,13 @@
 // cannot drift from reality — a hand-maintained list is what let BUGS-74's
 // first fix miss the legacy editor.
 //
-// 181 entries.
+// 183 entries.
 
 export const SRC = {
   codeowners: '.github/CODEOWNERS',
   pullRequestTemplate: '.github/PULL_REQUEST_TEMPLATE.md',
   dependabot: '.github/dependabot.yml',
+  scheduledWorkflowExceptions: '.github/scheduled-workflow-exceptions.json',
   signupSurface: '.github/signup-surface.paths',
   workflows: '.github/workflows',
   backupComplete: '.github/workflows/backup-complete.yml',
@@ -49,6 +50,7 @@ export const SRC = {
   checkFixOnlyPromote: 'scripts/check-fix-only-promote.sh',
   checkGuardPathDrift: 'scripts/check-guard-path-drift.py',
   checkRoutineOwnership: 'scripts/check-routine-ownership.sh',
+  checkScheduledWorkflowsActive: 'scripts/check-scheduled-workflows-active.py',
   checkSchemaTypeParity: 'scripts/check-schema-type-parity.py',
   checkTestReimplementation: 'scripts/check-test-reimplementation.py',
   checkUiCopyOwnership: 'scripts/check-ui-copy-ownership.sh',

--- a/tests/support/test-floor-baseline.json
+++ b/tests/support/test-floor-baseline.json
@@ -1,6 +1,6 @@
 {
   "$comment": "GENERATED — regenerate with `npm run gen:test-floor`. The enforced test floor. The guard fails if the counts DROP (a test was deleted) and also if they RISE (this baseline is stale and is overstating how much of the estate is actually protected). The rise case is the one that matters: the previous hand-maintained floor sat at 29 files / 320 blocks against an actual 260 / 2963, so ~89% of the tests could have been deleted silently. Raise it in the SAME commit as any net-new test.",
   "measured_at": "2026-08-09",
-  "test_files": 261,
-  "test_blocks": 2973
+  "test_files": 262,
+  "test_blocks": 2986
 }


### PR DESCRIPTION
## A disabled workflow still has a perfect file on disk

That sentence is the whole control.

Every existing check in this repo reasons about `.github/workflows/*.yml` as **text** — `check-workflow-integrity.sh` greps it, CTL-023 confirms the file exists and that something invokes it, CTL-035 confirms its path literals still match live files. **All of them pass for a workflow GitHub will never run again**, because `state: disabled_manually` lives in the GitHub API and nowhere in the repository.

## What it found

Measured 2026-08-09 — **4 of the 20** workflows declaring a cron schedule were not active, and had not run since mid-June:

| Workflow | Cron | Dark for |
|---|---|---|
| `anomaly-detect.yml` | `*/15 * * * *` | ~8 weeks |
| `affiliate-link-smoke.yml` | `17 * * * *` | ~8 weeks |
| `mutation-testing.yml` | `0 4 * * 0` | ~8 weeks |
| `auto-promote-to-staging.yml` | `0 23 * * 0` | ~8 weeks |

`anomaly-detect` is the one to look at twice: a monitoring control on a **15-minute** cadence, silent for two months.

## Why it stayed invisible for months rather than days

**The docs said it was running.** CLAUDE.md's *Scheduled Workflows* section still lists "Sunday 04:00 — Stryker mutation testing" as a live cadence, and the *Deployment Pipeline* section says staging promotion "also auto-runs Sunday 23:00 UTC". Documentation describing a schedule is indistinguishable from a schedule.

**Dependabot kept bumping all four files** ([#474](https://github.com/luisa-sys/lyra/pull/474), 22 July), so they kept appearing in PR diffs looking actively maintained. The one signal a reviewer would plausibly notice was pointing the wrong way.

This is **SEC-79 exactly** — `health-check.yml` and `weekly-report.yml` sat disabled for over a month while everything reported green. The lesson taken from SEC-79 (register controls; assert they exist and are invoked) is right, but **doesn't cover this**: existence and invocation were never what broke.

## Design decisions worth reviewing

**Warn-only to start**, the same warn→block path as the KAN-413 signup gate. Blocking today would fail every unrelated PR on a founder-only decision about four workflows, and a gate that blocks work nobody can unblock is a gate that gets switched off. Flip with `SCHEDULED_WORKFLOW_GATE_ENFORCE=1`.

**The exceptions file is deliberately empty.** It would have been easy to list the four and go green — `auto-promote-to-staging` in particular *looks* like it may be off on purpose under the SEC-98 manual-promote policy. But nobody has said so, and writing that guess into an exception file is how a finding becomes a permanent silence.

**A stale exception fails outright**, even in warn mode, so the list cannot only grow. A list that only grows is a suppression list.

**Fails closed (exit 2)** when it cannot establish the truth — no API access, unparseable exceptions file, empty API response, or a scan that somehow finds no scheduled workflows. A control whose subject is *"looks fine but isn't running"* must not report a pass when it can't tell.

**`--self-test` pins seven parsing decisions.** The load-bearing one: a **commented-out cron is not a live schedule**. `backup-complete.yml` ships its cadence commented until the backup is commissioned, and reading that as scheduled would raise a finding nobody can ever resolve — which is how a gate teaches people to wave it through.

## Verification

- **262 suites / 3184 tests green**, `tsc` clean, every guard exit 0
- Verified live: warn mode exits 0 naming all four; `--enforce` exits 1
- `--self-test` 7/7

## Decisions this needs from you

Four workflows, each independently:

1. **`anomaly-detect`** (`*/15`) — security monitoring. Re-enable, or except with a reason?
2. **`mutation-testing`** (Sunday 04:00) — CLAUDE.md documents this as live. Note it also validates `stryker.config.mjs`'s mutate globs, which KAN-415 D1 just changed.
3. **`affiliate-link-smoke`** (hourly) — last 3 runs were *failures* before it went dark, which may be why.
4. **`auto-promote-to-staging`** (Sunday 23:00) — CLAUDE.md documents this as live; plausibly off on purpose post-SEC-98.

Once decided, CLAUDE.md and `docs/RUNBOOK.md` need updating to match — deliberately not pre-empted here, since the correct edit depends on which way each goes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
