### PR TITLE
fix(CTL-037): the env-access ratchet was matching DOCSTRINGS

### DIFF
--- a/scripts/check-env-access.py
+++ b/scripts/check-env-access.py
@@ -112,6 +112,96 @@ def tracked_ts_files() -> list[str]:
     return sorted(files)
 
 
+
+def code_only(line: str, in_block: bool) -> tuple[str, bool]:
+    """Return (the executable part of `line`, whether a block comment is open after it).
+
+    CTL-037 matched DOCSTRINGS. It flagged src/modules/access/context.ts for a
+    NEW env read that did not exist, having matched the phrase `process.env.X`
+    in a comment explaining where the reads live — and extracted the variable
+    name "X" from it. Same comment-shadowing class as CTL-039 and the SEC-100
+    sitemap scan, arrived at from the other direction.
+
+    It errs SAFE — a comment can only ADD a finding, never suppress one — so
+    this is noise rather than danger. But noise on a ratchet is how a ratchet
+    gets waved through, and the phrasing workaround (never write the literal in
+    a comment) is exactly the kind of unwritten rule that erodes.
+
+    Comments cannot simply be stripped before scanning: the escape hatch
+    (`env-access-ok`) LIVES in a comment and is detected on the full line. So
+    the two are separated — this returns the code, the caller keeps the
+    original for hatch detection.
+
+    String literals are blanked FIRST, so a `//` inside a URL does not start a
+    comment. `process.env.X` never appears inside a real string literal, and if
+    it did, treating it as a read would be a false positive anyway.
+    """
+    out: list[str] = []
+    i, n = 0, len(line)
+    while i < n:
+        if in_block:
+            end = line.find("*/", i)
+            if end == -1:
+                return "".join(out), True
+            in_block = False
+            i = end + 2
+            continue
+        ch = line[i]
+        if ch in "'\"":
+            # Ordinary string: skip it whole, honouring backslash escapes.
+            quote = ch
+            i += 1
+            while i < n:
+                if line[i] == "\\":
+                    i += 2
+                    continue
+                if line[i] == quote:
+                    i += 1
+                    break
+                i += 1
+            continue
+        if ch == "`":
+            # TEMPLATE LITERAL. Its ${...} interpolations are CODE, not string
+            # content, and blanking them wholesale is how this fix first went
+            # wrong: src/app/dashboard/page.tsx reads NEXT_PUBLIC_SITE_URL only
+            # inside `${...}`, so a naive skip made a REAL read vanish and the
+            # ratchet reported a phantom migration. A normaliser that removes
+            # too much reports agreement that is not there.
+            i += 1
+            while i < n:
+                if line[i] == "\\":
+                    i += 2
+                    continue
+                if line[i] == "`":
+                    i += 1
+                    break
+                if line.startswith("${", i):
+                    depth = 1
+                    i += 2
+                    while i < n and depth:
+                        if line[i] == "{":
+                            depth += 1
+                        elif line[i] == "}":
+                            depth -= 1
+                            if depth == 0:
+                                i += 1
+                                break
+                        out.append(line[i])
+                        i += 1
+                    continue
+                i += 1
+            continue
+        if line.startswith("//", i):
+            return "".join(out), False
+        if line.startswith("/*", i):
+            in_block = True
+            i += 2
+            continue
+        out.append(ch)
+        i += 1
+    return "".join(out), in_block
+
+
 def scan() -> tuple[dict[str, list[str]], list[dict]]:
     """Returns (file -> sorted var list, active exceptions)."""
     found: dict[str, set[str]] = {}
@@ -126,9 +216,12 @@ def scan() -> tuple[dict[str, list[str]], list[dict]]:
         except OSError as exc:
             raise Unparseable(f"cannot read {rel}: {exc}")
 
+        in_block = False
         for i, line in enumerate(lines):
-            vars_here = set(VAR_RE.findall(line))
-            dyn_here = bool(DYN_RE.search(line))
+            # Match against CODE ONLY; the hatch below still reads the full line.
+            code, in_block = code_only(line, in_block)
+            vars_here = set(VAR_RE.findall(code))
+            dyn_here = bool(DYN_RE.search(code))
             if not vars_here and not dyn_here:
                 continue
 
@@ -245,6 +338,34 @@ def main() -> int:
 
 def self_test() -> int:
     cases: list[tuple[str, bool]] = []
+
+    # ── comment-awareness (KAN-415 D4) ──────────────────────────────────
+    # CTL-037 matched DOCSTRINGS until 2026-08-10, and flagged a file for a read
+    # that did not exist by extracting the variable name "X" from the phrase
+    # `process.env.X` in a comment. These pin both directions, because the first
+    # attempt at the fix over-corrected: it blanked template literals wholesale,
+    # which made a REAL read inside `${...}` vanish and reported a phantom
+    # migration. A normaliser that removes too much is worse than none.
+    def _vars(line: str, in_block: bool = False) -> list[str]:
+        code, _ = code_only(line, in_block)
+        return sorted(VAR_RE.findall(code))
+
+    cases += [
+        ("real read is found", _vars("const x = process.env.FOO;") == ["FOO"]),
+        ("line comment is not", _vars("// process.env.FOO") == []),
+        ("block comment is not", _vars("/* process.env.FOO */") == []),
+        ("trailing comment is not", _vars("const x = 1; // process.env.FOO") == []),
+        ("code before a comment survives",
+         _vars("const x = process.env.FOO; // process.env.BAR") == ["FOO"]),
+        ("TEMPLATE INTERPOLATION IS CODE",
+         _vars("const u = `${process.env.FOO}/x`;") == ["FOO"]),
+        ("plain string is not code", _vars("const s = 'process.env.FOO';") == []),
+        ("a // inside a string does not start a comment",
+         _vars("const u = 'https://a.example'; const x = process.env.FOO;") == ["FOO"]),
+        ("a continuation line inside a block comment is not code",
+         _vars(" * The seven process.env.X reads", in_block=True) == []),
+    ]
+
 
     cases.append(("static var found", VAR_RE.findall("const a = process.env.FOO_BAR") == ["FOO_BAR"]))
     cases.append(("dynamic read detected", bool(DYN_RE.search("process.env[key]"))))


### PR DESCRIPTION
## The ratchet was matching comments

CTL-037 flagged a file for a **`process.env` read that does not exist** — it matched a docstring explaining where the reads live, and extracted the variable name `X` from the phrase `process.env.X`.

Same comment-shadowing class as CTL-039 and the SEC-100 sitemap scan, arrived at from the other direction.

It errs **safe** — a comment can only *add* a finding, never suppress one — so this was noise rather than danger. But noise on a ratchet is how a ratchet gets waved through, and the workaround ("never write the literal in a comment") is exactly the kind of unwritten rule that erodes. Found during D4, where the offending comment was explaining CTL-037's own baseline.

## Comments can't simply be stripped

The escape hatch (`env-access-ok`) **lives in a comment** and is detected on the full line. So the two are separated: `code_only()` returns the executable part for matching; the caller keeps the original for hatch detection.

## The first attempt over-corrected, and the ratchet caught it

Blanking string literals wholesale also blanked **template literals** — but `${...}` is *code*, not string content, and `src/app/dashboard/page.tsx` reads `NEXT_PUBLIC_SITE_URL` only inside one.

The count dropped **72 → 71** and the guard reported a *phantom migration*: a file "no longer reading `process.env`" that had never stopped.

That's the exact hazard I'd written into CTL-043's normaliser two commits earlier — *a normaliser that removes too much reports agreement that is not there* — and I walked into it anyway ten minutes later. **The ratchet failing in the STALE direction is what surfaced it**, which is the half of a two-way ratchet people are tempted to leave out.

## Nine fixtures, pinning both directions

| Case | Expected |
|---|---|
| real read | found |
| line / block / trailing comment | not found |
| code before a comment | found |
| **`${process.env.FOO}` interpolation** | **found — it's code** |
| plain string literal | not found |
| **`//` inside a URL string** | doesn't start a comment |
| continuation line inside an open block comment | not found |

**Mutation-proven** with a tracked probe: a comment mentioning `process.env.X` exits 0; a real read *in the same file* exits 1, naming the variable.

Baseline unchanged at **72 across 37** — this corrects what the scanner *sees*, not what the estate does.

`Prevention: CTL-037` — the control existed and was itself defective. The fixtures are the prevention; a scanner without comment fixtures will match comments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)