### PR TITLE
docs: handoff for continuing KAN-415 D9 / SEC-104 promotion in another session

### DIFF
--- a/docs/HANDOFF-2026-08-11.md
+++ b/docs/HANDOFF-2026-08-11.md
@@ -1,0 +1,212 @@
+# Handoff — 2026-08-11 (KAN-415 D7/D8, SEC-104, CTL-048)
+
+**Written for a session that has none of the previous session's context** — a
+cloud instance, a different machine, a different profile. Everything needed is
+either here or named by path. Read `CLAUDE.md` first; this is the delta on top
+of it.
+
+---
+
+## 1. Where everything actually is
+
+| | commit | tree SHA | contents |
+|---|---|---|---|
+| `develop` | `c437ccb7` | `41ce4a80b78f` | D7 + D8 + **SEC-104 + CTL-048** |
+| `staging` | `eda6f6f7` | `e4088d8563b9` | D7 + D8 |
+| `beta` | `4c345662` | `e4088d8563b9` | D7 + D8 |
+| `main` | `6833735d` | `e4088d8563b9` | D7 + D8 — tagged **v0.1.96** |
+
+⚠️ **Compare environments by TREE SHA, never by ahead/behind.** The 2026-06-20
+re-root makes `main` read "565 ahead" of branches whose trees are identical.
+`beta` and `main` are flat here; `develop` is **3 commits ahead of staging** and
+carries SEC-104.
+
+**Databases — all three already have the SEC-104 objects**, applied *before* the
+code, deliberately:
+
+| | `public_profiles` view | INV-8 in `security_invariants_report()` |
+|---|---|---|
+| dev `ilprytcrnqyrsbsrfujj` | ✅ 17 cols, `security_invoker=on` | ✅ |
+| staging `uobmlkzrjkptwhttzmmi` | ✅ 17 cols, `security_invoker=on` | ✅ |
+| prod `llzkgprqewuwkiwclowi` | ✅ 17 cols, `security_invoker=on` | ✅ 0 violations |
+
+**Ordering rule that matters:** the code reads `public_profiles`. If code reaches
+an environment before the view does, every public page 500s. The databases are
+ahead of the code on purpose — keep it that way for any future environment.
+
+---
+
+## 2. What shipped
+
+**KAN-415 D7 — all 10 `'use server'` closures extracted** into
+`src/modules/trust-safety/{report-actions,user-actions}.ts` and
+`src/modules/oauth-as/consent-flow.ts`. **D8 — the profile domain core** into
+`src/modules/profile/`. Both are live in production (v0.1.96). Programme is
+**56% extracted** (65 module files / 116 in-scope; `src/lib/`'s 24 convene files
+are permanently out of scope).
+
+**D-6, a real security fix:** `is_published` was in `ALLOWED_PROFILE_FIELDS`,
+making `updateProfileFields` a second publish path — which is why the KAN-408 age
+gate existed **twice**, the second copy only to stop the allowlist bypassing the
+first. Removed; one entry point (`publishProfile()`) now.
+
+**SEC-104 — `public.public_profiles`.** The public-visibility predicate moved
+from eight call sites into a database view. On `develop`, not yet promoted.
+
+**CTL-048 — live column parity across the three databases**, blocking the
+promotion. On `develop`, not yet promoted.
+
+---
+
+## 3. The next actions, in order
+
+### 3.1 Promote `develop` → production (SEC-104 + CTL-048)
+
+Standing founder approval exists for this programme; deployments through to
+production were authorised 2026-08-11. Chain is `develop → staging → beta → main`
+(SEC-98 — **no chain bypass**, and a bypass needs the literal phrase
+`BYPASS CONTROLS` plus a separate risk acknowledgement).
+
+```bash
+gh workflow run "Promote to Staging" --ref main -f confirm=promote
+```
+
+Then `"Promote Staging to Beta"` with `-f confirm=promote`, then
+`"Promote to Production"` with `-f confirm=PRODUCTION -f promote_mode=manual`.
+
+⚠️ **CTL-048 runs for the first time in this promotion** and is a hard `needs` of
+the merge job. If it fails, that is the gate working — read its output before
+assuming a bug. It compares the three live databases and each committed
+`src/types/database/<env>.ts` snapshot against its own database.
+
+⚠️ **`promote-to-production.yml` has a live bug (task #25).** Its
+*Wait for production deploy (SHA-matched)* step reports **success while the deploy
+is still `waiting`** on the Production environment approval gate — so *Create
+release tag*, *Production smoke tests* and *Auto-rollback* all get **skipped**,
+and main ships untagged. Recovery, verified working on 2026-08-11:
+
+```bash
+gh api repos/luisa-sys/lyra/actions/runs/<DEPLOY_RUN_ID>/pending_deployments --input approve.json
+```
+
+where `approve.json` is `{"environment_ids":[<id>],"state":"approved","comment":"..."}`.
+**Never `-F`** — it cannot build the `environment_ids` array and silently does
+nothing. Then verify `pending_deployments` returns **0** rather than trusting the
+response body. Afterwards, replicate the lost supervision by hand: smoke the site,
+and create the tag with the workflow's own logic —
+`git describe --tags --abbrev=0`, increment the patch, `git tag -a`, push.
+
+### 3.2 KAN-415 D9 — `public-profile` (NOW UNBLOCKED)
+
+D9 was gated on SEC-104 and SEC-104 is done. The module should own *"read from
+`public_profiles`"* rather than *"remember two predicates at every call site"* —
+that call-site convention no longer exists to freeze. Preserve SEC-82 cache
+headers; URLs unchanged. Plan: `docs/modularisation/LYRA_MODULARISATION_PLAN_2026-07-26.md`
+(⚠️ it carries a SUPERSEDED banner and inline REVERSED markers — read those).
+
+### 3.3 Open findings worth picking up
+
+- **Sitemap is build-time cached (task #27).** Verified on dev: suspending a
+  member correctly 404s their profile and both recommendations routes and removes
+  them from `/search`, but they **remain in `/sitemap.xml`** (`x-vercel-cache: HIT`;
+  a cache-buster does not dislodge it). `src/app/sitemap.ts` declares no
+  `revalidate`/`dynamic`. **Pre-existing — not caused by SEC-104** (the old code
+  had the same property; the issue is *when* the query runs, not what it filters)
+  — but it defeats SEC-100's stated purpose for the window between a suspension
+  and the next deploy.
+- **SEC-107 (task #11).** Production lacks 4 `profiles` columns the other two
+  have: `phone_search_hash`, `postcode_search_hash`, `discoverable_by_phone`,
+  `discoverable_by_postcode`. Measured live: dev 42 / staging 42 / **prod 38**.
+- **BUGS-91 (task #9).** DB migration versions have never matched repo filenames;
+  `supabase db push` is unusable as a result. Use the Supabase MCP
+  `apply_migration` tool.
+- **KAN-414 F4 (`docs/modularisation/KAN-414-F4-HANDOVER-2026-08-01.md`).** 38
+  untriaged vacuous-test leads. Triage the photo-upload MIME hits first — if that
+  allowed-MIME list is comment-only, the storage bucket's file-type restriction
+  is unguarded.
+
+---
+
+## 4. Traps that cost real time here
+
+**The `SRC` manifest deletes keys on a file move.** `tests/support/source-paths.ts`
+contains its own values as literals, so `scripts/gen-test-paths.mjs` rediscovers
+them — the manifest is *self-sustaining in steady state*, which is exactly why
+the failure surprises. A move breaks the loop and the key **vanishes**; then
+`SRC.gone === undefined` and `expect(x).not.toContain(undefined)` **passes
+forever**. Seed new keys in `tests/support/source-path-seeds.ts`. `.ts` tests get
+a compile error; **`.js` tests get no warning at all**. Estate guard:
+`tests/unit/source-path-manifest-integrity.test.ts`. This fired again during D8 —
+three keys dropped, two silently.
+
+**`modules.json` has TWO path-keyed regions** — `paths` *and* `publicApi` (a
+`file` per exported symbol). D8 updated the first and the extraction DoD gate
+caught the second, seven entries later.
+
+**`git ls-files` cannot see unstaged files.** Deriving `owns.files` before
+`git add` gives the wrong number. Stage, then measure.
+
+**The extraction DoD gate reads the PR body from the *event payload*.** Editing
+the body and re-running replays the same stale payload — only a **new push**
+refreshes it. Write `EXTRACTION-DOD-COVERAGE` / `-DESIGN-SYSTEM` /
+`-ROUTINE-PROMPTS` into the body *then* push. It also flags a moved path
+mentioned in a **comment**; reword rather than reaching for `EXTRACTION-DOD-OK`.
+
+**The KAN-411 UI guard fires on pure data-source changes** to
+`src/app/**/page.tsx`. Add the `UI-Change-Approved: <KEY>` trailer. **Do not add
+a carve-out** — those files contain real founder-owned UI, and carving them out
+would blind the guard permanently. ⚠️ The guard also expects the Jira ticket to
+carry the `ui-approval-required` label; SEC-104 may still need it.
+
+**`json.dumps(..., ensure_ascii=False)` rewrites escaped characters file-wide.**
+It unescaped an em-dash in `tests/support/comment-assertion-baseline.json`. Leave
+`ensure_ascii` at its default and diff before committing.
+
+**Prod DB writes are classifier-gated.** `apply_migration` against production was
+refused until the founder explicitly authorised that specific action. Surface it;
+do not route around it.
+
+**Finder leaves empty `"<name> 2"` directories** beside real ones. Untracked and
+invisible to `git status`, visible to globs and path-anchored rules. `rmdir` them.
+
+---
+
+## 5. How to verify a claim here
+
+The house rule that has repeatedly paid: **break the thing on purpose, watch the
+test go red, put it back — and assert the mutation actually applied first.** A
+string-replace that matches nothing produces a green run indistinguishable from a
+real one. This session ran ~15 mutations across SEC-104, D-6, INV-8 and CTL-048
+with zero survivors; the two that mattered most were the ones proving CTL-048
+could not exist and protect nothing (`continue-on-error`, and returning 0 with no
+credentials).
+
+The canonical catalogue is **`CLAUDE.md` → "Writing a test that can actually
+fail"** — eight ways a Lyra test has gone green while guarding nothing, all real.
+
+**Current floors:** 278 suites / 3630 tests. `npm run test:unit`,
+`npx tsc --noEmit`, `npm run lint` (0 errors, 35 pre-existing warnings),
+`npm run depcruise` (0 errors; 2 pre-existing `no-cross-segment-app` warnings).
+
+⚠️ `npm test` does not exist — the script is `npm run test:unit`. A bare
+`npx jest` also picks up the Playwright specs and reports 7 spurious failures.
+
+---
+
+## 6. One design decision not to relitigate
+
+Moving a guard into the database **moves its failure mode**. The behavioural
+sitemap test went red the moment the code stopped writing the filter by hand —
+correctly, because a unit test cannot see a view. The resolution was three-part,
+and all three are load-bearing:
+
+1. the test double now **models the view** (`tests/unit/sitemap-suspension-behaviour.test.ts`);
+2. source scans were narrowed to what they can honestly prove — *"the code reads
+   the constrained source"* — with the narrowing written at each site;
+3. the other half became **INV-8**, which asserts per-database that the view
+   exists, constrains both predicates, and is `security_invoker=on` — and **fires
+   when the view is ABSENT**, because "verify it if it exists" reports clean on
+   the one database where it was never applied.
+
+*An invariant relocated into the database needs its control relocated with it, or
+the guarantee is only a comment.*


### PR DESCRIPTION
Self-contained handoff at `docs/HANDOFF-2026-08-11.md` for a session with none of this one's context.

Docs-only. Covers exact branch/tree SHAs, the database-ahead-of-code ordering rule for SEC-104, the promotion commands, the live `promote-to-production` wait-for-deploy defect and its verified recovery, and the traps that cost time this session.

Refs: KAN-415, SEC-104