### PR TITLE
fix(CTL-038): the ratchet ignored progress, contradicting its own docstring

### DIFF
--- a/scripts/check-test-reimplementation.py
+++ b/scripts/check-test-reimplementation.py
@@ -252,12 +252,38 @@ def compare(found: list[dict], baseline: list[dict]) -> tuple[list[str], list[st
                 f"WORSE: {f['test']} vs {f['subject']} went "
                 f"{b['severity']} -> {f['severity']}."
             )
+        elif RANK[f["severity"]] < RANK[b["severity"]]:
+            # The docstring promised this and the code did not do it. A
+            # baselined finding that has PARTLY been fixed (vacuous -> partial)
+            # left the baseline saying 'vacuous' forever, and the guard printed
+            # "none new, none stale" — a verdict disagreeing with the file it
+            # ratchets against.
+            #
+            # It errs safe, which is why it is low severity and not high: it
+            # over-states the problem rather than hiding one. But an over-stated
+            # baseline is still a baseline nobody can read, and the severity
+            # word is the only remaining signal of how bad a known finding is.
+            failures.append(
+                f"IMPROVED: {f['test']} vs {f['subject']} went "
+                f"{b['severity']} -> {f['severity']}. Lower the baseline in this "
+                f"commit — a ratchet that ignores progress stops describing reality."
+            )
         else:
             extra = sorted(set(f["shared"]) - set(b.get("shared", [])))
             if extra:
                 failures.append(
                     f"WORSE: {f['test']} vs {f['subject']} now also "
                     f"duplicates {', '.join(extra)}."
+                )
+            gone = sorted(set(b.get("shared", [])) - set(f["shared"]))
+            if gone:
+                # Same shape one level down: a symbol that stopped being
+                # duplicated must leave the baseline, or the list slowly becomes
+                # a description of the past.
+                failures.append(
+                    f"IMPROVED: {f['test']} vs {f['subject']} no longer "
+                    f"duplicates {', '.join(gone)}. Remove it from the baseline "
+                    f"in this commit."
                 )
 
     for k, b in sorted(base.items()):


### PR DESCRIPTION
## The docstring promised both directions; the code only did one

`scripts/check-test-reimplementation.py:41-48` says:

> *"The baseline is shrink-only and fails in **BOTH** directions: a baselined finding that has been **FIXED** also fails, until the baseline is updated. A list you may only add to is a suppression list, not a ratchet."*

`compare()` had **no branch for severity going DOWN**, and none for the shared-symbol list **shrinking**. So a partial fix left the baseline permanently over-stating the finding while the guard printed *"none new, none stale"* — a verdict that disagrees with the file it's ratcheting against.

## Reproduced with the audit's own mutation

Adding a real `require()` of `src/modules/guards/rate-limit.ts` to `tests/unit/rate-limit.test.js` takes it from `vacuous` to `partial`:

| | Before | After |
|---|---|---|
| output | `CTL-038 OK — 3 known finding(s), none new, none stale.` | `::error::IMPROVED: ... went vacuous -> partial. Lower the baseline in this commit — a ratchet that ignores progress stops describing reality.` |
| exit | **0** | **1** |

`rc=0` again once reverted.

## Why this is low, not high — and why it still matters

It errs **safe**: it over-states the problem rather than hiding one. That's the whole reason it isn't higher severity.

But an over-stated baseline is still a baseline nobody can read. For a known finding, the **severity word is the only remaining signal** of how bad it is — and `tests/unit/rate-limit.test.js` is the auth rate limiter's suite. *"Is it still a copy, and how much of one"* is a question worth being able to answer from the baseline.

Both directions now covered: severity improving, and a symbol that stopped being duplicated.

## Provenance

Found by the adversarial audit of D1. The three high/critical findings are [#736](https://github.com/luisa-sys/lyra/pull/736), [#739](https://github.com/luisa-sys/lyra/pull/739) and [lyra-mcp-server#143](https://github.com/luisa-sys/lyra-mcp-server/pull/143); this is one of the lows.

## Verification

**265 suites / 3238 tests green**, `--self-test` OK, live run exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)