### PR TITLE
fix(CTL-042): decide all four dark workflows, and flip the gate to blocking

### DIFF
--- a/.github/scheduled-workflow-exceptions.json
+++ b/.github/scheduled-workflow-exceptions.json
@@ -8,18 +8,19 @@
     "the check outright — a list containing things that no longer apply is a",
     "list nobody reads.",
     "",
-    "DELIBERATELY EMPTY as of 2026-08-09. Four scheduled workflows were found",
-    "inactive that day (anomaly-detect */15, affiliate-link-smoke hourly,",
-    "mutation-testing weekly, auto-promote-to-staging weekly), all dark since",
-    "mid-June. None of them is listed here, because nobody has yet said which",
-    "were switched off on purpose — and writing an exception on that guess is",
-    "how a finding becomes a permanent silence. They surface as warnings on",
-    "every run until a human decides: re-enable, or except with a reason.",
-    "",
-    "Note that CLAUDE.md currently documents at least two of them as live",
-    "cadences ('Sunday 04:00 - Stryker mutation testing', and staging promotion",
-    "'also auto-runs Sunday 23:00 UTC'). Whichever way each decision goes, the",
-    "docs move with it."
+    "DECIDED 2026-08-09 by Luisa. Four workflows were found dark since mid-June.",
+    "Two were re-enabled (anomaly-detect, mutation-testing) and are deliberately",
+    "absent from this file — listing an active workflow here is an error. The",
+    "two below are excepted with reasons rather than re-enabled."
   ],
-  "exceptions": {}
+  "exceptions": {
+    ".github/workflows/affiliate-link-smoke.yml": {
+      "key": "BUGS-90",
+      "reason": "Its last three scheduled runs FAILED before it went dark on 2026-06-16, so re-enabling it would put a known-red hourly job back on the board without fixing what it is reporting. Decided 2026-08-09 (Luisa): stay off until the failure is diagnosed. Re-enabling it is the fix; this exception is the placeholder, not the answer."
+    },
+    ".github/workflows/auto-promote-to-staging.yml": {
+      "key": "SEC-98",
+      "reason": "Weekly develop->staging auto-promote. SEC-98 made production change control manual-only and withdrew the fix-only auto-promote exception on 2026-07-23; an unattended promote sits awkwardly beside that even though staging is not production. Decided 2026-08-09 (Luisa): stay off. NOTE: CLAUDE.md's Deployment Pipeline section still describes this as auto-running Sunday 23:00 UTC — that line is now wrong and is corrected in this commit."
+    }
+  }
 }

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -317,6 +317,13 @@ jobs:
         # SCHEDULED_WORKFLOW_GATE_ENFORCE=1.
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # FLIPPED TO BLOCKING 2026-08-09. It shipped warn-only because four
+          # workflows were dark pending a founder decision, and a gate that
+          # blocks every unrelated PR on something nobody can clear is a gate
+          # that gets switched off. That decision is made: two re-enabled, two
+          # excepted with reasons. Nothing is left unaccounted for, so the
+          # warn->block path completes here.
+          SCHEDULED_WORKFLOW_GATE_ENFORCE: '1'
         run: |
           set -euo pipefail
           python3 scripts/check-scheduled-workflows-active.py --self-test

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -329,7 +329,7 @@ The gates, in summary — this table is **not** the full set:
 The pipeline is: **develop → staging → beta → main** (promotion-based, four envs since KAN-175).
 
 - All feature work goes to `develop` via PR
-- Promotion to staging: `gh workflow run promote-to-staging.yml -f confirm=promote` (also auto-runs Sunday 23:00 UTC — see KAN-173 / `docs/RELEASE_POLICY.md`)
+- Promotion to staging: `gh workflow run promote-to-staging.yml -f confirm=promote`. ⚠️ **The Sunday 23:00 UTC auto-promote is OFF** (decided 2026-08-09). `auto-promote-to-staging.yml` is `disabled_manually` and is recorded as a deliberate exception in `.github/scheduled-workflow-exceptions.json` under SEC-98 — an unattended promote sits awkwardly beside manual-only production change control. This line previously said it auto-ran, and had said so for the ~8 weeks the workflow was actually dark; **documentation describing a schedule is indistinguishable from a schedule**, which is half of why CTL-042 exists. See KAN-173 / `docs/RELEASE_POLICY.md` for the original cadence.
 - Promotion to beta: `gh workflow run promote-staging-to-beta.yml -f confirm=promote` (manual — gate for `beta.checklyra.com`, which uses prod Supabase + the in-app beta gate; see KAN-175)
 - Promotion to production: `gh workflow run promote-to-production.yml -f confirm=PRODUCTION` (merges `beta → main`). **Default: manual — no exception currently active.** **WITHDRAWN 2026-07-23:** the fix-only auto-promote-to-production exception (originally owner-authorized 2026-06-21, allowing the weekly health/regression routine — SEC-22 / `docs/WEEKLY_HEALTH_REGRESSION_ROUTINE.md` — to auto-promote when every pending change was a bug-fix) was revoked by Luisa on 2026-07-23. Production promote is manual-only again; the routine prepares + reports release-readiness only and must NOT run `promote-to-production.yml` or `promote-staging-to-beta.yml` under any auto-fix-only condition. The historical exception text below (and in `docs/RELEASE_POLICY.md` / `docs/WEEKLY_HEALTH_REGRESSION_ROUTINE.md`) is retained for context only — do not act on it unless Luisa explicitly reinstates it in writing, here, with a new date. <details><summary>Historical exception text (inactive)</summary>
 
@@ -824,7 +824,7 @@ See `docs/RUNBOOK.md` for the full schedule. Key times (UTC):
 
 - Sunday 02:00 — Database backup
 - Sunday 02:30 — Platform backup (repos, DNS, schema to R2)
-- Sunday 04:00 — Stryker mutation testing
+- Sunday 04:00 — Stryker mutation testing. **Re-enabled 2026-08-09** after being `disabled_manually` and silently dark since 2026-06-14; this line kept describing it as live throughout (CTL-042).
 - Sunday 05:00 — Backup restore test
 - Monday 07:00 — Weekly report (emails via Resend)
 - Wednesday 07:00 — Security audit (npm audit + email alerts via Resend)


### PR DESCRIPTION
## All four decided, and the gate completes its warn→block path

**Decided 2026-08-09.** Four scheduled workflows had been `disabled_manually` and silently dark since mid-June.

### Re-enabled — verified active via the API, not assumed

| Workflow | Cron | Note |
|---|---|---|
| `anomaly-detect.yml` | `*/15 * * * *` | security monitoring, ~8 weeks silent |
| `mutation-testing.yml` | `0 4 * * 0` | also validates `stryker.config.mjs`'s mutate globs, which **D1 changed** — so that change has been unverified since |

### Excepted with reasons, not re-enabled

**`affiliate-link-smoke.yml`** — its last **three** scheduled runs failed before it went dark. Re-enabling it would put a known-red hourly job back on the board without fixing what it reports. *The exception is a placeholder, not an answer* — re-enabling it **is** the fix (BUGS-90).

**`auto-promote-to-staging.yml`** — an unattended weekly promote sits awkwardly beside SEC-98's manual-only production change control, even though staging isn't production.

### The gate is now blocking

CTL-042 shipped warn-only on purpose: four workflows were dark pending a decision only you could make, and *a gate that blocks every unrelated PR on something nobody can clear is a gate that gets switched off*. That decision is made and nothing is unaccounted for, so the warn→block path completes. Verified: `--enforce` exits 0 today.

### Two doc lines were lying

**CLAUDE.md said staging promotion "also auto-runs Sunday 23:00 UTC".** It hasn't since 2026-06-14. That line kept describing a live cadence throughout the ~8 weeks the workflow was dark — which is half of why CTL-042 exists at all.

> **Documentation describing a schedule is indistinguishable from a schedule.**

The Stryker line is true again as of today, and now records that it *wasn't*, so the next reader knows the gap existed rather than assuming continuity.

### Also on the same decision

[lyra-mcp-server#143](https://github.com/luisa-sys/lyra-mcp-server/pull/143) merged — repointing the three dead references to lyra paths D1 moved.

`Prevention: CTL-042` — this is the control that found it, and flipping it to blocking is what stops the next one going dark unnoticed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)