### PR TITLE
fix(tests): the test-floor guard reproduced a known flake 15 lines away

### DIFF
--- a/scripts/gen-test-floor.mjs
+++ b/scripts/gen-test-floor.mjs
@@ -29,11 +29,15 @@
  */
 import { execSync } from 'node:child_process';
 import { readFileSync, writeFileSync } from 'node:fs';
-import { join, dirname } from 'node:path';
+import { join, dirname, basename } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
 const OUT = join(ROOT, 'tests/support/test-floor-baseline.json');
+/** Shared with both guard suites — see tests/support/transient-probes.json. */
+const TRANSIENT_PROBE_RE = new RegExp(
+  JSON.parse(readFileSync(join(ROOT, 'tests/support/transient-probes.json'), 'utf8')).pattern,
+);
 
 /** The measurement the guard uses. Kept here so the two cannot disagree. */
 export function measure() {
@@ -41,11 +45,24 @@ export function measure() {
     "npx jest --testPathPatterns='tests/(unit|scripts)' --listTests",
     { cwd: ROOT, encoding: 'utf8' },
   );
-  const files = listed.trim().split('\n').filter(Boolean);
+  // Same transient-probe exclusion as the guard. If these two ever disagree the
+  // baseline is measured against a different set than the gate enforces, which
+  // is a silent, permanent off-by-N.
+  const files = listed
+    .trim()
+    .split('\n')
+    .filter(Boolean)
+    .filter((f) => !TRANSIENT_PROBE_RE.test(basename(f)));
 
   let blocks = 0;
   for (const f of files) {
-    const content = readFileSync(f, 'utf8');
+    let content;
+    try {
+      content = readFileSync(f, 'utf8');
+    } catch (err) {
+      if (err.code === 'ENOENT') continue;
+      throw err;
+    }
     // test()/it() at line start, allowing indentation. Approximate — does not
     // expand `test.each([...])` — and deliberately matches the heuristic in
     // weekly-report.yml so the two stay aligned.

--- a/tests/support/test-floor-baseline.json
+++ b/tests/support/test-floor-baseline.json
@@ -2,5 +2,5 @@
   "$comment": "GENERATED — regenerate with `npm run gen:test-floor`. The enforced test floor. The guard fails if the counts DROP (a test was deleted) and also if they RISE (this baseline is stale and is overstating how much of the estate is actually protected). The rise case is the one that matters: the previous hand-maintained floor sat at 29 files / 320 blocks against an actual 260 / 2963, so ~89% of the tests could have been deleted silently. Raise it in the SAME commit as any net-new test.",
   "measured_at": "2026-08-09",
   "test_files": 264,
-  "test_blocks": 3007
+  "test_blocks": 3011
 }

--- a/tests/support/transient-probes.json
+++ b/tests/support/transient-probes.json
@@ -1,0 +1,27 @@
+{
+  "$comment": [
+    "The naming convention for TRANSIENT PROBE test files, in one place.",
+    "",
+    "Several guard suites prove their subject by writing a probe file into",
+    "tests/unit/, running the checker against it, and deleting it. Jest runs",
+    "suites in PARALLEL, so any other suite that enumerates test files via",
+    "`jest --listTests` can observe a probe that is gone by the time it reads",
+    "it — an ENOENT with nothing to do with what that suite asserts.",
+    "",
+    "This already happened once and 'failed five unrelated PRs in a row'",
+    "(tests/unit/test-meta-integrity.test.js). It was fixed there and then",
+    "reproduced verbatim in the KAN-415 test-floor guard, because the pattern",
+    "was a private const rather than a shared fact. Hence this file: three",
+    "readers, one definition, and CTL-043's lesson applied locally — the fix",
+    "for a copy that drifts is to stop having copies.",
+    "",
+    "Readers must ALSO tolerate an ENOENT on read. The exclusion closes the",
+    "common case; the read guard closes the window between listing and reading."
+  ],
+  "pattern": "^__.*_probe__.*\\.test\\.(js|ts)$",
+  "readers": [
+    "tests/unit/test-meta-integrity.test.js",
+    "tests/unit/test-regression-guard.test.js",
+    "scripts/gen-test-floor.mjs"
+  ]
+}

--- a/tests/unit/test-meta-integrity.test.js
+++ b/tests/unit/test-meta-integrity.test.js
@@ -111,7 +111,63 @@ const SELF_FILENAME = path.basename(__filename);
 // do with what this file asserts, and which failed five unrelated PRs in a row.
 // Excluding the naming convention is the fix; the readFileSync guard below
 // closes the remaining window between listing and reading.
-const TRANSIENT_PROBE_RE = /^__.*_probe__.*\.test\.js$/;
+// Read from tests/support/transient-probes.json rather than declared here.
+// This was a private const, and the KAN-415 test-floor guard reproduced the
+// very flake this comment describes because it could not see it. One
+// definition, three readers — CTL-043's lesson applied locally: the fix for a
+// copy that drifts is to stop having copies.
+const TRANSIENT_PROBE_RE = new RegExp(
+  require('../support/transient-probes.json').pattern,
+);
+
+describe('transient-probe convention has ONE definition (KAN-415)', () => {
+  // The pattern was a private const in this file, carrying a comment saying the
+  // flake it prevents had "failed five unrelated PRs in a row". The KAN-415
+  // test-floor guard then reproduced that exact flake, because a private const
+  // is invisible to the next person who enumerates test files. These assertions
+  // stop the definition being copied back.
+  const SHARED = require('../support/transient-probes.json');
+
+  test('the shared definition exists and declares its readers', () => {
+    expect(typeof SHARED.pattern).toBe('string');
+    expect(Array.isArray(SHARED.readers)).toBe(true);
+    expect(SHARED.readers.length).toBeGreaterThanOrEqual(3);
+  });
+
+  test('every declared reader exists and reads the shared file', () => {
+    for (const rel of SHARED.readers) {
+      const abs = path.join(REPO_ROOT, rel);
+      expect(fs.existsSync(abs)).toBe(true);
+      const src = fs.readFileSync(abs, 'utf8');
+      // Must reference the shared definition...
+      expect(src).toContain('transient-probes.json');
+      // ...and must NOT re-declare the regex inline. A literal /^__.*_probe__/
+      // in a reader is the copy that caused this.
+      expect(src).not.toMatch(/=\s*\/\^__\.\*_probe__/);
+    }
+  });
+
+  test('every reader tolerates a file vanishing between listing and reading', () => {
+    // The exclusion closes the common case; this closes the window between
+    // `--listTests` returning a path and the reader opening it. Without it the
+    // guard is merely less flaky, not correct.
+    for (const rel of SHARED.readers) {
+      const src = fs.readFileSync(path.join(REPO_ROOT, rel), 'utf8');
+      if (!src.includes('readFileSync')) continue;
+      expect(src).toContain("ENOENT");
+    }
+  });
+
+  test('the pattern matches the probes that actually exist, both ways', () => {
+    const re = new RegExp(SHARED.pattern);
+    expect(re.test('__ctl038_probe__.test.js')).toBe(true);
+    expect(re.test('__ctl039_probe__.test.js')).toBe(true);
+    // A too-greedy pattern would silently drop the whole suite and every
+    // enumerating guard would pass while measuring nothing.
+    expect(re.test('seo.test.js')).toBe(false);
+    expect(re.test('middleware-gate-order.test.ts')).toBe(false);
+  });
+});
 
 describe('KAN-168: every test block must make at least one assertion', () => {
   // Discover all unit test files (excluding self — see SELF_FILENAME above).

--- a/tests/unit/test-regression-guard.test.js
+++ b/tests/unit/test-regression-guard.test.js
@@ -13,6 +13,12 @@
 
 const { execSync } = require('child_process');
 const path = require('path');
+
+// One definition, shared with tests/unit/test-meta-integrity.test.js and
+// scripts/gen-test-floor.mjs. See tests/support/transient-probes.json.
+const TRANSIENT_PROBE_RE = new RegExp(
+  require('../support/transient-probes.json').pattern,
+);
 const fs = require('fs');
 
 const REPO_ROOT = path.join(__dirname, '../..');
@@ -42,10 +48,31 @@ describe('KAN-110 + KAN-168: Test count regression guard', () => {
       "npx jest --testPathPatterns='tests/(unit|scripts)' --listTests",
       { cwd: REPO_ROOT, encoding: 'utf8' },
     );
-    const files = listed.trim().split('\n').filter(Boolean);
+    // Exclude TRANSIENT PROBES. Several guard suites prove their subject by
+    // writing a probe file into tests/unit/, running the checker, and deleting
+    // it. Jest runs suites in PARALLEL, so `--listTests` can observe a probe
+    // that is gone by the time we read it — an ENOENT with nothing to do with
+    // the test floor. That exact flake already 'failed five unrelated PRs in a
+    // row' once (see tests/unit/test-meta-integrity.test.js) and was
+    // reproduced here because the pattern was a private const rather than a
+    // shared fact. It is now one definition, in transient-probes.json.
+    const files = listed
+      .trim()
+      .split('\n')
+      .filter(Boolean)
+      .filter((f) => !TRANSIENT_PROBE_RE.test(path.basename(f)));
     let blocks = 0;
     for (const f of files) {
-      const content = fs.readFileSync(f, 'utf8');
+      let content;
+      try {
+        content = fs.readFileSync(f, 'utf8');
+      } catch (err) {
+        // Closes the remaining window between listing and reading. Only ENOENT
+        // — anything else is a real problem and must not be swallowed, because
+        // silently skipping files is how a floor guard stops guarding.
+        if (err.code === 'ENOENT') continue;
+        throw err;
+      }
       blocks += (content.match(/^[ \t]*(test|it)\(/gm) || []).length;
     }
     return { files: files.length, blocks };


### PR DESCRIPTION
## A flake I reintroduced 15 lines from where it was already fixed

[#737](https://github.com/luisa-sys/lyra/pull/737)'s Quality Gate went red on:

```
ENOENT: no such file or directory, open 'tests/unit/__ctl039_probe__.test.js'
```

Not a floor mismatch — a **race**. Two guard suites prove their subject by writing a probe file into `tests/unit/`, running the checker against it, and deleting it (CTL-038's and CTL-039's tests). Jest runs suites **in parallel**, so the floor guard's `jest --listTests` can observe a probe that's gone by the time it reads it.

## The part worth sitting with

This exact flake was **already diagnosed and fixed** — in `tests/unit/test-meta-integrity.test.js`, whose comment reads:

> *"Jest runs suites in parallel, so `--listTests` above can observe a probe that is gone by the time we read it — an ENOENT that has nothing to do with what this file asserts, and **which failed five unrelated PRs in a row**."*

The fix was a **private const in that file**. I wrote the KAN-415 test-floor guard today, enumerating test files exactly the same way, and reproduced the flake verbatim — because a private const is invisible to the next person who writes an enumerating guard.

The prose was right there and could not help.

## The fix

The pattern is now a shared fact — `tests/support/transient-probes.json` — with three declared readers: both guard suites and `gen-test-floor.mjs`.

**That third reader matters independently.** The generator and the guard *must* measure the same population, or the baseline is taken against a different set than the gate enforces — a silent, permanent off-by-N rather than a visible failure.

This is **CTL-043's lesson applied locally**: the fix for a copy that drifts is to stop having copies.

## Two layers, because exclusion alone isn't correctness

1. Probe files excluded **by name**.
2. Every reader tolerates **ENOENT on read** — closing the window between `--listTests` returning a path and the reader opening it.

Only `ENOENT` is swallowed. Anything else still throws, because silently skipping unreadable files is how a floor guard stops guarding.

## Proven deterministically, not by waiting for the race

Given a listing containing a deleted probe:

| | Result |
|---|---|
| old code | **throws** `ENOENT __ctl039_probe__.test.js` |
| new code | skips the probe, **still counts the real file** (9 blocks) |

Also re-run with a probe present, and with one deleted mid-run — green in both.

## Regression-guarded

A new suite asserts every declared reader references the shared file, does **not** re-declare the regex inline, and handles `ENOENT`. **Mutation-proven** — re-inlining the copy reddens it.

The pattern is asserted **both ways**: a too-greedy version would silently drop the whole suite and leave every enumerating guard passing while measuring nothing.

## Verification

**263 suites / 3197 tests green**, `tsc` clean.

`Prevention: CTL-018` — the control existed and its lesson was trapped in one file. Sharing the definition *is* the prevention; no new control needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
