### PR TITLE
refactor(access): decompose middleware.ts into a gate pipeline — KAN-415 D4 (in progress)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -35,6 +35,9 @@
 /src/app/oauth/                     @luisa-sys
 /src/modules/oauth-as/lib/          @luisa-sys
 /src/lib/beta-access/               @luisa-sys
+# KAN-415 D4: the request-gating pipeline. Same reasoning as beta-access —
+# a change here decides who reaches the app at all.
+/src/modules/access/                @luisa-sys
 /src/app/admin/                     @luisa-sys
 /src/modules/platform/cookie-domain.ts           @luisa-sys
 /src/modules/platform/env.ts                     @luisa-sys

--- a/.github/signup-surface.paths
+++ b/.github/signup-surface.paths
@@ -41,6 +41,9 @@ src/modules/platform/env.ts
 
 # Middleware routing/gating that decides where a new user lands
 src/middleware.ts
+# KAN-415 D4: the gating logic that decided where a new user lands moved here.
+# Without this line the signup gate stops covering the code it was written for.
+src/modules/access/**
 
 # Account-creation DB trigger + profiles defaults (content-filtered, see note)
 supabase/migrations/**

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -461,7 +461,7 @@ jobs:
           
           # Check if any key files changed
           KEY_CHANGE=false
-          echo "$CHANGED" | grep -qE "^(src/app/|src/middleware|supabase/migrations/|\.github/workflows/|public/\.well-known/|scripts/)" && KEY_CHANGE=true
+          echo "$CHANGED" | grep -qE "^(src/app/|src/middleware|src/modules/|supabase/migrations/|\.github/workflows/|public/\.well-known/|scripts/)" && KEY_CHANGE=true
           
           # If key files changed, check if ARCHITECTURE.md was also updated
           if [ "$KEY_CHANGE" = true ]; then

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -399,7 +399,12 @@ jobs:
       - name: Install dependencies
         run: npm ci
       - name: Run ESLint
-        run: npm run lint
+        # CTL-046 lives in eslint.config.mjs — a no-restricted-syntax rule scoped
+        # to the access gates. Naming the config here is what connects the
+        # control to its invoker in controls/registry.json; `npm run lint` alone
+        # reaches it only by convention, and a convention is precisely what the
+        # registry exists to stop us relying on.
+        run: npm run lint  # uses eslint.config.mjs
       - name: Run type check
         run: npm run type-check
       - name: Dependency-rule gate (KAN-425)

--- a/controls/registry.json
+++ b/controls/registry.json
@@ -787,6 +787,40 @@
       "escape_hatch": "Edit shared-code-manifest.json: change an entry's mode from exact to normalised (comments and the NodeNext extension only), or move it to the `deferred` list with a reason. Deferred entries are PRINTED on every run, so a deferral cannot quietly become permanent. An empty shared list fails outright rather than passing vacuously.",
       "self_test": "--self-test covers 8 normalisation fixtures, including the two that matter in opposite directions: differing headers plus a '.js' extension must compare EQUAL, while a changed severity comparison or string literal must still differ, and a double-slash inside a string literal must survive. Mutation-proven live 2026-08-09 in three directions: a real change to the exact-mode file goes red, a comment-only change to the normalised-mode file stays green, and a real logic change to the normalised-mode file goes red.",
       "added": "2026-08-09"
+    },
+    {
+      "id": "CTL-045",
+      "name": "Access gate ORDER is a checked artefact",
+      "defect_class": "silently-reordered-security-gate",
+      "summary": "Asserts the access pipelines' exact ORDER, the pairwise invariants that make certain reorderings catastrophic, and that every gate written is wired exactly once. Gate order in src/middleware.ts was a behavioural contract with NO test before KAN-415 D4: whether the suspension gate runs before the beta gate decides whether a suspended user lands on /suspended or /waitlist, and whether SEC-36's 404 runs before authentication decides whether an unauthenticated caller can reach production's oauth_clients. Three instruments, deliberately complementary: exact-order deep-equals catch EVERY change; ORDER_CONSTRAINTS carries the five pairwise invariants as data with tickets and reasons, so a reviewer can tell a cosmetic reordering from a live security regression in seconds; and a registry/ORDER set-equality test closes a failure mode the decomposition CREATES - a gate that exists, type-checks, is unit-tested and never runs. A constraint naming a gate that no longer exists fails rather than passing vacuously on two -1s comparing equal.",
+      "implementation": "tests/unit/access-pipeline.test.ts",
+      "kind": "test",
+      "wired_in": [
+        ".github/workflows/pr-checks.yml"
+      ],
+      "prevents": [
+        "KAN-415"
+      ],
+      "escape_hatch": "None. Changing an order means editing the expected literal, which is a visible diff a reviewer can weigh against ORDER_CONSTRAINTS' stated reasons. Landed LAST in D4 on purpose: written earlier, every subsequent commit would have edited its own expected list, and in a log that is indistinguishable from weakening it.",
+      "self_test": "Mutation-proven 2026-08-10. Also guarded at the TYPE level by a dedicated type-level file under tests/types \u2014 an @ts-expect-error on assigning an authed gate into a pre-auth pipeline, which fails the build if the error DISAPPEARS. Verified by flipping Gate.run from a property to a method shorthand - property form gives 1 compile error, shorthand gives 0, and the type file then reports TS2578 unused directive. That difference is invisible in review, which is why it is pinned twice.",
+      "added": "2026-08-10"
+    },
+    {
+      "id": "CTL-046",
+      "name": "Access gates must not bypass the exemption table",
+      "defect_class": "control-bypassed-while-its-own-tests-stay-green",
+      "summary": "An ESLint no-restricted-syntax rule, scoped to the three gates that consult the exemption table (suspension, beta-tier, admin-host), forbidding direct === / !== comparisons against pathname. Those comparisons are exactly what the table replaced - 19 disjuncts across three inline chains - and a single direct pathname equality comparison added to a gate would bypass it SILENTLY: the table's own tests would still pass, because the table would still be correct; it would simply no longer be the only thing deciding. startsWith stays legal, because /admin needs it and it is the literal qa-sweep/inventory.py derives the admin prefix list from. One legitimate exception exists and is declared at its site: string-building the /admin rewrite for the root path. The plan predicted zero false positives; there is one, and narrowing the selector to allow its shape would also allow a real bypass written the same way, so the exception is declared rather than the rule weakened.",
+      "implementation": "eslint.config.mjs",
+      "kind": "ci-gate",
+      "wired_in": [
+        ".github/workflows/pr-checks.yml"
+      ],
+      "prevents": [
+        "KAN-415"
+      ],
+      "escape_hatch": "An eslint-disable-next-line at the specific site, with a comment saying why the comparison is not an exemption decision. Deliberately per-site rather than a selector carve-out.",
+      "self_test": "Mutation-proven 2026-08-10: adding a direct pathname equality comparison to the beta-tier gate makes npm run lint report the CTL-046 error; reverting clears it. The scoped files contain zero other such comparisons, so the rule fires only on the edit that matters.",
+      "added": "2026-08-10"
     }
   ]
 }

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -29,6 +29,43 @@ const eslintConfig = defineConfig([
     },
   },
   // Override default ignores of eslint-config-next.
+  // ── CTL-046 (KAN-415 D4) ──────────────────────────────────────────────
+  // The three gates that consult the exemption table must not compare
+  // `pathname` directly. Those comparisons are exactly what the table
+  // replaced — 19 disjuncts across three inline `||` chains — and a single
+  // `ctx.pathname === '/gifts'` added to a gate would bypass it silently: the
+  // table's own tests would still pass, because the table would still be
+  // correct; it would simply no longer be the only thing deciding.
+  //
+  // Scoped to these three files only. After C6/C7 they contain ZERO such
+  // comparisons, so the rule has no false positives today and fires on the one
+  // edit that matters. `startsWith` stays legal — /admin needs it, and it is
+  // the literal qa-sweep/inventory.py derives the admin prefix list from.
+  {
+    files: [
+      "src/modules/access/gates/suspension.ts",
+      "src/modules/access/gates/beta-tier.ts",
+      "src/modules/access/gates/admin-host.ts",
+    ],
+    rules: {
+      "no-restricted-syntax": [
+        "error",
+        {
+          selector:
+            "BinaryExpression[operator=/^[!=]==$/] > MemberExpression[property.name='pathname']",
+          message:
+            "CTL-046: this gate must not compare `pathname` directly — path exemptions belong in src/modules/access/exemptions.ts. A comparison here bypasses the table while the table's own tests stay green. `startsWith` is still allowed.",
+        },
+        {
+          selector:
+            "BinaryExpression[operator=/^[!=]==$/] > Identifier[name='pathname']",
+          message:
+            "CTL-046: this gate must not compare `pathname` directly — path exemptions belong in src/modules/access/exemptions.ts.",
+        },
+      ],
+    },
+  },
+
   globalIgnores([
     // Default ignores of eslint-config-next:
     ".next/**",

--- a/modules.json
+++ b/modules.json
@@ -922,7 +922,7 @@
         "src/modules/access/"
       ],
       "owns": {
-        "files": 17,
+        "files": 22,
         "tables": [],
         "rpcs": [],
         "profilesColumns": [

--- a/modules.json
+++ b/modules.json
@@ -922,7 +922,7 @@
         "src/modules/access/"
       ],
       "owns": {
-        "files": 25,
+        "files": 28,
         "tables": [],
         "rpcs": [],
         "profilesColumns": [

--- a/modules.json
+++ b/modules.json
@@ -922,7 +922,7 @@
         "src/modules/access/"
       ],
       "owns": {
-        "files": 23,
+        "files": 25,
         "tables": [],
         "rpcs": [],
         "profilesColumns": [

--- a/modules.json
+++ b/modules.json
@@ -922,7 +922,7 @@
         "src/modules/access/"
       ],
       "owns": {
-        "files": 22,
+        "files": 23,
         "tables": [],
         "rpcs": [],
         "profilesColumns": [

--- a/modules.json
+++ b/modules.json
@@ -922,7 +922,7 @@
         "src/modules/access/"
       ],
       "owns": {
-        "files": 15,
+        "files": 17,
         "tables": [],
         "rpcs": [],
         "profilesColumns": [

--- a/modules.json
+++ b/modules.json
@@ -918,10 +918,11 @@
         "src/app/waitlist/",
         "src/app/suspended/",
         "src/app/join/",
-        "src/middleware.ts"
+        "src/middleware.ts",
+        "src/modules/access/"
       ],
       "owns": {
-        "files": 12,
+        "files": 15,
         "tables": [],
         "rpcs": [],
         "profilesColumns": [

--- a/qa-sweep/inventory.py
+++ b/qa-sweep/inventory.py
@@ -683,6 +683,27 @@ def build(repo=REPO):
             "src/middleware.ts unreadable — the auth model cannot be derived, and "
             "guessing it would mark authed pages public"
         )
+    # KAN-415 D4: the auth model's literals moved out of src/middleware.ts into
+    # named gates. The derivation regexes are unchanged — what changed is where
+    # the source lives — so the gate files are concatenated before deriving.
+    #
+    # This is exactly the failure mode CTL-033 exists for: after D4, deriving
+    # from src/middleware.ts alone yields an EMPTY model, and an empty model is
+    # fatal by design (see below) because it "would flatter every coverage
+    # number downstream". The fatal check is deliberately left exactly as it is;
+    # widening the SOURCE is the fix, not weakening the ASSERTION.
+    gates_dir = os.path.join(os.path.dirname(middleware_path), "modules", "access", "gates")
+    if os.path.isdir(gates_dir):
+        for name in sorted(os.listdir(gates_dir)):
+            if not name.endswith(".ts"):
+                continue
+            gate_src = read(os.path.join(gates_dir, name))
+            if gate_src is None:
+                raise SystemExit2(
+                    "access gate {0} unreadable — the auth model would derive from a "
+                    "partial corpus, which is worse than not deriving at all".format(name)
+                )
+            mw_src += "\n" + gate_src
     model = derive_auth_model(mw_src)
     if not model["admin_prefixes"] or not model["authed_prefixes"]:
         raise SystemExit2(

--- a/scripts/check-guard-path-drift.py
+++ b/scripts/check-guard-path-drift.py
@@ -494,7 +494,7 @@ REGISTRY: list[Artefact] = [
              "silent-skip on drift: a moved worker file means the deploy never runs"),
     Artefact(".github/workflows/pr-checks.yml", "regex",
              _fixed(".github/workflows/pr-checks.yml",
-                    [r"^(src/app/|src/middleware|supabase/migrations/|\.github/workflows/"
+                    [r"^(src/app/|src/middleware|src/modules/|supabase/migrations/|\.github/workflows/"
                      r"|public/\.well-known/|scripts/)"]),
              "architecture-doc freshness check"),
     # --- build / test tooling ------------------------------------------------

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,30 +1,36 @@
-import { createServerClient } from '@supabase/ssr';
-import { NextResponse, type NextRequest } from 'next/server';
-import { rateLimit, RATE_LIMITS } from '@/modules/guards/rate-limit';
-import { withParentCookieDomain } from '@/modules/platform/cookie-domain';
-import { buildCspReportOnly } from '@/modules/guards/security-headers';
-import { generateCspNonce, stampCspReportOnly } from '@/modules/access/csp';
-import {
-  buildDeployContext,
-  createEdgeContext,
-  type AuthedContext,
-  type MiddlewareEnvRaw,
-} from '@/modules/access/context';
-import { isExemptFrom } from '@/modules/access/exemptions';
-import { isOauthServerPath } from '@/modules/access/oauth-server-paths';
-import { runGates } from '@/modules/access/gate';
-import { betaTier } from '@/modules/access/gates/beta-tier';
-import { suspension } from '@/modules/access/gates/suspension';
-import { establishSession } from '@/modules/access/session';
-import { AUTHED_PIPELINE, PRE_AUTH_PIPELINE } from '@/modules/access/pipeline';
-import { clientIp } from '@/modules/guards/client-ip';
-
-// SEC-120: the precedence rule lives in ONE place now — see
-// src/modules/guards/client-ip.ts. It used to be duplicated here and in
-// rate-limit-shared.ts, and the duplication was the recurrence mechanism.
-function getClientIp(request: NextRequest): string {
-  return clientIp(request.headers);
-}
+/**
+ * The middleware composition root — KAN-415 D4 C8.
+ *
+ * ⚠️ THIS FILE HAS NO FUNCTION BODY, AND THAT IS THE POINT.
+ *
+ * It reads the environment, and wires that reader to the access pipeline. The
+ * request path itself lives in src/modules/access/pipeline.ts as an ordered
+ * list of named gates, each in its own file with its own reasoning.
+ *
+ * Through D5-D9 the neighbouring code gets rewritten repeatedly, and the
+ * cheapest way to "just handle one more case" would be to open this file and
+ * insert `if (x) return y;` above the pipeline. Every ordering test would still
+ * pass — the gates would still run in order, they would simply no longer be the
+ * only thing that runs. With no body there is nowhere to put it, and adding one
+ * is a visible structural change rather than a one-line edit.
+ *
+ * WHAT USED TO BE HERE: 326 lines doing six unrelated jobs, two sequential
+ * `profiles` reads, and two overlapping inline exemption arrays. The gate ORDER
+ * and the fail-open/fail-closed asymmetry were behavioural contracts with no
+ * test at all — that is why D4 began by writing 61 characterisation assertions
+ * and only then moved anything.
+ *
+ * WHERE THINGS WENT:
+ *   the gates            src/modules/access/gates/*.ts
+ *   their order          src/modules/access/pipeline.ts (PRE_AUTH_ORDER, AUTHED_ORDER)
+ *   path exemptions      src/modules/access/exemptions.ts (one declarative table)
+ *   the SEC-36 surface   src/modules/access/oauth-server-paths.ts (an INCLUSION set,
+ *                        deliberately NOT in the exemption table — see its header)
+ *   session + cookies    src/modules/access/session.ts
+ *   the CSP nonce        src/modules/access/csp.ts
+ */
+import { createAccessMiddleware } from '@/modules/access/pipeline';
+import type { MiddlewareEnvRaw } from '@/modules/access/context';
 
 /**
  * The seven env reads, in one place, as data.
@@ -33,7 +39,8 @@ function getClientIp(request: NextRequest): string {
  * (env-access-baseline.json) records `src/middleware.ts` with exactly these
  * seven variables; relocating the reads would change that baseline without
  * changing anything about what is actually read. Handing the values on as a
- * plain object also makes every consumer testable without the ambient environment.
+ * plain object also makes every consumer testable without the ambient
+ * environment.
  */
 function readMiddlewareEnv(): MiddlewareEnvRaw {
   return {
@@ -47,68 +54,7 @@ function readMiddlewareEnv(): MiddlewareEnvRaw {
   };
 }
 
-export async function middleware(request: NextRequest) {
-  const pathname = request.nextUrl.pathname;
-  const deploy = buildDeployContext(readMiddlewareEnv());
-
-  // Lazy on purpose: the SEC-36 404 below returns before any document is
-  // served and must not pay for a nonce it will never use. A getRandomValues
-  // spy in middleware-response-contract.test.ts asserts exactly that.
-  let cspCache: string | undefined;
-  const csp = (): string => {
-    if (cspCache === undefined) cspCache = buildCspReportOnly(generateCspNonce());
-    return cspCache;
-  };
-
-  // ── PRE-AUTHENTICATION GATES ───────────────────────────────────────────
-  // Three gates, in an order that is behaviour rather than style: the SEC-36
-  // beta-OAuth 404 must not be reachable by staying under a rate limit and must
-  // not depend on auth state; the PKCE redirect must precede anything that
-  // could bounce a user mid-exchange. Each carries its own reasoning in
-  // src/modules/access/gates/, and the order is asserted from the outside in
-  // tests/unit/middleware-gate-order.test.ts.
-  //
-  // They run against an EdgeContext, which has no `user` and no Supabase
-  // client — so "check the user first" is not an edit that can be written here.
-  const edge = createEdgeContext(request, deploy, csp);
-  const preAuth = await runGates(PRE_AUTH_PIPELINE, edge);
-  if (preAuth !== null) return preAuth;
-
-  // Skip Supabase auth if env vars not configured
-  const supabaseUrl = deploy.supabaseUrl;
-  const supabaseAnonKey = deploy.supabaseAnonKey;
-
-  if (!supabaseUrl || !supabaseAnonKey) {
-    return stampCspReportOnly(NextResponse.next(), csp());
-  }
-
-  // ── THE SESSION BOUNDARY ───────────────────────────────────────────────
-  // Not a gate, deliberately: it is a precondition of the authed pipeline
-  // existing at all, and modelling it as a gate would place it in an ordered
-  // list where it could be moved. Everything above this line runs without
-  // knowing who is asking; everything below may.
-  const { supabase, user, res } = await establishSession(
-    request,
-    supabaseUrl,
-    supabaseAnonKey,
-  );
-  // Read `res.current` at the point of RETURN, never captured here — the cookie
-  // callback rebuilds it during getUser(). See session.ts.
-
-  // ── AUTHED GATES ───────────────────────────────────────────────────────
-  // Five gates, in an order that is behaviour rather than style: admin-host
-  // returns early so an operator whose own profile is not `live` still reaches
-  // the console; suspension precedes beta-tier so a suspended user lands on
-  // /suspended rather than /waitlist. Each gate carries its own reasoning in
-  // src/modules/access/gates/, and every ordering is asserted from the outside
-  // in tests/unit/middleware-gate-order.test.ts.
-  const authed: AuthedContext = { ...edge, supabase, user, res };
-  const authedOutcome = await runGates(AUTHED_PIPELINE, authed);
-  if (authedOutcome !== null) return authedOutcome;
-
-
-  return stampCspReportOnly(res.current, csp());
-}
+export const middleware = createAccessMiddleware(readMiddlewareEnv);
 
 export const config = {
   matcher: [

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -13,6 +13,8 @@ import {
 import { isExemptFrom } from '@/modules/access/exemptions';
 import { isOauthServerPath } from '@/modules/access/oauth-server-paths';
 import { runGates } from '@/modules/access/gate';
+import { betaTier } from '@/modules/access/gates/beta-tier';
+import { suspension } from '@/modules/access/gates/suspension';
 import { establishSession } from '@/modules/access/session';
 import { PRE_AUTH_PIPELINE } from '@/modules/access/pipeline';
 import { clientIp } from '@/modules/guards/client-ip';
@@ -143,71 +145,13 @@ export async function middleware(request: NextRequest) {
     }
   }
 
-  // KAN-319: suspended-user gate (all deploys). A suspended user's public
-  // profile is already hidden by RLS; this also blocks their own use of the app
-  // and sends them to /suspended with an appeal route. Runs before the beta gate
-  // so a suspended user lands on /suspended, not /waitlist. Exempts the
-  // suspended page itself + the auth/logout flow + assets to avoid loops.
-  const suspensionExempt = isExemptFrom('suspension', pathname);
-  if (user && !suspensionExempt) {
-    const { data: suspProfile, error: suspErr } = await supabase
-      .from('profiles')
-      .select('is_suspended')
-      .eq('user_id', user.id)
-      .maybeSingle();
-    // Observability: never fail silently on a lookup error. We fail OPEN here
-    // (let the request proceed) rather than closed, because a suspended user's
-    // public exposure is already prevented at the data tier by RLS
-    // (published-and-not-suspended), so this gate only governs their own
-    // session — and failing closed on a transient profiles-read error would
-    // wrongly lock out the whole authenticated userbase.
-    if (suspErr) {
-      console.error('[middleware] suspension lookup failed (failing open):', suspErr.message);
-    }
-    if (suspProfile?.is_suspended) {
-      const url = request.nextUrl.clone();
-      url.pathname = '/suspended';
-      url.search = '';
-      return NextResponse.redirect(url);
-    }
-  }
-
-  // KAN-326: tier-aware access gate. Active on the "prod family" — the beta
-  // deploy (IS_BETA_DEPLOY=true, tier 'beta') and the real production deploy
-  // (checklyra.com, tier 'prod'). Dev/stage are single full envs (deployTier
-  // null) and are not gated here. An authenticated user is:
-  //   - not live          -> sent to /waitlist
-  //   - live, wrong tier  -> sent to their tier's site (beta <-> prod), so a
-  //                          promoted user always lands on the right site
-  //                          (sessions carry via the shared .checklyra.com cookie).
-  // The /waitlist page itself + auth pages are exempt to avoid redirect loops.
-  const deployTier = deploy.deployTier;
-  const exemptFromBetaGate = isExemptFrom('beta-tier', pathname);
-
-  if (deployTier && user && !exemptFromBetaGate) {
-    const { data: profile } = await supabase
-      .from('profiles')
-      .select('user_status, access_tier')
-      .eq('user_id', user.id)
-      .maybeSingle();
-
-    if (profile?.user_status !== 'live') {
-      const url = request.nextUrl.clone();
-      url.pathname = '/waitlist';
-      url.search = '';
-      return NextResponse.redirect(url);
-    }
-    if (profile.access_tier !== deployTier) {
-      // Live user on the wrong site — move them to their tier's host, keeping path.
-      const targetHost =
-        profile.access_tier === 'prod'
-          ? 'https://checklyra.com'
-          : 'https://beta.checklyra.com';
-      return NextResponse.redirect(
-        new URL(`${targetHost}${pathname}${request.nextUrl.search}`),
-      );
-    }
-  }
+  // ── AUTHED GATES (partial — the remaining three land in C7) ────────────
+  // suspension BEFORE beta-tier, so a suspended user lands on /suspended
+  // rather than /waitlist. Each gate carries its own reasoning; the ORDER is
+  // asserted from the outside in middleware-gate-order.test.ts.
+  const authed = { ...edge, supabase, user, res };
+  const authedOutcome = await runGates([suspension, betaTier], authed);
+  if (authedOutcome !== null) return authedOutcome;
 
   // Redirect unauthenticated users away from protected routes
   if (!user && request.nextUrl.pathname.startsWith('/dashboard')) {

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -4,6 +4,8 @@ import { rateLimit, RATE_LIMITS } from '@/modules/guards/rate-limit';
 import { withParentCookieDomain } from '@/modules/platform/cookie-domain';
 import { cfAccessEnabled, verifyCfAccessToken } from '@/modules/guards/cf-access';
 import { buildCspReportOnly } from '@/modules/guards/security-headers';
+import { generateCspNonce, stampCspReportOnly } from '@/modules/access/csp';
+import { buildDeployContext, type MiddlewareEnvRaw } from '@/modules/access/context';
 import { clientIp } from '@/modules/guards/client-ip';
 
 // SEC-120: the precedence rule lives in ONE place now — see
@@ -11,28 +13,6 @@ import { clientIp } from '@/modules/guards/client-ip';
 // rate-limit-shared.ts, and the duplication was the recurrence mechanism.
 function getClientIp(request: NextRequest): string {
   return clientIp(request.headers);
-}
-
-// SEC-63: per-request CSP nonce, base64 of 16 random bytes. Edge runtime
-// provides Web Crypto (crypto.getRandomValues) + btoa globally.
-function generateCspNonce(): string {
-  const bytes = new Uint8Array(16);
-  crypto.getRandomValues(bytes);
-  let bin = '';
-  for (const b of bytes) bin += String.fromCharCode(b);
-  return btoa(bin);
-}
-
-// SEC-63: stamp the staged nonce CSP as Report-Only on a document response.
-// Report-Only NEVER blocks — browsers only surface violations — so this is a
-// zero-risk observation step ahead of enforcing the nonce policy (the follow-up
-// SEC-63 leg, which also wires the nonce into first-party scripts + flips to
-// the enforced `Content-Security-Policy` header + adds a deploy-time header
-// smoke). Applied only to document-serving responses; redirects/JSON errors
-// don't need a CSP.
-function stampCspReportOnly(res: NextResponse, csp: string): NextResponse {
-  res.headers.set('Content-Security-Policy-Report-Only', csp);
-  return res;
 }
 
 /**
@@ -52,8 +32,39 @@ function isOauthServerPath(pathname: string): boolean {
   );
 }
 
+/**
+ * The seven env reads, in one place, as data.
+ *
+ * They stay in THIS file deliberately. CTL-037's baseline
+ * (env-access-baseline.json) records `src/middleware.ts` with exactly these
+ * seven variables; relocating the reads would change that baseline without
+ * changing anything about what is actually read. Handing the values on as a
+ * plain object also makes every consumer testable without the ambient environment.
+ */
+function readMiddlewareEnv(): MiddlewareEnvRaw {
+  return {
+    IS_BETA_DEPLOY: process.env.IS_BETA_DEPLOY,
+    NEXT_PUBLIC_SITE_URL: process.env.NEXT_PUBLIC_SITE_URL,
+    VERCEL_ENV: process.env.VERCEL_ENV,
+    ADMIN_HOST: process.env.ADMIN_HOST,
+    ADMIN_HOST_ENFORCED: process.env.ADMIN_HOST_ENFORCED,
+    NEXT_PUBLIC_SUPABASE_URL: process.env.NEXT_PUBLIC_SUPABASE_URL,
+    NEXT_PUBLIC_SUPABASE_ANON_KEY: process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY,
+  };
+}
+
 export async function middleware(request: NextRequest) {
   const pathname = request.nextUrl.pathname;
+  const deploy = buildDeployContext(readMiddlewareEnv());
+
+  // Lazy on purpose: the SEC-36 404 below returns before any document is
+  // served and must not pay for a nonce it will never use. A getRandomValues
+  // spy in middleware-response-contract.test.ts asserts exactly that.
+  let cspCache: string | undefined;
+  const csp = (): string => {
+    if (cspCache === undefined) cspCache = buildCspReportOnly(generateCspNonce());
+    return cspCache;
+  };
 
   // ---------------------------------------------------------------------
   // SEC-36: beta has no OAuth authorization server. Turn it OFF, don't key it.
@@ -79,20 +90,17 @@ export async function middleware(request: NextRequest) {
   // further down CANNOT reach because that one only runs for authenticated
   // requests.
   // ---------------------------------------------------------------------
-  if (process.env.IS_BETA_DEPLOY === 'true' && isOauthServerPath(pathname)) {
+  if (deploy.isBetaDeploy && isOauthServerPath(pathname)) {
     return new NextResponse(null, { status: 404 });
   }
 
-  // SEC-63: derive a per-request nonce + the Report-Only nonce CSP once, then
-  // stamp it on each document-serving response before it returns.
-  const cspReportOnly = buildCspReportOnly(generateCspNonce());
 
   // KAN-309: admin.checklyra.com host routing. Enforced only when
   // ADMIN_HOST_ENFORCED=true (set on prod once the DNS + Cloudflare Access app
   // are live) — until then /admin keeps working on every host, so shipping this
   // code is non-breaking.
-  const adminHost = process.env.ADMIN_HOST ?? 'admin.checklyra.com';
-  const adminHostEnforced = process.env.ADMIN_HOST_ENFORCED === 'true';
+  const adminHost = deploy.adminHost;
+  const adminHostEnforced = deploy.adminHostEnforced;
   const requestHost =
     request.headers.get('host') ?? request.headers.get('x-forwarded-host') ?? '';
   const isAdminHost = requestHost === adminHost;
@@ -128,11 +136,11 @@ export async function middleware(request: NextRequest) {
   }
 
   // Skip Supabase auth if env vars not configured
-  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
-  const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+  const supabaseUrl = deploy.supabaseUrl;
+  const supabaseAnonKey = deploy.supabaseAnonKey;
 
   if (!supabaseUrl || !supabaseAnonKey) {
-    return stampCspReportOnly(NextResponse.next(), cspReportOnly);
+    return stampCspReportOnly(NextResponse.next(), csp());
   }
 
   let supabaseResponse = NextResponse.next({
@@ -193,11 +201,11 @@ export async function middleware(request: NextRequest) {
         url.pathname = '/admin' + (pathname === '/' ? '' : pathname);
         const rewrite = NextResponse.rewrite(url);
         supabaseResponse.cookies.getAll().forEach((c) => rewrite.cookies.set(c));
-        return stampCspReportOnly(rewrite, cspReportOnly);
+        return stampCspReportOnly(rewrite, csp());
       }
       // Already an /admin path (or passthrough) — serve it, and crucially skip
       // the beta gate below so an admin isn't bounced to /waitlist.
-      return stampCspReportOnly(supabaseResponse, cspReportOnly);
+      return stampCspReportOnly(supabaseResponse, csp());
     }
     // Any non-admin host must never serve /admin — send it to the subdomain.
     if (pathname.startsWith('/admin')) {
@@ -250,15 +258,7 @@ export async function middleware(request: NextRequest) {
   //                          promoted user always lands on the right site
   //                          (sessions carry via the shared .checklyra.com cookie).
   // The /waitlist page itself + auth pages are exempt to avoid redirect loops.
-  const isBetaDeploy = process.env.IS_BETA_DEPLOY === 'true';
-  const isProdSite =
-    process.env.NEXT_PUBLIC_SITE_URL === 'https://checklyra.com' &&
-    process.env.VERCEL_ENV === 'production';
-  const deployTier: 'beta' | 'prod' | null = isBetaDeploy
-    ? 'beta'
-    : isProdSite
-      ? 'prod'
-      : null;
+  const deployTier = deploy.deployTier;
   const exemptFromBetaGate =
     pathname === '/waitlist' ||
     pathname === '/suspended' || // KAN-319: suspended users land here, not /waitlist
@@ -316,7 +316,7 @@ export async function middleware(request: NextRequest) {
     return NextResponse.redirect(url);
   }
 
-  return stampCspReportOnly(supabaseResponse, cspReportOnly);
+  return stampCspReportOnly(supabaseResponse, csp());
 }
 
 export const config = {

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -5,7 +5,13 @@ import { withParentCookieDomain } from '@/modules/platform/cookie-domain';
 import { cfAccessEnabled, verifyCfAccessToken } from '@/modules/guards/cf-access';
 import { buildCspReportOnly } from '@/modules/guards/security-headers';
 import { generateCspNonce, stampCspReportOnly } from '@/modules/access/csp';
-import { buildDeployContext, type MiddlewareEnvRaw } from '@/modules/access/context';
+import {
+  buildDeployContext,
+  createEdgeContext,
+  type MiddlewareEnvRaw,
+} from '@/modules/access/context';
+import { runGates } from '@/modules/access/gate';
+import { PRE_AUTH_PIPELINE } from '@/modules/access/pipeline';
 import { clientIp } from '@/modules/guards/client-ip';
 
 // SEC-120: the precedence rule lives in ONE place now — see
@@ -66,74 +72,29 @@ export async function middleware(request: NextRequest) {
     return cspCache;
   };
 
-  // ---------------------------------------------------------------------
-  // SEC-36: beta has no OAuth authorization server. Turn it OFF, don't key it.
+  // ── PRE-AUTHENTICATION GATES ───────────────────────────────────────────
+  // Three gates, in an order that is behaviour rather than style: the SEC-36
+  // beta-OAuth 404 must not be reachable by staying under a rate limit and must
+  // not depend on auth state; the PKCE redirect must precede anything that
+  // could bounce a user mid-exchange. Each carries its own reasoning in
+  // src/modules/access/gates/, and the order is asserted from the outside in
+  // tests/unit/middleware-gate-order.test.ts.
   //
-  // Beta advertised ITSELF as the issuer and answered on /oauth/token,
-  // /register and /revoke, while /.well-known/jwks.json returned 500 — it has
-  // no RS256 keypair on the beta scope and never has. Verified 2026-08-09:
-  // NOTHING points at it. Both resource servers derive the AS from
-  // LYRA_SITE_URL — prod MCP leaves it unset (defaults to checklyra.com) and
-  // dev MCP sets dev.checklyra.com. That is the "confirm unused" question
-  // SEC-36 asked in June, answered with evidence.
-  //
-  // Giving beta a keypair would have been the WRONG fix. Beta runs on the
-  // PRODUCTION Supabase project (gotcha #19), so a working beta AS would mint
-  // tokens whose `sub` is a real production user and write jti rows into
-  // production's oauth_access_tokens — a token factory for production
-  // identities in the deliberately less-hardened environment, separated from
-  // prod only by an `iss` string comparison in the verifier.
-  //
-  // 404, not 403: beta genuinely has no authorization server, and that is what
-  // a client should discover. It also closes the unauthenticated DCR write
-  // into production's oauth_clients via /oauth/register, which the beta gate
-  // further down CANNOT reach because that one only runs for authenticated
-  // requests.
-  // ---------------------------------------------------------------------
-  if (deploy.isBetaDeploy && isOauthServerPath(pathname)) {
-    return new NextResponse(null, { status: 404 });
-  }
-
-
-  // KAN-309: admin.checklyra.com host routing. Enforced only when
-  // ADMIN_HOST_ENFORCED=true (set on prod once the DNS + Cloudflare Access app
-  // are live) — until then /admin keeps working on every host, so shipping this
-  // code is non-breaking.
+  // They run against an EdgeContext, which has no `user` and no Supabase
+  // client — so "check the user first" is not an edit that can be written here.
+  // KAN-309 / SEC-34 / SEC-37 admin-host facts. Derived here rather than in a
+  // gate because three later blocks read them; they move with the admin gate in
+  // C7. `cfEnabled` is inert until CF_ACCESS_* are configured.
   const adminHost = deploy.adminHost;
   const adminHostEnforced = deploy.adminHostEnforced;
   const requestHost =
     request.headers.get('host') ?? request.headers.get('x-forwarded-host') ?? '';
   const isAdminHost = requestHost === adminHost;
-  // SEC-34/SEC-37: app-layer Cloudflare Access verification is enforced once
-  // CF_ACCESS_TEAM_DOMAIN + CF_ACCESS_AUD are set (inert before that).
   const cfEnabled = cfAccessEnabled();
 
-  // Supabase PKCE: redirect code param to /auth/callback for session exchange
-  const code = request.nextUrl.searchParams.get('code');
-  if (code && pathname === '/') {
-    const url = request.nextUrl.clone();
-    url.pathname = '/auth/callback';
-    return NextResponse.redirect(url);
-  }
-
-  // Rate limit auth endpoints (login, signup, auth callback)
-  if (
-    pathname === '/login' ||
-    pathname === '/signup' ||
-    pathname.startsWith('/auth/')
-  ) {
-    // Only rate limit POST requests (form submissions)
-    if (request.method === 'POST') {
-      const ip = getClientIp(request);
-      const { limited, retryAfter } = rateLimit(`auth:${ip}`, RATE_LIMITS.auth);
-      if (limited) {
-        return NextResponse.json(
-          { error: 'Too many attempts. Please try again later.' },
-          { status: 429, headers: { 'Retry-After': String(retryAfter) } }
-        );
-      }
-    }
-  }
+  const edge = createEdgeContext(request, deploy, csp);
+  const preAuth = await runGates(PRE_AUTH_PIPELINE, edge);
+  if (preAuth !== null) return preAuth;
 
   // Skip Supabase auth if env vars not configured
   const supabaseUrl = deploy.supabaseUrl;

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -2,12 +2,12 @@ import { createServerClient } from '@supabase/ssr';
 import { NextResponse, type NextRequest } from 'next/server';
 import { rateLimit, RATE_LIMITS } from '@/modules/guards/rate-limit';
 import { withParentCookieDomain } from '@/modules/platform/cookie-domain';
-import { cfAccessEnabled, verifyCfAccessToken } from '@/modules/guards/cf-access';
 import { buildCspReportOnly } from '@/modules/guards/security-headers';
 import { generateCspNonce, stampCspReportOnly } from '@/modules/access/csp';
 import {
   buildDeployContext,
   createEdgeContext,
+  type AuthedContext,
   type MiddlewareEnvRaw,
 } from '@/modules/access/context';
 import { isExemptFrom } from '@/modules/access/exemptions';
@@ -16,7 +16,7 @@ import { runGates } from '@/modules/access/gate';
 import { betaTier } from '@/modules/access/gates/beta-tier';
 import { suspension } from '@/modules/access/gates/suspension';
 import { establishSession } from '@/modules/access/session';
-import { PRE_AUTH_PIPELINE } from '@/modules/access/pipeline';
+import { AUTHED_PIPELINE, PRE_AUTH_PIPELINE } from '@/modules/access/pipeline';
 import { clientIp } from '@/modules/guards/client-ip';
 
 // SEC-120: the precedence rule lives in ONE place now — see
@@ -70,16 +70,6 @@ export async function middleware(request: NextRequest) {
   //
   // They run against an EdgeContext, which has no `user` and no Supabase
   // client — so "check the user first" is not an edit that can be written here.
-  // KAN-309 / SEC-34 / SEC-37 admin-host facts. Derived here rather than in a
-  // gate because three later blocks read them; they move with the admin gate in
-  // C7. `cfEnabled` is inert until CF_ACCESS_* are configured.
-  const adminHost = deploy.adminHost;
-  const adminHostEnforced = deploy.adminHostEnforced;
-  const requestHost =
-    request.headers.get('host') ?? request.headers.get('x-forwarded-host') ?? '';
-  const isAdminHost = requestHost === adminHost;
-  const cfEnabled = cfAccessEnabled();
-
   const edge = createEdgeContext(request, deploy, csp);
   const preAuth = await runGates(PRE_AUTH_PIPELINE, edge);
   if (preAuth !== null) return preAuth;
@@ -105,73 +95,17 @@ export async function middleware(request: NextRequest) {
   // Read `res.current` at the point of RETURN, never captured here — the cookie
   // callback rebuilds it during getUser(). See session.ts.
 
-  // KAN-309 / SEC-37: route the admin tools to the admin subdomain, and verify
-  // Cloudflare Access on the admin host. Isolation applies when
-  // ADMIN_HOST_ENFORCED=true OR CF Access is configured — so enabling CF Access
-  // can never leave /admin reachable on a public host by forgetting a flag.
-  if (adminHostEnforced || cfEnabled) {
-    if (isAdminHost) {
-      // SEC-34/SEC-37: every request reaching the admin host must carry a valid
-      // Cloudflare Access JWT — this rejects anything that hit the origin
-      // without transiting the CF edge (leaked preview URL, spoofed Host,
-      // direct origin). Inert (allows all) until CF_ACCESS_* are configured.
-      if (
-        cfEnabled &&
-        !(await verifyCfAccessToken(request.headers.get('cf-access-jwt-assertion')))
-      ) {
-        return new NextResponse('Forbidden: Cloudflare Access required.', {
-          status: 403,
-        });
-      }
-      // Let the auth/login flow, API routes and assets pass through unchanged.
-      const passthrough = isExemptFrom('admin-passthrough', pathname);
-      if (!passthrough && !pathname.startsWith('/admin')) {
-        // admin.checklyra.com/users → /admin/users, carrying refreshed cookies.
-        const url = request.nextUrl.clone();
-        url.pathname = '/admin' + (pathname === '/' ? '' : pathname);
-        const rewrite = NextResponse.rewrite(url);
-        res.current.cookies.getAll().forEach((c) => rewrite.cookies.set(c));
-        return stampCspReportOnly(rewrite, csp());
-      }
-      // Already an /admin path (or passthrough) — serve it, and crucially skip
-      // the beta gate below so an admin isn't bounced to /waitlist.
-      return stampCspReportOnly(res.current, csp());
-    }
-    // Any non-admin host must never serve /admin — send it to the subdomain.
-    if (pathname.startsWith('/admin')) {
-      return NextResponse.redirect(
-        new URL(`https://${adminHost}${pathname}${request.nextUrl.search}`),
-      );
-    }
-  }
-
-  // ── AUTHED GATES (partial — the remaining three land in C7) ────────────
-  // suspension BEFORE beta-tier, so a suspended user lands on /suspended
-  // rather than /waitlist. Each gate carries its own reasoning; the ORDER is
-  // asserted from the outside in middleware-gate-order.test.ts.
-  const authed = { ...edge, supabase, user, res };
-  const authedOutcome = await runGates([suspension, betaTier], authed);
+  // ── AUTHED GATES ───────────────────────────────────────────────────────
+  // Five gates, in an order that is behaviour rather than style: admin-host
+  // returns early so an operator whose own profile is not `live` still reaches
+  // the console; suspension precedes beta-tier so a suspended user lands on
+  // /suspended rather than /waitlist. Each gate carries its own reasoning in
+  // src/modules/access/gates/, and every ordering is asserted from the outside
+  // in tests/unit/middleware-gate-order.test.ts.
+  const authed: AuthedContext = { ...edge, supabase, user, res };
+  const authedOutcome = await runGates(AUTHED_PIPELINE, authed);
   if (authedOutcome !== null) return authedOutcome;
 
-  // Redirect unauthenticated users away from protected routes
-  if (!user && request.nextUrl.pathname.startsWith('/dashboard')) {
-    const url = request.nextUrl.clone();
-    url.pathname = '/login';
-    return NextResponse.redirect(url);
-  }
-
-  // Redirect authenticated users away from auth pages
-  if (
-    user &&
-    (request.nextUrl.pathname === '/login' ||
-      request.nextUrl.pathname === '/signup')
-  ) {
-    const url = request.nextUrl.clone();
-    // KAN-175: on beta, ineligible users belong at /waitlist, not /dashboard.
-    // The dashboard redirect would just bounce them through the beta gate again.
-    url.pathname = '/dashboard';
-    return NextResponse.redirect(url);
-  }
 
   return stampCspReportOnly(res.current, csp());
 }

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -10,6 +10,8 @@ import {
   createEdgeContext,
   type MiddlewareEnvRaw,
 } from '@/modules/access/context';
+import { isExemptFrom } from '@/modules/access/exemptions';
+import { isOauthServerPath } from '@/modules/access/oauth-server-paths';
 import { runGates } from '@/modules/access/gate';
 import { PRE_AUTH_PIPELINE } from '@/modules/access/pipeline';
 import { clientIp } from '@/modules/guards/client-ip';
@@ -19,23 +21,6 @@ import { clientIp } from '@/modules/guards/client-ip';
 // rate-limit-shared.ts, and the duplication was the recurrence mechanism.
 function getClientIp(request: NextRequest): string {
   return clientIp(request.headers);
-}
-
-/**
- * Paths that make up the OAuth authorization server surface (SEC-36).
- *
- * Both the public `/.well-known/*` paths and the internal `/api/well-known/*`
- * they rewrite to are listed. Middleware sees the public path, but the rewrite
- * targets are directly addressable too, so gating only one half would leave a
- * back door.
- */
-function isOauthServerPath(pathname: string): boolean {
-  return (
-    pathname.startsWith('/oauth/') ||
-    pathname === '/.well-known/oauth-authorization-server' ||
-    pathname === '/.well-known/jwks.json' ||
-    pathname.startsWith('/api/well-known/')
-  );
 }
 
 /**
@@ -151,11 +136,7 @@ export async function middleware(request: NextRequest) {
         });
       }
       // Let the auth/login flow, API routes and assets pass through unchanged.
-      const passthrough =
-        pathname === '/login' ||
-        pathname.startsWith('/auth/') ||
-        pathname.startsWith('/api/') ||
-        pathname.startsWith('/_next/');
+      const passthrough = isExemptFrom('admin-passthrough', pathname);
       if (!passthrough && !pathname.startsWith('/admin')) {
         // admin.checklyra.com/users → /admin/users, carrying refreshed cookies.
         const url = request.nextUrl.clone();
@@ -181,12 +162,7 @@ export async function middleware(request: NextRequest) {
   // and sends them to /suspended with an appeal route. Runs before the beta gate
   // so a suspended user lands on /suspended, not /waitlist. Exempts the
   // suspended page itself + the auth/logout flow + assets to avoid loops.
-  const suspensionExempt =
-    pathname === '/suspended' ||
-    pathname === '/login' ||
-    pathname.startsWith('/auth/') ||
-    pathname.startsWith('/_next/') ||
-    pathname === '/favicon.ico';
+  const suspensionExempt = isExemptFrom('suspension', pathname);
   if (user && !suspensionExempt) {
     const { data: suspProfile, error: suspErr } = await supabase
       .from('profiles')
@@ -220,17 +196,7 @@ export async function middleware(request: NextRequest) {
   //                          (sessions carry via the shared .checklyra.com cookie).
   // The /waitlist page itself + auth pages are exempt to avoid redirect loops.
   const deployTier = deploy.deployTier;
-  const exemptFromBetaGate =
-    pathname === '/waitlist' ||
-    pathname === '/suspended' || // KAN-319: suspended users land here, not /waitlist
-    pathname === '/status' || // SEC-4: public status page is never beta-gated
-    pathname === '/login' ||
-    pathname === '/signup' ||
-    pathname === '/join' || // KAN-337: beta-invite deep-link sets a cookie + redirects to /signup
-    pathname === '/confirm-age' || // 18+ declaration: ask before the waitlist bounce, not after
-    pathname.startsWith('/auth/') ||
-    pathname.startsWith('/_next/') ||
-    pathname === '/favicon.ico';
+  const exemptFromBetaGate = isExemptFrom('beta-tier', pathname);
 
   if (deployTier && user && !exemptFromBetaGate) {
     const { data: profile } = await supabase

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -13,6 +13,7 @@ import {
 import { isExemptFrom } from '@/modules/access/exemptions';
 import { isOauthServerPath } from '@/modules/access/oauth-server-paths';
 import { runGates } from '@/modules/access/gate';
+import { establishSession } from '@/modules/access/session';
 import { PRE_AUTH_PIPELINE } from '@/modules/access/pipeline';
 import { clientIp } from '@/modules/guards/client-ip';
 
@@ -89,33 +90,18 @@ export async function middleware(request: NextRequest) {
     return stampCspReportOnly(NextResponse.next(), csp());
   }
 
-  let supabaseResponse = NextResponse.next({
+  // ── THE SESSION BOUNDARY ───────────────────────────────────────────────
+  // Not a gate, deliberately: it is a precondition of the authed pipeline
+  // existing at all, and modelling it as a gate would place it in an ordered
+  // list where it could be moved. Everything above this line runs without
+  // knowing who is asking; everything below may.
+  const { supabase, user, res } = await establishSession(
     request,
-  });
-
-  const supabase = createServerClient(supabaseUrl, supabaseAnonKey, {
-    cookies: {
-      getAll() {
-        return request.cookies.getAll();
-      },
-      setAll(cookiesToSet) {
-        cookiesToSet.forEach(({ name, value }) =>
-          request.cookies.set(name, value)
-        );
-        supabaseResponse = NextResponse.next({
-          request,
-        });
-        cookiesToSet.forEach(({ name, value, options }) =>
-          supabaseResponse.cookies.set(name, value, withParentCookieDomain(options))
-        );
-      },
-    },
-  });
-
-  // Refresh the session — this is critical for server-side auth
-  const {
-    data: { user },
-  } = await supabase.auth.getUser();
+    supabaseUrl,
+    supabaseAnonKey,
+  );
+  // Read `res.current` at the point of RETURN, never captured here — the cookie
+  // callback rebuilds it during getUser(). See session.ts.
 
   // KAN-309 / SEC-37: route the admin tools to the admin subdomain, and verify
   // Cloudflare Access on the admin host. Isolation applies when
@@ -142,12 +128,12 @@ export async function middleware(request: NextRequest) {
         const url = request.nextUrl.clone();
         url.pathname = '/admin' + (pathname === '/' ? '' : pathname);
         const rewrite = NextResponse.rewrite(url);
-        supabaseResponse.cookies.getAll().forEach((c) => rewrite.cookies.set(c));
+        res.current.cookies.getAll().forEach((c) => rewrite.cookies.set(c));
         return stampCspReportOnly(rewrite, csp());
       }
       // Already an /admin path (or passthrough) — serve it, and crucially skip
       // the beta gate below so an admin isn't bounced to /waitlist.
-      return stampCspReportOnly(supabaseResponse, csp());
+      return stampCspReportOnly(res.current, csp());
     }
     // Any non-admin host must never serve /admin — send it to the subdomain.
     if (pathname.startsWith('/admin')) {
@@ -243,7 +229,7 @@ export async function middleware(request: NextRequest) {
     return NextResponse.redirect(url);
   }
 
-  return stampCspReportOnly(supabaseResponse, csp());
+  return stampCspReportOnly(res.current, csp());
 }
 
 export const config = {

--- a/src/modules/access/context.ts
+++ b/src/modules/access/context.ts
@@ -1,0 +1,146 @@
+/**
+ * The request context the access gates run against — KAN-415 D4.
+ *
+ * TWO CONTEXTS, AND THE SPLIT IS THE POINT
+ * ----------------------------------------
+ * `EdgeContext` has no `user` and no `supabase` client. Not because those are
+ * inconvenient to thread, but because a gate that must run BEFORE authentication
+ * should be unable to reach auth state at all.
+ *
+ * SEC-36's beta-OAuth 404 is the reason this matters. It exists to close an
+ * unauthenticated DCR write into PRODUCTION's oauth_clients (beta runs on the
+ * prod Supabase project, gotcha #19), so it must answer identically whether or
+ * not anyone is signed in. Handing it a `user` field would make "check the user
+ * first" a one-line edit that type-checks. Not handing it one makes that edit
+ * impossible to write.
+ *
+ * `AuthedContext` extends it with the client, the user, and the live response
+ * handle. Gates typed against it cannot be placed in the pre-auth pipeline —
+ * see gate.ts for how the type system is made to enforce that rather than
+ * merely document it.
+ *
+ * WHY `res` IS A HANDLE AND NOT A VALUE
+ * ------------------------------------
+ * `{ current: NextResponse }`, read at the moment of return, never captured
+ * earlier. @supabase/ssr rotates the session DURING getUser and calls the
+ * `setAll` cookie callback from inside it; that callback REBUILDS the response
+ * object. Anything holding the earlier instance returns a response without the
+ * refreshed cookie — every user logged out on token rotation, silently.
+ *
+ * That failure mode had no test at all until D4 C1; it now has one, and a
+ * mutation capturing the response by value reddens exactly it.
+ */
+import type { NextRequest, NextResponse } from 'next/server';
+
+/**
+ * The raw env slice, read ONCE per request and passed as data.
+ *
+ * The seven direct env member expressions stay in src/middleware.ts, which
+ * is what CTL-037's baseline records — it lists this file with exactly these
+ * seven variables, and moving the reads would change that baseline without
+ * changing what is read. Passing the values as data keeps the ratchet honest
+ * and makes every consumer below testable without touching process.env.
+ */
+export interface MiddlewareEnvRaw {
+  readonly IS_BETA_DEPLOY?: string;
+  readonly NEXT_PUBLIC_SITE_URL?: string;
+  readonly VERCEL_ENV?: string;
+  readonly ADMIN_HOST?: string;
+  readonly ADMIN_HOST_ENFORCED?: string;
+  readonly NEXT_PUBLIC_SUPABASE_URL?: string;
+  readonly NEXT_PUBLIC_SUPABASE_ANON_KEY?: string;
+}
+
+/** The derived deployment facts, computed once. */
+export interface DeployContext {
+  readonly isBetaDeploy: boolean;
+  /**
+   * KAN-326. The "prod family" only: the beta deploy and the real production
+   * deploy. dev and staging are single full environments and are NOT tier-gated
+   * — `null` is a meaningful third value, not a missing one.
+   */
+  readonly deployTier: 'beta' | 'prod' | null;
+  readonly adminHost: string;
+  readonly adminHostEnforced: boolean;
+  readonly supabaseUrl?: string;
+  readonly supabaseAnonKey?: string;
+}
+
+export const DEFAULT_ADMIN_HOST = 'admin.checklyra.com';
+
+/**
+ * Derived exactly as src/middleware.ts derived it inline. Transcribed, not
+ * reinterpreted — a cross-product table test asserts old === new over every
+ * combination of the three inputs that feed `deployTier`.
+ */
+export function buildDeployContext(env: MiddlewareEnvRaw): DeployContext {
+  const isBetaDeploy = env.IS_BETA_DEPLOY === 'true';
+  const isProdSite =
+    env.NEXT_PUBLIC_SITE_URL === 'https://checklyra.com' && env.VERCEL_ENV === 'production';
+  return {
+    isBetaDeploy,
+    deployTier: isBetaDeploy ? 'beta' : isProdSite ? 'prod' : null,
+    adminHost: env.ADMIN_HOST ?? DEFAULT_ADMIN_HOST,
+    adminHostEnforced: env.ADMIN_HOST_ENFORCED === 'true',
+    supabaseUrl: env.NEXT_PUBLIC_SUPABASE_URL,
+    supabaseAnonKey: env.NEXT_PUBLIC_SUPABASE_ANON_KEY,
+  };
+}
+
+/** Everything available BEFORE authentication. Deliberately no user, no client. */
+export interface EdgeContext {
+  readonly request: NextRequest;
+  readonly pathname: string;
+  readonly env: DeployContext;
+  /** Memoised. Not computed until a gate actually needs to stamp a document. */
+  csp(): string;
+}
+
+/** Everything available AFTER the session boundary. */
+export interface AuthedContext extends EdgeContext {
+  readonly supabase: SupabaseLike;
+  readonly user: { id: string } | null;
+  /** Live handle — read `.current` at the point of return, never before. */
+  readonly res: { current: NextResponse };
+}
+
+/**
+ * The narrow slice of the Supabase client the gates actually use.
+ *
+ * Deliberately structural rather than importing SupabaseClient: the gates use
+ * two methods, and a wide type here would let a future gate reach for anything
+ * on the client without that showing up as a boundary change.
+ */
+export interface SupabaseLike {
+  from(table: string): {
+    select(columns: string): {
+      eq(
+        column: string,
+        value: string,
+      ): {
+        maybeSingle(): Promise<{
+          data: Record<string, unknown> | null;
+          error: { message: string } | null;
+        }>;
+      };
+    };
+  };
+}
+
+/** Build the pre-auth context. `csp` is lazy so the SEC-36 404 pays nothing. */
+export function createEdgeContext(
+  request: NextRequest,
+  env: DeployContext,
+  buildCsp: () => string,
+): EdgeContext {
+  let cached: string | undefined;
+  return {
+    request,
+    pathname: request.nextUrl.pathname,
+    env,
+    csp() {
+      if (cached === undefined) cached = buildCsp();
+      return cached;
+    },
+  };
+}

--- a/src/modules/access/csp.ts
+++ b/src/modules/access/csp.ts
@@ -1,0 +1,36 @@
+/**
+ * SEC-63 per-request CSP nonce, lifted out of src/middleware.ts — KAN-415 D4.
+ *
+ * Moved verbatim. The only change is that callers now reach it through a
+ * memoised `ctx.csp()` rather than computing it eagerly at the top of the
+ * request, because the SEC-36 404 returns before any document is served and
+ * should not pay for a nonce it will not use. That laziness is asserted by a
+ * getRandomValues spy in middleware-response-contract.test.ts.
+ */
+
+/** base64 of 16 random bytes. The edge runtime provides Web Crypto + btoa globally. */
+export function generateCspNonce(): string {
+  const bytes = new Uint8Array(16);
+  crypto.getRandomValues(bytes);
+  let bin = '';
+  for (const b of bytes) bin += String.fromCharCode(b);
+  return btoa(bin);
+}
+
+/**
+ * Stamp the staged nonce CSP as Report-Only on a document response.
+ *
+ * Report-Only NEVER blocks — browsers only surface violations — so this is a
+ * zero-risk observation step ahead of enforcing the nonce policy (the follow-up
+ * SEC-63 leg, which also wires the nonce into first-party scripts, flips to the
+ * enforced header, and adds a deploy-time header smoke).
+ *
+ * Applied only to DOCUMENT-serving responses; redirects and JSON errors do not
+ * need a CSP. Which exits qualify is now pinned as a map in
+ * middleware-response-contract.test.ts — before that, nothing in the repo read
+ * this header off a middleware response at all.
+ */
+export function stampCspReportOnly<T extends { headers: Headers }>(res: T, csp: string): T {
+  res.headers.set('Content-Security-Policy-Report-Only', csp);
+  return res;
+}

--- a/src/modules/access/exemptions.ts
+++ b/src/modules/access/exemptions.ts
@@ -1,0 +1,140 @@
+/**
+ * THE exemption table — KAN-415 D4.
+ *
+ * src/middleware.ts carried three separate inline `||` chains asking "is this
+ * path exempt from this gate": 4 disjuncts for the admin-host passthrough, 5
+ * for the suspension gate, 10 for the beta/tier gate. They overlapped without
+ * saying so, and a path could be added to one and forgotten in another with
+ * nothing to notice.
+ *
+ * WHY EXEMPTION MAY BE DATA AND GATE ORDER MAY NOT
+ * -----------------------------------------------
+ * The next reader will reasonably ask why one programme turns one list into a
+ * declarative table and insists the other stays as control flow. The answer is
+ * a property of the two, not a preference:
+ *
+ *   Exemption is a PURE, ORDER-FREE DISJUNCTION over pathname. Reordering the
+ *   rows below cannot change any answer. So the order carries no information,
+ *   and a table loses nothing.
+ *
+ *   Gate order is NOT. Whether the suspension gate runs before the beta gate
+ *   decides whether a suspended user lands on /suspended or /waitlist, and
+ *   whether SEC-36's 404 runs before authentication decides whether an
+ *   unauthenticated caller can reach production's oauth_clients. Order there
+ *   IS the behaviour, and it stays as explicit, readable control flow.
+ *
+ * WHAT IS DELIBERATELY NOT HERE
+ * -----------------------------
+ * `isOauthServerPath` lives in ./oauth-server-paths.ts, same vocabulary, same
+ * primitive, separate export. It is an INCLUSION set — the paths SEC-36 turns
+ * OFF on beta — and folding it into a table whose column header reads "exempt
+ * from" is one careless edit away from a polarity inversion that disables the
+ * 404 closing an unauthenticated DCR write into PRODUCTION's oauth_clients
+ * (beta runs on the prod Supabase project, gotcha #19).
+ *
+ * The admin gate's own `!pathname.startsWith('/admin')` is also absent: that is
+ * "this is already an admin path", the gate's own domain rather than an
+ * exemption — and it is the literal `qa-sweep/inventory.py` derives the ADMIN
+ * prefix list from.
+ */
+import { compile, matchesAny, type CompiledMatchers, type PathMatch } from './matchers';
+
+export type ExemptGate = 'suspension' | 'beta-tier' | 'admin-passthrough';
+
+interface ExemptionRow {
+  readonly match: PathMatch;
+  readonly gates: readonly ExemptGate[];
+  readonly why: string;
+}
+
+const exact = (path: string): PathMatch => ({ kind: 'exact', path });
+const prefix = (path: string): PathMatch => ({ kind: 'prefix', path });
+
+/**
+ * Eleven rows, transcribed cell-by-cell from the three original predicates.
+ * Column totals MUST be suspension 5, beta-tier 10, admin-passthrough 4 —
+ * asserted in exemptions.test.ts against a literal copy of the originals.
+ */
+export const EXEMPTIONS: readonly ExemptionRow[] = [
+  {
+    match: exact('/suspended'),
+    gates: ['suspension', 'beta-tier'],
+    why: 'KAN-319 — the suspension redirect lands here. Exempt from both gates or it loops.',
+  },
+  {
+    match: exact('/login'),
+    gates: ['suspension', 'beta-tier', 'admin-passthrough'],
+    why: 'A suspended or non-live user must still be able to reach the login form.',
+  },
+  {
+    match: prefix('/auth/'),
+    gates: ['suspension', 'beta-tier', 'admin-passthrough'],
+    why: 'The session exchange must complete before anything can know who you are.',
+  },
+  {
+    match: prefix('/_next/'),
+    gates: ['suspension', 'beta-tier', 'admin-passthrough'],
+    why:
+      'Next.js build assets. Gating them would redirect the JS and CSS of the very ' +
+      'page a user is being sent to, so the destination renders unstyled and broken.',
+  },
+  {
+    match: exact('/favicon.ico'),
+    gates: ['suspension', 'beta-tier'],
+    why: 'Asset. The route matcher lets it through, so the gates must too.',
+  },
+  {
+    match: exact('/waitlist'),
+    gates: ['beta-tier'],
+    why:
+      "The beta gate's own destination. NOT suspension-exempt: a suspended user on " +
+      '/waitlist is still sent to /suspended, which is current behaviour.',
+  },
+  {
+    match: exact('/status'),
+    gates: ['beta-tier'],
+    why: 'SEC-4 — public status page, never beta-gated. External monitoring depends on it.',
+  },
+  {
+    match: exact('/signup'),
+    gates: ['beta-tier'],
+    why:
+      'Account creation precedes tier assignment. NOT admin-passthrough — adding it ' +
+      'there would change the admin rewrite.',
+  },
+  {
+    match: exact('/join'),
+    gates: ['beta-tier'],
+    why: 'KAN-337 — beta-invite deep link; sets a cookie and redirects to /signup.',
+  },
+  {
+    match: exact('/confirm-age'),
+    gates: ['beta-tier'],
+    why: 'The 18+ declaration is asked BEFORE the waitlist bounce, not after.',
+  },
+  {
+    match: prefix('/api/'),
+    gates: ['admin-passthrough'],
+    why: 'Admin-host passthrough only — route handlers are not pages to be rewritten.',
+  },
+];
+
+const GATES: readonly ExemptGate[] = ['suspension', 'beta-tier', 'admin-passthrough'];
+
+/** Compiled once at module load, not per request. */
+const COMPILED: Record<ExemptGate, CompiledMatchers> = GATES.reduce(
+  (acc, gate) => {
+    acc[gate] = compile(EXEMPTIONS.filter((r) => r.gates.includes(gate)).map((r) => r.match));
+    return acc;
+  },
+  {} as Record<ExemptGate, CompiledMatchers>,
+);
+
+export function isExemptFrom(gate: ExemptGate, pathname: string): boolean {
+  return matchesAny(COMPILED[gate], pathname);
+}
+
+/** Test-only introspection. Lets a test enumerate a gate's matchers without reaching into COMPILED. */
+export function exemptMatchersFor(gate: ExemptGate): readonly PathMatch[] {
+  return EXEMPTIONS.filter((r) => r.gates.includes(gate)).map((r) => r.match);
+}

--- a/src/modules/access/gate.ts
+++ b/src/modules/access/gate.ts
@@ -1,0 +1,68 @@
+/**
+ * The gate contract and the runner — KAN-415 D4.
+ *
+ * A gate answers one question about one request: "do I terminate this, and if
+ * so with what response?" `null` means continue. That is the whole protocol.
+ *
+ * ⚠️ `run` IS DECLARED AS A PROPERTY, NOT A METHOD SHORTHAND. This is
+ * load-bearing and easy to undo by accident.
+ *
+ *     readonly run: (ctx: Ctx) => GateOutcome        // property  — CONTRAVARIANT
+ *     run(ctx: Ctx): GateOutcome                     // shorthand — BIVARIANT
+ *
+ * Under `strictFunctionTypes` (tsconfig has `strict: true`) a property-declared
+ * function parameter is checked contravariantly, so `Gate<AuthedContext>` is
+ * NOT assignable to `Gate<EdgeContext>` — putting the suspension or beta-tier
+ * gate into the pre-authentication pipeline becomes a COMPILE ERROR.
+ *
+ * Written as a method shorthand, TypeScript checks parameters bivariantly for
+ * historical reasons, the assignment is accepted, and the guarantee silently
+ * evaporates while the code still reads as though it holds. Whoever "tidies"
+ * this into shorthand will not see anything break.
+ *
+ * WHY ORDER IS NOT DATA
+ * ---------------------
+ * The pipelines below are ordered arrays, and it is tempting to call that
+ * "order as data". It is not, and the distinction matters: the ARRAYS are data,
+ * but which array a gate may appear in is a TYPE, and the sequence within an
+ * array is a behavioural contract pinned by tests, not a configuration knob.
+ * See exemptions.ts for the converse — exemption genuinely is order-free data.
+ */
+import type { NextResponse } from 'next/server';
+
+/** `null` continues to the next gate. Anything else terminates the request. */
+export type GateOutcome = NextResponse | null;
+
+export interface Gate<Ctx> {
+  /** Stable identifier. Used by tests to assert the pipeline's contents and order. */
+  readonly id: string;
+  /** The ticket that explains why this gate exists at all. */
+  readonly ticket: string;
+  /** One sentence: what this gate protects, in terms of a user or an attacker. */
+  readonly why: string;
+  /** ⚠️ Property, not shorthand — see the file header. */
+  readonly run: (ctx: Ctx) => GateOutcome | Promise<GateOutcome>;
+}
+
+/**
+ * Run gates in order; the first non-null outcome wins.
+ *
+ * The thenable probe rather than a blanket `await`: most gates are synchronous
+ * (a path check, an env check), and `await` on a non-promise still schedules a
+ * microtask. This runs on EVERY request in the edge runtime, so the synchronous
+ * ones stay synchronous.
+ */
+export async function runGates<Ctx>(
+  pipeline: readonly Gate<Ctx>[],
+  ctx: Ctx,
+): Promise<GateOutcome> {
+  for (let i = 0; i < pipeline.length; i += 1) {
+    const outcome = pipeline[i].run(ctx);
+    const resolved =
+      outcome !== null && typeof (outcome as Promise<GateOutcome>)?.then === 'function'
+        ? await (outcome as Promise<GateOutcome>)
+        : (outcome as GateOutcome);
+    if (resolved !== null) return resolved;
+  }
+  return null;
+}

--- a/src/modules/access/gates/admin-host.ts
+++ b/src/modules/access/gates/admin-host.ts
@@ -1,0 +1,78 @@
+/**
+ * KAN-309 / SEC-34 / SEC-37 — admin.checklyra.com host isolation.
+ *
+ * Lifted verbatim from src/middleware.ts. Three behaviours in one gate because
+ * they are one decision — "is this request on the admin host, and is it
+ * allowed":
+ *
+ *   1. On the admin host with CF Access configured, every request must carry a
+ *      valid Cloudflare Access JWT. This rejects anything that hit the origin
+ *      without transiting the CF edge — a leaked preview URL, a spoofed Host,
+ *      a direct origin hit. Inert (allows all) until CF_ACCESS_* are set.
+ *   2. On the admin host, non-passthrough non-/admin paths are REWRITTEN under
+ *      /admin, carrying the refreshed cookies.
+ *   3. On any other host, /admin is redirected to the admin subdomain.
+ *
+ * Isolation applies when ADMIN_HOST_ENFORCED=true OR CF Access is configured,
+ * so enabling CF Access can never leave /admin reachable on a public host by
+ * forgetting a flag.
+ *
+ * ⚠️ THE ADMIN PATH CHECK MUST STAY A LITERAL `.startsWith('/admin')`.
+ * qa-sweep/inventory.py:342 derives the admin prefix list with the regex
+ *     pathname\\.startsWith\\(\\s*'(/admin[^']*)'\\s*\\)
+ * and an EMPTY derivation is fatal — inventory.py raises SystemExit2 because an
+ * empty model "would flatter every coverage number downstream". The regex
+ * matches inside `ctx.pathname.startsWith(...)`, so the form below is fine; a
+ * refactor to a helper or a constant is not.
+ */
+import { NextResponse } from 'next/server';
+import { cfAccessEnabled, verifyCfAccessToken } from '@/modules/guards/cf-access';
+import type { AuthedContext } from '../context';
+import { isExemptFrom } from '../exemptions';
+import type { Gate } from '../gate';
+
+export const adminHost: Gate<AuthedContext> = {
+  id: 'admin-host',
+  ticket: 'KAN-309',
+  why: 'The admin console must exist only on its own host, behind Cloudflare Access.',
+  run: async (ctx) => {
+    const cfEnabled = cfAccessEnabled();
+    if (!ctx.env.adminHostEnforced && !cfEnabled) return null;
+
+    const requestHost =
+      ctx.request.headers.get('host') ?? ctx.request.headers.get('x-forwarded-host') ?? '';
+    const isAdminHost = requestHost === ctx.env.adminHost;
+
+    if (isAdminHost) {
+      if (
+        cfEnabled &&
+        !(await verifyCfAccessToken(ctx.request.headers.get('cf-access-jwt-assertion')))
+      ) {
+        return new NextResponse('Forbidden: Cloudflare Access required.', { status: 403 });
+      }
+      const passthrough = isExemptFrom('admin-passthrough', ctx.pathname);
+      if (!passthrough && !ctx.pathname.startsWith('/admin')) {
+        const url = ctx.request.nextUrl.clone();
+        url.pathname = '/admin' + (ctx.pathname === '/' ? '' : ctx.pathname);
+        const rewrite = NextResponse.rewrite(url);
+        ctx.res.current.cookies.getAll().forEach((c) => rewrite.cookies.set(c));
+        rewrite.headers.set('Content-Security-Policy-Report-Only', ctx.csp());
+        return rewrite;
+      }
+      // Already an /admin path (or passthrough) — serve it, and crucially RETURN
+      // so the beta gate below never runs. An admin whose own profile is not
+      // `live` must still reach the console, or enabling the beta gate locks out
+      // the operator. Pinned by middleware-gate-order.test.ts.
+      ctx.res.current.headers.set('Content-Security-Policy-Report-Only', ctx.csp());
+      return ctx.res.current;
+    }
+
+    // Any non-admin host must never serve /admin.
+    if (ctx.pathname.startsWith('/admin')) {
+      return NextResponse.redirect(
+        new URL(`https://${ctx.env.adminHost}${ctx.pathname}${ctx.request.nextUrl.search}`),
+      );
+    }
+    return null;
+  },
+};

--- a/src/modules/access/gates/admin-host.ts
+++ b/src/modules/access/gates/admin-host.ts
@@ -53,6 +53,13 @@ export const adminHost: Gate<AuthedContext> = {
       const passthrough = isExemptFrom('admin-passthrough', ctx.pathname);
       if (!passthrough && !ctx.pathname.startsWith('/admin')) {
         const url = ctx.request.nextUrl.clone();
+        // CTL-046 exception. This is STRING BUILDING, not an exemption
+        // decision: without it the root path rewrites to '/admin/' rather than
+        // '/admin'. The rule is right to be strict enough to catch it —
+        // narrowing the selector to allow this shape would also allow a real
+        // bypass written the same way — so the exception is declared here, at
+        // the one site where it applies.
+        // eslint-disable-next-line no-restricted-syntax -- KAN-415: CTL-046, string building not an exemption decision (see above)
         url.pathname = '/admin' + (ctx.pathname === '/' ? '' : ctx.pathname);
         const rewrite = NextResponse.rewrite(url);
         ctx.res.current.cookies.getAll().forEach((c) => rewrite.cookies.set(c));

--- a/src/modules/access/gates/auth-page-redirect.ts
+++ b/src/modules/access/gates/auth-page-redirect.ts
@@ -1,0 +1,28 @@
+/**
+ * Authenticated users are redirected away from the auth pages.
+ *
+ * Lifted verbatim from src/middleware.ts, including the KAN-175 note: on beta,
+ * an ineligible user belongs at /waitlist rather than /dashboard — but sending
+ * them to /dashboard is correct here, because the beta gate ABOVE this one has
+ * already run and would have bounced them. Routing them straight to /waitlist
+ * from here would duplicate that decision in two places.
+ */
+import { NextResponse } from 'next/server';
+import type { AuthedContext } from '../context';
+import type { Gate } from '../gate';
+
+export const authPageRedirect: Gate<AuthedContext> = {
+  id: 'auth-page-redirect',
+  ticket: 'KAN-175',
+  why: 'A signed-in user landing on /login or /signup should be taken to the app.',
+  run: (ctx) => {
+    const { user } = ctx;
+    const p = ctx.request.nextUrl.pathname;
+    if (user && (p === '/login' || p === '/signup')) {
+      const url = ctx.request.nextUrl.clone();
+      url.pathname = '/dashboard';
+      return NextResponse.redirect(url);
+    }
+    return null;
+  },
+};

--- a/src/modules/access/gates/auth-rate-limit.ts
+++ b/src/modules/access/gates/auth-rate-limit.ts
@@ -1,0 +1,38 @@
+/**
+ * Rate-limit POSTs to the auth endpoints.
+ *
+ * Lifted verbatim from src/middleware.ts, including the two details that look
+ * like details and are not:
+ *
+ *   POST ONLY. A GET of /login is a page view; rate-limiting it would break
+ *   ordinary navigation. Only form submissions are limited.
+ *
+ *   The key is `auth:${ip}` via getClientIp, which is SEC-120's hardened
+ *   trusted-proxy resolution — not a raw header read.
+ */
+import { NextResponse } from 'next/server';
+import { clientIp } from '@/modules/guards/client-ip';
+import { rateLimit, RATE_LIMITS } from '@/modules/guards/rate-limit';
+import type { EdgeContext } from '../context';
+import type { Gate } from '../gate';
+
+function isAuthEndpoint(pathname: string): boolean {
+  return pathname === '/login' || pathname === '/signup' || pathname.startsWith('/auth/');
+}
+
+export const authRateLimit: Gate<EdgeContext> = {
+  id: 'auth-rate-limit',
+  ticket: 'SEC-12',
+  why: 'Credential stuffing against the login and signup forms.',
+  run: (ctx) => {
+    if (!isAuthEndpoint(ctx.pathname) || ctx.request.method !== 'POST') return null;
+    // clientIp takes Headers, matching the local wrapper this replaces.
+    const ip = clientIp(ctx.request.headers);
+    const { limited, retryAfter } = rateLimit(`auth:${ip}`, RATE_LIMITS.auth);
+    if (!limited) return null;
+    return NextResponse.json(
+      { error: 'Too many attempts. Please try again later.' },
+      { status: 429, headers: { 'Retry-After': String(retryAfter) } },
+    );
+  },
+};

--- a/src/modules/access/gates/beta-oauth-404.ts
+++ b/src/modules/access/gates/beta-oauth-404.ts
@@ -1,0 +1,44 @@
+/**
+ * SEC-36 — beta has no OAuth authorization server. Turn it OFF, don't key it.
+ *
+ * Lifted verbatim from src/middleware.ts. The reasoning is preserved in full
+ * because it is the reason this gate runs FIRST, before authentication and
+ * before any database read:
+ *
+ *   Beta advertised ITSELF as the issuer and answered on /oauth/token,
+ *   /register and /revoke, while /.well-known/jwks.json returned 500 — it has
+ *   no RS256 keypair on the beta scope and never has. Verified 2026-08-09:
+ *   NOTHING points at it. Both resource servers derive the AS from
+ *   LYRA_SITE_URL — prod MCP leaves it unset (defaults to checklyra.com) and
+ *   dev MCP sets dev.checklyra.com.
+ *
+ *   Giving beta a keypair would have been the WRONG fix. Beta runs on the
+ *   PRODUCTION Supabase project (gotcha #19), so a working beta AS would mint
+ *   tokens whose `sub` is a real production user and write jti rows into
+ *   production's oauth_access_tokens — a token factory for production
+ *   identities in the deliberately less-hardened environment, separated from
+ *   prod only by an `iss` string comparison in the verifier.
+ *
+ *   404, not 403: beta genuinely has no authorization server, and that is what
+ *   a client should discover. It also closes the unauthenticated DCR write into
+ *   production's oauth_clients via /oauth/register, which the beta gate further
+ *   down CANNOT reach, because that one only runs for authenticated requests.
+ *
+ * That last sentence is why this is typed `Gate<EdgeContext>`: it must answer
+ * identically whether or not anyone is signed in, and an EdgeContext has no
+ * `user` to consult even by mistake.
+ */
+import { NextResponse } from 'next/server';
+import type { EdgeContext } from '../context';
+import type { Gate } from '../gate';
+import { isOauthServerPath } from '../oauth-server-paths';
+
+export const betaOauth404: Gate<EdgeContext> = {
+  id: 'beta-oauth-404',
+  ticket: 'SEC-36',
+  why: 'Beta has no authorization server; answering as one mints production identities.',
+  run: (ctx) =>
+    ctx.env.isBetaDeploy && isOauthServerPath(ctx.pathname)
+      ? new NextResponse(null, { status: 404 })
+      : null,
+};

--- a/src/modules/access/gates/beta-tier.ts
+++ b/src/modules/access/gates/beta-tier.ts
@@ -1,0 +1,89 @@
+/**
+ * KAN-326 — the tier-aware access gate.
+ *
+ * Active on the "prod family" only: the beta deploy and the real production
+ * deploy. dev and staging are single full environments (deployTier null) and
+ * are not gated here. An authenticated user is:
+ *   - not live         -> /waitlist
+ *   - live, wrong tier -> their own tier's site (beta <-> prod), so a promoted
+ *                         user always lands on the right one. Sessions carry
+ *                         across via the shared .checklyra.com cookie.
+ *
+ * Runs AFTER the suspension gate, so a suspended user reaches /suspended rather
+ * than /waitlist. Pinned behaviourally in middleware-gate-order.test.ts.
+ *
+ * ── THE ERROR PATH, AND WHY IT LOOKS LIKE THIS ────────────────────────────
+ *
+ * This gate used to destructure only `{ data: profile }` and never inspect
+ * `error`. A transient profiles-read failure therefore made `profile`
+ * undefined, which is `!== 'live'`, which redirected a LEGITIMATE LIVE USER to
+ * /waitlist — silently. No log line, no signal, and no way for that user to
+ * recover: they ARE live, they simply cannot prove it while the read is
+ * failing.
+ *
+ * The suspension gate fifty lines above was explicitly hardened against exactly
+ * this ("Observability: never fail silently on a lookup error") and fails OPEN
+ * with a console.error. Same read, opposite direction, no log. One of the two
+ * was wrong.
+ *
+ * DECIDED 2026-08-09 (Luisa): FAIL CLOSED, BUT LOGGED.
+ *
+ * The direction stays. This gate governs ACCESS TO A GATED PRODUCT, whereas the
+ * suspension gate governs a suspended user's own session — admitting an
+ * unverified user to beta on a transient database error is the worse outcome,
+ * so /waitlist remains the answer. What changes is the SILENCE: an error is now
+ * logged, distinguishably from the ordinary not-live case, so the difference
+ * between "this user is not live" and "we could not tell" is visible in the
+ * logs rather than inferred from a support ticket.
+ *
+ * The characterisation test that pinned the silent behaviour is updated in the
+ * same commit, and it now asserts the log rather than its absence.
+ */
+import { NextResponse } from 'next/server';
+import type { AuthedContext } from '../context';
+import { isExemptFrom } from '../exemptions';
+import type { Gate } from '../gate';
+
+export const betaTier: Gate<AuthedContext> = {
+  id: 'beta-tier',
+  ticket: 'KAN-326',
+  why: 'Only live users of THIS tier may use this deploy; everyone else is routed away.',
+  run: async (ctx) => {
+    const { user, env } = ctx;
+    // Exemption checked inside the guard, not eagerly — see suspension.ts.
+    if (!env.deployTier || !user || isExemptFrom('beta-tier', ctx.pathname)) return null;
+
+    const { data: profile, error } = await ctx.supabase
+      .from('profiles')
+      .select('user_status, access_tier')
+      .eq('user_id', user.id)
+      .maybeSingle();
+
+    if (error) {
+      // Fail CLOSED (the redirect below still happens) but no longer SILENTLY.
+      // A live user bounced by this branch cannot self-recover, so the one
+      // thing that must not happen is nobody knowing it occurred.
+      console.error(
+        '[middleware] beta-tier lookup failed (failing closed to /waitlist):',
+        error.message,
+      );
+    }
+
+    if (profile?.user_status !== 'live') {
+      const url = ctx.request.nextUrl.clone();
+      url.pathname = '/waitlist';
+      url.search = '';
+      return NextResponse.redirect(url);
+    }
+
+    if (profile.access_tier !== env.deployTier) {
+      const targetHost =
+        profile.access_tier === 'prod' ? 'https://checklyra.com' : 'https://beta.checklyra.com';
+      return NextResponse.redirect(
+        new URL(`${targetHost}${ctx.pathname}${ctx.request.nextUrl.search}`),
+      );
+    }
+
+    return null;
+  },
+};

--- a/src/modules/access/gates/pkce-code-redirect.ts
+++ b/src/modules/access/gates/pkce-code-redirect.ts
@@ -1,0 +1,27 @@
+/**
+ * Supabase PKCE — hand a `?code=` on the root path to the callback route.
+ *
+ * Lifted verbatim from src/middleware.ts.
+ *
+ * Runs before the beta/tier gate, and that ordering is behaviour rather than
+ * taste: a user mid-exchange holds a code but has no session yet. Bounce them
+ * to /waitlist before /auth/callback runs and the session never forms, so they
+ * can never become `live` and never stop being bounced. That is a login loop,
+ * not a redirect. Pinned by middleware-gate-order.test.ts.
+ */
+import { NextResponse } from 'next/server';
+import type { EdgeContext } from '../context';
+import type { Gate } from '../gate';
+
+export const pkceCodeRedirect: Gate<EdgeContext> = {
+  id: 'pkce-code-redirect',
+  ticket: 'KAN-88',
+  why: 'A PKCE exchange must reach /auth/callback before any gate can know who you are.',
+  run: (ctx) => {
+    const code = ctx.request.nextUrl.searchParams.get('code');
+    if (!code || ctx.pathname !== '/') return null;
+    const url = ctx.request.nextUrl.clone();
+    url.pathname = '/auth/callback';
+    return NextResponse.redirect(url);
+  },
+};

--- a/src/modules/access/gates/protected-route.ts
+++ b/src/modules/access/gates/protected-route.ts
@@ -1,0 +1,36 @@
+/**
+ * Anonymous users are redirected away from /dashboard.
+ *
+ * Lifted verbatim from src/middleware.ts.
+ *
+ * ⚠️ THE `const { user } = ctx;` DESTRUCTURE IS LOAD-BEARING, and not for
+ * style. qa-sweep/inventory.py:344 derives the AUTHED prefix list with
+ *
+ *     !\\s*user\\s*&&([^;{}]{0,400}?)startsWith\\(\\s*'([^']+)'\\s*\\)
+ *
+ * That regex matches `!user && … startsWith('/dashboard')`. It does NOT match
+ * `!ctx.user && …` — the `ctx.` prefix breaks `!\\s*user\\s*&&`.
+ *
+ * If it fails to match, `authed_prefixes` derives EMPTY, and inventory.py:686
+ * raises SystemExit2 because an empty model "would flatter every coverage
+ * number downstream" — taking tests/scripts/qa-sweep-inventory.test.js down
+ * wholesale. One destructure is the entire difference.
+ */
+import { NextResponse } from 'next/server';
+import type { AuthedContext } from '../context';
+import type { Gate } from '../gate';
+
+export const protectedRoute: Gate<AuthedContext> = {
+  id: 'protected-route',
+  ticket: 'KAN-30',
+  why: 'An anonymous visitor must not reach the authenticated dashboard.',
+  run: (ctx) => {
+    const { user } = ctx;
+    if (!user && ctx.request.nextUrl.pathname.startsWith('/dashboard')) {
+      const url = ctx.request.nextUrl.clone();
+      url.pathname = '/login';
+      return NextResponse.redirect(url);
+    }
+    return null;
+  },
+};

--- a/src/modules/access/gates/suspension.ts
+++ b/src/modules/access/gates/suspension.ts
@@ -1,0 +1,58 @@
+/**
+ * KAN-319 — a suspended user is blocked from their own session.
+ *
+ * Lifted verbatim from src/middleware.ts, including the fail-open decision and
+ * its reasoning, which is the load-bearing part of this gate:
+ *
+ *   Never fail silently on a lookup error. We fail OPEN here (let the request
+ *   proceed) rather than closed, because a suspended user's public exposure is
+ *   already prevented at the data tier by RLS (published-and-not-suspended), so
+ *   this gate only governs their own session — and failing closed on a
+ *   transient profiles-read error would wrongly lock out the whole
+ *   authenticated userbase.
+ *
+ * Runs BEFORE the beta/tier gate so a suspended user lands on /suspended rather
+ * than /waitlist. That ordering is asserted behaviourally in
+ * middleware-gate-order.test.ts, where moving this gate below the beta gate
+ * reddens exactly one test.
+ *
+ * ⚠️ The console.error signature is pinned by that suite:
+ *   toHaveBeenCalledWith(stringContaining('failing open'), 'connection reset')
+ * Two arguments, and the message must contain "failing open". Reformatting it
+ * into one interpolated string breaks a test that exists precisely because a
+ * silent fail-open is indistinguishable from no gate at all.
+ */
+import { NextResponse } from 'next/server';
+import type { AuthedContext } from '../context';
+import { isExemptFrom } from '../exemptions';
+import type { Gate } from '../gate';
+
+export const suspension: Gate<AuthedContext> = {
+  id: 'suspension',
+  ticket: 'KAN-319',
+  why: 'A suspended user must not continue using the app from their own session.',
+  run: async (ctx) => {
+    const { user } = ctx;
+    // The exemption check is INSIDE the user guard, not eagerly at the top as
+    // it was inline. Unobservable — isExemptFrom is a pure predicate — and it
+    // is where the real per-request saving is: anonymous traffic no longer
+    // computes an exemption it will never consult.
+    if (!user || isExemptFrom('suspension', ctx.pathname)) return null;
+
+    const { data: suspProfile, error: suspErr } = await ctx.supabase
+      .from('profiles')
+      .select('is_suspended')
+      .eq('user_id', user.id)
+      .maybeSingle();
+
+    if (suspErr) {
+      console.error('[middleware] suspension lookup failed (failing open):', suspErr.message);
+    }
+    if (!suspProfile?.is_suspended) return null;
+
+    const url = ctx.request.nextUrl.clone();
+    url.pathname = '/suspended';
+    url.search = '';
+    return NextResponse.redirect(url);
+  },
+};

--- a/src/modules/access/matchers.ts
+++ b/src/modules/access/matchers.ts
@@ -1,0 +1,52 @@
+/**
+ * Path matching for the access module — KAN-415 D4.
+ *
+ * Two kinds only: exact and prefix. That is not a simplification, it is the
+ * complete vocabulary of every path predicate in src/middleware.ts today —
+ * verified disjunct by disjunct across all three inline lists. No globs, no
+ * regexes: a regex in a per-request path predicate is a performance question
+ * and a correctness question at once, and neither is one this module needs.
+ *
+ * Compiled once at module load. Per request the cost is one Set.has plus an
+ * indexed loop over a short prefix array — no closure per row, no iterator
+ * allocation, no regex compilation. This runs in the edge runtime on EVERY
+ * request, so the shape matters more than it would elsewhere.
+ */
+
+export type PathMatch =
+  | { readonly kind: 'exact'; readonly path: string }
+  | { readonly kind: 'prefix'; readonly path: string };
+
+/** A matcher list flattened for lookup. Build once, read many. */
+export interface CompiledMatchers {
+  readonly exact: ReadonlySet<string>;
+  readonly prefixes: readonly string[];
+}
+
+export function compile(matches: readonly PathMatch[]): CompiledMatchers {
+  const exact = new Set<string>();
+  const prefixes: string[] = [];
+  for (const m of matches) {
+    if (m.kind === 'exact') exact.add(m.path);
+    else prefixes.push(m.path);
+  }
+  return { exact, prefixes };
+}
+
+/**
+ * Exact match, or startsWith one of the prefixes.
+ *
+ * Note the prefixes carry their own trailing slash ('/auth/', not '/auth').
+ * That is deliberate and load-bearing: `/auth` alone would also match
+ * `/authenticate`, and `/_next` would match `/_nextdoor`. The original
+ * predicates were written with the trailing slash and the near-misses are
+ * pinned as tests.
+ */
+export function matchesAny(compiled: CompiledMatchers, pathname: string): boolean {
+  if (compiled.exact.has(pathname)) return true;
+  const { prefixes } = compiled;
+  for (let i = 0; i < prefixes.length; i += 1) {
+    if (pathname.startsWith(prefixes[i])) return true;
+  }
+  return false;
+}

--- a/src/modules/access/oauth-server-paths.ts
+++ b/src/modules/access/oauth-server-paths.ts
@@ -1,0 +1,44 @@
+/**
+ * The OAuth authorization-server surface — KAN-415 D4.
+ *
+ * ⚠️ THIS IS AN INCLUSION SET, NOT AN EXEMPTION SET. Deliberately a separate
+ * module from ./exemptions.ts, with its own name and its own export, even
+ * though it shares the PathMatch vocabulary and the matchesAny primitive.
+ *
+ * Every path here is one SEC-36 TURNS OFF on the beta deploy. Folding it into a
+ * table whose column header reads "exempt from" would put it one careless edit
+ * — one polarity inversion — away from disabling the 404 entirely.
+ *
+ * What that 404 is holding shut, from src/middleware.ts:
+ *   Beta advertised ITSELF as the issuer and answered on /oauth/token,
+ *   /register and /revoke while /.well-known/jwks.json returned 500. Beta runs
+ *   on the PRODUCTION Supabase project (gotcha #19), so a working beta AS would
+ *   mint tokens whose `sub` is a real production user and write jti rows into
+ *   production's oauth_access_tokens. The 404 also closes an unauthenticated
+ *   DCR write into production's oauth_clients via /oauth/register — which the
+ *   beta gate further down CANNOT reach, because that one only runs for
+ *   authenticated requests.
+ *
+ * Both halves are listed: middleware sees the public /.well-known/* paths, but
+ * the internal /api/well-known/* rewrite targets are directly addressable too,
+ * so gating only one half leaves a back door.
+ */
+import { compile, matchesAny, type PathMatch } from './matchers';
+
+const OAUTH_SERVER_PATHS: readonly PathMatch[] = [
+  { kind: 'prefix', path: '/oauth/' },
+  { kind: 'exact', path: '/.well-known/oauth-authorization-server' },
+  { kind: 'exact', path: '/.well-known/jwks.json' },
+  { kind: 'prefix', path: '/api/well-known/' },
+];
+
+const COMPILED = compile(OAUTH_SERVER_PATHS);
+
+export function isOauthServerPath(pathname: string): boolean {
+  return matchesAny(COMPILED, pathname);
+}
+
+/** Test-only introspection, mirroring exemptMatchersFor. */
+export function oauthServerMatchers(): readonly PathMatch[] {
+  return OAUTH_SERVER_PATHS;
+}

--- a/src/modules/access/pipeline.ts
+++ b/src/modules/access/pipeline.ts
@@ -110,6 +110,75 @@ export const AUTHED_PIPELINE: readonly Gate<AuthedContext>[] = AUTHED_ORDER.map(
 });
 
 /**
+ * The pairwise orderings that are SECURITY OR CORRECTNESS invariants, as data.
+ *
+ * Complementary to the exact-order test rather than a substitute for it:
+ * exact-order catches EVERY change to the sequence, this says WHICH changes are
+ * catastrophic and why. A reviewer looking at a reordered array can read this
+ * and know in seconds whether the change is cosmetic or a live security
+ * regression.
+ *
+ * Each is resolved to indices and asserted `before < after`, so a constraint
+ * naming a gate that no longer exists fails loudly rather than passing
+ * vacuously.
+ */
+export interface OrderConstraint {
+  readonly pipeline: 'pre-auth' | 'authed';
+  readonly before: string;
+  readonly after: string;
+  readonly ticket: string;
+  readonly why: string;
+}
+
+export const ORDER_CONSTRAINTS: readonly OrderConstraint[] = [
+  {
+    pipeline: 'pre-auth',
+    before: 'beta-oauth-404',
+    after: 'auth-rate-limit',
+    ticket: 'SEC-36',
+    why:
+      'The 404 must not be reachable by staying under a rate limit. It closes an ' +
+      "unauthenticated DCR write into PRODUCTION's oauth_clients — beta runs on the " +
+      'prod Supabase project (gotcha #19).',
+  },
+  {
+    pipeline: 'pre-auth',
+    before: 'pkce-code-redirect',
+    after: 'auth-rate-limit',
+    ticket: 'KAN-88',
+    why:
+      'A PKCE exchange must reach /auth/callback. Rate-limiting it first would ' +
+      'strand a user mid-login with no session and no way to acquire one.',
+  },
+  {
+    pipeline: 'authed',
+    before: 'admin-host',
+    after: 'beta-tier',
+    ticket: 'KAN-309',
+    why:
+      'The admin branch RETURNS. An operator whose own profile is not `live` must ' +
+      'still reach the console — otherwise enabling the beta gate locks out the ' +
+      'person who would fix it.',
+  },
+  {
+    pipeline: 'authed',
+    before: 'suspension',
+    after: 'beta-tier',
+    ticket: 'KAN-319',
+    why: 'A suspended user must land on /suspended, not /waitlist.',
+  },
+  {
+    pipeline: 'authed',
+    before: 'beta-tier',
+    after: 'auth-page-redirect',
+    ticket: 'KAN-175',
+    why:
+      'An ineligible user belongs at /waitlist. Sending them to /dashboard first ' +
+      'would bounce them through the beta gate a second time.',
+  },
+];
+
+/**
  * ── THE COMPOSITION ROOT ───────────────────────────────────────────────────
  *
  * The entire request path, as a factory. src/middleware.ts becomes a call to

--- a/src/modules/access/pipeline.ts
+++ b/src/modules/access/pipeline.ts
@@ -23,8 +23,18 @@
  * cheaper, earlier signal: it catches a gate that was written and never wired,
  * or wired twice, before anything has to run.
  */
-import type { AuthedContext, EdgeContext } from './context';
-import type { Gate } from './gate';
+import { NextResponse, type NextRequest } from 'next/server';
+import { buildCspReportOnly } from '@/modules/guards/security-headers';
+import {
+  buildDeployContext,
+  createEdgeContext,
+  type AuthedContext,
+  type EdgeContext,
+  type MiddlewareEnvRaw,
+} from './context';
+import { generateCspNonce, stampCspReportOnly } from './csp';
+import { establishSession } from './session';
+import { runGates, type Gate } from './gate';
 import { authRateLimit } from './gates/auth-rate-limit';
 import { betaOauth404 } from './gates/beta-oauth-404';
 import { pkceCodeRedirect } from './gates/pkce-code-redirect';
@@ -98,3 +108,59 @@ export const AUTHED_PIPELINE: readonly Gate<AuthedContext>[] = AUTHED_ORDER.map(
   if (!gate) throw new Error(`AUTHED_ORDER names an unknown gate: ${id}`);
   return gate;
 });
+
+/**
+ * ── THE COMPOSITION ROOT ───────────────────────────────────────────────────
+ *
+ * The entire request path, as a factory. src/middleware.ts becomes a call to
+ * this plus its env reader plus `config`, and — the point — HAS NO FUNCTION
+ * BODY LEFT.
+ *
+ * That is not tidiness. Through D5-D9 this file's neighbours get rewritten
+ * repeatedly, and the cheapest way to "just handle one more case" is to open
+ * src/middleware.ts and insert `if (x) return y;` above the pipeline. Every
+ * ordering test would still pass: the gates still run in order, they are simply
+ * no longer the only thing that runs. With no body there is nowhere to put it,
+ * and adding one is a visible structural change rather than a one-line edit.
+ *
+ * The fail-open when Supabase is unconfigured stays HERE rather than becoming a
+ * gate, for the same reason establishSession is not one: it is a precondition
+ * of the authed pipeline existing at all, and a gate lives in an ordered list
+ * where it could be moved above the pre-auth gates that must not depend on it.
+ */
+export function createAccessMiddleware(readEnv: () => MiddlewareEnvRaw) {
+  return async function middleware(request: NextRequest): Promise<NextResponse> {
+    const deploy = buildDeployContext(readEnv());
+
+    // Lazy: the SEC-36 404 returns before any document is served and must not
+    // pay for a nonce it will never use. A getRandomValues spy asserts it.
+    let cspCache: string | undefined;
+    const csp = (): string => {
+      if (cspCache === undefined) cspCache = buildCspReportOnly(generateCspNonce());
+      return cspCache;
+    };
+
+    const edge = createEdgeContext(request, deploy, csp);
+    const preAuth = await runGates(PRE_AUTH_PIPELINE, edge);
+    if (preAuth !== null) return preAuth;
+
+    const { supabaseUrl, supabaseAnonKey } = deploy;
+    if (!supabaseUrl || !supabaseAnonKey) {
+      // Fail OPEN: no Supabase means no auth gates at all. Correct for local
+      // and CI boots that have no credentials, and it means the security
+      // posture below is exactly as strong as the presence of two environment
+      // variables. Pinned by middleware-gate-order.test.ts.
+      return stampCspReportOnly(NextResponse.next(), csp());
+    }
+
+    const { supabase, user, res } = await establishSession(request, supabaseUrl, supabaseAnonKey);
+
+    const authed: AuthedContext = { ...edge, supabase, user, res };
+    const authedOutcome = await runGates(AUTHED_PIPELINE, authed);
+    if (authedOutcome !== null) return authedOutcome;
+
+    // res.current, not a captured value — the cookie callback rebuilt it
+    // during getUser(). See session.ts.
+    return stampCspReportOnly(res.current, csp());
+  };
+}

--- a/src/modules/access/pipeline.ts
+++ b/src/modules/access/pipeline.ts
@@ -1,0 +1,65 @@
+/**
+ * The gate pipelines — KAN-415 D4.
+ *
+ * TWO PIPELINES, SPLIT AT A NAMED BOUNDARY
+ * ----------------------------------------
+ * `PRE_AUTH_PIPELINE` runs against an `EdgeContext`: no user, no Supabase
+ * client, no database. `AUTHED_PIPELINE` runs against an `AuthedContext`, after
+ * the session boundary.
+ *
+ * The split is enforced by the type system, not by convention. `Gate.run` is
+ * declared as a PROPERTY in gate.ts, so under `strictFunctionTypes` a
+ * `Gate<AuthedContext>` is not assignable to `Gate<EdgeContext>` — adding the
+ * suspension gate to the pre-auth array is a compile error rather than a
+ * silently reordered security control. See gate.ts for why the declaration form
+ * matters and how "tidying" it undoes the guarantee.
+ *
+ * ORDER WITHIN AN ARRAY IS BEHAVIOUR
+ * ----------------------------------
+ * These arrays are ordered, and the order is not a preference. Every ordering
+ * below is asserted from the outside, through the real `middleware`, in
+ * tests/unit/middleware-gate-order.test.ts — where four separate reorderings
+ * each redden exactly one test. The registry/order set-equality test below is a
+ * cheaper, earlier signal: it catches a gate that was written and never wired,
+ * or wired twice, before anything has to run.
+ */
+import type { AuthedContext, EdgeContext } from './context';
+import type { Gate } from './gate';
+import { authRateLimit } from './gates/auth-rate-limit';
+import { betaOauth404 } from './gates/beta-oauth-404';
+import { pkceCodeRedirect } from './gates/pkce-code-redirect';
+
+/** Every pre-auth gate that exists, keyed by id. Not an order. */
+export const PRE_AUTH_GATES: Readonly<Record<string, Gate<EdgeContext>>> = {
+  [betaOauth404.id]: betaOauth404,
+  [pkceCodeRedirect.id]: pkceCodeRedirect,
+  [authRateLimit.id]: authRateLimit,
+};
+
+/**
+ * The order they run in. Stated separately from the registry so that "which
+ * gates exist" and "in what sequence" are two reviewable facts rather than one
+ * array where a reordering hides among additions.
+ *
+ * beta-oauth-404 is FIRST, and that is the ordering with security consequences:
+ * it must not be reachable by staying under a rate limit, and it must not
+ * depend on auth state. See gates/beta-oauth-404.ts.
+ */
+export const PRE_AUTH_ORDER: readonly string[] = [
+  'beta-oauth-404',
+  'pkce-code-redirect',
+  'auth-rate-limit',
+];
+
+export const PRE_AUTH_PIPELINE: readonly Gate<EdgeContext>[] = PRE_AUTH_ORDER.map((id) => {
+  const gate = PRE_AUTH_GATES[id];
+  // Fail at module load, not per request: a typo'd id would otherwise put
+  // `undefined` in the pipeline and throw on the first request in production.
+  if (!gate) throw new Error(`PRE_AUTH_ORDER names an unknown gate: ${id}`);
+  return gate;
+});
+
+/** Placeholder for C7 — the authed pipeline is assembled once its gates exist. */
+export const AUTHED_GATES: Readonly<Record<string, Gate<AuthedContext>>> = {};
+export const AUTHED_ORDER: readonly string[] = [];
+export const AUTHED_PIPELINE: readonly Gate<AuthedContext>[] = [];

--- a/src/modules/access/pipeline.ts
+++ b/src/modules/access/pipeline.ts
@@ -28,6 +28,11 @@ import type { Gate } from './gate';
 import { authRateLimit } from './gates/auth-rate-limit';
 import { betaOauth404 } from './gates/beta-oauth-404';
 import { pkceCodeRedirect } from './gates/pkce-code-redirect';
+import { adminHost } from './gates/admin-host';
+import { authPageRedirect } from './gates/auth-page-redirect';
+import { betaTier } from './gates/beta-tier';
+import { protectedRoute } from './gates/protected-route';
+import { suspension } from './gates/suspension';
 
 /** Every pre-auth gate that exists, keyed by id. Not an order. */
 export const PRE_AUTH_GATES: Readonly<Record<string, Gate<EdgeContext>>> = {
@@ -59,7 +64,37 @@ export const PRE_AUTH_PIPELINE: readonly Gate<EdgeContext>[] = PRE_AUTH_ORDER.ma
   return gate;
 });
 
-/** Placeholder for C7 — the authed pipeline is assembled once its gates exist. */
-export const AUTHED_GATES: Readonly<Record<string, Gate<AuthedContext>>> = {};
-export const AUTHED_ORDER: readonly string[] = [];
-export const AUTHED_PIPELINE: readonly Gate<AuthedContext>[] = [];
+/** Every authed gate that exists, keyed by id. Not an order. */
+export const AUTHED_GATES: Readonly<Record<string, Gate<AuthedContext>>> = {
+  [adminHost.id]: adminHost,
+  [suspension.id]: suspension,
+  [betaTier.id]: betaTier,
+  [protectedRoute.id]: protectedRoute,
+  [authPageRedirect.id]: authPageRedirect,
+};
+
+/**
+ * The order they run in. Three of these orderings are behaviour with
+ * consequences, all pinned behaviourally in middleware-gate-order.test.ts:
+ *
+ *   admin-host BEFORE beta-tier — the admin branch RETURNS, so an operator
+ *     whose own profile is not `live` still reaches the console. Without this
+ *     ordering, enabling the beta gate locks out the person who would fix it.
+ *   suspension BEFORE beta-tier — a suspended user lands on /suspended, not
+ *     /waitlist.
+ *   beta-tier BEFORE auth-page-redirect — an ineligible user is bounced to
+ *     /waitlist rather than sent to /dashboard and bounced from there.
+ */
+export const AUTHED_ORDER: readonly string[] = [
+  'admin-host',
+  'suspension',
+  'beta-tier',
+  'protected-route',
+  'auth-page-redirect',
+];
+
+export const AUTHED_PIPELINE: readonly Gate<AuthedContext>[] = AUTHED_ORDER.map((id) => {
+  const gate = AUTHED_GATES[id];
+  if (!gate) throw new Error(`AUTHED_ORDER names an unknown gate: ${id}`);
+  return gate;
+});

--- a/src/modules/access/session.ts
+++ b/src/modules/access/session.ts
@@ -1,0 +1,80 @@
+/**
+ * The session boundary — KAN-415 D4 C5.
+ *
+ * Everything the middleware needs in order to know WHO is asking: the Supabase
+ * client, its cookie plumbing, and the `getUser()` call that refreshes the
+ * session. Lifted from src/middleware.ts unchanged.
+ *
+ * ⚠️ THE RESPONSE IS A LIVE HANDLE, NOT A VALUE, AND THAT IS THE WHOLE POINT.
+ *
+ * @supabase/ssr rotates the session DURING `getUser()` and calls the `setAll`
+ * cookie callback from inside it. That callback REBUILDS the response object —
+ * `NextResponse.next({ request })` with the refreshed cookies applied. So the
+ * response that must eventually be returned to the browser does not exist yet
+ * when this function starts, and anything holding the earlier instance returns
+ * a response WITHOUT the refreshed cookie.
+ *
+ * The visible symptom is every user being logged out on token rotation. The
+ * invisible part is that until D4 C1 there was no test that could see it:
+ * `options.cookies.setAll` was invoked by ZERO of the 33 middleware tests,
+ * because both mocks constructed `createServerClient` as a zero-argument
+ * factory and discarded the options object. There is now a test that refreshes
+ * during `getUser` and asserts the cookie lands, on both document-serving
+ * exits, and a mutation capturing the response by value reddens exactly it.
+ *
+ * Hence `{ current }`: callers read `.current` at the moment they return, never
+ * before.
+ */
+import { createServerClient } from '@supabase/ssr';
+import { NextResponse, type NextRequest } from 'next/server';
+import { withParentCookieDomain } from '@/modules/platform/cookie-domain';
+import type { SupabaseLike } from './context';
+
+export interface Session {
+  readonly supabase: SupabaseLike;
+  readonly user: { id: string } | null;
+  /** Live handle. Read `.current` at the point of return. */
+  readonly res: { current: NextResponse };
+}
+
+/**
+ * Build the client, refresh the session, and hand back both the user and the
+ * response handle.
+ *
+ * The caller decides what to do when Supabase is not configured — see the
+ * named fail-open boundary in src/middleware.ts. Deliberately NOT a gate: it is
+ * a precondition of the authed pipeline existing at all, and modelling it as a
+ * gate would put it in an ordered list where it could be moved.
+ */
+export async function establishSession(
+  request: NextRequest,
+  supabaseUrl: string,
+  supabaseAnonKey: string,
+): Promise<Session> {
+  const res: { current: NextResponse } = { current: NextResponse.next({ request }) };
+
+  const supabase = createServerClient(supabaseUrl, supabaseAnonKey, {
+    cookies: {
+      getAll() {
+        return request.cookies.getAll();
+      },
+      setAll(cookiesToSet) {
+        cookiesToSet.forEach(({ name, value }) => request.cookies.set(name, value));
+        // Rebuild from the mutated request, then re-apply with the parent
+        // cookie domain so the session is shared across *.checklyra.com
+        // (SEC-40). Both halves are load-bearing and were lifted together.
+        res.current = NextResponse.next({ request });
+        cookiesToSet.forEach(({ name, value, options }) =>
+          res.current.cookies.set(name, value, withParentCookieDomain(options)),
+        );
+      },
+    },
+  });
+
+  // Refreshing the session is the reason this middleware runs on every request.
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  return { supabase: supabase as unknown as SupabaseLike, user, res };
+}

--- a/tests/scripts/qa-sweep-inventory.test.js
+++ b/tests/scripts/qa-sweep-inventory.test.js
@@ -154,13 +154,35 @@ describe('qa-sweep/inventory.py — parsing', () => {
     expect(r.exitCode).toBe(0);
   });
 
-  test('the auth model is derived from middleware, not hardcoded', () => {
-    // Derived means a middleware change moves the inventory instead of
-    // silently invalidating it.
-    const mw = fs.readFileSync(path.join(ROOT, SRC.middleware), 'utf-8');
-    expect(mw).toContain("pathname.startsWith('/admin')");
+  test('the auth model is derived from the gate corpus, not hardcoded', () => {
+    // REPOINTED, KAN-415 D4 C7 (approved 2026-08-09). This read
+    // src/middleware.ts and asserted it contained "pathname.startsWith('/admin')".
+    // The literal moved into src/modules/access/gates/admin-host.ts when the
+    // middleware was decomposed; inventory.py now concatenates the gates before
+    // deriving, so the DERIVATION is unchanged and only its source widened.
+    //
+    // The assertion is repointed at the corpus rather than at one file, which
+    // is strictly stronger: it no longer passes because a particular file
+    // happens to mention a string, and it keeps holding as later phases move
+    // gates again.
+    const gatesDir = path.join(ROOT, path.dirname(SRC.middleware), 'modules', 'access', 'gates');
+    const corpus = [fs.readFileSync(path.join(ROOT, SRC.middleware), 'utf-8')]
+      .concat(
+        fs
+          .readdirSync(gatesDir)
+          .filter((f) => f.endsWith('.ts'))
+          .map((f) => fs.readFileSync(path.join(gatesDir, f), 'utf-8')),
+      )
+      .join('\n');
+    expect(corpus).toContain("pathname.startsWith('/admin')");
+
+    // The part that actually matters: DERIVED, not hardcoded. An empty model is
+    // fatal in inventory.py by design, because it would reclassify every gated
+    // page as public and flatter every coverage number downstream.
     expect(INV.auth_model.admin_prefixes).toContain('/admin');
     expect(INV.auth_model.authed_prefixes).toContain('/dashboard');
+    expect(INV.auth_model.admin_prefixes.length).toBeGreaterThan(0);
+    expect(INV.auth_model.authed_prefixes.length).toBeGreaterThan(0);
   });
 
   test('routes are classified by that derived auth model', () => {

--- a/tests/support/comment-assertion-baseline.json
+++ b/tests/support/comment-assertion-baseline.json
@@ -153,18 +153,6 @@
       "severity": "comment-shadowed"
     },
     {
-      "test": "tests/unit/auth.test.js",
-      "subject": "src/middleware.ts",
-      "assertion": "/dashboard",
-      "severity": "comment-shadowed"
-    },
-    {
-      "test": "tests/unit/auth.test.js",
-      "subject": "src/middleware.ts",
-      "assertion": "/login",
-      "severity": "comment-shadowed"
-    },
-    {
       "test": "tests/unit/backup.test.js",
       "subject": ".github/workflows/backup-database.yml",
       "assertion": "SUPABASE_DB_URL",

--- a/tests/support/source-paths.json
+++ b/tests/support/source-paths.json
@@ -1,7 +1,7 @@
 {
   "$comment": "GENERATED — regenerate with `npm run gen:test-paths`. Mirror of tests/support/source-paths.ts for .cjs and shell consumers (KAN-414 F4).",
   "generated_from": "literals referenced by tracked files under tests/",
-  "count": 187,
+  "count": 188,
   "SRC": {
     "codeowners": ".github/CODEOWNERS",
     "pullRequestTemplate": ".github/PULL_REQUEST_TEMPLATE.md",
@@ -167,6 +167,7 @@
     "sweep": "src/lib/retention/sweep.ts",
     "middleware": "src/middleware.ts",
     "modules": "src/modules",
+    "gate": "src/modules/access/gate.ts",
     "fileMagicBytes": "src/modules/guards/file-magic-bytes.ts",
     "sanitise": "src/modules/guards/sanitise.ts",
     "turnstile": "src/modules/guards/turnstile.ts",

--- a/tests/support/source-paths.ts
+++ b/tests/support/source-paths.ts
@@ -13,7 +13,7 @@
 // cannot drift from reality — a hand-maintained list is what let BUGS-74's
 // first fix miss the legacy editor.
 //
-// 187 entries.
+// 188 entries.
 
 export const SRC = {
   codeowners: '.github/CODEOWNERS',
@@ -180,6 +180,7 @@ export const SRC = {
   sweep: 'src/lib/retention/sweep.ts',
   middleware: 'src/middleware.ts',
   modules: 'src/modules',
+  gate: 'src/modules/access/gate.ts',
   fileMagicBytes: 'src/modules/guards/file-magic-bytes.ts',
   sanitise: 'src/modules/guards/sanitise.ts',
   turnstile: 'src/modules/guards/turnstile.ts',

--- a/tests/support/test-floor-baseline.json
+++ b/tests/support/test-floor-baseline.json
@@ -1,6 +1,6 @@
 {
   "$comment": "GENERATED — regenerate with `npm run gen:test-floor`. The enforced test floor. The guard fails if the counts DROP (a test was deleted) and also if they RISE (this baseline is stale and is overstating how much of the estate is actually protected). The rise case is the one that matters: the previous hand-maintained floor sat at 29 files / 320 blocks against an actual 260 / 2963, so ~89% of the tests could have been deleted silently. Raise it in the SAME commit as any net-new test.",
   "measured_at": "2026-08-09",
-  "test_files": 267,
-  "test_blocks": 3060
+  "test_files": 268,
+  "test_blocks": 3068
 }

--- a/tests/support/test-floor-baseline.json
+++ b/tests/support/test-floor-baseline.json
@@ -1,6 +1,6 @@
 {
   "$comment": "GENERATED — regenerate with `npm run gen:test-floor`. The enforced test floor. The guard fails if the counts DROP (a test was deleted) and also if they RISE (this baseline is stale and is overstating how much of the estate is actually protected). The rise case is the one that matters: the previous hand-maintained floor sat at 29 files / 320 blocks against an actual 260 / 2963, so ~89% of the tests could have been deleted silently. Raise it in the SAME commit as any net-new test.",
   "measured_at": "2026-08-09",
-  "test_files": 266,
-  "test_blocks": 3051
+  "test_files": 267,
+  "test_blocks": 3060
 }

--- a/tests/support/test-floor-baseline.json
+++ b/tests/support/test-floor-baseline.json
@@ -1,6 +1,6 @@
 {
   "$comment": "GENERATED — regenerate with `npm run gen:test-floor`. The enforced test floor. The guard fails if the counts DROP (a test was deleted) and also if they RISE (this baseline is stale and is overstating how much of the estate is actually protected). The rise case is the one that matters: the previous hand-maintained floor sat at 29 files / 320 blocks against an actual 260 / 2963, so ~89% of the tests could have been deleted silently. Raise it in the SAME commit as any net-new test.",
   "measured_at": "2026-08-10",
-  "test_files": 270,
-  "test_blocks": 3090
+  "test_files": 271,
+  "test_blocks": 3095
 }

--- a/tests/support/test-floor-baseline.json
+++ b/tests/support/test-floor-baseline.json
@@ -1,6 +1,6 @@
 {
   "$comment": "GENERATED — regenerate with `npm run gen:test-floor`. The enforced test floor. The guard fails if the counts DROP (a test was deleted) and also if they RISE (this baseline is stale and is overstating how much of the estate is actually protected). The rise case is the one that matters: the previous hand-maintained floor sat at 29 files / 320 blocks against an actual 260 / 2963, so ~89% of the tests could have been deleted silently. Raise it in the SAME commit as any net-new test.",
   "measured_at": "2026-08-09",
-  "test_files": 268,
-  "test_blocks": 3068
+  "test_files": 269,
+  "test_blocks": 3078
 }

--- a/tests/support/test-floor-baseline.json
+++ b/tests/support/test-floor-baseline.json
@@ -1,6 +1,6 @@
 {
   "$comment": "GENERATED — regenerate with `npm run gen:test-floor`. The enforced test floor. The guard fails if the counts DROP (a test was deleted) and also if they RISE (this baseline is stale and is overstating how much of the estate is actually protected). The rise case is the one that matters: the previous hand-maintained floor sat at 29 files / 320 blocks against an actual 260 / 2963, so ~89% of the tests could have been deleted silently. Raise it in the SAME commit as any net-new test.",
   "measured_at": "2026-08-09",
-  "test_files": 265,
-  "test_blocks": 3037
+  "test_files": 266,
+  "test_blocks": 3051
 }

--- a/tests/support/test-floor-baseline.json
+++ b/tests/support/test-floor-baseline.json
@@ -2,5 +2,5 @@
   "$comment": "GENERATED — regenerate with `npm run gen:test-floor`. The enforced test floor. The guard fails if the counts DROP (a test was deleted) and also if they RISE (this baseline is stale and is overstating how much of the estate is actually protected). The rise case is the one that matters: the previous hand-maintained floor sat at 29 files / 320 blocks against an actual 260 / 2963, so ~89% of the tests could have been deleted silently. Raise it in the SAME commit as any net-new test.",
   "measured_at": "2026-08-10",
   "test_files": 271,
-  "test_blocks": 3095
+  "test_blocks": 3100
 }

--- a/tests/support/test-floor-baseline.json
+++ b/tests/support/test-floor-baseline.json
@@ -1,6 +1,6 @@
 {
   "$comment": "GENERATED — regenerate with `npm run gen:test-floor`. The enforced test floor. The guard fails if the counts DROP (a test was deleted) and also if they RISE (this baseline is stale and is overstating how much of the estate is actually protected). The rise case is the one that matters: the previous hand-maintained floor sat at 29 files / 320 blocks against an actual 260 / 2963, so ~89% of the tests could have been deleted silently. Raise it in the SAME commit as any net-new test.",
-  "measured_at": "2026-08-09",
+  "measured_at": "2026-08-10",
   "test_files": 269,
   "test_blocks": 3078
 }

--- a/tests/support/test-floor-baseline.json
+++ b/tests/support/test-floor-baseline.json
@@ -1,6 +1,6 @@
 {
   "$comment": "GENERATED — regenerate with `npm run gen:test-floor`. The enforced test floor. The guard fails if the counts DROP (a test was deleted) and also if they RISE (this baseline is stale and is overstating how much of the estate is actually protected). The rise case is the one that matters: the previous hand-maintained floor sat at 29 files / 320 blocks against an actual 260 / 2963, so ~89% of the tests could have been deleted silently. Raise it in the SAME commit as any net-new test.",
   "measured_at": "2026-08-10",
-  "test_files": 269,
-  "test_blocks": 3078
+  "test_files": 270,
+  "test_blocks": 3090
 }

--- a/tests/types/access-pipeline-misorder.ts
+++ b/tests/types/access-pipeline-misorder.ts
@@ -1,0 +1,37 @@
+/**
+ * A TYPE-LEVEL guard: an authed gate must not be placeable in the pre-auth
+ * pipeline. KAN-415 D4 C9 (CTL-045).
+ *
+ * This file contains no runtime assertions and is never executed. It is checked
+ * by `npm run type-check` (tsc --noEmit), which tsconfig includes.
+ *
+ * `@ts-expect-error` is the instrument: it fails the build if the error it
+ * expects DISAPPEARS. So if someone changes `Gate.run` from a property to a
+ * method shorthand — which silently makes TypeScript check the parameter
+ * bivariantly and lets an authed gate into the pre-auth array — this file goes
+ * red, rather than the guarantee evaporating in silence.
+ *
+ * Verified empirically at C4: property form -> 1 compile error, shorthand -> 0.
+ * The difference is invisible in review; nothing about the code reads
+ * differently afterwards. That is exactly why it is pinned twice, here and by a
+ * source assertion in access-pipeline.test.ts.
+ */
+import type { AuthedContext, EdgeContext } from '@/modules/access/context';
+import type { Gate } from '@/modules/access/gate';
+
+const authedGate: Gate<AuthedContext> = {
+  id: 'type-probe',
+  ticket: 'KAN-415',
+  why: 'A gate that reads auth state, used only to prove it cannot run pre-auth.',
+  run: (ctx) => {
+    // Reaching for `user` is what makes this genuinely an authed gate rather
+    // than one that merely claims to be.
+    void ctx.user;
+    return null;
+  },
+};
+
+// @ts-expect-error An authed gate must NOT be assignable to a pre-auth pipeline.
+const misordered: readonly Gate<EdgeContext>[] = [authedGate];
+
+void misordered;

--- a/tests/unit/access-context.test.ts
+++ b/tests/unit/access-context.test.ts
@@ -1,0 +1,94 @@
+/**
+ * DeployContext derives exactly what src/middleware.ts derived inline.
+ * KAN-415 D4 C3.
+ *
+ * `deployTier` decides whether the tier gate runs at all, and it is a
+ * THREE-valued result from a two-branch conditional over three env variables.
+ * That is the shape most likely to be got subtly wrong in a move — so it is
+ * checked as a cross-product against a literal transcription of the original,
+ * not by inspection.
+ */
+import { buildDeployContext, DEFAULT_ADMIN_HOST } from '@/modules/access/context';
+
+/** src/middleware.ts, transcribed. Does not import the implementation. */
+function originalDeployTier(env: Record<string, string | undefined>): 'beta' | 'prod' | null {
+  const isBetaDeploy = env.IS_BETA_DEPLOY === 'true';
+  const isProdSite =
+    env.NEXT_PUBLIC_SITE_URL === 'https://checklyra.com' && env.VERCEL_ENV === 'production';
+  return isBetaDeploy ? 'beta' : isProdSite ? 'prod' : null;
+}
+
+const BETA = [undefined, 'true', 'false', 'TRUE', ''];
+const SITE = [undefined, 'https://checklyra.com', 'https://beta.checklyra.com', ''];
+const VERCEL = [undefined, 'production', 'preview', ''];
+
+describe('deployTier — every combination, against the original', () => {
+  test('agrees on all 80 combinations of the three inputs', () => {
+    const disagreements: string[] = [];
+    for (const b of BETA) {
+      for (const s of SITE) {
+        for (const v of VERCEL) {
+          const env = { IS_BETA_DEPLOY: b, NEXT_PUBLIC_SITE_URL: s, VERCEL_ENV: v };
+          const got = buildDeployContext(env).deployTier;
+          const want = originalDeployTier(env);
+          if (got !== want) disagreements.push(`${b}/${s}/${v}: got ${got} want ${want}`);
+        }
+      }
+    }
+    expect(disagreements).toEqual([]);
+  });
+
+  test('the cross-product actually produces all three outcomes', () => {
+    // Otherwise the agreement above could be agreement on a single value.
+    const seen = new Set<string>();
+    for (const b of BETA) for (const s of SITE) for (const v of VERCEL) {
+      seen.add(String(buildDeployContext({ IS_BETA_DEPLOY: b, NEXT_PUBLIC_SITE_URL: s, VERCEL_ENV: v }).deployTier));
+    }
+    expect([...seen].sort()).toEqual(['beta', 'null', 'prod']);
+  });
+
+  test('beta wins over prod when both would qualify', () => {
+    // The ternary order is behaviour: a deploy that is somehow both must be
+    // treated as beta, never as production.
+    expect(
+      buildDeployContext({
+        IS_BETA_DEPLOY: 'true',
+        NEXT_PUBLIC_SITE_URL: 'https://checklyra.com',
+        VERCEL_ENV: 'production',
+      }).deployTier,
+    ).toBe('beta');
+  });
+
+  test('prod requires BOTH the site URL and VERCEL_ENV', () => {
+    expect(buildDeployContext({ NEXT_PUBLIC_SITE_URL: 'https://checklyra.com' }).deployTier).toBeNull();
+    expect(buildDeployContext({ VERCEL_ENV: 'production' }).deployTier).toBeNull();
+  });
+});
+
+describe('the rest of the snapshot', () => {
+  test('adminHost defaults, and an explicit value wins', () => {
+    expect(buildDeployContext({}).adminHost).toBe(DEFAULT_ADMIN_HOST);
+    expect(buildDeployContext({ ADMIN_HOST: 'x.example' }).adminHost).toBe('x.example');
+  });
+
+  test('adminHostEnforced is strictly the string "true"', () => {
+    // Not truthiness: 'false' and '1' must both be false, or enabling admin
+    // isolation by typo becomes possible.
+    expect(buildDeployContext({ ADMIN_HOST_ENFORCED: 'true' }).adminHostEnforced).toBe(true);
+    expect(buildDeployContext({ ADMIN_HOST_ENFORCED: 'false' }).adminHostEnforced).toBe(false);
+    expect(buildDeployContext({ ADMIN_HOST_ENFORCED: '1' }).adminHostEnforced).toBe(false);
+    expect(buildDeployContext({}).adminHostEnforced).toBe(false);
+  });
+
+  test('isBetaDeploy is strictly the string "true" too', () => {
+    expect(buildDeployContext({ IS_BETA_DEPLOY: 'true' }).isBetaDeploy).toBe(true);
+    expect(buildDeployContext({ IS_BETA_DEPLOY: 'TRUE' }).isBetaDeploy).toBe(false);
+  });
+
+  test('supabase credentials pass through untouched, including absent', () => {
+    const c = buildDeployContext({ NEXT_PUBLIC_SUPABASE_URL: 'u', NEXT_PUBLIC_SUPABASE_ANON_KEY: 'k' });
+    expect(c.supabaseUrl).toBe('u');
+    expect(c.supabaseAnonKey).toBe('k');
+    expect(buildDeployContext({}).supabaseUrl).toBeUndefined();
+  });
+});

--- a/tests/unit/access-exemptions.test.ts
+++ b/tests/unit/access-exemptions.test.ts
@@ -1,0 +1,212 @@
+/**
+ * The exemption table is EQUIVALENT to the three predicates it replaces.
+ * KAN-415 D4.
+ *
+ * The collapse of three inline `||` chains into one table is the only
+ * substitution in the whole D4 refactor that is not a verbatim move — every
+ * other commit relocates code unchanged. So it is the one that needs an
+ * independent oracle rather than inspection.
+ *
+ * THE ORACLE IS A LITERAL TRANSCRIPTION of the original predicates, copied from
+ * src/middleware.ts before the substitution and kept here verbatim. It does not
+ * import the new module, share a helper with it, or reference the table. That
+ * matters: a test that derived its expectations from EXEMPTIONS would be
+ * checking the table against itself, which is CTL-038's reimplementation shape
+ * wearing a different coat — it would agree with any table, including a wrong
+ * one.
+ */
+import {
+  EXEMPTIONS,
+  exemptMatchersFor,
+  isExemptFrom,
+  type ExemptGate,
+} from '@/modules/access/exemptions';
+import { isOauthServerPath } from '@/modules/access/oauth-server-paths';
+
+// ---------------------------------------------------------------------------
+// THE ORACLE — transcribed from src/middleware.ts, do not refactor to share
+// code with the implementation under test.
+// ---------------------------------------------------------------------------
+
+/** src/middleware.ts — `suspensionExempt`, 5 disjuncts. */
+function originalSuspensionExempt(pathname: string): boolean {
+  return (
+    pathname === '/suspended' ||
+    pathname === '/login' ||
+    pathname.startsWith('/auth/') ||
+    pathname.startsWith('/_next/') ||
+    pathname === '/favicon.ico'
+  );
+}
+
+/** src/middleware.ts — `exemptFromBetaGate`, 10 disjuncts. */
+function originalBetaGateExempt(pathname: string): boolean {
+  return (
+    pathname === '/waitlist' ||
+    pathname === '/suspended' ||
+    pathname === '/status' ||
+    pathname === '/login' ||
+    pathname === '/signup' ||
+    pathname === '/join' ||
+    pathname === '/confirm-age' ||
+    pathname.startsWith('/auth/') ||
+    pathname.startsWith('/_next/') ||
+    pathname === '/favicon.ico'
+  );
+}
+
+/** src/middleware.ts — the admin-host `passthrough`, 4 disjuncts. */
+function originalAdminPassthrough(pathname: string): boolean {
+  return (
+    pathname === '/login' ||
+    pathname.startsWith('/auth/') ||
+    pathname.startsWith('/api/') ||
+    pathname.startsWith('/_next/')
+  );
+}
+
+const ORACLE: Record<ExemptGate, (p: string) => boolean> = {
+  suspension: originalSuspensionExempt,
+  'beta-tier': originalBetaGateExempt,
+  'admin-passthrough': originalAdminPassthrough,
+};
+
+/**
+ * Every path either predicate mentions, plus the NEAR-MISSES that nothing in
+ * the repo tests today. The near-misses are the point: a prefix row written as
+ * '/auth' instead of '/auth/' would also match '/authenticate', and no existing
+ * test would notice.
+ */
+const PROBE_PATHS: readonly string[] = [
+  // the mentioned paths
+  '/suspended', '/login', '/favicon.ico', '/waitlist', '/status', '/signup',
+  '/join', '/confirm-age', '/auth/callback', '/auth/confirm', '/_next/static/x.js',
+  '/api/health', '/api/convene/x',
+  // near-misses — prefix rows must carry their trailing slash
+  '/auth', '/authenticate', '/_next', '/_nextdoor', '/api', '/apitest',
+  '/suspendedX', '/loginx', '/favicon.icoo', '/statuses', '/waitlists', '/joins',
+  '/signupx', '/confirm-age-later',
+  // ordinary traffic
+  '/', '/dashboard', '/dashboard/profile', '/admin', '/admin/users', '/some-slug',
+  '/oauth/token', '/.well-known/jwks.json',
+];
+
+const GATES: readonly ExemptGate[] = ['suspension', 'beta-tier', 'admin-passthrough'];
+
+describe('the exemption table agrees with the predicates it replaced', () => {
+  test.each(GATES)('%s — identical on every probe path', (gate) => {
+    const disagreements = PROBE_PATHS.filter(
+      (p) => isExemptFrom(gate, p) !== ORACLE[gate](p),
+    ).map((p) => `${p}: table=${isExemptFrom(gate, p)} original=${ORACLE[gate](p)}`);
+    // Named, not counted — a bare number sends the reader hunting.
+    expect(disagreements).toEqual([]);
+  });
+
+  test('the probe corpus actually exercises both answers for every gate', () => {
+    // Without this, a table that returned `false` for everything would pass the
+    // three tests above if the corpus happened to contain no exempt path. The
+    // oracle would agree with it, and both would be wrong together.
+    for (const gate of GATES) {
+      const yes = PROBE_PATHS.filter((p) => ORACLE[gate](p)).length;
+      const no = PROBE_PATHS.filter((p) => !ORACLE[gate](p)).length;
+      expect(yes).toBeGreaterThan(0);
+      expect(no).toBeGreaterThan(0);
+    }
+  });
+
+  test('column totals match the three original lists exactly: 5, 10, 4', () => {
+    // The plan's table claims these. Asserted rather than trusted, because a
+    // miscounted column is a path that silently lost or gained an exemption.
+    expect(exemptMatchersFor('suspension')).toHaveLength(5);
+    expect(exemptMatchersFor('beta-tier')).toHaveLength(10);
+    expect(exemptMatchersFor('admin-passthrough')).toHaveLength(4);
+  });
+});
+
+describe('the table cannot silently over-match', () => {
+  test('removing any row changes at least one answer — no row is dead or shadowed', () => {
+    // Catches a future `{ kind: 'prefix', path: '/' }` quietly exempting the
+    // world, and catches a duplicate row that does nothing.
+    for (const row of EXEMPTIONS) {
+      const withoutRow = EXEMPTIONS.filter((r) => r !== row);
+      for (const gate of row.gates) {
+        const remaining = withoutRow.filter((r) => r.gates.includes(gate)).map((r) => r.match);
+        const stillExempt = (p: string) =>
+          remaining.some((m) =>
+            m.kind === 'exact' ? p === m.path : p.startsWith(m.path),
+          );
+        const changed = PROBE_PATHS.some((p) => isExemptFrom(gate, p) !== stillExempt(p));
+        expect(`${gate}:${row.match.path} is load-bearing: ${changed}`)
+          .toBe(`${gate}:${row.match.path} is load-bearing: true`);
+      }
+    }
+  });
+
+  test('every prefix row carries a trailing slash', () => {
+    // '/auth' would match '/authenticate'. The originals were written with the
+    // slash; this stops a future edit dropping it.
+    for (const row of EXEMPTIONS) {
+      if (row.match.kind === 'prefix') {
+        expect(row.match.path.endsWith('/')).toBe(true);
+      }
+    }
+  });
+
+  test('every row explains itself', () => {
+    // A row with no reason is a row nobody can safely delete later.
+    for (const row of EXEMPTIONS) {
+      expect(row.why.trim().length).toBeGreaterThan(20);
+      expect(row.gates.length).toBeGreaterThan(0);
+    }
+  });
+});
+
+describe('the suspension ⊂ beta-tier relation, observed not encoded', () => {
+  test('every suspension-exempt path is also beta-tier exempt, today', () => {
+    // Recorded as an observation rather than modelled as inheritance:
+    // inheritance would make a future suspension-only path inexpressible, and
+    // would hide which gate a row actually serves. If this ever stops holding,
+    // someone reads this note instead of discovering it during an outage.
+    const violations = PROBE_PATHS.filter(
+      (p) => isExemptFrom('suspension', p) && !isExemptFrom('beta-tier', p),
+    );
+    expect(violations).toEqual([]);
+  });
+
+  test('the converse does NOT hold — they are genuinely different lists', () => {
+    // /waitlist is the case: beta-tier exempt, but a suspended user there is
+    // still sent to /suspended. If this ever passes empty, the two columns have
+    // silently merged.
+    const betaOnly = PROBE_PATHS.filter(
+      (p) => isExemptFrom('beta-tier', p) && !isExemptFrom('suspension', p),
+    );
+    expect(betaOnly.length).toBeGreaterThan(0);
+    expect(betaOnly).toContain('/waitlist');
+  });
+});
+
+describe('the OAuth surface is an INCLUSION set, kept apart on purpose', () => {
+  test('it matches exactly what middleware.ts matched', () => {
+    const original = (p: string) =>
+      p.startsWith('/oauth/') ||
+      p === '/.well-known/oauth-authorization-server' ||
+      p === '/.well-known/jwks.json' ||
+      p.startsWith('/api/well-known/');
+    const disagreements = PROBE_PATHS.concat([
+      '/oauth/register', '/oauth/token', '/api/well-known/jwks.json',
+      '/.well-known/other', '/oauth', '/api/well-knownx',
+    ]).filter((p) => isOauthServerPath(p) !== original(p));
+    expect(disagreements).toEqual([]);
+  });
+
+  test('no OAuth path leaked into the exemption table', () => {
+    // The polarity trap, asserted directly. A path that is meant to be TURNED
+    // OFF appearing in a table headed "exempt from" is the one edit that would
+    // quietly re-open an unauthenticated write into production oauth_clients.
+    for (const gate of GATES) {
+      for (const m of exemptMatchersFor(gate)) {
+        expect(isOauthServerPath(m.path)).toBe(false);
+      }
+    }
+  });
+});

--- a/tests/unit/access-pipeline.test.ts
+++ b/tests/unit/access-pipeline.test.ts
@@ -1,0 +1,141 @@
+/**
+ * The gate pipeline's structural invariants — KAN-415 D4 C4.
+ *
+ * middleware-gate-order.test.ts asserts ORDER from the outside, through the real
+ * `middleware`, and is mutation-proven. This file asserts the cheaper, earlier
+ * things that file cannot see: that every gate written is actually wired, that
+ * none is wired twice, and that the type-level ordering guarantee has not been
+ * quietly undone.
+ */
+import fs from 'fs';
+import path from 'path';
+import {
+  PRE_AUTH_GATES,
+  PRE_AUTH_ORDER,
+  PRE_AUTH_PIPELINE,
+} from '@/modules/access/pipeline';
+import { runGates, type Gate } from '@/modules/access/gate';
+
+const { SRC } = require('../support/source-paths.json');
+// Assembled from an existing manifest entry rather than written out or seeded:
+// the F4 ratchet counts raw path literals in tests, and gen-test-paths is
+// self-feeding — a key whose literal exists ONLY in the manifest gets dropped
+// on the next regeneration. SRC.middleware gives us 'src'.
+const SRC_DIR = path.posix.dirname(SRC.middleware);
+const GATE_TS = path.posix.join(SRC_DIR, 'modules', 'access', 'gate.ts');
+
+const ROOT = path.resolve(__dirname, '../../');
+
+describe('the registry and the order describe the same set', () => {
+  test('every registered gate appears in the order, exactly once', () => {
+    // Catches the two failure modes a single array would hide: a gate written
+    // and never wired (dead code that reads as a control), and a gate wired
+    // twice (runs twice, and the second run is unreachable).
+    expect([...PRE_AUTH_ORDER].sort()).toEqual(Object.keys(PRE_AUTH_GATES).sort());
+    expect(new Set(PRE_AUTH_ORDER).size).toBe(PRE_AUTH_ORDER.length);
+  });
+
+  test('the compiled pipeline matches the declared order', () => {
+    expect(PRE_AUTH_PIPELINE.map((g) => g.id)).toEqual([...PRE_AUTH_ORDER]);
+  });
+
+  test('SEC-36 is first — it must not be reachable by staying under a rate limit', () => {
+    // The one ordering in this pipeline with a security consequence, asserted
+    // here as well as behaviourally, because this failure is cheap to catch and
+    // expensive to discover.
+    expect(PRE_AUTH_ORDER[0]).toBe('beta-oauth-404');
+  });
+
+  test('every gate carries an id, a ticket and a reason', () => {
+    for (const gate of PRE_AUTH_PIPELINE) {
+      expect(gate.id).toMatch(/^[a-z0-9-]+$/);
+      expect(gate.ticket).toMatch(/^[A-Z][A-Z0-9]+-[0-9]+$/);
+      expect(gate.why.trim().length).toBeGreaterThan(20);
+    }
+  });
+});
+
+describe('the type-level ordering guarantee is still armed', () => {
+  /**
+   * `Gate.run` must stay a PROPERTY. As a method shorthand TypeScript checks
+   * parameters bivariantly, `Gate<AuthedContext>` becomes assignable to
+   * `Gate<EdgeContext>`, and an authed gate can be placed in the pre-auth
+   * pipeline with no error at all.
+   *
+   * Verified empirically while writing this, by flipping the declaration and
+   * re-running tsc against a smuggling probe: PROPERTY → 1 compile error,
+   * SHORTHAND → 0. The guarantee is real, and it is invisible — nothing about
+   * the code reads differently afterwards.
+   *
+   * This is a source-text assertion, which is a weaker instrument than the
+   * behaviour it guards, and that is stated rather than glossed: a compile
+   * error cannot be asserted from inside jest. It is here because the
+   * alternative is nothing.
+   */
+  test('gate.ts declares run as a property, not a method shorthand', () => {
+    const raw = fs.readFileSync(path.join(ROOT, GATE_TS), 'utf8');
+    // COMMENTS STRIPPED FIRST. gate.ts's header quotes both declaration forms
+    // in order to explain the difference, so an assertion against raw source
+    // would be satisfied by the explanation even if the declaration were
+    // deleted. CTL-039 caught exactly that when this test was first written —
+    // the guard flagged it as comment-shadowed on the same run that introduced
+    // it, which is the control working on its author.
+    const code = raw
+      .replace(/\/\*[\s\S]*?\*\//g, '')
+      .replace(/^[ \t]*\/\/.*$/gm, '');
+    expect(code).toMatch(/readonly run:\s*\(ctx: Ctx\)\s*=>/);
+    // The shorthand form, which would silently disarm the guarantee.
+    expect(code).not.toMatch(/^\s*run\(ctx: Ctx\)/m);
+  });
+});
+
+describe('runGates — the protocol', () => {
+  const gate = (id: string, outcome: unknown): Gate<Record<string, never>> => ({
+    id,
+    ticket: 'KAN-415',
+    why: 'a synthetic gate used only to exercise the runner protocol',
+    run: () => outcome as never,
+  });
+
+  test('null continues; the first non-null wins', async () => {
+    const marker = { headers: new Headers() } as never;
+    const out = await runGates(
+      [gate('a', null), gate('b', marker), gate('c', { other: true })] as never,
+      {} as never,
+    );
+    expect(out).toBe(marker);
+  });
+
+  test('all null means continue past the pipeline', async () => {
+    expect(await runGates([gate('a', null), gate('b', null)] as never, {} as never)).toBeNull();
+  });
+
+  test('an empty pipeline is a no-op, not an error', async () => {
+    expect(await runGates([], {} as never)).toBeNull();
+  });
+
+  test('a later gate does NOT run once one has terminated', async () => {
+    // The property that makes ordering meaningful at all.
+    const ran: string[] = [];
+    const tracking = (id: string, outcome: unknown): Gate<Record<string, never>> => ({
+      id, ticket: 'KAN-415', why: 'records whether it was reached during the run',
+      run: () => { ran.push(id); return outcome as never; },
+    });
+    await runGates(
+      [tracking('a', null), tracking('b', { headers: new Headers() }), tracking('c', null)] as never,
+      {} as never,
+    );
+    expect(ran).toEqual(['a', 'b']);
+  });
+
+  test('async gates are awaited, sync gates are not made async', async () => {
+    // The thenable probe. A blanket `await` would still work, but schedules a
+    // microtask per gate on every request in the edge runtime.
+    const marker = { headers: new Headers() } as never;
+    const asyncGate: Gate<Record<string, never>> = {
+      id: 'async', ticket: 'KAN-415', why: 'returns a promise, to prove the runner awaits it',
+      run: async () => marker,
+    };
+    expect(await runGates([asyncGate] as never, {} as never)).toBe(marker);
+  });
+});

--- a/tests/unit/access-pipeline.test.ts
+++ b/tests/unit/access-pipeline.test.ts
@@ -10,6 +10,10 @@
 import fs from 'fs';
 import path from 'path';
 import {
+  AUTHED_GATES,
+  AUTHED_ORDER,
+  AUTHED_PIPELINE,
+  ORDER_CONSTRAINTS,
   PRE_AUTH_GATES,
   PRE_AUTH_ORDER,
   PRE_AUTH_PIPELINE,
@@ -137,5 +141,70 @@ describe('runGates — the protocol', () => {
       run: async () => marker,
     };
     expect(await runGates([asyncGate] as never, {} as never)).toBe(marker);
+  });
+});
+
+describe('ORDER is an exact, checked artefact (CTL-045)', () => {
+  /**
+   * Deep-equal against hard-coded literals, with a reason per position.
+   *
+   * This lands LAST in D4 on purpose. Written earlier, every subsequent commit
+   * would have had to edit its own expected list — and in a log, editing the
+   * expectation to match the code is indistinguishable from weakening it.
+   */
+  test('PRE_AUTH_ORDER is exactly this, in this sequence', () => {
+    expect([...PRE_AUTH_ORDER]).toEqual([
+      'beta-oauth-404',    // SEC-36: before auth, before rate limiting, before any read
+      'pkce-code-redirect',// a login exchange must complete before anything can gate it
+      'auth-rate-limit',   // credential stuffing, POST only
+    ]);
+  });
+
+  test('AUTHED_ORDER is exactly this, in this sequence', () => {
+    expect([...AUTHED_ORDER]).toEqual([
+      'admin-host',        // returns early; an operator must reach the console
+      'suspension',        // /suspended, not /waitlist
+      'beta-tier',         // tier routing
+      'protected-route',   // anonymous -> /login
+      'auth-page-redirect',// signed-in -> /dashboard
+    ]);
+  });
+
+  test('every authed gate is wired exactly once', () => {
+    expect([...AUTHED_ORDER].sort()).toEqual(Object.keys(AUTHED_GATES).sort());
+    expect(new Set(AUTHED_ORDER).size).toBe(AUTHED_ORDER.length);
+    expect(AUTHED_PIPELINE.map((g) => g.id)).toEqual([...AUTHED_ORDER]);
+  });
+});
+
+describe('ORDER_CONSTRAINTS — which reorderings are catastrophic, and why', () => {
+  const orderFor = (p: string) => (p === 'pre-auth' ? PRE_AUTH_ORDER : AUTHED_ORDER);
+
+  test.each(ORDER_CONSTRAINTS.map((c) => [`${c.before} before ${c.after} (${c.ticket})`, c] as const))(
+    '%s',
+    (_label, c) => {
+      const order = orderFor(c.pipeline);
+      const bi = order.indexOf(c.before);
+      const ai = order.indexOf(c.after);
+      // A constraint naming a gate that no longer exists must FAIL, not pass
+      // vacuously on two -1s comparing equal.
+      expect(bi).toBeGreaterThanOrEqual(0);
+      expect(ai).toBeGreaterThanOrEqual(0);
+      expect(bi).toBeLessThan(ai);
+    },
+  );
+
+  test('every constraint carries a ticket and a reason a reviewer can act on', () => {
+    for (const c of ORDER_CONSTRAINTS) {
+      expect(c.ticket).toMatch(/^[A-Z][A-Z0-9]+-[0-9]+$/);
+      expect(c.why.trim().length).toBeGreaterThan(40);
+    }
+  });
+
+  test('the constraint set covers both pipelines', () => {
+    // If it only ever described one, half the ordering would be unguarded by
+    // this instrument while looking covered.
+    const pipelines = new Set(ORDER_CONSTRAINTS.map((c) => c.pipeline));
+    expect([...pipelines].sort()).toEqual(['authed', 'pre-auth']);
   });
 });

--- a/tests/unit/access-profiles-gates.test.ts
+++ b/tests/unit/access-profiles-gates.test.ts
@@ -1,0 +1,139 @@
+/**
+ * The two profiles gates, per-gate — KAN-415 D4 C6.
+ *
+ * middleware-gate-order.test.ts asserts them through the real middleware, which
+ * is the authority. This file adds what only a per-gate test can: each gate's
+ * exact column list, so a future attempt to merge the two queries shows up as a
+ * gate selecting columns it does not own, rather than as a silent single read.
+ *
+ * D4 constraint 6 forbids merging them — the second read is conditional on the
+ * first not redirecting — and this is the tripwire for it at the unit level.
+ */
+import { NextRequest, NextResponse } from 'next/server';
+import type { AuthedContext } from '@/modules/access/context';
+import { betaTier } from '@/modules/access/gates/beta-tier';
+import { suspension } from '@/modules/access/gates/suspension';
+
+const selected: string[] = [];
+
+function ctx(
+  pathname: string,
+  {
+    user = { id: 'u1' } as { id: string } | null,
+    row = null as Record<string, unknown> | null,
+    error = null as { message: string } | null,
+    deployTier = 'beta' as 'beta' | 'prod' | null,
+  } = {},
+): AuthedContext {
+  const request = new NextRequest(new URL(`https://checklyra.com${pathname}`), {
+    headers: { host: 'checklyra.com' },
+  });
+  return {
+    request,
+    pathname,
+    env: {
+      isBetaDeploy: deployTier === 'beta',
+      deployTier,
+      adminHost: 'admin.checklyra.com',
+      adminHostEnforced: false,
+    },
+    csp: () => 'csp',
+    user,
+    res: { current: NextResponse.next() },
+    supabase: {
+      from: () => ({
+        select: (cols: string) => {
+          selected.push(cols);
+          return { eq: () => ({ maybeSingle: async () => ({ data: row, error }) }) };
+        },
+      }),
+    },
+  } as unknown as AuthedContext;
+}
+
+beforeEach(() => {
+  selected.length = 0;
+});
+
+describe('each gate selects ONLY its own columns', () => {
+  test('suspension reads is_suspended and nothing else', async () => {
+    await suspension.run(ctx('/dashboard', { row: { is_suspended: false } }));
+    expect(selected).toEqual(['is_suspended']);
+  });
+
+  test('beta-tier reads user_status and access_tier, and not is_suspended', async () => {
+    await betaTier.run(ctx('/dashboard', { row: { user_status: 'live', access_tier: 'beta' } }));
+    expect(selected).toEqual(['user_status, access_tier']);
+    expect(selected[0]).not.toContain('is_suspended');
+  });
+});
+
+describe('suspension', () => {
+  test('redirects a suspended user to /suspended', async () => {
+    const out = await suspension.run(ctx('/dashboard', { row: { is_suspended: true } }));
+    expect(new URL(out!.headers.get('location')!).pathname).toBe('/suspended');
+  });
+
+  test('an exempt path is not even read — the query is skipped entirely', async () => {
+    // The exemption check moved INSIDE the user guard in C6. Unobservable in
+    // behaviour, but it means an exempt request costs no database read, which
+    // is where the real per-request saving is.
+    const out = await suspension.run(ctx('/login', { row: { is_suspended: true } }));
+    expect(out).toBeNull();
+    expect(selected).toEqual([]);
+  });
+
+  test('an anonymous request costs no read', async () => {
+    await suspension.run(ctx('/dashboard', { user: null }));
+    expect(selected).toEqual([]);
+  });
+
+  test('a lookup ERROR fails OPEN and says so — two args, "failing open"', async () => {
+    // The signature is pinned by middleware-gate-order.test.ts too. Reformatting
+    // it into one interpolated string breaks a test that exists because a
+    // silent fail-open is indistinguishable from no gate at all.
+    const spy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    const out = await suspension.run(ctx('/dashboard', { error: { message: 'boom' } }));
+    expect(out).toBeNull();
+    expect(spy).toHaveBeenCalledWith(expect.stringContaining('failing open'), 'boom');
+    spy.mockRestore();
+  });
+});
+
+describe('beta-tier', () => {
+  test('a non-live user goes to /waitlist', async () => {
+    const out = await betaTier.run(ctx('/dashboard', { row: { user_status: 'pending', access_tier: 'beta' } }));
+    expect(new URL(out!.headers.get('location')!).pathname).toBe('/waitlist');
+  });
+
+  test('a live user on the wrong tier is sent to their own host, keeping the path', async () => {
+    const out = await betaTier.run(
+      ctx('/dashboard/profile', { row: { user_status: 'live', access_tier: 'prod' } }),
+    );
+    const url = new URL(out!.headers.get('location')!);
+    expect(url.host).toBe('checklyra.com');
+    expect(url.pathname).toBe('/dashboard/profile');
+  });
+
+  test('deployTier null means the gate is inert — dev and staging are not tier-gated', async () => {
+    const out = await betaTier.run(ctx('/dashboard', { deployTier: null, row: { user_status: 'pending', access_tier: 'beta' } }));
+    expect(out).toBeNull();
+    expect(selected).toEqual([]);
+  });
+
+  test('a lookup ERROR fails CLOSED and says so — the 2026-08-09 decision', async () => {
+    // Direction unchanged (still /waitlist); the silence is what changed.
+    const spy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    const out = await betaTier.run(ctx('/dashboard', { error: { message: 'boom' } }));
+    expect(new URL(out!.headers.get('location')!).pathname).toBe('/waitlist');
+    expect(spy).toHaveBeenCalledWith(expect.stringContaining('failing closed'), 'boom');
+    spy.mockRestore();
+  });
+
+  test('an ordinary not-live user logs nothing', async () => {
+    const spy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    await betaTier.run(ctx('/dashboard', { row: { user_status: 'pending', access_tier: 'beta' } }));
+    expect(spy).not.toHaveBeenCalled();
+    spy.mockRestore();
+  });
+});

--- a/tests/unit/auth.test.js
+++ b/tests/unit/auth.test.js
@@ -27,13 +27,28 @@ describe('Auth pages', () => {
     expect(fs.existsSync(path.join(root, SRC.dashboardPage))).toBe(true);
   });
 
-  test('middleware exists and handles auth routes', () => {
-    const middlewarePath = path.join(root, SRC.middleware);
-    expect(fs.existsSync(middlewarePath)).toBe(true);
-    const content = fs.readFileSync(middlewarePath, 'utf8');
-    expect(content).toContain('/dashboard');
-    expect(content).toContain('/login');
-    expect(content).toContain('auth.getUser');
+  test('middleware exists', () => {
+    // REPOINTED, KAN-415 D4 C5 (approved 2026-08-09).
+    //
+    // This block used to read src/middleware.ts as SOURCE TEXT and assert it
+    // contained the strings '/dashboard', '/login' and 'auth.getUser'. All
+    // three moved: the session refresh into src/modules/access/session.ts, the
+    // two paths into the gates and the exemption table.
+    //
+    // Replacing them with behavioural assertions is a STRENGTHENING, and the
+    // repo already knew the old form was weak: BOTH '/dashboard' and '/login'
+    // are recorded in tests/support/comment-assertion-baseline.json as
+    // COMMENT-SHADOWED — satisfiable by a header comment alone, with the code
+    // deleted. A toContain on source text cannot tell "the middleware redirects
+    // anonymous users to /login" from "someone mentioned /login in a comment".
+    //
+    // The behaviour those three strings were standing in for is now asserted
+    // properly, through the real middleware, in:
+    //   tests/unit/middleware-gate-order.test.ts       (the redirects, and their ORDER)
+    //   tests/unit/middleware-response-contract.test.ts (getUser's cookie refresh
+    //                                                    actually reaching the response)
+    // Both are mutation-proven; the source-text form never was.
+    expect(fs.existsSync(path.join(root, SRC.middleware))).toBe(true);
   });
 
   test('server actions file exists with signUp, signIn, signOut', () => {

--- a/tests/unit/middleware-composition-root.test.ts
+++ b/tests/unit/middleware-composition-root.test.ts
@@ -1,0 +1,77 @@
+/**
+ * src/middleware.ts has no function body — KAN-415 D4 C8.
+ *
+ * This is the one property of the decomposition that no behavioural test can
+ * express, because it is about what CANNOT be written rather than what happens.
+ *
+ * Through D5-D9 the neighbouring code gets rewritten repeatedly, and the
+ * cheapest way to "just handle one more case" would be to open the middleware
+ * and insert `if (x) return y;` above the pipeline. EVERY ORDERING TEST WOULD
+ * STILL PASS — the gates would still run in order; they would simply no longer
+ * be the only thing that runs. Nothing else in the suite can see that.
+ *
+ * With no body there is nowhere to put it, and adding one is a visible
+ * structural change rather than a one-line edit.
+ *
+ * Verified at C8 that Next 16.2.12 accepts a non-function `middleware` export:
+ * `npm run build` exits 0 and .next/server/middleware-manifest.json carries the
+ * entry with its matcher and `server/src/middleware.js`. That was the one
+ * Next-specific unknown in the plan, and it resolved in favour of the strong
+ * shape rather than the documented fallback.
+ */
+import fs from 'fs';
+import path from 'path';
+
+const ROOT = path.resolve(__dirname, '../../');
+const { SRC } = require('../support/source-paths.json');
+
+/** Comments stripped — the header describes the very shapes this forbids. */
+function code(): string {
+  return fs
+    .readFileSync(path.join(ROOT, SRC.middleware), 'utf8')
+    .replace(/\/\*[\s\S]*?\*\//g, '')
+    .replace(/^[ \t]*\/\/.*$/gm, '');
+}
+
+describe('the composition root cannot grow a body', () => {
+  test('middleware is a const bound to the factory, not a function declaration', () => {
+    const src = code();
+    expect(src).toMatch(/export const middleware = createAccessMiddleware\(/);
+    // The shape that would reopen the hole.
+    expect(src).not.toMatch(/export\s+(async\s+)?function\s+middleware/);
+    expect(src).not.toMatch(/export\s+default\s+async\s+function/);
+  });
+
+  test('the only function declared here is the env reader', () => {
+    // A second function would be somewhere for request logic to accumulate,
+    // one helper at a time, without ever looking like a structural change.
+    const declared = [...code().matchAll(/function\s+([A-Za-z0-9_]+)\s*\(/g)].map((m) => m[1]);
+    expect(declared).toEqual(['readMiddlewareEnv']);
+  });
+
+  test('the env reader returns a literal and nothing else', () => {
+    // It must stay a plain data read. A conditional or an early return here is
+    // request logic wearing a different hat.
+    const src = code();
+    const body = src.slice(src.indexOf('function readMiddlewareEnv'));
+    const upToClose = body.slice(0, body.indexOf('\n}'));
+    expect(upToClose).not.toMatch(/\bif\s*\(/);
+    expect(upToClose).not.toMatch(/\breturn\b[\s\S]*\breturn\b/);
+  });
+
+  test('the route matcher is unchanged — it decides which requests exist at all', () => {
+    // Not a refactor detail: a narrowed matcher silently un-gates whole route
+    // trees, and nothing else in the suite would notice.
+    expect(code()).toContain(
+      "'/((?!_next/static|_next/image|favicon.ico|.*\\\\.(?:svg|png|jpg|jpeg|gif|webp)$).*)'",
+    );
+  });
+
+  test('no gate logic is left here — the file imports the pipeline, it does not implement one', () => {
+    const src = code();
+    expect(src).toMatch(/from '@\/modules\/access\/pipeline'/);
+    // Terminal responses are the pipeline's business now.
+    expect(src).not.toMatch(/NextResponse\.(redirect|rewrite|json)/);
+    expect(src).not.toMatch(/\.startsWith\(/);
+  });
+});

--- a/tests/unit/middleware-gate-order.test.ts
+++ b/tests/unit/middleware-gate-order.test.ts
@@ -270,35 +270,57 @@ describe('fail-CLOSED paths — the other half of the asymmetry', () => {
   });
 
   /**
-   * ⚠️ CHARACTERISATION OF A DEFECT, NOT AN ENDORSEMENT.
+   * ⚠️ THIS WAS A DEFECT. IT IS NOW A DECISION.
    *
-   * The beta/tier gate destructures only `{ data: profile }` and never looks at
-   * `error`. So a transient profiles-read failure makes `profile` undefined,
-   * which is `!== 'live'`, which redirects a legitimate live user to /waitlist —
-   * SILENTLY. No log line, no signal.
+   * The beta/tier gate destructured only `{ data: profile }` and never looked
+   * at `error`. A transient profiles-read failure made `profile` undefined,
+   * which is `!== 'live'`, which redirected a LEGITIMATE LIVE USER to /waitlist
+   * — silently. No log, no signal, and no way for that user to self-recover:
+   * they ARE live, they just cannot prove it while the read is failing.
    *
-   * The suspension gate immediately above it was explicitly hardened against
-   * exactly this ("Observability: never fail silently on a lookup error") and
-   * chose to fail OPEN with a console.error. Fifty lines later the same read
-   * fails CLOSED and says nothing.
+   * The suspension gate fifty lines above was explicitly hardened against
+   * exactly this ("never fail silently on a lookup error") and fails OPEN with
+   * a console.error. Same read, opposite direction, no log.
    *
-   * This test asserts the CURRENT behaviour so the decomposition is provably
-   * equivalent. It is deliberately not fixed here: changing it is a behaviour
-   * change to a production access gate and belongs in its own ticket, with its
-   * own decision about whether the right answer is fail-open, fail-closed, or
-   * fail-closed-but-logged.
+   * DECIDED 2026-08-09 (Luisa): FAIL CLOSED, BUT LOGGED.
+   *
+   * The direction stays — this gate governs access to a gated product, whereas
+   * suspension governs a suspended user's own session, and admitting an
+   * unverified user to beta on a transient database error is the worse outcome.
+   * What changes is the silence.
+   *
+   * This assertion previously read `expect(spy).not.toHaveBeenCalled()`, with a
+   * comment saying that if a future change started logging here the test would
+   * fail and someone would read the note. That is exactly what happened, in the
+   * commit that made the change. Updated deliberately, not to make a build
+   * green.
    */
-  test('a beta-gate query ERROR silently redirects a live user to /waitlist', async () => {
+  test('a beta-gate query ERROR fails closed to /waitlist, and SAYS SO', async () => {
     const spy = jest.spyOn(console, 'error').mockImplementation(() => {});
     process.env.IS_BETA_DEPLOY = 'true';
     mockProfileError = { message: 'connection reset' };
     const res = await middleware(req('/dashboard'));
+    // The direction is unchanged: still closed, still /waitlist.
     expect(loc(res)?.pathname).toBe('/waitlist');
-    // The point of the test: nothing was logged. If a future change starts
-    // logging here, this assertion fails and someone reads the comment above.
-    expect(spy).not.toHaveBeenCalled();
+    // The silence is not. And it must be DISTINGUISHABLE from the ordinary
+    // not-live case, or the log cannot answer "was this user actually live?".
+    expect(spy).toHaveBeenCalledWith(
+      expect.stringContaining('failing closed'),
+      'connection reset',
+    );
   });
-});
+
+  test('an ordinary not-live user is NOT logged as an error', async () => {
+    // The other half. If every /waitlist bounce logged, the log would be noise
+    // and the error case would be invisible inside it — which is the same
+    // failure as not logging at all, arrived at from the other direction.
+    const spy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    process.env.IS_BETA_DEPLOY = 'true';
+    mockProfile = { user_status: 'pending', access_tier: 'beta' };
+    const res = await middleware(req('/dashboard'));
+    expect(loc(res)?.pathname).toBe('/waitlist');
+    expect(spy).not.toHaveBeenCalled();
+  });});
 
 describe('exemption tables — the loops they exist to prevent', () => {
   // Two overlapping inline exemption arrays today; D4 replaces them with one

--- a/tests/unit/middleware-response-contract.test.ts
+++ b/tests/unit/middleware-response-contract.test.ts
@@ -1,0 +1,294 @@
+/**
+ * middleware.ts — the response-level contracts the 29 gate-order tests cannot see.
+ * KAN-415 D4, commit C1. Written against the CURRENT code, before anything moves.
+ *
+ * WHY A SECOND FILE RATHER THAN MORE OF THE FIRST
+ * -----------------------------------------------
+ * `middleware-gate-order.test.ts` pins WHICH GATE WINS. It does that well and is
+ * mutation-proven. But it observes almost nothing about the response object
+ * itself, and the D4 decomposition moves exactly the machinery that builds one:
+ * the Supabase client's cookie plumbing, the CSP nonce, and the admin rewrite.
+ *
+ * Three gaps were measured before writing this, not assumed:
+ *
+ *   (a) `options.cookies.setAll` is invoked by ZERO of the 33 existing tests.
+ *       Both existing mocks construct `createServerClient` as a ZERO-ARGUMENT
+ *       factory — `createServerClient: () => ({...})` — so the options object
+ *       carrying the cookie callbacks is discarded unread. The refreshed
+ *       session cookie, and `withParentCookieDomain` on it, are therefore
+ *       completely unguarded. That is the single most load-bearing thing D4
+ *       relocates (C5 moves the client construction wholesale).
+ *
+ *   (b) No test reads a CSP header off a middleware response.
+ *       `security-headers.test.ts` exercises `buildCspReportOnly` in isolation
+ *       and reads next.config.ts. Whether a given EXIT stamps the header is
+ *       unobserved — so a decomposition that stamped every response, or none,
+ *       would be invisible.
+ *
+ *   (c) `admin-host-routing.test.ts` has 5 tests and asserts no passthrough
+ *       path at all. The passthrough list (`/login`, `/auth/*`, `/api/*`,
+ *       `/_next/*`) is the difference between an admin host that works and one
+ *       that rewrites its own login page into `/admin/login`.
+ *
+ * And (d): the two sequential `profiles` reads, whose ORDER and CONDITIONALITY
+ * are constraint 6 of the D4 brief — the second read must not happen when the
+ * first redirects.
+ *
+ * These assert CURRENT behaviour. Where current behaviour is arguably wrong it
+ * is pinned as-is with a comment, not corrected — this file exists so the
+ * refactor has something to be equivalent TO.
+ */
+process.env.NEXT_PUBLIC_SUPABASE_URL = 'https://test.supabase.co';
+process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY = 'anon-key';
+
+let mockUser: { id: string } | null = { id: 'user-1' };
+let mockSuspended: boolean | null = false;
+let mockProfile: { user_status: string; access_tier: string } | null = null;
+
+/** Every profiles read, in order — the tripwire for constraint 6. */
+let profileReads: string[] = [];
+/** When true, the mock rotates the session inside getUser, as the real client does. */
+let refreshOnGetUser = false;
+const REFRESHED_COOKIE = 'sb-access-token';
+/** Whatever the middleware handed createServerClient as its third argument. */
+let capturedOptions: { cookies?: { getAll?: () => unknown; setAll?: (c: unknown[]) => void } } | null = null;
+
+jest.mock('@supabase/ssr', () => ({
+  // NOTE the arity. The existing mocks are `() => ({...})` and silently drop
+  // this object, which is why setAll has never been exercised.
+  createServerClient: (_url: string, _key: string, options: Record<string, never>) => {
+    capturedOptions = options as typeof capturedOptions;
+    return {
+      auth: {
+        getUser: async () => {
+          // @supabase/ssr rotates the session DURING getUser and calls setAll
+          // from inside it. Reproducing that timing is the whole point: the
+          // middleware's callback rebuilds `supabaseResponse`, so anything that
+          // captured the old instance returns a response without the new cookie.
+          if (refreshOnGetUser) {
+            (options as unknown as { cookies: { setAll: (c: unknown[]) => void } }).cookies.setAll([
+              { name: REFRESHED_COOKIE, value: 'new-token', options: { path: '/' } },
+            ]);
+          }
+          return { data: { user: mockUser } };
+        },
+      },
+      from: (table: string) => ({
+        select: (cols: string) => {
+          profileReads.push(`${table}:${cols}`);
+          return {
+            eq: () => ({
+              maybeSingle: async () =>
+                cols.includes('is_suspended')
+                  ? { data: { is_suspended: mockSuspended }, error: null }
+                  : { data: mockProfile, error: null },
+            }),
+          };
+        },
+      }),
+    };
+  },
+}));
+
+jest.mock('@/modules/guards/rate-limit', () => ({
+  RATE_LIMITS: { auth: { windowMs: 1000, max: 5 } },
+  rateLimit: () => ({ limited: false, retryAfter: 0 }),
+}));
+
+let mockCfEnabled = false;
+jest.mock('@/modules/guards/cf-access', () => ({
+  cfAccessEnabled: () => mockCfEnabled,
+  verifyCfAccessToken: async () => true,
+}));
+
+import { NextRequest } from 'next/server';
+import { middleware } from '@/middleware';
+
+const CSP_HEADER = 'Content-Security-Policy-Report-Only';
+
+function req(
+  path: string,
+  { method = 'GET', host = 'checklyra.com' }: { method?: string; host?: string } = {},
+): NextRequest {
+  return new NextRequest(new URL(`https://${host}${path}`), { method, headers: { host } });
+}
+
+beforeEach(() => {
+  mockUser = { id: 'user-1' };
+  mockSuspended = false;
+  mockProfile = { user_status: 'live', access_tier: 'prod' };
+  mockCfEnabled = false;
+  profileReads = [];
+  capturedOptions = null;
+  refreshOnGetUser = false;
+  delete process.env.IS_BETA_DEPLOY;
+  delete process.env.ADMIN_HOST_ENFORCED;
+  delete process.env.VERCEL_ENV;
+  delete process.env.NEXT_PUBLIC_SITE_URL;
+});
+
+describe('(a) the cookie-refresh path — invoked by none of the existing 33 tests', () => {
+  test('middleware supplies BOTH cookie callbacks to createServerClient', async () => {
+    // The precondition for everything else here. If the options object stops
+    // being passed, every assertion below passes vacuously — so assert the
+    // shape before relying on it.
+    await middleware(req('/dashboard'));
+    expect(capturedOptions).not.toBeNull();
+    expect(typeof capturedOptions?.cookies?.getAll).toBe('function');
+    expect(typeof capturedOptions?.cookies?.setAll).toBe('function');
+  });
+
+  test('a session refreshed DURING getUser lands on the returned response', async () => {
+    // The one that matters. @supabase/ssr rotates the session inside getUser
+    // and calls setAll from there; the middleware's callback REBUILDS
+    // supabaseResponse at that moment. Any refactor that captures the response
+    // by value before this point returns one without the new cookie — and every
+    // user gets logged out on token rotation, silently, with all 33 other tests
+    // still green.
+    refreshOnGetUser = true;
+    const res = await middleware(req('/dashboard'));
+    expect(res.cookies.get(REFRESHED_COOKIE)?.value).toBe('new-token');
+  });
+
+  test('the refreshed cookie also survives the ADMIN REWRITE exit', async () => {
+    // A separate exit that rebuilds the response object from scratch and copies
+    // cookies across by hand (`supabaseResponse.cookies.getAll().forEach`).
+    // That hand-copy is exactly the kind of step a decomposition drops.
+    process.env.ADMIN_HOST_ENFORCED = 'true';
+    refreshOnGetUser = true;
+    const res = await middleware(req('/users', { host: 'admin.checklyra.com' }));
+    expect(res.headers.get('x-middleware-rewrite')).toBeTruthy();
+    expect(res.cookies.get(REFRESHED_COOKIE)?.value).toBe('new-token');
+  });
+
+  test('no refresh means no stray cookie — the assertion above is not trivially true', async () => {
+    refreshOnGetUser = false;
+    const res = await middleware(req('/dashboard'));
+    expect(res.cookies.get(REFRESHED_COOKIE)).toBeUndefined();
+  });
+});
+
+describe('(b) which exits stamp the CSP header — a map, not a spot-check', () => {
+  // Report-Only never blocks, so a missing header is invisible in production
+  // until the SEC-63 follow-up flips it to enforcing. Then it is very visible.
+  test('the terminal response carries the CSP header', async () => {
+    const res = await middleware(req('/some-page'));
+    expect(res.headers.get(CSP_HEADER)).toBeTruthy();
+  });
+
+  test('the env-missing fail-open response carries it too', async () => {
+    const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
+    delete process.env.NEXT_PUBLIC_SUPABASE_URL;
+    try {
+      const res = await middleware(req('/some-page'));
+      expect(res.headers.get(CSP_HEADER)).toBeTruthy();
+    } finally {
+      process.env.NEXT_PUBLIC_SUPABASE_URL = url;
+    }
+  });
+
+  test.each([
+    ['SEC-36 404', '/oauth/register'],
+  ])('%s does NOT carry a CSP header — it is not a document', async (_label, path) => {
+    process.env.IS_BETA_DEPLOY = 'true';
+    const res = await middleware(req(path));
+    expect(res.headers.get(CSP_HEADER)).toBeNull();
+  });
+
+  test('a redirect does not carry a CSP header', async () => {
+    mockUser = null;
+    const res = await middleware(req('/dashboard'));
+    expect(res.headers.get(CSP_HEADER)).toBeNull();
+  });
+
+  test('the SEC-36 404 path generates NO nonce — it returns before the CSP is built', async () => {
+    // Cost, and evidence of ordering. The nonce costs a getRandomValues call on
+    // every request that reaches it; the 404 must return first. If a
+    // decomposition builds the context (and the nonce) eagerly at the top, this
+    // is the test that notices.
+    process.env.IS_BETA_DEPLOY = 'true';
+    const spy = jest.spyOn(globalThis.crypto, 'getRandomValues');
+    try {
+      await middleware(req('/oauth/register'));
+      expect(spy).not.toHaveBeenCalled();
+    } finally {
+      spy.mockRestore();
+    }
+  });
+});
+
+describe('(c) admin-host passthrough is a SET, not two examples', () => {
+  const onAdminHost = (p: string) => req(p, { host: 'admin.checklyra.com' });
+
+  beforeEach(() => {
+    process.env.ADMIN_HOST_ENFORCED = 'true';
+  });
+
+  test.each(['/login', '/auth/callback', '/api/health', '/_next/static/x.js'])(
+    '%s is served unchanged on the admin host — rewriting it would break the console',
+    async (path) => {
+      const res = await middleware(onAdminHost(path));
+      // Not rewritten into /admin/... and not redirected away.
+      expect(res.headers.get('location')).toBeNull();
+      expect(res.headers.get('x-middleware-rewrite') || '').not.toContain('/admin');
+    },
+  );
+
+  test.each(['/users', '/favicon.ico', '/suspended'])(
+    '%s IS rewritten under /admin on the admin host',
+    async (path) => {
+      const res = await middleware(onAdminHost(path));
+      const rewrite = res.headers.get('x-middleware-rewrite');
+      expect(rewrite).toBeTruthy();
+      expect(new URL(rewrite as string).pathname).toBe(`/admin${path}`);
+    },
+  );
+
+  test('the admin rewrite carries the CSP header — it serves a document', async () => {
+    const res = await middleware(onAdminHost('/users'));
+    expect(res.headers.get(CSP_HEADER)).toBeTruthy();
+  });
+
+  test('an already-/admin path is served, not rewritten again', async () => {
+    const res = await middleware(onAdminHost('/admin/users'));
+    expect(res.headers.get('x-middleware-rewrite')).toBeNull();
+    expect(res.headers.get('location')).toBeNull();
+  });
+});
+
+describe('(d) the two profiles reads — order and conditionality (constraint 6)', () => {
+  test('a live beta user on /dashboard performs exactly two reads, in order', async () => {
+    process.env.IS_BETA_DEPLOY = 'true';
+    mockProfile = { user_status: 'live', access_tier: 'beta' };
+    await middleware(req('/dashboard'));
+    expect(profileReads).toEqual(['profiles:is_suspended', 'profiles:user_status, access_tier']);
+  });
+
+  test('the SECOND read does not happen when the first redirects', async () => {
+    // The invariant that makes "merge the two queries" a behaviour change
+    // rather than an optimisation. A suspended user must cost one read, not two.
+    process.env.IS_BETA_DEPLOY = 'true';
+    mockSuspended = true;
+    await middleware(req('/dashboard'));
+    expect(profileReads).toEqual(['profiles:is_suspended']);
+  });
+
+  test('an anonymous request performs no reads at all', async () => {
+    process.env.IS_BETA_DEPLOY = 'true';
+    mockUser = null;
+    await middleware(req('/'));
+    expect(profileReads).toEqual([]);
+  });
+
+  test('each read selects only its own columns', async () => {
+    // Pins the column lists so a future merge shows up as a gate selecting
+    // columns it does not own, rather than as a silent single query.
+    process.env.IS_BETA_DEPLOY = 'true';
+    mockProfile = { user_status: 'live', access_tier: 'beta' };
+    await middleware(req('/dashboard'));
+    expect(profileReads[0]).toBe('profiles:is_suspended');
+    expect(profileReads[1]).toBe('profiles:user_status, access_tier');
+    expect(profileReads[0]).not.toContain('user_status');
+    expect(profileReads[1]).not.toContain('is_suspended');
+  });
+});

--- a/tests/unit/sec4-status-page.test.js
+++ b/tests/unit/sec4-status-page.test.js
@@ -8,6 +8,7 @@
 const fs = require('fs');
 const path = require('path');
 const { SRC } = require('../support/source-paths.json');
+const { isExemptFrom } = require('@/modules/access/exemptions');
 
 const root = path.join(__dirname, '../..');
 const PAGE = fs.readFileSync(path.join(root, SRC.statusPage), 'utf8');
@@ -23,7 +24,22 @@ describe('SEC-4 status page', () => {
   });
 
   test('is exempt from the beta gate (public on beta)', () => {
-    expect(MW).toMatch(/pathname === '\/status'/);
+    // REPOINTED, KAN-415 D4 C2b (approved 2026-08-09). This used to read
+    // src/middleware.ts as source text and match `pathname === '/status'`. The
+    // beta-gate exemptions moved into a declarative table, so that literal is
+    // no longer in that file.
+    //
+    // The replacement is STRICTLY STRONGER. A toMatch on source text passes on
+    // any stray mention — a comment, a variable name, a different gate's list —
+    // whereas this asks the exemption table the actual question SEC-4 cares
+    // about: is /status exempt from the beta gate? It would fail if the row
+    // were deleted, if it were moved to the wrong gate, or if it were
+    // misspelled, none of which the old assertion could distinguish.
+    expect(isExemptFrom('beta-tier', '/status')).toBe(true);
+    // And the inverse, which the old form could not express at all: /status is
+    // NOT exempt from the suspension gate. A suspended user does not get a free
+    // pass to the status page by virtue of it being public.
+    expect(isExemptFrom('suspension', '/status')).toBe(false);
   });
 
   test('is allow-listed in the maintenance worker (reachable on prod)', () => {


### PR DESCRIPTION
## D4 — `access` extraction and the `middleware.ts` gate pipeline

**In progress.** Opening early so CI validates each step. Commits land incrementally; the suite is green at every one.

The plan this executes came from a four-design judge panel (17 agents, three lenses: equivalence, edge-safety, durability). `test-first` won at 8.7 with five grafts from the losing designs.

### The definition of "done" here

**The 55 middleware characterisation assertions must pass UNCHANGED.** They are the definition of equivalence, and no commit in this PR touches `middleware-gate-order.test.ts`, `middleware-suspension.test.ts` or `middleware-response-contract.test.ts` after C1 creates the third.

### Landed so far

| Commit | What |
|---|---|
| **C1** | The four nets the 29 gate-order tests cannot provide |
| **C2a** | The exemption table, proven equivalent to the three predicates it replaces |
| **C3** | Env snapshot, `DeployContext`, lazy CSP |

**C1** closed three measured gaps. The load-bearing one: `options.cookies.setAll` was invoked by **zero of the 33** existing tests, because both mocks construct `createServerClient` as a zero-argument factory and discard the options object. The refreshed session cookie was completely unguarded — and C5 moves exactly that code. The new mock refreshes *during* `getUser`, which is when `@supabase/ssr` really calls it, so a by-value capture of the response now reddens a test instead of logging every user out on token rotation.

**C2a** is the only substitution in D4 that isn't a verbatim move, so it gets an independent oracle: a literal transcription of the three original predicates that does not import the table. A test deriving its expectations from `EXEMPTIONS` would agree with any table, including a wrong one.

The probe corpus includes near-misses nothing tested before — `/auth` without its trailing slash, `/authenticate`, `/_nextdoor`, `/favicon.icoo`. And `isOauthServerPath` is kept in a **separate module**: it's an *inclusion* set, and folding it into a table headed "exempt from" is one polarity inversion from disabling the 404 that closes an unauthenticated DCR write into production's `oauth_clients`.

**C3** keeps the seven `process.env` reads in `middleware.ts` on purpose — CTL-037's baseline records them there, and moving them would change the baseline without changing what's read. `env-access-baseline.json` is byte-identical.

### Everything is mutation-proven

| Target | Mutations | Result |
|---|---|---|
| C1 nets | stale captured response · no CSP on terminal · eager nonce · dropped `/api/` passthrough · unconditional second read | each reddens only what it should |
| C2a table | dropped `/status` row · prefix loses its slash · extra gate on `/signup` · OAuth path leaks in | 2 / 4 / 2 / 3 red |

### A guard defect found on the way

CTL-037 flagged `context.ts` for a `process.env` read **that does not exist** — it matched a docstring and extracted the variable name `X` from the phrase `process.env.X`. It does not strip comments. Same class as CTL-039 and the SEC-100 sitemap scan. It errs safe (a comment can only *add* a finding), so it's noisy rather than dangerous. Fixing the scanner is a separate PR — mixing it in here would make the equivalence claim unreviewable.

### Still to come

C2b (the middleware substitution — **needs sign-off**, see below), C4 the runner and pre-auth pipeline, C5 `establishSession`, C6 the two profiles gates, C7 the remaining gates and the QA sweep.

### ⚠️ Sign-off needed before C2b/C5/C7

Five assertions in three test files, plus one Python tool, read `src/middleware.ts` **as source text** and will go red as code moves out of it. Per the Test Integrity Policy each repoint needs explicit approval. All are **strengthenings** — a `toMatch` on source text passes on a stray mention, and two are already baselined as `comment-shadowed`, meaning they can be satisfied by a comment alone.

Detail is in the commit bodies and will be posted as a comment for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)