### PR TITLE
feat(CTL-043): catch shared-code drift across repos — no package, no tokens (KAN-418)

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -317,6 +317,28 @@ jobs:
           set -euo pipefail
           python3 scripts/check-scheduled-workflows-active.py --self-test
           python3 scripts/check-scheduled-workflows-active.py
+      - name: Shared-code drift across repos (CTL-043, KAN-418)
+        # content-moderation.ts and moderation-policy.ts exist as COPIES in
+        # lyra AND lyra-mcp-server, with nothing checking they still agree.
+        # KAN-418 offered publishing @lyra/contracts instead; that was declined
+        # 2026-08-09 ("minimise the supply chain surface") because a private
+        # package consumed by the web app and both Railway services becomes a
+        # path where whoever can publish executes in production in three places.
+        #
+        # This costs zero tokens: lyra-mcp-server is PUBLIC, so the built-in
+        # GITHUB_TOKEN reads it. It does not remove the duplication, it removes
+        # the silence.
+        #
+        # moderation-policy.ts was ALREADY textually drifted when this landed
+        # (different headers + the NodeNext '.js' extension) with identical
+        # logic - which is why that entry compares NORMALISED. A byte check
+        # would have been red on day one for a reason nobody can fix.
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          python3 scripts/check-shared-code-drift.py --self-test
+          python3 scripts/check-shared-code-drift.py
       - name: Auto-heal pattern catalogue self-test (KAN-63 Tier 4)
         # Verify every entry in scripts/auto-fix-patterns.json still
         # matches its fixture under tests/fixtures/auto-fix-logs/, and

--- a/controls/registry.json
+++ b/controls/registry.json
@@ -770,6 +770,23 @@
       "escape_hatch": "None by design. If a library root genuinely must be exempt from the boundary rule, remove it from modules.json's declared paths - which is a visible, argued change - rather than narrowing the anchor, which is invisible.",
       "self_test": "Mutation-proven 2026-08-09: narrowing the anchor back to the pre-D1 value reddens 3 of the 7 assertions. Fixtures are enumerated from git ls-files, never sampled - a hand-picked list proves the rule covers the paths someone thought of, which is precisely how the original anchor looked correct.",
       "added": "2026-08-09"
+    },
+    {
+      "id": "CTL-043",
+      "name": "Shared-code drift across repos",
+      "defect_class": "duplicated-source-diverges-silently",
+      "summary": "Compares files that exist as COPIES in lyra and lyra-mcp-server and fails when they diverge. The web app and the MCP servers share rules but no code, so every shared rule is a copy that drifts, and this has already caused a production defect (admin_approve_beta wrote two columns a lyra migration had dropped). lyra-mcp-server/src/convene-recommend-scoring.ts opens by admitting it is a verbatim copy with no mechanism to keep it one. KAN-418 offered two fixes - publish @lyra/contracts, or vendor plus a CI diff. The package was declined 2026-08-09 to minimise supply-chain surface: it would create a path where whoever can publish executes in production on Vercel and both Railway services, and would place read tokens in four runtimes. This alternative costs zero tokens, zero registries and zero runtime dependencies because lyra-mcp-server is public and CI reads it with the built-in GITHUB_TOKEN. It does not remove the duplication; it removes the silence. Found on first run that moderation-policy.ts had ALREADY drifted textually - header comments plus the mandatory NodeNext '.js' import extension - with logic identical, which is why that entry compares normalised.",
+      "implementation": "scripts/check-shared-code-drift.py",
+      "kind": "ci-gate",
+      "wired_in": [
+        ".github/workflows/pr-checks.yml"
+      ],
+      "prevents": [
+        "KAN-418"
+      ],
+      "escape_hatch": "Edit shared-code-manifest.json: change an entry's mode from exact to normalised (comments and the NodeNext extension only), or move it to the `deferred` list with a reason. Deferred entries are PRINTED on every run, so a deferral cannot quietly become permanent. An empty shared list fails outright rather than passing vacuously.",
+      "self_test": "--self-test covers 8 normalisation fixtures, including the two that matter in opposite directions: differing headers plus a '.js' extension must compare EQUAL, while a changed severity comparison or string literal must still differ, and a double-slash inside a string literal must survive. Mutation-proven live 2026-08-09 in three directions: a real change to the exact-mode file goes red, a comment-only change to the normalised-mode file stays green, and a real logic change to the normalised-mode file goes red.",
+      "added": "2026-08-09"
     }
   ]
 }

--- a/scripts/check-shared-code-drift.py
+++ b/scripts/check-shared-code-drift.py
@@ -1,0 +1,239 @@
+#!/usr/bin/env python3
+"""scripts/check-shared-code-drift.py — CTL-043 (KAN-418).
+
+Shared code that lives as a COPY in two repos, with nothing checking the copies
+still agree.
+
+KAN-418 offered two ways to fix that: publish `@lyra/contracts` and have all
+three deployables consume it, or keep the copies and add a CI drift check. The
+package route was declined on 2026-08-09 — *"do the minimum work and minimise
+the supply chain surface"* — and the reasoning holds up: a private package
+consumed by the web app and both Railway services becomes a new compromise path
+where whoever can publish can execute in production in three places, and it puts
+read tokens in four runtimes plus a publish token in a fifth.
+
+This costs **zero tokens, zero registries, zero runtime dependencies**.
+`lyra-mcp-server` is a PUBLIC repo, so CI reads it with the built-in
+`GITHUB_TOKEN`. Nothing new is provisioned anywhere.
+
+It does NOT remove the duplication. It removes the SILENCE. Divergence becomes a
+red build instead of a defect found months later — which is the failure this was
+actually written for: `admin_approve_beta` wrote two columns a `lyra` migration
+had dropped, and `convene-recommend-scoring.ts` carries a header admitting it is
+a verbatim copy with no mechanism to keep it one.
+
+WHY NORMALISED COMPARISON EXISTS
+    The MCP repos are `"type": "module"` + NodeNext, so they MUST write
+    `./content-moderation.js` where the web app writes `./content-moderation`.
+    That difference is real, permanent and harmless.
+
+    When this was first run, `moderation-policy.ts` was ALREADY textually
+    drifted — different header comments plus that extension. A byte comparison
+    would have failed on day one on a difference nobody can fix, and a gate that
+    is red for reasons nobody can fix is a gate that gets switched off by Friday.
+    So `mode: normalised` strips comments and normalises the extension, and
+    compares what actually executes.
+
+    Verified at the time: with comments and the extension normalised away, the
+    two copies of `moderation-policy.ts` are IDENTICAL. The drift was cosmetic.
+    It would not have been obvious which it was without looking, and nothing was
+    looking.
+
+USAGE
+    check-shared-code-drift.py              compare every guarded entry
+    check-shared-code-drift.py --self-test  normalisation fixtures
+
+EXIT
+    0  every guarded copy agrees
+    1  a copy has drifted
+    2  cannot verify — fail closed
+"""
+from __future__ import annotations
+
+import base64
+import hashlib
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+MANIFEST = ROOT / "shared-code-manifest.json"
+FETCH_ATTEMPTS = 3
+
+
+def die_unverifiable(msg: str) -> None:
+    print(f"::error::check-shared-code-drift: {msg}")
+    print(
+        "::error::  Failing closed (exit 2). This control's entire job is to notice a "
+        "difference, so 'could not look' must never print as 'they match'."
+    )
+    sys.exit(2)
+
+
+def normalise(text: str) -> str:
+    """Strip what may legitimately differ; keep everything that executes.
+
+    Comments go because the copies carry different provenance headers by design
+    — the MCP one says "ported from the web app", which is true and useful and
+    should not be a build failure.
+
+    The NodeNext '.js' import extension goes because it is mandatory in one repo
+    and forbidden in the other. Nothing else is touched: no whitespace
+    collapsing inside string literals, no case folding, no reordering. A
+    normaliser that removes too much reports agreement that is not there, which
+    is worse than no check.
+    """
+    # Block comments, then line comments. Order matters: a '//' inside a /* */
+    # would otherwise survive as a fragment.
+    text = re.sub(r"/\*.*?\*/", "", text, flags=re.S)
+    text = re.sub(r"^[ \t]*//.*$", "", text, flags=re.M)
+    # './x.js' -> './x' in import/export specifiers only.
+    text = re.sub(r"(from\s+['\"]\.{1,2}/[^'\"]+?)\.js(['\"])", r"\1\2", text)
+    # Blank-line runs left behind by comment removal.
+    text = re.sub(r"\n\s*\n+", "\n", text)
+    return text.strip()
+
+
+def fetch_remote(repo: str, path: str) -> str:
+    """Read a file from another repo via gh. Retries, then fails CLOSED."""
+    last = ""
+    for attempt in range(1, FETCH_ATTEMPTS + 1):
+        try:
+            res = subprocess.run(
+                ["gh", "api", f"/repos/{repo}/contents/{path}", "--jq", ".content"],
+                capture_output=True, text=True, timeout=45,
+            )
+        except (OSError, subprocess.TimeoutExpired) as exc:
+            last = f"{type(exc).__name__}: {exc}"
+            continue
+        if res.returncode == 0 and res.stdout.strip():
+            try:
+                return base64.b64decode(res.stdout.strip()).decode("utf-8")
+            except (ValueError, UnicodeDecodeError) as exc:
+                die_unverifiable(f"{repo}/{path}: response was not decodable UTF-8 ({exc})")
+        last = res.stderr.strip()[:300] or f"exit {res.returncode}"
+        if "404" in last or "Not Found" in last:
+            # Not transient: the file the manifest names is gone. That is a
+            # finding, not a network problem — a manifest entry pointing at a
+            # deleted file is dead cover that still reads as protection.
+            die_unverifiable(
+                f"{repo}/{path} does not exist. The manifest names a file that is not there — "
+                "either the remote copy was deleted (in which case remove the entry deliberately) "
+                "or it moved (in which case update the entry)."
+            )
+    die_unverifiable(f"could not read {repo}/{path} after {FETCH_ATTEMPTS} attempts: {last}")
+    return ""  # unreachable
+
+
+def main() -> int:
+    if not MANIFEST.exists():
+        die_unverifiable(f"{MANIFEST.name} is missing — nothing could be compared.")
+    try:
+        manifest = json.loads(MANIFEST.read_text())
+    except json.JSONDecodeError as exc:
+        die_unverifiable(f"{MANIFEST.name} is not valid JSON: {exc}")
+
+    sources = manifest.get("sources") or {}
+    shared = manifest.get("shared") or []
+    if not shared:
+        die_unverifiable(
+            "the manifest guards nothing. An empty shared list would pass every run while "
+            "proving nothing — if the duplication is genuinely gone, delete this control."
+        )
+
+    problems = 0
+    for entry in shared:
+        local_rel, src_key = entry.get("local"), entry.get("source")
+        remote_rel, mode = entry.get("remote"), entry.get("mode", "exact")
+        if not (local_rel and src_key and remote_rel):
+            die_unverifiable(f"malformed manifest entry: {entry!r}")
+        if src_key not in sources:
+            die_unverifiable(f"entry '{local_rel}' names unknown source '{src_key}'")
+        if mode not in ("exact", "normalised"):
+            die_unverifiable(f"entry '{local_rel}' has unknown mode '{mode}'")
+
+        local_path = ROOT / local_rel
+        if not local_path.exists():
+            print(f"::error::  {local_rel} does not exist locally, but the manifest guards it.")
+            print("::error::    If it moved, update shared-code-manifest.json in the same commit.")
+            problems += 1
+            continue
+
+        repo = sources[src_key]["repo"]
+        local_text = local_path.read_text(encoding="utf-8")
+        remote_text = fetch_remote(repo, remote_rel)
+
+        a, b = (local_text, remote_text) if mode == "exact" else (normalise(local_text), normalise(remote_text))
+        ha = hashlib.sha256(a.encode()).hexdigest()
+        hb = hashlib.sha256(b.encode()).hexdigest()
+
+        if ha == hb:
+            print(f"  ok  {local_rel}  ==  {repo}/{remote_rel}  ({mode})")
+            continue
+
+        problems += 1
+        print(f"::error::  DRIFT: {local_rel} != {repo}/{remote_rel} ({mode} comparison)")
+        print(f"::error::    local  sha256 {ha[:16]}")
+        print(f"::error::    remote sha256 {hb[:16]}")
+        print(f"::error::    {entry.get('why', '')}")
+        if mode == "exact":
+            print("::error::    If the difference is only comments or a NodeNext '.js' import "
+                  "extension, this entry should be mode 'normalised' — say so explicitly rather "
+                  "than deleting the entry.")
+        print("::error::    Otherwise: change BOTH copies in lockstep, in linked PRs "
+              "(MCP-main lockstep policy, KAN-222).")
+
+    total = len(shared)
+    deferred = manifest.get("deferred") or []
+    if deferred:
+        # Printed every run. A deferred entry that nobody is reminded of is an
+        # entry that quietly becomes permanent.
+        print(f"check-shared-code-drift: {len(deferred)} known duplicate(s) DEFERRED, not guarded:")
+        for d in deferred:
+            print(f"    {d.get('local')}  ~  {d.get('remote')}   ({d.get('why','')[:100]})")
+
+    if problems:
+        print(f"::error::check-shared-code-drift: {problems} of {total} shared file(s) have drifted.")
+        return 1
+    print(f"check-shared-code-drift: {total} shared file(s) still agree across repos. ✓")
+    return 0
+
+
+def self_test() -> int:
+    cases = [
+        ("block comment stripped",
+         normalise("/* hi */\nconst a = 1;") == "const a = 1;"),
+        ("line comment stripped",
+         normalise("// hi\nconst a = 1;") == "const a = 1;"),
+        ("NodeNext .js extension normalised",
+         normalise("import x from './a.js';") == normalise("import x from './a';")),
+        # The difference that actually exists between the two live copies.
+        ("differing headers + extension compare equal",
+         normalise("/** web app */\nimport { m } from './content-moderation';\nexport const x = 1;")
+         == normalise("/** ported to MCP */\nimport { m } from './content-moderation.js';\nexport const x = 1;")),
+        # The normaliser must not be so eager that it hides real changes.
+        ("a REAL logic change still differs",
+         normalise("if (s === 'block') return 1;") != normalise("if (s === 'warn') return 1;")),
+        ("a changed string literal still differs",
+         normalise("const e = 'blocked';") != normalise("const e = 'allowed';")),
+        # A '//' inside a string is not a comment. Getting this wrong would let a
+        # URL change slip past unnoticed.
+        ("a double-slash inside a string literal survives",
+         "https://a.example" in normalise("const u = 'https://a.example';")),
+        ("bare package imports are untouched",
+         normalise("import z from 'node:fs';") == "import z from 'node:fs';"),
+    ]
+    failed = [n for n, ok in cases if not ok]
+    for name, ok in cases:
+        print(f"  {'ok  ' if ok else 'FAIL'} {name}")
+    if failed:
+        print(f"::error::self-test: {len(failed)} case(s) failed: {', '.join(failed)}")
+        return 1
+    print(f"self-test: {len(cases)}/{len(cases)} passed")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(self_test() if "--self-test" in sys.argv else main())

--- a/shared-code-manifest.json
+++ b/shared-code-manifest.json
@@ -1,0 +1,57 @@
+{
+  "$comment": [
+    "KAN-418 — shared code that exists as a COPY in more than one repo.",
+    "",
+    "This is the deliberately-chosen alternative to publishing @lyra/contracts.",
+    "The ticket offered two routes: a private npm package consumed by all three",
+    "deployables, or a vendored copy plus a CI drift check. The package route was",
+    "declined on 2026-08-09 (Luisa: 'do the minimum work and minimise the supply",
+    "chain surface'), because it would create a new compromise path — whoever can",
+    "publish can execute in production on Vercel AND both Railway services — and",
+    "would put read tokens in four runtimes and a publish token in a fifth place.",
+    "",
+    "This costs zero tokens, zero registries and zero runtime dependencies. It",
+    "does NOT remove the duplication; it removes the SILENCE. Divergence becomes",
+    "a red build instead of a defect discovered months later.",
+    "",
+    "COMPARISON MODES",
+    "  exact       byte-identical. Use where the copies genuinely are.",
+    "  normalised  identical after stripping comments and normalising the",
+    "              NodeNext '.js' import extension. Needed because the MCP repos",
+    "              are 'type: module' + NodeNext and MUST write './x.js' where",
+    "              the web app writes './x' — a real, permanent, harmless",
+    "              difference. A byte comparison here would fail on day one and",
+    "              be switched off by the end of the week."
+  ],
+  "sources": {
+    "lyra-mcp-server": {
+      "repo": "luisa-sys/lyra-mcp-server",
+      "public": true,
+      "note": "Public, so CI reads it with the built-in GITHUB_TOKEN. No new secret."
+    }
+  },
+  "shared": [
+    {
+      "local": "src/lib/content-moderation.ts",
+      "source": "lyra-mcp-server",
+      "remote": "src/content-moderation.ts",
+      "mode": "exact",
+      "why": "The moderation wordlist and severity grading. Byte-identical across both repos as of 2026-08-09 (md5 b07eac8ed85ae3cc5669522f0afad395), and there is no reason for it ever not to be."
+    },
+    {
+      "local": "src/lib/moderation-policy.ts",
+      "source": "lyra-mcp-server",
+      "remote": "src/moderation-policy.ts",
+      "mode": "normalised",
+      "why": "The block/warn/none decision applied to a moderation result. The two copies differ ONLY in header comments and the NodeNext '.js' import extension - verified 2026-08-09, the logic is identical. This is the file that proves the point: it had already drifted textually, nobody knew, and nothing would have told us if the drift had been behavioural."
+    }
+  ],
+  "deferred": [
+    {
+      "local": "src/lib/recommend/convene/",
+      "source": "lyra-mcp-server",
+      "remote": "src/convene-recommend-scoring.ts",
+      "why": "The MCP copy's own header says it is a verbatim copy of lyra's convene scoring. NOT guarded, because convene is out of scope for the modularisation programme (KAN-470, BLOCKED) and is dark on every environment - CONVENE_ENABLED is not true anywhere, so nothing executes either copy. Add it here if convene is ever turned back on; that is listed in KAN-470's re-entry checklist."
+    }
+  ]
+}

--- a/tests/scripts/check-shared-code-drift.test.js
+++ b/tests/scripts/check-shared-code-drift.test.js
@@ -1,0 +1,138 @@
+/**
+ * CTL-043 — shared code that exists as a copy in two repos must not diverge.
+ *
+ * The live check reaches another repo over the network, which a unit test must
+ * not do. So this suite covers the two halves that can rot without leaving the
+ * machine: the NORMALISER (via the script's own fixtures, plus its behaviour
+ * asserted directly) and the MANIFEST (well-formed, entries real, nothing
+ * quietly emptied). The network path runs for real on every CI run of
+ * pr-checks.yml — that limitation is stated rather than papered over.
+ *
+ * The normaliser is the part worth guarding. It exists so a permanent, harmless
+ * difference — the NodeNext '.js' import extension the MCP repos are REQUIRED
+ * to write and the web app is required not to — does not produce a red build
+ * nobody can fix. But a normaliser that removes too much reports agreement that
+ * is not there, which is strictly worse than having no check at all. Both
+ * directions are asserted below.
+ */
+const { execFileSync } = require('child_process');
+const fs = require('fs');
+const path = require('path');
+
+const ROOT = path.resolve(__dirname, '../../');
+const { SRC } = require('../support/source-paths.json');
+const SCRIPT = path.join(ROOT, SRC.checkSharedCodeDrift);
+// Repo-root file, like modules.json: outside every root the test-path
+// manifest's harvest regex can reach, so named directly.
+const MANIFEST = path.join(ROOT, 'shared-code-manifest.json');
+
+function run(args) {
+  try {
+    return { exitCode: 0, stdout: execFileSync('python3', [SCRIPT, ...args], { cwd: ROOT, encoding: 'utf8' }) };
+  } catch (err) {
+    return { exitCode: err.status ?? 1, stdout: `${err.stdout || ''}${err.stderr || ''}` };
+  }
+}
+
+describe('check-shared-code-drift.py (CTL-043)', () => {
+  const source = fs.readFileSync(SCRIPT, 'utf8');
+
+  test('exists and is executable', () => {
+    expect(fs.existsSync(SCRIPT)).toBe(true);
+    expect(fs.statSync(SCRIPT).mode & 0o111).toBeTruthy();
+  });
+
+  test('self-test passes in full', () => {
+    const r = run(['--self-test']);
+    expect(r.exitCode).toBe(0);
+    expect(r.stdout).toMatch(/self-test: \d+\/\d+ passed/);
+  });
+
+  test('the normaliser ignores comments and the NodeNext extension', () => {
+    // The difference that genuinely exists between the two live copies of
+    // moderation-policy.ts. If this stopped holding, the gate would be red on
+    // a difference nobody is allowed to fix.
+    const r = run(['--self-test']);
+    expect(r.stdout).toMatch(/ok\s+differing headers \+ extension compare equal/);
+    expect(r.stdout).toMatch(/ok\s+NodeNext \.js extension normalised/);
+  });
+
+  test('the normaliser still sees real changes — the direction that matters', () => {
+    // A normaliser that is too eager reports agreement that is not there. These
+    // three fixtures are what stop this control becoming decorative.
+    const r = run(['--self-test']);
+    expect(r.stdout).toMatch(/ok\s+a REAL logic change still differs/);
+    expect(r.stdout).toMatch(/ok\s+a changed string literal still differs/);
+    expect(r.stdout).toMatch(/ok\s+a double-slash inside a string literal survives/);
+  });
+
+  test('it fails CLOSED rather than reporting agreement it could not verify', () => {
+    expect(source).toMatch(/def die_unverifiable/);
+    expect(source).toMatch(/sys\.exit\(2\)/);
+    expect(source).toMatch(/'could not look' must never print as 'they match'/);
+    // A missing remote file is a FINDING, not a network blip — a manifest entry
+    // pointing at a deleted file is dead cover that still reads as protection.
+    expect(source).toMatch(/does not exist\. The manifest names a file that is not there/);
+    expect(source).toMatch(/FETCH_ATTEMPTS/);
+  });
+
+  test('an empty shared list fails instead of passing vacuously', () => {
+    expect(source).toMatch(/the manifest guards nothing/);
+    expect(source).toMatch(/if the duplication is genuinely gone, delete this control/);
+  });
+
+  test('deferred entries are PRINTED on every run', () => {
+    // A deferral nobody is reminded of is a deferral that becomes permanent.
+    expect(source).toMatch(/DEFERRED, not guarded/);
+  });
+
+  test('the manifest is well-formed and guards at least one file', () => {
+    const m = JSON.parse(fs.readFileSync(MANIFEST, 'utf8'));
+    expect(Array.isArray(m.shared)).toBe(true);
+    expect(m.shared.length).toBeGreaterThan(0);
+    for (const e of m.shared) {
+      expect(typeof e.local).toBe('string');
+      expect(typeof e.remote).toBe('string');
+      expect(['exact', 'normalised']).toContain(e.mode);
+      expect(m.sources[e.source]).toBeDefined();
+      // Every entry must justify itself. "why" is what tells a future reader
+      // whether `normalised` was a considered choice or a way to go green.
+      expect(String(e.why || '').trim().length).toBeGreaterThan(30);
+    }
+  });
+
+  test('every guarded local file actually exists', () => {
+    const m = JSON.parse(fs.readFileSync(MANIFEST, 'utf8'));
+    for (const e of m.shared) {
+      expect(fs.existsSync(path.join(ROOT, e.local))).toBe(true);
+    }
+  });
+
+  test('every deferred entry carries a reason', () => {
+    const m = JSON.parse(fs.readFileSync(MANIFEST, 'utf8'));
+    for (const e of m.deferred || []) {
+      expect(String(e.why || '').trim().length).toBeGreaterThan(30);
+    }
+  });
+
+  test('no source repo is marked public unless it really is readable without a token', () => {
+    // The zero-secrets property this control is built on. If a source repo
+    // stopped being public, CI would need a PAT and the surface we declined to
+    // add would arrive by the back door — so the claim is written down and
+    // asserted rather than assumed.
+    const m = JSON.parse(fs.readFileSync(MANIFEST, 'utf8'));
+    for (const s of Object.values(m.sources)) {
+      expect(typeof s.repo).toBe('string');
+      expect(s.public).toBe(true);
+    }
+  });
+
+  test('is wired into pr-checks.yml and registered', () => {
+    const wf = fs.readFileSync(path.join(ROOT, SRC.prChecks), 'utf8');
+    expect(wf).toContain('check-shared-code-drift.py');
+    const reg = JSON.parse(fs.readFileSync(path.join(ROOT, 'controls/registry.json'), 'utf8'));
+    const entry = (reg.controls || reg).find((c) => c.id === 'CTL-043');
+    expect(entry).toBeDefined();
+    expect(entry.implementation).toContain('check-shared-code-drift.py');
+  });
+});

--- a/tests/support/source-paths.json
+++ b/tests/support/source-paths.json
@@ -1,7 +1,7 @@
 {
   "$comment": "GENERATED — regenerate with `npm run gen:test-paths`. Mirror of tests/support/source-paths.ts for .cjs and shell consumers (KAN-414 F4).",
   "generated_from": "literals referenced by tracked files under tests/",
-  "count": 186,
+  "count": 187,
   "SRC": {
     "codeowners": ".github/CODEOWNERS",
     "pullRequestTemplate": ".github/PULL_REQUEST_TEMPLATE.md",
@@ -39,6 +39,7 @@
     "checkRoutineOwnership": "scripts/check-routine-ownership.sh",
     "checkScheduledWorkflowsActive": "scripts/check-scheduled-workflows-active.py",
     "checkSchemaTypeParity": "scripts/check-schema-type-parity.py",
+    "checkSharedCodeDrift": "scripts/check-shared-code-drift.py",
     "checkTestReimplementation": "scripts/check-test-reimplementation.py",
     "checkUiCopyOwnership": "scripts/check-ui-copy-ownership.sh",
     "checkWorkflowIntegrity": "scripts/check-workflow-integrity.sh",

--- a/tests/support/source-paths.ts
+++ b/tests/support/source-paths.ts
@@ -13,7 +13,7 @@
 // cannot drift from reality — a hand-maintained list is what let BUGS-74's
 // first fix miss the legacy editor.
 //
-// 186 entries.
+// 187 entries.
 
 export const SRC = {
   codeowners: '.github/CODEOWNERS',
@@ -52,6 +52,7 @@ export const SRC = {
   checkRoutineOwnership: 'scripts/check-routine-ownership.sh',
   checkScheduledWorkflowsActive: 'scripts/check-scheduled-workflows-active.py',
   checkSchemaTypeParity: 'scripts/check-schema-type-parity.py',
+  checkSharedCodeDrift: 'scripts/check-shared-code-drift.py',
   checkTestReimplementation: 'scripts/check-test-reimplementation.py',
   checkUiCopyOwnership: 'scripts/check-ui-copy-ownership.sh',
   checkWorkflowIntegrity: 'scripts/check-workflow-integrity.sh',

--- a/tests/support/test-floor-baseline.json
+++ b/tests/support/test-floor-baseline.json
@@ -1,6 +1,6 @@
 {
   "$comment": "GENERATED — regenerate with `npm run gen:test-floor`. The enforced test floor. The guard fails if the counts DROP (a test was deleted) and also if they RISE (this baseline is stale and is overstating how much of the estate is actually protected). The rise case is the one that matters: the previous hand-maintained floor sat at 29 files / 320 blocks against an actual 260 / 2963, so ~89% of the tests could have been deleted silently. Raise it in the SAME commit as any net-new test.",
   "measured_at": "2026-08-09",
-  "test_files": 263,
-  "test_blocks": 2995
+  "test_files": 264,
+  "test_blocks": 3007
 }


### PR DESCRIPTION
## KAN-418, done the cheap way — no package, no registry, no tokens

KAN-418 offered two routes to stop shared code diverging: **publish `@lyra/contracts`** and have all three deployables consume it, or **keep the copies and add a CI diff**.

Taking the second, per your call: *"do the minimum work and minimise the supply chain surface."*

The reasoning stands on its own terms, and the ticket's own security section makes the case: a private package consumed by the web app **and both Railway services** creates a path where whoever can publish executes in production in three places, and it puts read tokens in four runtimes plus a publish token in a fifth.

**This costs zero tokens, zero registries, zero runtime dependencies.** `lyra-mcp-server` is a **public** repo, so CI reads it with the built-in `GITHUB_TOKEN`. Nothing is provisioned anywhere — no action needed from you.

It does **not** remove the duplication. It removes the **silence**.

## What it found on the first run

**`moderation-policy.ts` had already drifted, and nobody knew.**

The logic turns out to be **identical** — verified by normalising away comments and the import extension and comparing what actually executes. So there is no live moderation defect, and I'd rather say that plainly than dress it up.

But that's the point rather than a reprieve: **nothing would have told us if it had been behavioural.** The difference between "cosmetic" and "the web app and the MCP server now moderate user content differently" was one nobody was in a position to notice.

| File | Mode | Status |
|---|---|---|
| `content-moderation.ts` | `exact` | byte-identical (md5 `b07eac8e`) |
| `moderation-policy.ts` | `normalised` | logic identical; headers + `.js` extension differ |

## Why `normalised` exists at all

The MCP repos are `"type": "module"` + NodeNext, so they **must** write `./content-moderation.js` where the web app **must not**. That difference is real, permanent and unfixable.

A byte comparison would have been red on day one for a reason nobody is allowed to resolve — and **a gate that is red for reasons nobody can fix is a gate switched off by Friday.**

The mode is per-entry and every entry carries a `why`, so choosing `normalised` is a recorded decision rather than a way to go green.

**The normaliser is the actual risk here.** One that removes too much reports agreement that isn't there, which is worse than no check. Both directions are pinned in `--self-test`:

- differing headers + `.js` extension → must compare **equal**
- a changed severity comparison, a changed string literal, a double-slash inside a string literal → must still **differ**

**Mutation-proven live, three directions:**

| Mutation | Result |
|---|---|
| real change to the `exact`-mode file | ✅ red |
| **comment-only** change to the `normalised`-mode file | ✅ **green** (correct) |
| real logic change to the `normalised`-mode file | ✅ red |

## Convene is deferred, not forgotten

`convene-recommend-scoring.ts` is the third known duplicate. It is listed under `deferred` **with a reason**, not guarded — convene is out of scope ([KAN-470](https://checklyra.atlassian.net/browse/KAN-470)) and dark on every environment, so neither copy executes.

**Deferred entries are printed on every run**, because a deferral nobody is reminded of becomes permanent. Re-guarding it is on KAN-470's re-entry checklist.

## Fail-closed behaviour

- Network failure → retries 3×, then **exit 2**. Never "they match".
- A **404** on a manifested remote path is a **finding**, not a blip — an entry pointing at a deleted file is dead cover that still reads as protection.
- An **empty** `shared` list fails outright rather than passing vacuously.

## Verification

**263 suites / 3196 tests green**, `tsc` clean, all guards exit 0, `--self-test` 8/8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[KAN-470]: https://checklyra.atlassian.net/browse/KAN-470?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ