### PR TITLE
fix: don't fail-closed on missing gh when MCP_TARBALL fixture is set

### DIFF
--- a/scripts/check-extraction-dod.sh
+++ b/scripts/check-extraction-dod.sh
@@ -446,7 +446,11 @@ attest out-of-repo "EXTRACTION-DOD-ROUTINE-PROMPTS" \
 # Uses the same zero-secret route as CTL-043: public repo, built-in GITHUB_TOKEN.
 if is_suppressed mcp-repo; then
   echo "check-extraction-dod: [mcp-repo] SKIPPED by an active exception."
-elif ! command -v gh >/dev/null 2>&1; then
+elif [ -z "${MCP_TARBALL:-}" ] && ! command -v gh >/dev/null 2>&1; then
+  # gh is only actually invoked below when MCP_TARBALL is unset (the `gh api`
+  # tarball download). When MCP_TARBALL IS set — the test suite's injection
+  # point, or an operator's own pre-fetched tarball — gh is never called, so
+  # its mere absence must not fail this check closed.
   die_unverifiable "gh is not available, so the lyra-mcp-server back-references could not be checked. This coupling has already broken once undetected."
 else
   # ONE request. The first cut fetched every candidate file once per moved path


### PR DESCRIPTION
## Summary

`scripts/check-extraction-dod.sh` (CTL-033, the KAN-428 extraction Definition-of-Done gate) checked `command -v gh` and failed closed (exit 2) whenever the `gh` CLI binary was absent — **before** checking whether `MCP_TARBALL` was set. But `MCP_TARBALL` is the test suite's documented injection point that lets the mcp-repo back-reference check run without ever calling `gh` (it copies a pre-built tarball instead of `gh api .../tarball/HEAD`). So any environment with no `gh` binary at all failed this check even when a tarball fixture made `gh` irrelevant.

Found running the Weekly Health + Regression routine in an environment with no `gh` CLI (GitHub access there goes through MCP tools instead). `RUN_E2E=1 bash scripts/weekly-health-regression.sh` on `develop` HEAD reported `unit` and `scripts` phases FAIL — `tests/scripts/check-extraction-dod.test.js`, 28/38 failing, all the same root cause (every `runMove()` call supplies `MCP_TARBALL`).

Fix: only fail closed on missing `gh` when `MCP_TARBALL` is *also* unset. No other logic changes — the tarball-present branch already never calls `gh`, so this only removes a false failure.

## Jira Ticket

BUGS-93

## Checklist

- [x] Unit tests added/updated for new/changed functionality — no new tests needed; the existing 38-case suite already specified the intended behavior and now passes as-written, without any test modification
- [x] All existing tests pass (`npm run test:unit`)
- [x] Lint passes (`npm run lint`)
- [x] Type check passes (`npm run type-check`)
- [x] Build succeeds (`npm run build`)
- [x] Coverage has not decreased — script-only one-line reorder, no source lines removed
- [x] No eslint-disable or ts-ignore without KAN-XX reference — n/a, bash script
- [x] Dependency-rule gate reviewed — n/a, no TS import changes
- [x] ARCHITECTURE.md updated if architectural changes were made — N/A, no architecture change
- [x] Ops routine / Control-Room registry updated if scheduled-routine behaviour, cadence, or ownership changed — N/A, gate behavior/exit-code semantics unchanged, only the internal check order
- [x] Docs / system map updated — N/A with reason: pure bug fix restoring the gate's own documented intent, no system-map impact
- [x] Design loop (KAN-441) — N/A, `scripts/**` is explicitly outside founder-owned UI/copy paths

## Extraction Definition-of-Done (KAN-428)

N/A — this PR does not move (delete or rename) any file under `src/`.

---

_Filed and verified as part of the Weekly Health + Regression routine (autonomous, bounded per CLAUDE.md rules). Full regression suite core phases (lint/type-check/unit/scripts/build/audit) confirmed PASS on `develop` HEAD + this fix before opening._


---
_Generated by [Claude Code](https://claude.ai/code/session_01F6c34RGAcCyCafFdGpuX5B)_