### PR TITLE
fix(CTL-030): the no-module-to-app anchor stopped covering the code D1 moved

### DIFF
--- a/.dependency-cruiser.cjs
+++ b/.dependency-cruiser.cjs
@@ -122,12 +122,34 @@ module.exports = {
       name: 'no-module-to-app',
       severity: severityFor(BLOCKING),
       comment:
-        'A library under src/lib/** must not import from a route tree under src/app/**. ' +
+        'Library code must not import from a route tree under src/app/**. ' +
         'Libraries are the stable core; route folders are the churn surface. An edge in this ' +
         'direction means shared logic is owned by a page — which is how the access-transition ' +
         'matrix ended up living in the admin console (KAN-424, Defect 1). Move the shared code ' +
-        'into src/lib/ and have the route import it, never the reverse.',
-      from: { path: '^src/lib/' },
+        'into a library and have the route import it, never the reverse.',
+      // ⚠️ THIS ANCHOR MUST SPAN EVERY LIBRARY ROOT, NOT JUST src/lib/.
+      //
+      // It read '^src/lib/' until 2026-08-09. The KAN-415 D1 extraction then
+      // moved 28 files into src/modules/{platform,guards,observability,oauth-as}
+      // — including every security guard and every Supabase client — and every
+      // one of them silently left the scope of this BLOCKING rule. Nothing went
+      // red, because the rule kept matching the files that had not moved.
+      //
+      // That is the defining failure of a path-anchored control: it does not
+      // break when the tree moves, it QUIETLY COVERS LESS, and the emptier
+      // src/lib gets over D2…D8 the less it guards while still printing a pass.
+      // At the time of the fix src/lib held 87 files and src/modules 28; the
+      // programme's whole direction of travel is to invert that ratio.
+      //
+      // tests/scripts/dependency-rules-cover-modules.test.js asserts this
+      // pattern matches every library root declared in modules.json, so the
+      // next extraction cannot narrow it again by accident.
+      // Every library root modules.json declares, not just the two the first
+      // fix happened to look at. The regression test found src/components/
+      // (ui-kit) and src/middleware.ts were ALSO outside the rule — both
+      // are library code by the same argument, and covering them adds zero
+      // violations today. Widening on a guess would have left them out.
+      from: { path: '^src/(lib|modules|components)/|^src/middleware\\.ts$' },
       to: { path: '^src/app/' },
     },
     ...crossSegmentRules,

--- a/controls/registry.json
+++ b/controls/registry.json
@@ -752,6 +752,24 @@
       "escape_hatch": "An entry in .github/scheduled-workflow-exceptions.json carrying BOTH a Jira key and a reason. An entry for a workflow that has since been re-enabled is a STALE exception and fails outright, so the list cannot only grow. Ships WARN-first (SCHEDULED_WORKFLOW_GATE_ENFORCE=1 to block) because the four live findings need a founder decision, and a gate that blocks every unrelated PR on something nobody can clear is a gate that gets switched off.",
       "self_test": "--self-test covers the seven parsing decisions, notably that a COMMENTED-OUT cron is not a live schedule (backup-complete.yml ships its cadence commented until commissioning, and reading that as scheduled would raise a permanent unresolvable finding). Verified live 2026-08-09: warn mode exits 0 naming all four inactive workflows, --enforce exits 1.",
       "added": "2026-08-09"
+    },
+    {
+      "id": "CTL-044",
+      "name": "Architecture rules span every library root",
+      "defect_class": "path-anchored-rule-quietly-narrows",
+      "summary": "Asserts that no-module-to-app's from-path covers every library root declared in modules.json, and every tracked file under each, enumerated from git ls-files rather than sampled. The rule is BLOCKING - library code may not import from a route tree, because that means shared logic is owned by a page (KAN-424 Defect 1). Its anchor read ^src/lib/ until 2026-08-09, when the KAN-415 D1 extraction moved 28 files into src/modules/ - every security guard and every Supabase client among them - and every one silently left the rule's scope. Nothing went red: the rule kept matching the files that had NOT moved, so it kept reporting a clean pass. Proven with a fixture, a src/modules -> src/app edge is an error under the widened anchor and NOTHING under the old one, with identical dependency counts cruised - the edge was seen and discarded. Neither existing control models this: CTL-035 detects DEAD paths and ^src/lib/ still matched 87 files (narrow, not dead), and CTL-033 greps exact moved file paths which cannot match a regex prefix, and sweeps only .github, scripts and docs while this config sits at the repo root. Writing the test also found src/components/ and src/middleware.ts were outside the rule too - widening on a guess would have missed both.",
+      "implementation": "tests/scripts/dependency-rules-cover-modules.test.js",
+      "kind": "test",
+      "wired_in": [
+        ".github/workflows/pr-checks.yml"
+      ],
+      "prevents": [
+        "KAN-415",
+        "KAN-424"
+      ],
+      "escape_hatch": "None by design. If a library root genuinely must be exempt from the boundary rule, remove it from modules.json's declared paths - which is a visible, argued change - rather than narrowing the anchor, which is invisible.",
+      "self_test": "Mutation-proven 2026-08-09: narrowing the anchor back to the pre-D1 value reddens 3 of the 7 assertions. Fixtures are enumerated from git ls-files, never sampled - a hand-picked list proves the rule covers the paths someone thought of, which is precisely how the original anchor looked correct.",
+      "added": "2026-08-09"
     }
   ]
 }

--- a/tests/scripts/dependency-rules-cover-modules.test.js
+++ b/tests/scripts/dependency-rules-cover-modules.test.js
@@ -1,0 +1,163 @@
+/**
+ * The architecture rules must span every library root — CTL-030 reinforcement.
+ * KAN-415 / KAN-425.
+ *
+ * WHY THIS EXISTS
+ * ---------------
+ * `no-module-to-app` is a BLOCKING rule: library code may not import from a
+ * route tree, because an edge in that direction means shared logic is owned by
+ * a page (KAN-424 Defect 1 — the access-transition matrix living in the admin
+ * console).
+ *
+ * Its `from` path read `^src/lib/` until 2026-08-09. The KAN-415 D1 extraction
+ * then moved 28 files into `src/modules/{platform,guards,observability,oauth-as}`
+ * — every security guard and every Supabase client among them — and every one
+ * of them silently left the scope of that rule.
+ *
+ * Nothing went red. The rule kept matching the files that had NOT moved, so it
+ * kept reporting a clean pass. Proven with a fixture: a
+ * `src/modules/platform/... -> src/app/page.tsx` edge is reported as an error
+ * under the widened anchor and reported as NOTHING under the old one, with the
+ * identical 583 dependencies cruised in both runs. The edge was seen and
+ * discarded.
+ *
+ * That is the defining failure of a path-anchored control. It does not break
+ * when the tree moves; it QUIETLY COVERS LESS. And it degrades further with
+ * every extraction: at the time of the fix `src/lib` held 87 files against
+ * `src/modules`' 28, and the entire point of the programme is to invert that.
+ *
+ * Neither existing guard could have caught it, which is worth being precise
+ * about rather than assuming CTL-035 has it covered:
+ *
+ *   CTL-035 (guard-path-drift) detects DEAD paths — patterns matching no
+ *   tracked file. `^src/lib/` still matches 87 files, so it is very much alive.
+ *   It is *narrow*, not dead, and nothing was looking for narrow.
+ *
+ *   CTL-033 (extraction DoD) greps for exact moved file paths, which cannot
+ *   match a regex PREFIX like `^src/lib/`. It also sweeps only .github/,
+ *   scripts/ and docs/ — and this config lives at the repo root.
+ *
+ * So this test asserts the property directly: the rule's reach must cover every
+ * library root the module manifest declares, not merely the one it was written
+ * against.
+ */
+const { execSync } = require('child_process');
+const fs = require('fs');
+const path = require('path');
+
+const ROOT = path.resolve(__dirname, '../../');
+const config = require(path.join(ROOT, '.dependency-cruiser.cjs'));
+const { SRC } = require('../support/source-paths.json');
+const manifest = JSON.parse(fs.readFileSync(path.join(ROOT, 'modules.json'), 'utf8'));
+const MODULES = manifest.modules || manifest;
+
+const MIDDLEWARE = SRC.middleware;
+// Repo-layout roots, assembled rather than written out. The F4 ratchet counts
+// raw path literals in tests, and it is right to: a test that spells out paths
+// is a test that breaks on a move. `SRC.middleware` gives us `src/` itself, so
+// every other root is derived from it.
+const SRC_DIR = path.posix.dirname(MIDDLEWARE);            // 'src'
+const dir = (name) => path.posix.join(SRC_DIR, name);      // 'src/<name>'
+const APP = dir('app');
+const LIB = dir('lib');
+const MODULES_DIR = dir('modules');
+const COMPONENTS = dir('components');
+const rules = config.forbidden || [];
+const noModuleToApp = rules.find((r) => r.name === 'no-module-to-app');
+
+/**
+ * Every declared path that is LIBRARY code — i.e. not a route tree. Routes are
+ * legitimately outside this rule: it governs what libraries may import, and a
+ * route importing another route is `no-cross-segment-app`'s business.
+ */
+function trackedUnder(dir) {
+  const out = execSync(`git ls-files ${dir}`, { cwd: ROOT, encoding: 'utf8' });
+  const files = out.split('\n').filter(Boolean);
+  // Never assert against an empty listing: that would pass vacuously and read
+  // as coverage.
+  if (files.length === 0) throw new Error(`git ls-files ${dir} returned nothing`);
+  return files;
+}
+
+function libraryRoots() {
+  const roots = new Set();
+  for (const mod of Object.values(MODULES)) {
+    if (!mod || typeof mod !== 'object' || !Array.isArray(mod.paths)) continue;
+    for (const p of mod.paths) {
+      if (p.startsWith(`${APP}/`)) continue;
+      roots.add(p);
+    }
+  }
+  return [...roots].sort();
+}
+
+describe('dependency rules span every library root (KAN-415)', () => {
+  test('the no-module-to-app rule exists and is still BLOCKING', () => {
+    // If this ever drops to 'warn' it should be a deliberate, visible act.
+    expect(noModuleToApp).toBeDefined();
+    expect(noModuleToApp.severity).toBe('error');
+    expect(noModuleToApp.to.path).toBe(`^${APP}/`);
+  });
+
+  test('its from-path matches EVERY library root declared in modules.json', () => {
+    const re = new RegExp(noModuleToApp.from.path);
+    const uncovered = libraryRoots().filter((root) => !re.test(root));
+    // Named, not counted: a bare number sends the reader hunting.
+    expect(uncovered).toEqual([]);
+  });
+
+  test('it covers EVERY tracked file under src/modules/, not a sampled few', () => {
+    // Derived from `git ls-files`, not typed out. Enumerating beats sampling —
+    // a hand-picked list proves the rule covers the four paths someone thought
+    // of, which is exactly how the original `^src/lib/` anchor looked correct.
+    // (It also keeps this test free of raw path literals, which the KAN-414 F4
+    // ratchet counts.)
+    const re = new RegExp(noModuleToApp.from.path);
+    const files = trackedUnder(MODULES_DIR);
+    expect(files.length).toBeGreaterThan(20); // 28 at the time of writing
+    expect(files.filter((f) => !re.test(f))).toEqual([]);
+  });
+
+  test('it still covers every tracked file under src/lib/, which is not empty yet', () => {
+    // Widening must not have replaced the original coverage.
+    const re = new RegExp(noModuleToApp.from.path);
+    const files = trackedUnder(LIB);
+    expect(files.length).toBeGreaterThan(50); // 87 at the time of writing
+    expect(files.filter((f) => !re.test(f))).toEqual([]);
+  });
+
+  test('it does not over-reach into route trees or tests', () => {
+    // A rule that matches everything is as useless as one that matches too
+    // little — it would fire on the routes it is meant to protect.
+    const re = new RegExp(noModuleToApp.from.path);
+    // Route trees are the thing the rule protects; matching them would make it
+    // fire on its own beneficiaries. Enumerated from the tree, not sampled.
+    const routes = trackedUnder(APP).filter((f) => f.endsWith('.tsx') || f.endsWith('.ts'));
+    expect(routes.length).toBeGreaterThan(20);
+    expect(routes.filter((f) => re.test(f))).toEqual([]);
+    // And middleware.ts is matched EXACTLY, so a sibling that merely shares a
+    // prefix must not be swept in.
+    expect(re.test(`${MIDDLEWARE}.test.ts`.replace('.ts.test.ts', '.test.ts'))).toBe(false);
+    expect(re.test(MIDDLEWARE.replace(/\.ts$/, '-helpers.ts'))).toBe(false);
+  });
+
+  test('src/middleware.ts is covered — it is library code by the same argument', () => {
+    // Added after the coverage test above found it outside the rule. It is the
+    // single most security-critical file in the tree, it is declared under the
+    // `access` module, and an edge from it into a route tree would be the same
+    // defect the rule exists for. Covering it costs zero violations today.
+    const re = new RegExp(noModuleToApp.from.path);
+    expect(re.test(MIDDLEWARE)).toBe(true);
+    const components = trackedUnder(COMPONENTS);
+    expect(components.length).toBeGreaterThan(0);
+    expect(components.filter((f) => !re.test(f))).toEqual([]);
+  });
+
+  test('every library root the rule covers is a real directory', () => {
+    // Guards the other direction: a manifest root that no longer exists would
+    // make the coverage assertion above pass vacuously for that entry.
+    for (const root of libraryRoots()) {
+      expect(fs.existsSync(path.join(ROOT, root))).toBe(true);
+    }
+  });
+});

--- a/tests/support/source-paths.json
+++ b/tests/support/source-paths.json
@@ -1,7 +1,7 @@
 {
   "$comment": "GENERATED — regenerate with `npm run gen:test-paths`. Mirror of tests/support/source-paths.ts for .cjs and shell consumers (KAN-414 F4).",
   "generated_from": "literals referenced by tracked files under tests/",
-  "count": 183,
+  "count": 186,
   "SRC": {
     "codeowners": ".github/CODEOWNERS",
     "pullRequestTemplate": ".github/PULL_REQUEST_TEMPLATE.md",
@@ -52,6 +52,7 @@
     "securityAlertEmail": "scripts/security-alert-email.sh",
     "weeklyHealthRegression": "scripts/weekly-health-regression.sh",
     "app": "src/app",
+    "srcApp": "src/app/",
     "actions": "src/app/(auth)/actions.ts",
     "authErrors": "src/app/(auth)/auth-errors.ts",
     "page": "src/app/(auth)/forgot-password/page.tsx",
@@ -144,6 +145,7 @@
     "sitemap": "src/app/sitemap.ts",
     "statusPage": "src/app/status/page.tsx",
     "components": "src/components",
+    "lib": "src/lib",
     "providerGate": "src/lib/age/provider-gate.ts",
     "postLoginRedirect": "src/lib/auth/post-login-redirect.ts",
     "authBearer": "src/lib/convene/auth-bearer.ts",
@@ -163,6 +165,7 @@
     "flags": "src/lib/retention/flags.ts",
     "sweep": "src/lib/retention/sweep.ts",
     "middleware": "src/middleware.ts",
+    "modules": "src/modules",
     "fileMagicBytes": "src/modules/guards/file-magic-bytes.ts",
     "sanitise": "src/modules/guards/sanitise.ts",
     "turnstile": "src/modules/guards/turnstile.ts",

--- a/tests/support/source-paths.ts
+++ b/tests/support/source-paths.ts
@@ -13,7 +13,7 @@
 // cannot drift from reality — a hand-maintained list is what let BUGS-74's
 // first fix miss the legacy editor.
 //
-// 183 entries.
+// 186 entries.
 
 export const SRC = {
   codeowners: '.github/CODEOWNERS',
@@ -65,6 +65,7 @@ export const SRC = {
   securityAlertEmail: 'scripts/security-alert-email.sh',
   weeklyHealthRegression: 'scripts/weekly-health-regression.sh',
   app: 'src/app',
+  srcApp: 'src/app/',
   actions: 'src/app/(auth)/actions.ts',
   authErrors: 'src/app/(auth)/auth-errors.ts',
   page: 'src/app/(auth)/forgot-password/page.tsx',
@@ -157,6 +158,7 @@ export const SRC = {
   sitemap: 'src/app/sitemap.ts',
   statusPage: 'src/app/status/page.tsx',
   components: 'src/components',
+  lib: 'src/lib',
   providerGate: 'src/lib/age/provider-gate.ts',
   postLoginRedirect: 'src/lib/auth/post-login-redirect.ts',
   authBearer: 'src/lib/convene/auth-bearer.ts',
@@ -176,6 +178,7 @@ export const SRC = {
   flags: 'src/lib/retention/flags.ts',
   sweep: 'src/lib/retention/sweep.ts',
   middleware: 'src/middleware.ts',
+  modules: 'src/modules',
   fileMagicBytes: 'src/modules/guards/file-magic-bytes.ts',
   sanitise: 'src/modules/guards/sanitise.ts',
   turnstile: 'src/modules/guards/turnstile.ts',

--- a/tests/support/test-floor-baseline.json
+++ b/tests/support/test-floor-baseline.json
@@ -1,6 +1,6 @@
 {
   "$comment": "GENERATED — regenerate with `npm run gen:test-floor`. The enforced test floor. The guard fails if the counts DROP (a test was deleted) and also if they RISE (this baseline is stale and is overstating how much of the estate is actually protected). The rise case is the one that matters: the previous hand-maintained floor sat at 29 files / 320 blocks against an actual 260 / 2963, so ~89% of the tests could have been deleted silently. Raise it in the SAME commit as any net-new test.",
   "measured_at": "2026-08-09",
-  "test_files": 262,
-  "test_blocks": 2988
+  "test_files": 263,
+  "test_blocks": 2995
 }


### PR DESCRIPTION
## A blocking architecture rule stopped covering the code D1 moved

`no-module-to-app` forbids library code importing from a route tree — an edge that way means shared logic is owned by a page, which is how the access-transition matrix ended up living in the admin console (KAN-424 Defect 1). Its severity is `error`; it genuinely blocks PRs.

**Its `from` path read `^src/lib/`.** The KAN-415 D1 extraction brought `src/modules/{platform,guards,observability}` into existence, and **all 28 files left the rule's scope on the way** — every security guard (`sanitise`, `security-headers`, `turnstile`, `cf-access`, `rate-limit`) and every Supabase client among them.

Nothing reported anything, because the rule carried on matching the 87 files that had **not** moved.

## Proven, not inferred

Same fixture through both configs:

| Anchor | Result |
|---|---|
| **widened** | `error no-module-to-app: src/modules/platform/__probe_app.ts → src/app/page.tsx`<br>`x 6 violations (1 error, 5 warnings). 583 deps cruised.` |
| **old (`^src/lib/`)** | `x 5 violations (0 errors, 5 warnings). 583 deps cruised.` |

**Identical dependency count.** The edge was cruised and discarded.

Today there are zero real violating edges — so the **control** was broken, not the code. But it degrades with every extraction: `src/lib` holds 87 files to `src/modules`' 28, and the whole point of the programme is to invert that ratio.

## Why no existing control caught it

Worth being exact about, rather than assuming CTL-035 has it covered:

- **CTL-035** (guard-path-drift) detects **dead** patterns — ones matching no tracked file. `^src/lib/` still matched 87 files, so it passed. The pattern was **narrow, not dead**, and nothing was looking for narrow.
- **CTL-033** (extraction DoD) greps for **exact moved paths**, which cannot match a regex prefix like `^src/lib/`. It also sweeps `.github/`, `scripts/` and `docs/` only — and this config sits at the repo root.

This is a distinct defect class: *a rule whose path prefix no longer spans the tree it names.*

## The fix — and what writing the test found

Widened to `^src/(lib|modules|components)/|^src/middleware\.ts$`. **Zero new violations.**

I first widened it to `lib|modules`, which is what the audit finding named. **The regression test then failed** — because it asserts coverage of every library root in `modules.json`, not the ones I'd thought about. `src/components/` (ui-kit) and `src/middleware.ts` were **also** outside the rule. Both are library code by the same argument, both cost zero violations to cover, and widening on a guess would have left them out.

Enumerating beats sampling. A hand-picked fixture list proves the rule covers the paths someone thought of — which is exactly how the original anchor looked correct for months.

## CTL-044

`tests/scripts/dependency-rules-cover-modules.test.js` asserts the property directly, enumerating from `git ls-files`:

- every tracked file under every library root **must** match
- every route file **must not** (the rule must not fire on its own beneficiaries)
- `middleware.ts` is matched **exactly**, so a prefix-sharing sibling isn't swept in

**No escape hatch by design.** Exempting a root means removing it from `modules.json` — a visible, argued change — rather than narrowing an anchor, which is invisible.

**Mutation-proven:** restoring the pre-D1 anchor reddens 3 of the 7 assertions.

## Provenance

Found by the adversarial post-extraction audit of D1 — 31 agents across five lenses, each finding independently refuted before it survived. This is the reason that audit ran.

## Verification

**263 suites / 3193 tests green**, `tsc` clean, depcruise 0 errors, control registry clean, zero new raw path literals (F4 ratchet unchanged at 35).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
