### PR TITLE
feat(security): SEC-104 — public_profiles view + CTL-048 live schema parity

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -232,6 +232,12 @@ jobs:
         # absent is the silent-skip pattern KAN-167 forbids. Regeneration is a
         # documented manual step.
         run: python3 scripts/check-schema-type-parity.py
+      - name: Live schema-parity checker self-test (CTL-048)
+        # The checker itself, exercised without credentials. Its LIVE run lives
+        # in promote-to-staging.yml, where the secrets are — but if the
+        # comparators rot, every environment would report clean for the wrong
+        # reason, and that must fail here rather than during a promotion.
+        run: python3 scripts/check-live-schema-parity.py --self-test
       - name: macOS Finder-duplicate file check (KAN-357)
         # Reject any committed " <n>"-suffixed file/dir (e.g. "[slug] 2/" or
         # "profile-sections 2.cjs"). These Finder-copy duplicates shadow the

--- a/.github/workflows/promote-to-staging.yml
+++ b/.github/workflows/promote-to-staging.yml
@@ -216,9 +216,47 @@ jobs:
             !tests/e2e/.auth/
           retention-days: 14
 
+  schema-parity:
+    # CTL-048 — column parity across the three LIVE databases, and between each
+    # database and its committed type snapshot.
+    #
+    # A promotion is exactly when a column gap becomes an outage: code written
+    # against dev's schema arrives at a database that lacks the column, and the
+    # first symptom is a 500 on whatever page reads it. Measured 2026-08-11,
+    # `public.profiles` had 42 columns on dev and staging and 38 on production.
+    #
+    # CTL-036 in pr-checks.yml is the repo-side half and needs no credentials;
+    # it compares the committed snapshots to each other. It cannot catch all
+    # three snapshots going stale the same way, which is the state they were
+    # actually in (every one missing `gift_voucher_hint`). This is the half that
+    # asks the databases, so it runs where the secrets are.
+    #
+    # Fail-closed: the script exits 2 if a credential is missing rather than
+    # skipping, per the Workflow & Backup Integrity Policy.
+    name: Live schema parity across dev / staging / prod (CTL-048)
+    needs: verify-source
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6
+
+      - name: Self-test the checker
+        # Prove the comparators can still fail before trusting a clean report.
+        run: python3 scripts/check-live-schema-parity.py --self-test
+
+      - name: Compare live schemas
+        env:
+          NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.NEXT_PUBLIC_SUPABASE_URL }}
+          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+          STAGING_SUPABASE_URL: ${{ secrets.STAGING_SUPABASE_URL }}
+          STAGING_SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.STAGING_SUPABASE_SERVICE_ROLE_KEY }}
+          PROD_SUPABASE_URL: ${{ secrets.PROD_SUPABASE_URL }}
+          PROD_SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.PROD_SUPABASE_SERVICE_ROLE_KEY }}
+        run: python3 scripts/check-live-schema-parity.py
+
   merge-and-deploy:
     name: Merge develop → staging
-    needs: [verify-source, signup-gate]
+    needs: [verify-source, signup-gate, schema-parity]
     runs-on: ubuntu-latest
     outputs:
       merged_sha: ${{ steps.merge.outputs.merged_sha }}

--- a/controls/registry.json
+++ b/controls/registry.json
@@ -841,6 +841,25 @@
       "self_test": "python3 scripts/check-docs-updated.py --self-test",
       "added": "2026-08-10",
       "notes": "Built after a 60-agent audit on 2026-08-10 compared every architecture/runbook/plan doc against the real tree. Three confirmed findings would have made a fresh session do the WRONG thing: the modularisation plan still read 'the extraction programme D1-D15 is DEFERRED ... No file moves into src/modules/' four days after that ruling was reversed and with 44 files already moved on main; CLAUDE.md and RUNBOOK.md both described no-module-to-app as covering src/lib/** only, long after the anchor was widened because 28 files had silently left a BLOCKING rule's scope; and RUNBOOK.md called the dependency gate non-blocking two weeks after it was flipped to error. Every one was written by someone who had just done the work and knew the truth - docs do not drift through carelessness, they drift because nothing is watching and the person who would notice already knows."
+    },
+    {
+      "id": "CTL-048",
+      "name": "Live schema parity",
+      "defect_class": "schema-parity-drift",
+      "summary": "Asks the three LIVE Supabase databases for their columns and asserts (a) every table present on more than one database exposes the same columns, except where supabase/schema-drift-baseline.json records a ticketed difference, and (b) each committed src/types/database/<env>.ts matches its own database. Exists because CTL-036 - the repo-side half - compares the three committed SNAPSHOTS to each other and therefore cannot see all three going stale the same way, which is the state they were in on 2026-08-11: every snapshot was missing gift_voucher_hint while all three databases had it, and CTL-036 was green. Runs in the promotion chain because a promotion is when a column gap becomes an outage - code written against one schema reaching a database with another. Detects drift in BOTH directions; dev is behind staging and prod on gathering_invite_messages.claimed_at (BUGS-62), so a prod-is-missing-only check would sail past it. Fails closed with exit 2 when a credential is absent rather than skipping.",
+      "implementation": "scripts/check-live-schema-parity.py",
+      "kind": "ci-gate",
+      "wired_in": [
+        ".github/workflows/promote-to-staging.yml",
+        ".github/workflows/pr-checks.yml"
+      ],
+      "prevents": [
+        "SEC-107",
+        "BUGS-62",
+        "KAN-420"
+      ],
+      "escape_hatch": "none - apply the missing migration, or record the difference in supabase/schema-drift-baseline.json with a ticket",
+      "added": "2026-08-11"
     }
   ]
 }

--- a/scripts/check-live-schema-parity.py
+++ b/scripts/check-live-schema-parity.py
@@ -1,0 +1,308 @@
+#!/usr/bin/env python3
+"""CTL-048 — column parity across the three LIVE databases, and against the
+committed type snapshots.
+
+WHY THIS EXISTS WHEN CTL-036 ALREADY DOES "SCHEMA DRIFT"
+--------------------------------------------------------
+`scripts/check-schema-type-parity.py` (CTL-036) is a real control and it works.
+But read its own docstring: it diffs the three COMMITTED snapshots in
+`src/types/database/{dev,staging,prod}.ts` against a recorded baseline. It never
+talks to a database — deliberately, because that needs credentials.
+
+That leaves one hole, and it is not hypothetical:
+
+    if all three snapshots go stale in the SAME way, CTL-036 compares
+    stale-to-stale, finds no RELATIVE drift, and passes — while every snapshot
+    is wrong about reality.
+
+Measured 2026-08-11: `public.profiles` has 42 columns on dev, 42 on staging and
+38 on production. All three committed snapshots said 41 / 41 / 37 — every one of
+them missing `gift_voucher_hint`, which the KAN-443 migration added to all three
+databases. CTL-036 was green throughout. It could not have been otherwise: it
+cannot see a column that no snapshot mentions.
+
+So this control asks the databases. It is the live counterpart, not a
+replacement — CTL-036 still runs on every PR (no credentials needed), and this
+runs where credentials exist.
+
+WHAT IT ASSERTS
+---------------
+1. LIVE-VS-LIVE. Every table present on more than one database exposes the same
+   column set, except where the difference is in the ticketed baseline
+   (`supabase/schema-drift-baseline.json`). Drift not in the baseline FAILS.
+2. LIVE-VS-SNAPSHOT. Each committed `src/types/database/<env>.ts` matches its
+   own live database. A stale snapshot FAILS, because the app compiles against
+   `dev` and a snapshot that overstates a database is how TypeScript ends up
+   asserting production has columns it does not have.
+3. Drift BOTH ways. `gathering_invite_messages.claimed_at` exists on staging and
+   production but NOT dev (BUGS-62) — so "prod is behind" is the common case,
+   not the rule, and a check that only looks for prod-is-missing would sail past
+   the reverse.
+
+WHY IT BLOCKS A PROMOTION RATHER THAN JUST REPORTING
+----------------------------------------------------
+The founder's framing, 2026-08-11: the gate should fire "as we do promotions".
+A promotion is precisely when a column gap becomes an outage — code written
+against dev's schema arrives at a database that lacks the column, and the first
+symptom is a 500 on whatever page reads it. Reporting it daily catches it within
+a day; blocking the promote catches it before it ships.
+
+⚠️ FAIL-CLOSED, AND NO SILENT SKIP.
+If a credential is absent this exits NON-ZERO and says which one. The Workflow &
+Backup Integrity Policy forbids the `if: env.X != ''` pattern for exactly this
+reason: a control that quietly passes when it cannot run is worse than no
+control, because it also produces a green tick.
+
+USAGE
+    python3 scripts/check-live-schema-parity.py            # all three
+    python3 scripts/check-live-schema-parity.py --self-test
+    python3 scripts/check-live-schema-parity.py --env prod
+
+ENVIRONMENT
+    NEXT_PUBLIC_SUPABASE_URL     / SUPABASE_SERVICE_ROLE_KEY          (dev)
+    STAGING_SUPABASE_URL         / STAGING_SUPABASE_SERVICE_ROLE_KEY  (staging)
+    PROD_SUPABASE_URL            / PROD_SUPABASE_SERVICE_ROLE_KEY     (prod)
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+BASELINE_PATH = REPO_ROOT / "supabase" / "schema-drift-baseline.json"
+SNAPSHOT_DIR = REPO_ROOT / "src" / "types" / "database"
+TIMEOUT_SECONDS = 30
+
+ENVIRONMENTS = [
+    ("dev", "NEXT_PUBLIC_SUPABASE_URL", "SUPABASE_SERVICE_ROLE_KEY"),
+    ("staging", "STAGING_SUPABASE_URL", "STAGING_SUPABASE_SERVICE_ROLE_KEY"),
+    ("prod", "PROD_SUPABASE_URL", "PROD_SUPABASE_SERVICE_ROLE_KEY"),
+]
+
+# PostgREST cannot query information_schema directly, so parity is read through
+# the same reporting-function pattern SEC-101 already uses. Until that function
+# exists everywhere, fall back to the REST root, which advertises every exposed
+# table and its columns in an OpenAPI document.
+OPENAPI_PATH = "/rest/v1/"
+
+
+def fetch_openapi(url: str, key: str) -> dict:
+    endpoint = url.rstrip("/") + OPENAPI_PATH
+    request = urllib.request.Request(
+        endpoint,
+        headers={"apikey": key, "Authorization": f"Bearer {key}", "Accept": "application/openapi+json"},
+        method="GET",
+    )
+    with urllib.request.urlopen(request, timeout=TIMEOUT_SECONDS) as response:
+        return json.loads(response.read().decode("utf-8"))
+
+
+def columns_from_openapi(doc: dict) -> dict[str, set[str]]:
+    """{table: {column, ...}} for every table PostgREST exposes."""
+    out: dict[str, set[str]] = {}
+    for name, definition in (doc.get("definitions") or {}).items():
+        props = definition.get("properties") or {}
+        if props:
+            out[name] = set(props.keys())
+    return out
+
+
+def columns_from_snapshot(env: str) -> dict[str, set[str]]:
+    """Parse `Row: { ... }` blocks out of a committed Database type snapshot.
+
+    Deliberately a parser over the committed text rather than a TypeScript
+    import: this must report what the FILE says, including when the file is
+    wrong. Importing it would make the check agree with itself.
+    """
+    path = SNAPSHOT_DIR / f"{env}.ts"
+    text = path.read_text(encoding="utf-8")
+    out: dict[str, set[str]] = {}
+    # Tables appear as `      <name>: {` followed eventually by `Row: {`.
+    for match in re.finditer(r"\n      (\w+): \{\n        Row: \{\n(.*?)\n        \}", text, re.S):
+        table, body = match.group(1), match.group(2)
+        cols = set()
+        for line in body.split("\n"):
+            m = re.match(r"\s*(\w+)\??:", line)
+            if m:
+                cols.add(m.group(1))
+        if cols:
+            out[table] = cols
+    return out
+
+
+def load_baseline() -> set[tuple[str, str, str]]:
+    """{(table, column, missing_from_env)} — the KNOWN, ticketed differences."""
+    if not BASELINE_PATH.exists():
+        return set()
+    raw = json.loads(BASELINE_PATH.read_text(encoding="utf-8"))
+    known: set[tuple[str, str, str]] = set()
+    for leg, payload in raw.items():
+        if not isinstance(payload, dict):
+            continue
+        for direction in ("only_in_first", "only_in_second"):
+            for entry in payload.get(direction, []) or []:
+                if not isinstance(entry, dict):
+                    continue
+                table = entry.get("table") or entry.get("object") or ""
+                column = entry.get("column") or entry.get("name") or ""
+                if table and column:
+                    # Recorded leg-agnostically: the point is "this pair is
+                    # known to differ somewhere", and the leg is in the file for
+                    # a human to read.
+                    known.add((table, column, "*"))
+    return known
+
+
+def compare_live(live: dict[str, dict[str, set[str]]], baseline) -> list[str]:
+    violations: list[str] = []
+    all_tables = sorted({t for env in live.values() for t in env})
+    for table in all_tables:
+        present_in = [e for e in live if table in live[e]]
+        if len(present_in) < 2:
+            continue  # a table on one database only is a different finding
+        union = set().union(*(live[e][table] for e in present_in))
+        for env in present_in:
+            for column in sorted(union - live[env][table]):
+                if (table, column, "*") in baseline:
+                    continue
+                others = [e for e in present_in if column in live[e][table]]
+                violations.append(
+                    f"{table}.{column} is MISSING on {env} but present on {', '.join(others)}"
+                )
+    return violations
+
+
+def compare_snapshots(live: dict[str, dict[str, set[str]]]) -> list[str]:
+    violations: list[str] = []
+    for env, tables in live.items():
+        try:
+            snap = columns_from_snapshot(env)
+        except FileNotFoundError:
+            violations.append(f"{env}: no committed snapshot at src/types/database/{env}.ts")
+            continue
+        for table in sorted(set(tables) & set(snap)):
+            missing = sorted(tables[table] - snap[table])
+            extra = sorted(snap[table] - tables[table])
+            if missing:
+                violations.append(
+                    f"{env}: src/types/database/{env}.ts is STALE — {table} has "
+                    f"{', '.join(missing)} on the database but not in the snapshot"
+                )
+            if extra:
+                violations.append(
+                    f"{env}: src/types/database/{env}.ts OVERSTATES — {table}.{extra[0]}"
+                    f"{' (+%d more)' % (len(extra) - 1) if len(extra) > 1 else ''} "
+                    f"is in the snapshot but NOT on the database"
+                )
+    return violations
+
+
+def self_test() -> int:
+    """Prove the comparators can fail. A checker nobody has seen fail is a
+    checker nobody has seen work."""
+    checks: list[tuple[str, bool]] = []
+
+    live = {
+        "dev": {"profiles": {"id", "slug", "gift_voucher_hint"}},
+        "prod": {"profiles": {"id", "slug"}},
+    }
+    v = compare_live(live, set())
+    checks.append(("live drift is detected", len(v) == 1 and "gift_voucher_hint" in v[0]))
+    checks.append(("the missing side is named", "MISSING on prod" in v[0]))
+
+    v = compare_live(live, {("profiles", "gift_voucher_hint", "*")})
+    checks.append(("a baselined difference is allowed", v == []))
+
+    identical = {"dev": {"profiles": {"id"}}, "prod": {"profiles": {"id"}}}
+    checks.append(("identical schemas produce no violation", compare_live(identical, set()) == []))
+
+    # Reverse drift (BUGS-62 shape): dev is the one behind.
+    reverse = {
+        "dev": {"t": {"id"}},
+        "prod": {"t": {"id", "claimed_at"}},
+    }
+    v = compare_live(reverse, set())
+    checks.append(("reverse drift (dev behind) is detected", len(v) == 1 and "MISSING on dev" in v[0]))
+
+    # A table on one database only must not be reported as drift.
+    single = {"dev": {"only_here": {"id"}}, "prod": {}}
+    checks.append(("a single-database table is not drift", compare_live(single, set()) == []))
+
+    passed = sum(1 for _, ok in checks if ok)
+    for name, ok in checks:
+        print(f"  {'ok  ' if ok else 'FAIL'} {name}")
+    print(f"live-schema-parity self-test: {passed}/{len(checks)} passed")
+    return 0 if passed == len(checks) else 1
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--self-test", action="store_true")
+    parser.add_argument("--env", action="append", help="limit to one or more environments")
+    args = parser.parse_args()
+
+    if args.self_test:
+        return self_test()
+
+    wanted = set(args.env) if args.env else {e for e, _, _ in ENVIRONMENTS}
+    live: dict[str, dict[str, set[str]]] = {}
+    missing_credentials: list[str] = []
+
+    for env, url_var, key_var in ENVIRONMENTS:
+        if env not in wanted:
+            continue
+        url, key = os.environ.get(url_var), os.environ.get(key_var)
+        if not url or not key:
+            # FAIL-CLOSED. Never skip: a green tick from a check that did not
+            # run is the failure mode this whole file exists to avoid.
+            missing_credentials.append(f"{env} (needs {url_var} and {key_var})")
+            continue
+        try:
+            live[env] = columns_from_openapi(fetch_openapi(url, key))
+        except (urllib.error.URLError, urllib.error.HTTPError, ValueError) as exc:
+            print(f"::error::check-live-schema-parity: could not read {env}: {exc}")
+            return 2
+
+    if missing_credentials:
+        for item in missing_credentials:
+            print(f"::error::check-live-schema-parity: no credentials for {item}")
+        print("A control that cannot run must not report success.")
+        return 2
+
+    if len(live) < 2:
+        print("::error::check-live-schema-parity: fewer than two databases read; nothing to compare")
+        return 2
+
+    baseline = load_baseline()
+    violations = compare_live(live, baseline) + compare_snapshots(live)
+
+    if violations:
+        for v in violations:
+            print(f"::error::check-live-schema-parity: {v}")
+        print()
+        print("Column parity is a promotion precondition: code written against one")
+        print("schema is about to reach a database with a different one, and the")
+        print("first symptom is a 500 on whatever page reads the missing column.")
+        print()
+        print("Fix by applying the missing migration, or — if the difference is")
+        print("known and ticketed — record it in supabase/schema-drift-baseline.json.")
+        print("Regenerate a stale snapshot with the documented step in docs/RUNBOOK.md.")
+        return 1
+
+    tables = len({t for env in live.values() for t in env})
+    print(
+        f"check-live-schema-parity OK — {len(live)} database(s), {tables} table(s), "
+        "columns agree and every committed snapshot matches its database."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/app/[slug]/page.tsx
+++ b/src/app/[slug]/page.tsx
@@ -96,11 +96,11 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const slug = decodeSlug(rawSlug);
 
   const { data: profile } = await getSupabase()
-    .from('profiles')
+    // SEC-104: the view carries published + not-suspended, so this service-role
+    // read is constrained by the query itself rather than by remembering (SEC-44).
+    .from('public_profiles')
     .select('display_name, headline, bio_short')
     .eq('slug', slug)
-    .eq('is_published', true)
-    .eq('is_suspended', false) // SEC-44: service-role render must exclude suspended profiles
     .single();
 
   if (!profile) {
@@ -226,11 +226,21 @@ export default async function PublicProfilePage({ params }: Props) {
   const slug = decodeSlug(rawSlug);
 
   const { data: profile } = await getSupabase()
-    .from('profiles')
+    // SEC-104. Two things changed here, and the second is the bigger one.
+    //
+    // 1. The published + not-suspended predicate now lives in the view body, so
+    //    a suspended profile 404s by construction (SEC-44) even though this is a
+    //    service-role read that RLS does not touch.
+    // 2. `select('*')` used to pull all 42 columns of `profiles` — including
+    //    is_admin, user_id, suspension_reason, the six age-verification columns
+    //    and the search hashes — of which this page uses 13. Against the view it
+    //    returns 17, and the 25 it does not need are no longer fetched at all.
+    //    An audit found none of them reached the browser, so this is a hardening
+    //    rather than a leak fix; but a column that is never selected cannot be
+    //    leaked by the next person to add a prop.
+    .from('public_profiles')
     .select('*')
     .eq('slug', slug)
-    .eq('is_published', true)
-    .eq('is_suspended', false) // SEC-44: suspended profiles must 404 on the public page, not render
     .single();
 
   if (!profile) {

--- a/src/app/api/recommendations/[slug]/route.ts
+++ b/src/app/api/recommendations/[slug]/route.ts
@@ -62,10 +62,13 @@ export async function GET(
   const supabase = getServiceClient();
 
   const { data: profile, error: profileError } = await supabase
-    .from('profiles')
+    // SEC-104: the `public_profiles` VIEW filters published + not-suspended in
+    // its body, so this service-role read is constrained by the query. The
+    // `!profile.is_published` check below is now belt-and-braces — an
+    // unpublished profile simply does not come back, and `!profile` catches it.
+    .from('public_profiles')
     .select('id, display_name, bio_short, headline, is_published')
     .eq('slug', slug)
-    .eq('is_suspended', false) // SEC-19/F-13: suspended profiles must not return recommendations
     .maybeSingle<ProfileRow>();
 
   if (profileError) {

--- a/src/app/api/recommendations/v2/[slug]/route.ts
+++ b/src/app/api/recommendations/v2/[slug]/route.ts
@@ -93,10 +93,13 @@ export async function GET(
   const supabase = getServiceClient();
 
   const { data: profile, error: profileError } = await supabase
-    .from('profiles')
+    // SEC-104: the `public_profiles` VIEW filters published + not-suspended in
+    // its body, so this service-role read is constrained by the query. The
+    // `!profile.is_published` check below is now belt-and-braces — an
+    // unpublished profile simply does not come back, and `!profile` catches it.
+    .from('public_profiles')
     .select('id, display_name, bio_short, headline, is_published, delivery_country_code')
     .eq('slug', slug)
-    .eq('is_suspended', false) // SEC-19/F-13: suspended profiles must not return recommendations
     .maybeSingle<ProfileRow>();
 
   if (profileError) {

--- a/src/app/examples/page.tsx
+++ b/src/app/examples/page.tsx
@@ -52,12 +52,10 @@ async function getExampleProfiles(): Promise<ExampleProfile[]> {
   try {
     const supabase = getSupabase();
     const { data } = await supabase
-      .from("profiles")
+      // SEC-104: the view carries the published + not-suspended predicate, so a
+      // service-role read (which bypasses RLS) is still constrained.
+      .from("public_profiles")
       .select("id, display_name, slug, headline, city, country, avatar_url")
-      .eq("is_published", true)
-      // SEC-100: service-role read, so RLS does not apply. Defence in depth —
-      // see the equivalent note in src/app/page.tsx.
-      .eq("is_suspended", false)
       .eq("is_homepage_example", true)
       .order("homepage_example_order", { ascending: true })
       .limit(60);

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -65,17 +65,14 @@ async function getPublishedProfiles(): Promise<HomeProfile[]> {
     // flag (default false) that a DB trigger restricts to @seed.checklyra.com
     // accounts, so no real profile (incl. Ben/Luisa) can ever appear here.
     const { data } = await supabase
-      .from("profiles")
+      // SEC-104: the `public_profiles` VIEW, not the table. This reads through
+      // the SERVICE-ROLE client, so RLS never applied — the invariant "a public
+      // query filters suspension" now lives in the view body, where it binds
+      // service_role too. Previously each call site had to remember it, and the
+      // re-derivation of which sites were safe is what SEC-44/80/81/83/85/100
+      // kept getting wrong.
+      .from("public_profiles")
       .select("display_name, slug, headline, avatar_url")
-      .eq("is_published", true)
-      // SEC-100: read through the SERVICE-ROLE client, so RLS (which enforces
-      // is_published AND NOT is_suspended) does not apply. The
-      // is_homepage_example allowlist already excludes real members, so this is
-      // defence in depth — but the invariant "public query filters suspension"
-      // must hold everywhere, or the next reviewer has to re-derive which call
-      // sites are safe. That re-derivation is what SEC-44/80/81/83/85 kept
-      // getting wrong. Guarded by scripts/check-suspension-guard-coverage.py.
-      .eq("is_suspended", false)
       .eq("is_homepage_example", true)
       .order("homepage_example_order", { ascending: true })
       .limit(6);

--- a/src/app/search/page.tsx
+++ b/src/app/search/page.tsx
@@ -134,16 +134,15 @@ export default async function SearchPage({
     // publicProfiles() so neither can drift and lose a guard on its own.
     const publicProfiles = () =>
       supabase
-        .from('profiles')
+        // SEC-104: the `public_profiles` VIEW, not the table. This page reads
+        // through the SERVICE-ROLE client, which bypasses RLS — so the policy on
+        // `profiles` never applied, and a suspended (moderated / taken-down)
+        // member stayed fully discoverable in public search (SEC-100, same
+        // mechanism as SEC-44 which fixed only /[slug]). The view's WHERE binds
+        // service_role, so both branches of this builder are covered by
+        // construction rather than by remembering.
+        .from('public_profiles')
         .select('id, display_name, slug, headline, city, country, avatar_url')
-        .eq('is_published', true)
-        // SEC-100: this page reads through the SERVICE-ROLE client, which bypasses
-        // RLS — so the `is_published = true AND is_suspended = false` policy on
-        // `profiles` does NOT apply here. Without this filter a suspended (i.e.
-        // moderated / taken-down) member stayed fully discoverable in public
-        // search. Identical mechanism to SEC-44, which fixed only /[slug].
-        // Guarded by scripts/check-suspension-guard-coverage.py.
-        .eq('is_suspended', false)
         .eq('is_homepage_example', false); // KAN-334: curated demo profiles never appear in real member discovery
 
     const [byField, byAffiliation] = await Promise.all([

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -18,16 +18,14 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     const supabase = createServiceRoleClient();
 
     const { data: profiles } = await supabase
-      .from('profiles')
-      .select('slug, updated_at')
-      .eq('is_published', true)
-      // SEC-100: the sitemap is built with the SERVICE-ROLE client, which
-      // bypasses RLS — the `is_published = true AND is_suspended = false`
-      // policy on `profiles` does NOT apply here. Without this filter a
-      // suspended (moderated / taken-down) member's slug was still published
-      // to search engines for crawling. Identical mechanism to SEC-44.
-      // Guarded by scripts/check-suspension-guard-coverage.py.
-      .eq('is_suspended', false);
+      // SEC-104: reads the `public_profiles` VIEW, not the table. The sitemap
+      // is built with the SERVICE-ROLE client, which bypasses RLS — so the
+      // policy on `profiles` never applied here, and a suspended member's slug
+      // was published to search engines for crawling (SEC-100, same mechanism
+      // as SEC-44). The view carries `is_published = true AND is_suspended =
+      // false` in its body, and a view's WHERE binds service_role.
+      .from('public_profiles')
+      .select('slug, updated_at');
 
     profilePages = (profiles || []).map((profile) => ({
       url: `${baseUrl}/${profile.slug}`,

--- a/src/types/database/dev.ts
+++ b/src/types/database/dev.ts
@@ -1393,6 +1393,7 @@ export type Database = {
           discoverable_by_phone: boolean
           discoverable_by_postcode: boolean
           display_name: string
+          gift_voucher_hint: string | null
           headline: string | null
           homepage_example_order: number | null
           id: string
@@ -1436,6 +1437,7 @@ export type Database = {
           discoverable_by_phone?: boolean
           discoverable_by_postcode?: boolean
           display_name: string
+          gift_voucher_hint?: string | null
           headline?: string | null
           homepage_example_order?: number | null
           id?: string
@@ -1479,6 +1481,7 @@ export type Database = {
           discoverable_by_phone?: boolean
           discoverable_by_postcode?: boolean
           display_name?: string
+          gift_voucher_hint?: string | null
           headline?: string | null
           homepage_example_order?: number | null
           id?: string

--- a/src/types/database/prod.ts
+++ b/src/types/database/prod.ts
@@ -1394,6 +1394,7 @@ export type Database = {
           dashboard_widget_state: Json
           delivery_country_code: string | null
           display_name: string
+          gift_voucher_hint: string | null
           headline: string | null
           homepage_example_order: number | null
           id: string
@@ -1433,6 +1434,7 @@ export type Database = {
           dashboard_widget_state?: Json
           delivery_country_code?: string | null
           display_name: string
+          gift_voucher_hint?: string | null
           headline?: string | null
           homepage_example_order?: number | null
           id?: string
@@ -1472,6 +1474,7 @@ export type Database = {
           dashboard_widget_state?: Json
           delivery_country_code?: string | null
           display_name?: string
+          gift_voucher_hint?: string | null
           headline?: string | null
           homepage_example_order?: number | null
           id?: string

--- a/src/types/database/staging.ts
+++ b/src/types/database/staging.ts
@@ -1396,6 +1396,7 @@ export type Database = {
           discoverable_by_phone: boolean
           discoverable_by_postcode: boolean
           display_name: string
+          gift_voucher_hint: string | null
           headline: string | null
           homepage_example_order: number | null
           id: string
@@ -1439,6 +1440,7 @@ export type Database = {
           discoverable_by_phone?: boolean
           discoverable_by_postcode?: boolean
           display_name: string
+          gift_voucher_hint?: string | null
           headline?: string | null
           homepage_example_order?: number | null
           id?: string
@@ -1482,6 +1484,7 @@ export type Database = {
           discoverable_by_phone?: boolean
           discoverable_by_postcode?: boolean
           display_name?: string
+          gift_voucher_hint?: string | null
           headline?: string | null
           homepage_example_order?: number | null
           id?: string

--- a/supabase/migrations/20260811210000_sec104_public_profiles_view.sql
+++ b/supabase/migrations/20260811210000_sec104_public_profiles_view.sql
@@ -1,0 +1,117 @@
+-- SEC-104 — `public.public_profiles`: the public-visibility predicate, moved
+-- from a code convention into a database object.
+--
+-- WHY
+-- ---
+-- Lyra's most recurrent security defect class is a visibility predicate applied
+-- at one call site and forgotten at its siblings: SEC-44, SEC-47, SEC-57,
+-- SEC-58, SEC-80, SEC-81, SEC-83, SEC-84, SEC-85, BUGS-21. Each fix was
+-- correct. Each covered the site in front of it. The next site was then found
+-- by the next audit rather than by CI.
+--
+-- `public.profiles` already carries the right RLS policy:
+--     "Anyone can read published non-suspended profiles"
+--         USING (is_published = true AND is_suspended = false)
+-- but the SERVICE-ROLE client bypasses RLS entirely, and 7 of the 8 public read
+-- sites use it. That is exactly how SEC-100 happened — suspended members served
+-- to public search and to search-engine crawlers three weeks after SEC-44 was
+-- closed and verified.
+--
+-- A WHERE clause in a view body is not a policy. It is part of the query, so it
+-- binds every caller including a BYPASSRLS superuser.
+--
+-- PROVEN, NOT ASSUMED (dev, 2026-08-11, in a rolled-back transaction):
+--   running as `postgres` (BYPASSRLS), a profile flipped to is_suspended = true
+--   was visible through the TABLE (1 row) and absent through an equivalent VIEW
+--   (0 rows). The mutation was asserted to have applied before the measurement
+--   was believed, and the transaction was aborted so the row was restored.
+--
+-- WHAT THIS IS NOT
+-- ----------------
+-- This is a HARDENING, not a live leak fix. An audit of the client boundary
+-- (2026-08-11) found that `src/app/[slug]/page.tsx` fetches all 42 columns via
+-- `.select('*')` but NOTHING sensitive crosses into the browser: the only
+-- client component in the tree, ReportButton, receives two scalars, and exactly
+-- 8 public-by-design columns reach the RSC payload. The fetch is over-broad;
+-- the render is not leaking. Both facts are worth stating plainly.
+--
+-- THE COLUMN SET, AND WHY IT IS 17 AND NOT 42
+-- -------------------------------------------
+-- Derived from what the 8 public read sites actually use — including columns
+-- used only as FILTERS or ORDER BY, which a union of `.select()` lists misses.
+-- `is_homepage_example` and `homepage_example_order` are never selected by any
+-- site, but /examples filters and orders on them; omitting them would have left
+-- that page broken in production.
+--
+-- Everything else is deliberately absent, and that absence is the control:
+-- is_admin, user_status, access_tier, suspension_reason, suspended_at, the six
+-- age-verification columns, the search hashes, postcode_prefix, beta_*,
+-- recipient_attributes, dashboard_widget_state, completion_score,
+-- onboarding_complete, share_availability_with_contacts, created_at, region,
+-- discoverable_by_*. A future `select('*')` against this view cannot leak them
+-- because they are not here to leak.
+--
+-- ⚠️ PORTABILITY — THE FOUR COLUMNS THIS VIEW MUST NOT NAME.
+-- Measured live on all three databases 2026-08-11: dev and staging carry 42
+-- profiles columns, PRODUCTION carries 38. Production alone lacks
+-- phone_search_hash, postcode_search_hash, discoverable_by_phone and
+-- discoverable_by_postcode (the KAN-153 half of SEC-107). CREATE VIEW naming a
+-- column the database does not have fails outright, so a view that named any of
+-- them would apply cleanly to dev and staging and then break the production
+-- migration. None of the four belongs in a public view anyway — they are search
+-- hashes and discovery flags — so the portability constraint and the security
+-- design agree. Do not add them here when SEC-107 is closed.
+--
+-- security_invoker = on:
+--   * for anon / authenticated, RLS on `profiles` ALSO applies (defence in
+--     depth — the view predicate and the policy must both pass);
+--   * for service_role, RLS is bypassed as it always was, and the view
+--     predicate is what remains — which is the entire point.
+--   With the default (off) the view would run as its owner and bypass RLS for
+--   every caller, which is strictly worse. Matches the house convention set by
+--   `mcp_per_ip_recent_count` (20260621090200).
+
+CREATE OR REPLACE VIEW public.public_profiles
+WITH (security_invoker = on) AS
+SELECT
+  -- Identity + routing
+  p.id,
+  p.user_id,              -- ownership comparison only (hides "Report" from the owner)
+  p.slug,
+  -- Rendered profile content
+  p.display_name,
+  p.headline,
+  p.bio_short,
+  p.city,
+  p.country,
+  p.avatar_url,
+  p.gift_voucher_hint,
+  -- Behaviour
+  p.section_visibility,   -- privacy-critical: drives per-item visibility inheritance
+  p.delivery_country_code,
+  p.updated_at,           -- sitemap lastmod
+  -- Curation (filter + order for /examples and /search)
+  p.is_homepage_example,
+  p.homepage_example_order,
+  -- Tautological here (always true / false), retained so existing call sites
+  -- that select or re-assert them keep working during and after the cutover.
+  p.is_published,
+  p.is_suspended
+FROM public.profiles p
+WHERE p.is_published = true
+  AND p.is_suspended = false;
+
+COMMENT ON VIEW public.public_profiles IS
+  'SEC-104. The public-visibility predicate as a database object rather than a '
+  'call-site convention. A view WHERE binds service_role, which RLS does not — '
+  'that asymmetry is why SEC-100 happened. Read this instead of public.profiles '
+  'for anything a logged-out visitor can see. Deliberately omits every column '
+  'not needed by a public surface; do not widen it without a security review, '
+  'and never add the KAN-153 search-hash / discoverability columns (absent on '
+  'production, and not public data).';
+
+-- Grants. Public surfaces are read by logged-out visitors, so anon needs SELECT
+-- here (unlike mcp_per_ip_recent_count, which is service-role only). SELECT
+-- only: this view is a read surface and must never be a write path.
+GRANT SELECT ON public.public_profiles TO anon, authenticated, service_role;
+REVOKE INSERT, UPDATE, DELETE, TRUNCATE ON public.public_profiles FROM anon, authenticated;

--- a/supabase/migrations/20260811210500_sec104_invariant_public_profiles_view.sql
+++ b/supabase/migrations/20260811210500_sec104_invariant_public_profiles_view.sql
@@ -1,0 +1,145 @@
+-- SEC-104 / SEC-101 v3 — INV-8: the `public_profiles` view is the guard now, so
+-- something has to check the guard.
+--
+-- WHY THIS MIGRATION EXISTS AT ALL
+-- --------------------------------
+-- SEC-104 moved `is_published = true AND is_suspended = false` out of eight
+-- call sites and into a view body. That is a real improvement — a view WHERE
+-- binds service_role, which RLS does not — but it MOVES the failure mode rather
+-- than removing it:
+--
+--   * before, a unit test could read the call site and prove the filter existed;
+--   * after, the filter lives in a database, and a unit test cannot see it.
+--
+-- So the repo's tests were narrowed to what they can honestly prove ("the code
+-- reads the view") and THIS is the other half: a live, per-environment
+-- assertion that the view on that database is actually what the code assumes.
+-- Without it the guarantee would only be a comment, and dev/staging/production
+-- could silently disagree — which is exactly the condition SEC-107 records for
+-- the KAN-153 columns.
+--
+-- FAIL-CLOSED. A MISSING VIEW IS A VIOLATION.
+-- The natural way to write this check is "if the view exists, verify it", which
+-- reports clean on the one environment where the view was never applied — the
+-- worst possible answer, because the code has already been cut over to read it.
+-- INV-8 therefore fires when the view is ABSENT, when its definition has lost
+-- either predicate, and when it is not security_invoker.
+--
+-- Note INV-7 does not cover the security_invoker case here: it only matches an
+-- EXPLICIT `security_invoker=false`, and a view created without the option has
+-- empty reloptions and defaults to invoker-off. INV-8 asserts the option is
+-- positively present.
+--
+-- Invariants 1-7 are reproduced verbatim from v2 (read back from the live
+-- database with pg_get_functiondef rather than copied from the v2 migration
+-- file, so this replaces what is actually running).
+
+create or replace function public.security_invariants_report()
+returns table (invariant text, object_name text, detail text)
+language sql
+stable
+set search_path to 'pg_catalog', 'public'
+as $function$
+  with secdef as (
+    select p.oid,
+           p.proname::text as obj,
+           p.proacl,
+           p.proconfig,
+           pg_get_functiondef(p.oid) as def
+    from pg_proc p
+    join pg_namespace n on n.oid = p.pronamespace
+    where n.nspname = 'public'
+      and p.prosecdef
+  )
+  select 'INV-1-secdef-anon-execute'::text, obj,
+         'anon holds EXECUTE on a SECURITY DEFINER function'::text
+    from secdef where has_function_privilege('anon', oid, 'EXECUTE')
+
+  union all
+  select 'INV-2-secdef-duplicate-overload'::text, obj,
+         'SECURITY DEFINER function has more than one overload — a signature change leaves the old one behind and the new one inherits the anon/authenticated default grants'::text
+    from secdef group by obj having count(*) > 1
+
+  union all
+  select 'INV-3-secdef-unpinned-search-path'::text, obj,
+         'SECURITY DEFINER function without SET search_path'::text
+    from secdef where proconfig is null
+
+  union all
+  select 'INV-4-secdef-authed-execute-no-authz'::text, obj,
+         'authenticated holds EXECUTE but the body performs no authorization check'::text
+    from secdef
+   where has_function_privilege('authenticated', oid, 'EXECUTE')
+     and def !~* '(is_admin|auth\.uid\(\)|auth\.role\(\)|has_role|request\.jwt)'
+
+  union all
+  select 'INV-5-table-rls-disabled'::text, c.relname::text,
+         'public table with row-level security disabled'::text
+    from pg_class c
+    join pg_namespace n on n.oid = c.relnamespace
+   where n.nspname = 'public' and c.relkind = 'r' and not c.relrowsecurity
+
+  union all
+  select 'INV-6-public-storage-bucket'::text, b.id::text,
+         'storage bucket is world-readable (public = true)'::text
+    from storage.buckets b where b.public
+
+  union all
+  select 'INV-7-secdef-view'::text, c.relname::text,
+         'view in public is defined SECURITY DEFINER'::text
+    from pg_class c
+    join pg_namespace n on n.oid = c.relnamespace
+   where n.nspname = 'public' and c.relkind = 'v'
+     and exists (
+       select 1 from unnest(coalesce(c.reloptions, '{}')) o
+        where o ilike 'security_invoker=false' or o ilike 'security_definer%'
+     )
+
+  -- INV-8 (SEC-104). Three ways the public-visibility guard can be wrong, all
+  -- reported against the same invariant so one waiver cannot silence a
+  -- different failure than the one it was written for.
+  union all
+  select 'INV-8-public-profiles-view-missing'::text, 'public_profiles'::text,
+         'SEC-104: the public_profiles view does not exist on this database, but the application reads it for every public profile surface'::text
+   where not exists (
+     select 1 from pg_class c
+       join pg_namespace n on n.oid = c.relnamespace
+      where n.nspname = 'public' and c.relname = 'public_profiles' and c.relkind = 'v'
+   )
+
+  union all
+  select 'INV-8-public-profiles-view-predicate'::text, 'public_profiles'::text,
+         'SEC-104: the public_profiles view exists but its definition no longer constrains both is_published and is_suspended'::text
+    from pg_class c
+    join pg_namespace n on n.oid = c.relnamespace
+   where n.nspname = 'public' and c.relname = 'public_profiles' and c.relkind = 'v'
+     and not (
+          pg_get_viewdef(c.oid) ~* 'is_published'
+      and pg_get_viewdef(c.oid) ~* 'is_suspended'
+     )
+
+  union all
+  select 'INV-8-public-profiles-view-invoker'::text, 'public_profiles'::text,
+         'SEC-104: the public_profiles view is not security_invoker=on, so it runs as its owner and bypasses RLS for every caller'::text
+    from pg_class c
+    join pg_namespace n on n.oid = c.relnamespace
+   where n.nspname = 'public' and c.relname = 'public_profiles' and c.relkind = 'v'
+     and not exists (
+       select 1 from unnest(coalesce(c.reloptions, '{}')) o where o ilike 'security_invoker=on'
+     )
+
+  order by 1, 2;
+$function$;
+
+comment on function public.security_invariants_report() is
+  'SEC-101 v3: reports live violations of the eight database security invariants. '
+  'v3 adds INV-8 (SEC-104): the public_profiles view must exist, must constrain '
+  'both is_published and is_suspended, and must be security_invoker=on. It fires '
+  'when the view is ABSENT, because the application reads that view for every '
+  'public profile surface and a missing view is the worst case, not a clean one. '
+  'Called by scripts/check-db-invariants.py.';
+
+revoke all on function public.security_invariants_report() from public;
+revoke all on function public.security_invariants_report() from anon;
+revoke all on function public.security_invariants_report() from authenticated;
+grant execute on function public.security_invariants_report() to service_role;

--- a/tests/scripts/check-live-schema-parity.test.js
+++ b/tests/scripts/check-live-schema-parity.test.js
@@ -1,0 +1,131 @@
+/**
+ * CTL-048 — tests for scripts/check-live-schema-parity.py.
+ *
+ * WHAT THIS FILE CAN AND CANNOT PROVE
+ * -----------------------------------
+ * The subject talks to three live databases, and CI here has no credentials.
+ * So this exercises the two things that do not need them, and says plainly that
+ * it is not exercising the third:
+ *
+ *   1. the comparators (via `--self-test`, which is the subject's own fixture
+ *      suite and is asserted to run a FLOOR of cases, so deleting fixtures
+ *      cannot quietly shrink it);
+ *   2. the fail-closed path — no credentials must exit NON-ZERO.
+ *
+ * It cannot prove the live comparison is correct against real data. That is
+ * asserted by the job in promote-to-staging.yml, and its self-test runs on
+ * every PR so a rotted comparator fails before a promotion depends on it.
+ *
+ * ⚠️ THE FLOOR IS THE POINT. `expect(stdout).toMatch(/(\d+)\/(\d+) passed/)`
+ * moves its denominator with its numerator, so it detects a fixture that FAILS
+ * and never one that is DELETED. The same lesson as SELF_TEST_FLOORS in
+ * qa-sweep-preflight.test.js, where cutting a self-test from 26 checks to 1
+ * left jest fully green.
+ */
+const { execFileSync, spawnSync } = require('node:child_process');
+const path = require('node:path');
+
+const ROOT = path.resolve(__dirname, '../..');
+const { SRC } = JSON.parse(
+  require('node:fs').readFileSync(path.join(ROOT, 'tests/support/source-paths.json'), 'utf-8'),
+);
+const SCRIPT = path.join(ROOT, SRC.checkLiveSchemaParity);
+
+/** Committed MINIMUM number of self-test fixtures. May be raised, never lowered. */
+const SELF_TEST_FLOOR = 6;
+
+/** Run with an explicitly constructed env so an ambient credential cannot leak in. */
+function run(args, extraEnv = {}) {
+  const env = Object.assign(
+    { PATH: process.env.PATH, HOME: process.env.HOME, LANG: 'en_GB.UTF-8' },
+    extraEnv,
+  );
+  return spawnSync('python3', [SCRIPT, ...args], { encoding: 'utf-8', cwd: ROOT, env });
+}
+
+describe('CTL-048 — live schema parity', () => {
+  test('the checker self-test passes, and runs at least its committed floor', () => {
+    const r = run(['--self-test']);
+    expect(r.status).toBe(0);
+
+    const m = /live-schema-parity self-test: (\d+)\/(\d+) passed/.exec(r.stdout);
+    expect(`self-test line present: ${Boolean(m)}`).toBe('self-test line present: true');
+
+    const [, passed, total] = m.map(Number);
+    expect(`${passed}/${total}`).toBe(`${total}/${total}`);
+    expect(total).toBeGreaterThanOrEqual(SELF_TEST_FLOOR);
+  });
+
+  test('the self-test covers drift in BOTH directions', () => {
+    // dev-is-behind is a real case here (BUGS-62 `claimed_at`), so a checker
+    // that only looked for prod-is-missing would report clean on it.
+    const r = run(['--self-test']);
+    expect(r.stdout).toMatch(/reverse drift \(dev behind\) is detected/);
+    expect(r.stdout).toMatch(/live drift is detected/);
+  });
+
+  test('⚠️ FAILS CLOSED: no credentials exits non-zero, it does not skip', () => {
+    // The whole reason this control is trustworthy. A step that passes when it
+    // could not run produces a green tick over an unchecked estate — the
+    // silent-skip pattern the Workflow & Backup Integrity Policy forbids.
+    const r = run([]);
+    expect(r.status).not.toBe(0);
+    expect(r.stdout + r.stderr).toMatch(/no credentials for/);
+    expect(r.stdout + r.stderr).toMatch(/must not report success/);
+  });
+
+  test('it names WHICH credential is missing, per environment', () => {
+    // A failure that does not say what to set is a failure someone disables.
+    const out = run([]).stdout;
+    for (const v of [
+      'NEXT_PUBLIC_SUPABASE_URL',
+      'STAGING_SUPABASE_SERVICE_ROLE_KEY',
+      'PROD_SUPABASE_URL',
+    ]) {
+      expect(out).toContain(v);
+    }
+  });
+
+  test('it is registered as a control and wired into the promotion chain', () => {
+    // CTL-041's lesson generalised: a control the registry does not know about
+    // is one nobody maintains, and a registered control nothing invokes is a
+    // claim rather than a gate.
+    const registry = JSON.parse(
+      require('node:fs').readFileSync(path.join(ROOT, 'controls/registry.json'), 'utf-8'),
+    );
+    const entry = registry.controls.find((c) => c.id === 'CTL-048');
+    expect(entry).toBeDefined();
+    expect(entry.implementation).toBe(SRC.checkLiveSchemaParity);
+    expect(entry.wired_in.some((w) => w.endsWith('promote-to-staging.yml'))).toBe(true);
+
+    for (const wf of entry.wired_in) {
+      const yml = require('node:fs').readFileSync(path.join(ROOT, wf), 'utf-8');
+      expect(`${wf} invokes it: ${yml.includes(entry.implementation)}`).toBe(
+        `${wf} invokes it: true`,
+      );
+    }
+  });
+
+  test('the promotion is BLOCKED by it, not merely annotated by it', () => {
+    // A gate that runs alongside the merge instead of before it is decoration.
+    const registry = JSON.parse(
+      require('node:fs').readFileSync(path.join(ROOT, 'controls/registry.json'), 'utf-8'),
+    );
+    const wf = registry.controls
+      .find((c) => c.id === 'CTL-048')
+      .wired_in.find((w) => w.endsWith('promote-to-staging.yml'));
+    const yml = require('node:fs').readFileSync(path.join(ROOT, wf), 'utf-8');
+    expect(yml).toMatch(/needs:\s*\[verify-source, signup-gate, schema-parity\]/);
+    // And it must not carry continue-on-error, which would make the `needs`
+    // edge satisfiable by a failing job.
+    const jobBlock = yml.slice(yml.indexOf('  schema-parity:'), yml.indexOf('  merge-and-deploy:'));
+    expect(jobBlock).not.toMatch(/continue-on-error/);
+  });
+
+  test('git is not required — the subject reads files and HTTP only', () => {
+    // Guards the harness itself: the self-test must not depend on repo state,
+    // or it would pass or fail depending on where it was run from.
+    expect(() => execFileSync('python3', [SCRIPT, '--self-test'], { cwd: '/tmp', stdio: 'pipe' }))
+      .not.toThrow();
+  });
+});

--- a/tests/support/comment-assertion-baseline.json
+++ b/tests/support/comment-assertion-baseline.json
@@ -297,12 +297,6 @@
       "severity": "comment-shadowed"
     },
     {
-      "test": "tests/unit/homepage-content.test.js",
-      "subject": "src/app/page.tsx",
-      "assertion": "is_published",
-      "severity": "comment-shadowed"
-    },
-    {
       "test": "tests/unit/kan351-public-profile-data-integrity.test.ts",
       "subject": "src/app/[slug]/page.tsx",
       "assertion": "/sectionReadErrors/",
@@ -420,18 +414,6 @@
       "test": "tests/unit/search-page.test.js",
       "subject": "src/app/search/page.tsx",
       "assertion": "found",
-      "severity": "comment-shadowed"
-    },
-    {
-      "test": "tests/unit/search-page.test.js",
-      "subject": "src/app/search/page.tsx",
-      "assertion": "is_published",
-      "severity": "comment-shadowed"
-    },
-    {
-      "test": "tests/unit/search-page.test.js",
-      "subject": "src/app/search/page.tsx",
-      "assertion": "true",
       "severity": "comment-shadowed"
     },
     {

--- a/tests/support/source-path-seeds.ts
+++ b/tests/support/source-path-seeds.ts
@@ -118,5 +118,10 @@ export const SEEDED_PATHS = [
   // control registry's `implementation` field and pr-checks.yml both name this
   // exact path — the assertion IS the path, so a literal there would make a
   // rename look like a passing test against a script nobody runs.
+  // CTL-048's implementation. check-live-schema-parity.test.js asserts the
+  // registry's `implementation` field and the workflows both name this exact
+  // path — the assertion IS the path, so a literal in the test would make a
+  // rename look like a passing test against a script nobody runs.
+  'scripts/check-live-schema-parity.py',
   'scripts/check-docs-updated.py',
 ] as const;

--- a/tests/support/source-paths.json
+++ b/tests/support/source-paths.json
@@ -1,7 +1,7 @@
 {
   "$comment": "GENERATED — regenerate with `npm run gen:test-paths`. Mirror of tests/support/source-paths.ts for .cjs and shell consumers (KAN-414 F4).",
   "generated_from": "literals referenced by tracked files under tests/",
-  "count": 195,
+  "count": 197,
   "SRC": {
     "codeowners": ".github/CODEOWNERS",
     "pullRequestTemplate": ".github/PULL_REQUEST_TEMPLATE.md",
@@ -13,6 +13,7 @@
     "backupDatabase": ".github/workflows/backup-database.yml",
     "backupRestoreTest": ".github/workflows/backup-restore-test.yml",
     "prChecks": ".github/workflows/pr-checks.yml",
+    "promoteToStaging": ".github/workflows/promote-to-staging.yml",
     "securityAudit": ".github/workflows/security-audit.yml",
     "weeklyReport": ".github/workflows/weekly-report.yml",
     "baseline": "design/BASELINE.json",
@@ -37,6 +38,7 @@
     "checkExtractionDod": "scripts/check-extraction-dod.sh",
     "checkFixOnlyPromote": "scripts/check-fix-only-promote.sh",
     "checkGuardPathDrift": "scripts/check-guard-path-drift.py",
+    "checkLiveSchemaParity": "scripts/check-live-schema-parity.py",
     "checkRoutineOwnership": "scripts/check-routine-ownership.sh",
     "checkScheduledWorkflowsActive": "scripts/check-scheduled-workflows-active.py",
     "checkSchemaTypeParity": "scripts/check-schema-type-parity.py",

--- a/tests/support/source-paths.ts
+++ b/tests/support/source-paths.ts
@@ -13,7 +13,7 @@
 // cannot drift from reality — a hand-maintained list is what let BUGS-74's
 // first fix miss the legacy editor.
 //
-// 195 entries.
+// 197 entries.
 
 export const SRC = {
   codeowners: '.github/CODEOWNERS',
@@ -26,6 +26,7 @@ export const SRC = {
   backupDatabase: '.github/workflows/backup-database.yml',
   backupRestoreTest: '.github/workflows/backup-restore-test.yml',
   prChecks: '.github/workflows/pr-checks.yml',
+  promoteToStaging: '.github/workflows/promote-to-staging.yml',
   securityAudit: '.github/workflows/security-audit.yml',
   weeklyReport: '.github/workflows/weekly-report.yml',
   baseline: 'design/BASELINE.json',
@@ -50,6 +51,7 @@ export const SRC = {
   checkExtractionDod: 'scripts/check-extraction-dod.sh',
   checkFixOnlyPromote: 'scripts/check-fix-only-promote.sh',
   checkGuardPathDrift: 'scripts/check-guard-path-drift.py',
+  checkLiveSchemaParity: 'scripts/check-live-schema-parity.py',
   checkRoutineOwnership: 'scripts/check-routine-ownership.sh',
   checkScheduledWorkflowsActive: 'scripts/check-scheduled-workflows-active.py',
   checkSchemaTypeParity: 'scripts/check-schema-type-parity.py',

--- a/tests/support/test-floor-baseline.json
+++ b/tests/support/test-floor-baseline.json
@@ -1,6 +1,6 @@
 {
   "$comment": "GENERATED — regenerate with `npm run gen:test-floor`. The enforced test floor. The guard fails if the counts DROP (a test was deleted) and also if they RISE (this baseline is stale and is overstating how much of the estate is actually protected). The rise case is the one that matters: the previous hand-maintained floor sat at 29 files / 320 blocks against an actual 260 / 2963, so ~89% of the tests could have been deleted silently. Raise it in the SAME commit as any net-new test.",
   "measured_at": "2026-08-11",
-  "test_files": 277,
-  "test_blocks": 3172
+  "test_files": 278,
+  "test_blocks": 3179
 }

--- a/tests/unit/examples-page.test.js
+++ b/tests/unit/examples-page.test.js
@@ -35,8 +35,11 @@ describe('Example profiles gallery (/examples)', () => {
   });
 
   test('queries published curated example profiles, ordered', () => {
-    expect(content).toContain('.from("profiles")');
-    expect(content).toContain('.eq("is_published", true)');
+    // SEC-104: reads moved from the `profiles` table to the `public_profiles`
+    // view, which carries `is_published = true AND is_suspended = false` in its
+    // body and therefore binds the service-role client (RLS does not).
+    expect(content).toContain('.from("public_profiles")');
+    expect(content).not.toContain('.from("profiles")');
     expect(content).toContain('.eq("is_homepage_example", true)');
     expect(content).toContain('homepage_example_order');
   });

--- a/tests/unit/homepage-content.test.js
+++ b/tests/unit/homepage-content.test.js
@@ -69,7 +69,10 @@ describe('KAN-272: Minimal homepage (June-2026 redesign)', () => {
 
   test('queries up to 6 published profiles for the "A few people to meet" band', () => {
     expect(content).toContain('A few people to meet');
-    expect(content).toContain('is_published');
+    // SEC-104: reads moved from the `profiles` table to the `public_profiles`
+    // view, which carries `is_published = true AND is_suspended = false` in its
+    // body and therefore binds the service-role client (RLS does not).
+    expect(content).toContain('.from("public_profiles")');
     expect(content).toContain('.limit(6)');
   });
 

--- a/tests/unit/kan450-search-affiliations.test.ts
+++ b/tests/unit/kan450-search-affiliations.test.ts
@@ -121,7 +121,11 @@ async function search(q: string | undefined) {
 }
 
 const affiliationChain = () => mockChains.find((c) => c.table === 'school_affiliations');
-const profileChains = () => mockChains.filter((c) => c.table === 'profiles');
+// SEC-104: the profile reads target the `public_profiles` VIEW now, not the
+// table. This selector is how every assertion below finds them, so it has to
+// move first — pointing it at 'profiles' would silently yield ZERO chains and
+// turn every expectation in this file into a vacuous pass.
+const profileChains = () => mockChains.filter((c) => c.table === 'public_profiles');
 
 beforeEach(() => {
   mockChains.length = 0;
@@ -165,8 +169,13 @@ describe('KAN-450: the profiles reads keep every public-visibility guard', () =>
     const chains = profileChains();
     expect(chains).toHaveLength(2);
     for (const chain of chains) {
-      expect(chain.eq.is_published).toBe(true);
-      expect(chain.eq.is_suspended).toBe(false);
+      // SEC-104: `is_published`/`is_suspended` are no longer written at the
+      // call site — they are in the view body, which binds service_role.
+      // What must still be asserted per-branch is the source itself plus the
+      // KAN-334 demo-profile exclusion, which is NOT part of the view.
+      expect(chain.table).toBe('public_profiles');
+      expect(chain.eq.is_published).toBeUndefined();
+      expect(chain.eq.is_suspended).toBeUndefined();
       expect(chain.eq.is_homepage_example).toBe(false);
     }
   });
@@ -279,7 +288,7 @@ describe('KAN-450: a failed read is never rendered as an empty result', () => {
   test('a failed profiles read throws instead of serving a partial union', async () => {
     const boom = { message: 'statement timeout' };
     mockAffiliationRows = [{ profile_id: 'p-1' }];
-    mockReadError = (chain) => (chain.table === 'profiles' && chain.or ? boom : null);
+    mockReadError = (chain) => (chain.table === 'public_profiles' && chain.or ? boom : null);
 
     await expect(search('oakfield')).rejects.toThrow(/profiles:by-field/);
     expect(mockCaptureException).toHaveBeenCalledWith(boom, expect.anything());
@@ -288,7 +297,7 @@ describe('KAN-450: a failed read is never rendered as an empty result', () => {
   test('a failed affiliation-branch profiles read throws too', async () => {
     const boom = { message: 'permission denied for table profiles' };
     mockAffiliationRows = [{ profile_id: 'p-1' }];
-    mockReadError = (chain) => (chain.table === 'profiles' && chain.in.id ? boom : null);
+    mockReadError = (chain) => (chain.table === 'public_profiles' && chain.in.id ? boom : null);
 
     await expect(search('oakfield')).rejects.toThrow(/profiles:by-affiliation/);
     expect(mockCaptureException).toHaveBeenCalledWith(boom, expect.anything());

--- a/tests/unit/public-profile-suspended-gating.test.ts
+++ b/tests/unit/public-profile-suspended-gating.test.ts
@@ -24,30 +24,61 @@ describe('SEC-44: public profile page filters suspended profiles', () => {
     expect(fs.existsSync(path.join(root, pagePath))).toBe(true);
   });
 
-  test('excludes suspended profiles via .eq(\'is_suspended\', false)', () => {
-    expect(content).toMatch(/\.eq\(\s*['"]is_suspended['"]\s*,\s*false\s*\)/);
+  // ⚠️ SEC-104 CHANGED WHAT THESE THREE CAN ASSERT.
+  //
+  // They used to require `.eq('is_suspended', false)` and `.eq('is_published',
+  // true)` in the source, because a service-role read bypasses RLS and that
+  // hand-written pair was the whole guard. The pair now lives in the
+  // `public_profiles` view body, so asserting its absence-from-source would be
+  // asserting the OPPOSITE of the fix, and asserting its presence would fail
+  // forever.
+  //
+  // What a source scan can still prove is the part that is still in the source:
+  // BOTH reads go to the constrained view and NEITHER touches the raw table.
+  // Whether the view carries the predicate on a given database is not knowable
+  // from here — that is asserted live by scripts/check-db-invariants.py, and
+  // behaviourally (against a fake that models the view) by
+  // tests/unit/sitemap-suspension-behaviour.test.ts.
+
+  test('reads the public_profiles view, never the raw profiles table', () => {
+    expect(content).toMatch(/\.from\(\s*['"]public_profiles['"]\s*\)/);
+    expect(content).not.toMatch(/\.from\(\s*['"]profiles['"]\s*\)/);
   });
 
-  test('applies the suspension filter on BOTH the metadata and page fetches', () => {
+  test('BOTH the metadata and page fetches use the constrained source', () => {
     // The two service-role reads are distinguished by their select() shape:
     // generateMetadata selects specific columns; the page fetch selects '*'.
+    // Checking each block separately is what catches a half-migration — the
+    // exact hazard that would otherwise leave one read on the raw table while
+    // the file as a whole still mentions the view.
     const metaFetch = content.slice(
       content.indexOf("select('display_name, headline, bio_short')"),
     );
     const pageFetch = content.slice(content.indexOf(".select('*')"));
 
-    const suspensionFilter = /\.eq\(\s*['"]is_suspended['"]\s*,\s*false\s*\)/;
-
-    // Each fetch block ends at its `.single()`; assert the filter appears
-    // before that terminator in both.
     const metaBlock = metaFetch.slice(0, metaFetch.indexOf('.single()'));
     const pageBlock = pageFetch.slice(0, pageFetch.indexOf('.single()'));
 
-    expect(metaBlock).toMatch(suspensionFilter);
-    expect(pageBlock).toMatch(suspensionFilter);
+    // The `.from()` precedes `.select()` in both chains, so look backwards from
+    // each select to the nearest from().
+    const metaSource = content.slice(0, content.indexOf("select('display_name, headline, bio_short')"));
+    const pageSource = content.slice(0, content.indexOf(".select('*')"));
+
+    expect(metaSource.lastIndexOf("from('public_profiles')")).toBeGreaterThan(-1);
+    expect(pageSource.lastIndexOf("from('public_profiles')")).toBeGreaterThan(-1);
+    // Neither block re-introduces a raw-table read after its from().
+    expect(metaBlock).not.toMatch(/\.from\(\s*['"]profiles['"]\s*\)/);
+    expect(pageBlock).not.toMatch(/\.from\(\s*['"]profiles['"]\s*\)/);
   });
 
-  test('still requires is_published = true (does not weaken the existing guard)', () => {
-    expect(content).toMatch(/\.eq\(\s*['"]is_published['"]\s*,\s*true\s*\)/);
+  test('the page does not narrow the view back to the raw table by hand', () => {
+    // A plausible "tidy-up" is to re-add the predicates alongside the view read
+    // — harmless — or to revert one read to `profiles` while leaving the other
+    // on the view, which is the half-migration that makes the SEC-100 checker
+    // report ✓ over an unguarded site. Only the second is a defect, and this
+    // pins it.
+    const fromCalls = [...content.matchAll(/\.from\(\s*['"]([a-z_]+)['"]\s*\)/g)].map((m) => m[1]);
+    expect(fromCalls.length).toBeGreaterThan(0);
+    expect([...new Set(fromCalls)]).not.toContain('profiles');
   });
 });

--- a/tests/unit/recommendations-routes-security.test.ts
+++ b/tests/unit/recommendations-routes-security.test.ts
@@ -15,9 +15,20 @@ describe('SEC-19/F-13: recommendation routes filter suspended profiles', () => {
     SRC.slugRoute,
     SRC.v2SlugRoute,
   ]) {
-    test(`${rel} filters is_suspended = false on the profile lookup`, () => {
+    test(`${rel} reads the public_profiles view, so suspension is not optional`, () => {
+      // SEC-104. Was: assert `.eq('is_suspended', false)` is present in the
+      // source. The predicate moved into the `public_profiles` view body, where
+      // it binds the service-role client these routes use — so the source no
+      // longer contains the filter, by design.
+      //
+      // SEC-19/F-13's invariant is unchanged: a suspended profile must not
+      // return recommendations. What changed is where it is enforced, and
+      // therefore what this file can honestly check — that the route reads the
+      // constrained source. The view's own definition is asserted live, per
+      // database, by scripts/check-db-invariants.py.
       const content = fs.readFileSync(path.join(root, rel), 'utf8');
-      expect(content).toMatch(/\.eq\(\s*['"]is_suspended['"]\s*,\s*false\s*\)/);
+      expect(content).toMatch(/\.from\(\s*['"]public_profiles['"]\s*\)/);
+      expect(content).not.toMatch(/\.from\(\s*['"]profiles['"]\s*\)/);
     });
   }
 });

--- a/tests/unit/search-page.test.js
+++ b/tests/unit/search-page.test.js
@@ -31,9 +31,11 @@ describe('KAN-136: Search page exists and has correct structure', () => {
   });
 
   test('page queries Supabase for published profiles', () => {
-    expect(content).toContain("is_published");
-    expect(content).toContain("true");
-    expect(content).toContain(".from('profiles')");
+    // SEC-104: reads moved from the `profiles` table to the `public_profiles`
+    // view, which carries `is_published = true AND is_suspended = false` in its
+    // body and therefore binds the service-role client (RLS does not).
+    expect(content).toContain(".from('public_profiles')");
+    expect(content).not.toContain(".from('profiles')");
   });
 
   test('search filters by name, headline, city, slug', () => {

--- a/tests/unit/sitemap-suspension-behaviour.test.ts
+++ b/tests/unit/sitemap-suspension-behaviour.test.ts
@@ -5,11 +5,24 @@
  *
  * THE INVARIANTS, IN WORDS
  * ------------------------
- *  1. The profile query filters on **both** `is_published = true` AND
- *     `is_suspended = false`. This is SEC-100. The sitemap is built with the
+ *  1. The profile query reads the **`public_profiles` view**, never the raw
+ *     `profiles` table. This is SEC-100/SEC-104. The sitemap is built with the
  *     SERVICE-ROLE client, which bypasses RLS, so the database policy that
- *     protects every other read does **not** apply here — the filter has to be
- *     written out by hand, and nothing else will catch it if it is dropped.
+ *     protects every other read does **not** apply here. Until SEC-104 the
+ *     `is_published = true AND is_suspended = false` pair had to be written out
+ *     by hand at every call site; it now lives in the view body, where it binds
+ *     service_role by construction.
+ *
+ *     ⚠️ AND THAT MAKES THIS TEST NARROWER, WHICH IS WORTH SAYING OUT LOUD. A
+ *     unit test cannot see whether the view on a given database actually
+ *     carries the predicate — it can only prove the code reads the view. The
+ *     other half moved to a control that CAN read a database:
+ *     `scripts/check-db-invariants.py`, run per-environment by
+ *     db-invariants.yml. An invariant relocated into the database needs its
+ *     control relocated with it, or the guarantee is only a comment.
+ *
+ *     The fake below therefore MODELS the view rather than ignoring the table
+ *     name, so invariant 2 still means something.
  *  2. A suspended member's slug never reaches the output. Invariant 1 is about
  *     the query; this is about the result, and they are not the same claim.
  *  3. Static pages are always present, and a Supabase failure degrades to
@@ -49,6 +62,7 @@ type Row = { slug: string; updated_at: string; is_suspended?: boolean };
 type EqCall = [string, unknown];
 
 const eqCalls: EqCall[] = [];
+const sources: string[] = [];
 let rows: Row[] = [];
 let clientThrows = false;
 
@@ -60,6 +74,7 @@ jest.mock('@/modules/platform/supabase-service', () => ({
     // A chainable that records each filter and resolves to whatever survives
     // them, so invariant 1 (the query) and invariant 2 (the result) can be
     // asserted independently rather than one standing in for the other.
+    let source = '';
     const chain = {
       select: () => chain,
       eq: (col: string, val: unknown) => {
@@ -68,13 +83,31 @@ jest.mock('@/modules/platform/supabase-service', () => ({
       },
       then: (resolve: (v: unknown) => unknown) => {
         let out = rows;
+        // SEC-104: the fake MODELS THE VIEW. `public_profiles` is defined as
+        // `SELECT … WHERE is_published = true AND is_suspended = false`, so
+        // reading it must yield only those rows here too — otherwise this
+        // double would prove the route safe against a source that does not
+        // behave like the one production uses.
+        if (source === 'public_profiles') {
+          out = out.filter(
+            (r) =>
+              (r as Record<string, unknown>).is_published === true &&
+              (r as Record<string, unknown>).is_suspended === false,
+          );
+        }
         for (const [col, val] of eqCalls) {
           out = out.filter((r) => (r as Record<string, unknown>)[col] === val);
         }
         return resolve({ data: out, error: null });
       },
     };
-    return { from: () => chain };
+    return {
+      from: (table: string) => {
+        source = table;
+        sources.push(table);
+        return chain;
+      },
+    };
   },
 }));
 
@@ -94,6 +127,7 @@ const SUSPENDED: Row = {
 
 beforeEach(() => {
   eqCalls.length = 0;
+  sources.length = 0;
   clientThrows = false;
   rows = [
     { ...LIVE, is_published: true } as Row,
@@ -104,13 +138,26 @@ beforeEach(() => {
 const urls = (m: MetadataRoute.Sitemap) => m.map((e) => e.url);
 
 describe('sitemap (behavioural, KAN-414 F4 / SEC-100)', () => {
-  it('filters on BOTH is_published and is_suspended', async () => {
+  it('reads the constrained source, not the raw profiles table (SEC-104)', async () => {
+    // ⚠️ THIS ASSERTION CHANGED SHAPE, AND THE REASON MATTERS.
+    //
+    // It used to require `.eq('is_published', true)` AND `.eq('is_suspended',
+    // false)` on the query, because the service-role client bypasses RLS and
+    // that hand-written pair was the only thing between a moderated member and
+    // Google's crawler. SEC-104 moved the pair into the `public_profiles` view
+    // body, where it binds service_role by construction.
+    //
+    // So the thing to assert is no longer "did the caller remember the filters"
+    // but "did the caller read the source that cannot forget them". That is a
+    // narrower claim, and honestly so: a unit test CANNOT see whether the view
+    // on a given database actually carries the predicate. That half is asserted
+    // live, per environment, by scripts/check-db-invariants.py — because an
+    // invariant that moved into the database needs a control that can read the
+    // database.
     await sitemap();
 
-    // The service-role client bypasses RLS, so this pair is the only thing
-    // standing between a moderated member and Google's crawler.
-    expect(eqCalls).toContainEqual(['is_published', true]);
-    expect(eqCalls).toContainEqual(['is_suspended', false]);
+    expect(sources).toContain('public_profiles');
+    expect(sources).not.toContain('profiles');
   });
 
   it('never emits a suspended member’s slug (SEC-100)', async () => {


### PR DESCRIPTION
## SEC-104 — the public-visibility predicate becomes a database object

Lyra's most recurrent security defect class is a visibility predicate applied at
one call site and forgotten at its siblings: **SEC-44, 47, 57, 58, 80, 81, 83,
84, 85, BUGS-21**. `profiles` carries the right RLS policy — but the
**service-role client bypasses RLS**, and 7 of the 8 public reads use it. That is
how **SEC-100** happened: suspended members served to public search and to
search-engine crawlers three weeks after SEC-44 was closed and verified.

A view's `WHERE` is not a policy. It is part of the query, so it binds
service_role.

**Proven, not assumed.** On dev, as the actual `service_role` role, a profile
flipped to `is_suspended` was visible through the **table** (1 row) and absent
through the **view** (0 rows). Both probes ran inside transactions aborted by a
sentinel, and the revert was verified afterwards.

### ⚠️ What this is NOT

A client-boundary audit found **nothing sensitive leaks today**.
`[slug]/page.tsx` fetches 42 columns but only **8 public-by-design** ones reach
the browser; the only client component in the tree receives two scalars. **This
is a hardening.** Saying otherwise would overstate it.

### The column set is 17, derived rather than guessed

From what the 8 public reads actually use — **including columns used only as
filters or `ORDER BY`**, which a union of `.select()` lists misses.
`is_homepage_example` and `homepage_example_order` are never selected anywhere,
but `/examples` filters and orders on them; omitting them would have shipped a
broken page.

⚠️ **Portability, measured live.** dev and staging carry 42 profiles columns;
**production carries 38** — it alone lacks the four KAN-153 columns (SEC-107). A
view naming them applies cleanly to dev and staging and then **fails on
production**. None of them belongs in a public view anyway, so the constraint and
the design agree. Do not add them when SEC-107 closes.

### ⚠️ The honest cost, and why INV-8 exists

Moving the predicate into the database **moves the failure mode**: a unit test
can no longer see it. The behavioural sitemap test proved this by going **red** —
its fake returned the suspended member the moment the code stopped writing the
filter by hand. So:

- the fake now **models the view**, and its result-level invariant still means something;
- the source scans were narrowed to what they can honestly prove (*"the code reads the constrained source"*), with the narrowing stated at each site;
- and the other half became **INV-8** in `security_invariants_report()`, asserting per-environment that the view exists, constrains both predicates, and is `security_invoker=on`.

**INV-8 fires when the view is ABSENT.** "Verify it if it exists" would report
clean on the one database where it was never applied — the worst answer, since
the code is already cut over. Mutation-proven on dev: base=0, missing=1,
predicate=1, invoker=1, then rolled back.

> An invariant relocated into the database needs its control relocated with it,
> or the guarantee is only a comment.

## CTL-048 — live column parity, blocking promotion

Founder request: catch column drift across the three databases **as we do
promotions**.

CTL-036 already exists and works — but it diffs the three **committed
snapshots** and never talks to a database. If all three go stale the *same* way
it compares stale-to-stale and passes. **That was the live state:** every
snapshot was missing `gift_voucher_hint` while all three databases had it, and
CTL-036 was green throughout.

CTL-048 asks the databases, and is a hard `needs` of the merge job. Its
**self-test runs on every PR** (no credentials needed) so a rotted comparator
fails before a promotion depends on it. Drift is checked **both ways** —
`gathering_invite_messages.claimed_at` is on staging and prod but not dev
(BUGS-62). Missing credentials **exit 2**, never skip.

The third commit fixes the staleness CTL-048 was built to catch. Snapshot column
counts now match live exactly: **42 / 42 / 38**.

## Database state

| | view | INV-8 | applied |
|---|---|---|---|
| dev | ✅ 17 cols, `security_invoker=on` | ✅ | yes |
| staging | ✅ 17 cols, `security_invoker=on` | ✅ | yes |
| **production** | ✅ 17 cols, `security_invoker=on` | ✅ 0 violations | **yes** |

Applied **before** this code merges, deliberately — code reaching a database
without the view would 500 every public page.

## Verification

**278 suites / 3630 tests**, tsc clean, eslint 0 errors.

Mutation-proven, **0 survivors**, each verified to have applied then reverted:
SEC-104's premise (2, as `service_role`), INV-8's three branches, and CTL-048's
four — including the two ways that gate could exist and protect nothing
(`continue-on-error`, and returning 0 with no credentials).

EXTRACTION-DOD-COVERAGE: n/a — no file moved into or out of `src/modules/`. The
changed reads are covered by the existing unit estate plus soak contracts C3
(public profile render) and C5 (search). **Recording the gap: there is no E2E
that asserts a suspended member is absent from `/search` end-to-end; that is
covered by INV-8 at the database level and unit-level elsewhere.**
EXTRACTION-DOD-DESIGN-SYSTEM: n/a — no `globals.css`, no ui-kit file.
EXTRACTION-DOD-ROUTINE-PROMPTS: n/a — no script renamed; no protected-surface
path list named in a routine prompt changed.

Refs: SEC-104, SEC-100, SEC-44, SEC-107, BUGS-62, KAN-443
