### PR TITLE
fix(sitemap): render /sitemap.xml per request (SEC-130) + correct three stale schema snapshots (SEC-131)

### DIFF
--- a/scripts/staging-soak.sh
+++ b/scripts/staging-soak.sh
@@ -135,6 +135,40 @@ expect_code "C1-sectxt"  "$SITE/.well-known/security.txt" "security.txt" 200 403
 # reachability check, not a latency-measurable page.
 expect_code "C1-join"    "$SITE/join"                     "join (invite) reachable" 200 301 302 307 308
 
+# ── C1 SEC-130: /sitemap.xml must be rendered PER REQUEST, not prerendered ────
+# The route declares `dynamic = 'force-dynamic'`, so a genuinely dynamic
+# response comes back with a no-store/no-cache Cache-Control. If it ever
+# regresses to build-time prerendering the header flips to a cacheable one —
+# and that is not cosmetic: it is exactly the state in which a SUSPENDED
+# member's slug stayed in the sitemap until the next deploy, while their profile
+# page 404'd and /search dropped them immediately. The unit test
+# (tests/unit/sitemap-suspension-behaviour.test.ts) can only pin the route
+# segment config; Jest does not run a Next build, so this is the probe that
+# observes the deployed behaviour.
+#
+# Biased to UNVERIFIED, deliberately: a missing Cache-Control means an
+# intermediary rewrote it, which we cannot interpret, and a false FAIL here
+# would block a release over a proxy quirk. Never a silent skip either — an
+# unreadable answer is reported as unreadable.
+sm_raw=$(curl -s -o /dev/null -D - -w '\nHTTPCODE:%{http_code}\n' \
+  --max-time "$CURL_MAX_TIME" "${CURL_HDRS[@]}" "$SITE/sitemap.xml" 2>/dev/null)
+sm_code=$(printf '%s' "$sm_raw" | sed -n 's/^HTTPCODE:\(.*\)$/\1/p' | tail -1 | tr -d '\r')
+[ -z "$sm_code" ] && sm_code="000"
+# Lowercased first: header names are case-insensitive and Vercel/CF do not agree
+# on casing. `tr 'A-Z' 'a-z'` rather than ${v,,} — bash 3.2 (gotcha #28).
+sm_cc=$(printf '%s' "$sm_raw" | tr 'A-Z' 'a-z' | sed -n 's/^cache-control:[[:space:]]*//p' | head -1 | tr -d '\r')
+if [ "$sm_code" != "200" ]; then
+  record UNVERIFIED "C1-sitemap-fresh" "sitemap.xml freshness — got $sm_code, cannot read headers (gated/unreachable)"
+elif [ -z "$sm_cc" ]; then
+  record UNVERIFIED "C1-sitemap-fresh" "sitemap.xml freshness — no Cache-Control returned; an intermediary may have stripped it"
+# -E, not a BRE \| alternation: BSD grep does not honour \| and would silently
+# never match, reporting a clean scan that never ran (gotcha #30).
+elif printf '%s' "$sm_cc" | grep -qE 'no-store|no-cache'; then
+  record PASS "C1-sitemap-fresh" "sitemap.xml rendered per request (cache-control: $sm_cc)"
+else
+  record FAIL "C1-sitemap-fresh" "sitemap.xml looks CACHED (cache-control: $sm_cc) — SEC-130 regression: a suspended member's slug can persist in the sitemap until the next deploy"
+fi
+
 # ── C1 release-conformance: /api/health JSON must match THIS env ──────────────
 # (the grey-cloud alias serves the SAME staging build, so siteUrl is still the
 # canonical https://stage.checklyra.com — the conformance check holds.)

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -2,6 +2,38 @@ import type { MetadataRoute } from 'next';
 import { createServiceRoleClient } from '@/modules/platform/supabase-service';
 import { env } from '@/modules/platform/env';
 
+/**
+ * SEC-130 — render on every request, never at build time.
+ *
+ * This route reads no dynamic API (no `cookies()`, no `headers()`, no
+ * `searchParams`), so Next PRERENDERS it during the build and then serves that
+ * one snapshot until the next deploy. The profile list is therefore frozen at
+ * build time, and suspending a member does not remove their slug from
+ * `/sitemap.xml` — it stays advertised to crawlers for however long it is until
+ * someone happens to deploy. Measured on dev: the member's profile page 404s
+ * immediately and they leave `/search` immediately, yet `/sitemap.xml` still
+ * listed them (`x-vercel-cache: HIT`, and a cache-buster did not dislodge it).
+ *
+ * That defeats the stated purpose of SEC-100. Suspension is how moderation and
+ * takedown are enforced on a service holding minors' personal data, and a
+ * takedown whose propagation is bounded only by the release cadence is not a
+ * takedown. SEC-104 fixed WHAT the query filters; this fixes WHEN it runs, and
+ * the two are independent — the view is correct and was already being read, but
+ * a correct query executed once at build time is still a stale answer.
+ *
+ * `force-dynamic` + `revalidate = 0` is the idiom already used for the
+ * freshness-critical routes in this repo (`src/app/status/page.tsx`,
+ * `src/app/api/health/route.ts`). A bounded `revalidate` was considered and
+ * rejected: it would trade an unbounded staleness window for a merely smaller
+ * one, and there is no load argument for the trade — production has 27
+ * published profiles, so this is one small indexed read on a route search
+ * engines fetch a handful of times a day. If crawl volume ever makes that
+ * untrue, a bounded `revalidate` is the knob to reach for, not a return to
+ * build-time caching.
+ */
+export const dynamic = 'force-dynamic';
+export const revalidate = 0;
+
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   const baseUrl = env.siteUrl();
 

--- a/src/types/database/dev.ts
+++ b/src/types/database/dev.ts
@@ -1198,6 +1198,7 @@ export type Database = {
         Row: {
           answer: string
           created_at: string | null
+          custom_prompt: string | null
           id: string
           profile_id: string
           prompt_id: string
@@ -1207,6 +1208,7 @@ export type Database = {
         Insert: {
           answer: string
           created_at?: string | null
+          custom_prompt?: string | null
           id?: string
           profile_id: string
           prompt_id: string
@@ -1216,6 +1218,7 @@ export type Database = {
         Update: {
           answer?: string
           created_at?: string | null
+          custom_prompt?: string | null
           id?: string
           profile_id?: string
           prompt_id?: string
@@ -1288,6 +1291,7 @@ export type Database = {
           category: Database["public"]["Enums"]["item_category"]
           created_at: string | null
           description: string | null
+          group_label: string | null
           id: string
           profile_id: string
           sort_order: number | null
@@ -1299,6 +1303,7 @@ export type Database = {
           category: Database["public"]["Enums"]["item_category"]
           created_at?: string | null
           description?: string | null
+          group_label?: string | null
           id?: string
           profile_id: string
           sort_order?: number | null
@@ -1310,6 +1315,7 @@ export type Database = {
           category?: Database["public"]["Enums"]["item_category"]
           created_at?: string | null
           description?: string | null
+          group_label?: string | null
           id?: string
           profile_id?: string
           sort_order?: number | null

--- a/src/types/database/prod.ts
+++ b/src/types/database/prod.ts
@@ -1201,6 +1201,7 @@ export type Database = {
         Row: {
           answer: string
           created_at: string | null
+          custom_prompt: string | null
           id: string
           profile_id: string
           prompt_id: string
@@ -1210,6 +1211,7 @@ export type Database = {
         Insert: {
           answer: string
           created_at?: string | null
+          custom_prompt?: string | null
           id?: string
           profile_id: string
           prompt_id: string
@@ -1219,6 +1221,7 @@ export type Database = {
         Update: {
           answer?: string
           created_at?: string | null
+          custom_prompt?: string | null
           id?: string
           profile_id?: string
           prompt_id?: string
@@ -1291,6 +1294,7 @@ export type Database = {
           category: Database["public"]["Enums"]["item_category"]
           created_at: string | null
           description: string | null
+          group_label: string | null
           id: string
           profile_id: string
           sort_order: number | null
@@ -1302,6 +1306,7 @@ export type Database = {
           category: Database["public"]["Enums"]["item_category"]
           created_at?: string | null
           description?: string | null
+          group_label?: string | null
           id?: string
           profile_id: string
           sort_order?: number | null
@@ -1313,6 +1318,7 @@ export type Database = {
           category?: Database["public"]["Enums"]["item_category"]
           created_at?: string | null
           description?: string | null
+          group_label?: string | null
           id?: string
           profile_id?: string
           sort_order?: number | null

--- a/src/types/database/staging.ts
+++ b/src/types/database/staging.ts
@@ -1201,6 +1201,7 @@ export type Database = {
         Row: {
           answer: string
           created_at: string | null
+          custom_prompt: string | null
           id: string
           profile_id: string
           prompt_id: string
@@ -1210,6 +1211,7 @@ export type Database = {
         Insert: {
           answer: string
           created_at?: string | null
+          custom_prompt?: string | null
           id?: string
           profile_id: string
           prompt_id: string
@@ -1219,6 +1221,7 @@ export type Database = {
         Update: {
           answer?: string
           created_at?: string | null
+          custom_prompt?: string | null
           id?: string
           profile_id?: string
           prompt_id?: string
@@ -1291,6 +1294,7 @@ export type Database = {
           category: Database["public"]["Enums"]["item_category"]
           created_at: string | null
           description: string | null
+          group_label: string | null
           id: string
           profile_id: string
           sort_order: number | null
@@ -1302,6 +1306,7 @@ export type Database = {
           category: Database["public"]["Enums"]["item_category"]
           created_at?: string | null
           description?: string | null
+          group_label?: string | null
           id?: string
           profile_id: string
           sort_order?: number | null
@@ -1313,6 +1318,7 @@ export type Database = {
           category?: Database["public"]["Enums"]["item_category"]
           created_at?: string | null
           description?: string | null
+          group_label?: string | null
           id?: string
           profile_id?: string
           sort_order?: number | null

--- a/tests/support/test-floor-baseline.json
+++ b/tests/support/test-floor-baseline.json
@@ -1,6 +1,6 @@
 {
   "$comment": "GENERATED — regenerate with `npm run gen:test-floor`. The enforced test floor. The guard fails if the counts DROP (a test was deleted) and also if they RISE (this baseline is stale and is overstating how much of the estate is actually protected). The rise case is the one that matters: the previous hand-maintained floor sat at 29 files / 320 blocks against an actual 260 / 2963, so ~89% of the tests could have been deleted silently. Raise it in the SAME commit as any net-new test.",
-  "measured_at": "2026-08-11",
+  "measured_at": "2026-08-12",
   "test_files": 278,
-  "test_blocks": 3179
+  "test_blocks": 3181
 }

--- a/tests/unit/sitemap-suspension-behaviour.test.ts
+++ b/tests/unit/sitemap-suspension-behaviour.test.ts
@@ -30,6 +30,23 @@
  *     outage, and the failure mode is silent.
  *  4. Every URL is absolute and built from the configured site URL, so a
  *     preview deployment cannot publish preview-host URLs to search engines.
+ *  5. The route is configured to render PER REQUEST, not at build time
+ *     (SEC-130). Invariants 1 and 2 are about what the query asks for; this is
+ *     about when it runs, and a correct query executed once at build time is
+ *     still a stale answer. Until this was fixed the route read no dynamic API,
+ *     so Next prerendered it and a suspended member's slug stayed in
+ *     `/sitemap.xml` until the next deploy — while their profile page 404'd and
+ *     `/search` dropped them immediately.
+ *
+ *     ⚠️ AND THIS ONE IS NARROWER STILL, WHICH IS WORTH SAYING OUT LOUD. Jest
+ *     imports a module; it does not run a Next build, so it CANNOT observe
+ *     whether the deployed route was prerendered. What it can do is pin the
+ *     route segment config — which is the actual mechanism Next reads to make
+ *     that decision, not a proxy for it. The deployed half (that
+ *     `/sitemap.xml` really comes back uncached) is asserted against a running
+ *     environment by the `C1-sitemap-fresh` probe in `scripts/staging-soak.sh`.
+ *     Same reasoning as invariant 1: a guarantee that lives outside the unit
+ *     needs a control that lives outside the unit.
  *
  * WHY THIS IS STRONGER — AND THE HISTORY THAT PROVES IT
  * -----------------------------------------------------
@@ -113,6 +130,12 @@ jest.mock('@/modules/platform/supabase-service', () => ({
 
 // `jest.mock` is hoisted above imports, so the route sees the stubs below.
 import sitemap from '@/app/sitemap';
+// Imported as a namespace as well, so the route segment config can be asserted
+// as the EVALUATED export rather than as source text. A `toContain` scan over
+// the file would also match the comment explaining why the config is there —
+// which is the CTL-039 failure mode, and this file's own header is a long
+// argument against it.
+import * as sitemapRoute from '@/app/sitemap';
 
 const LIVE: Row = {
   slug: 'ada',
@@ -206,5 +229,24 @@ describe('sitemap (behavioural, KAN-414 F4 / SEC-100)', () => {
       expect(e.changeFrequency).toBeDefined();
       expect(typeof e.priority).toBe('number');
     }
+  });
+});
+
+describe('sitemap freshness (SEC-130)', () => {
+  // Both assertions are POSITIVE on purpose. `expect(x).not.toBe(undefined)`
+  // style checks are how this repo has previously shipped tests that could
+  // never fail (catalogue entry 3 in CLAUDE.md): deleting the export makes the
+  // binding `undefined`, and a negative assertion against `undefined` passes
+  // forever. Asserting the exact expected value reddens on deletion AND on a
+  // silent change of value.
+  it('declares force-dynamic, so Next renders it per request', () => {
+    expect(sitemapRoute.dynamic).toBe('force-dynamic');
+  });
+
+  it('declares revalidate = 0, so no ISR window can re-stale it', () => {
+    // `force-dynamic` already implies this; stating it explicitly is what
+    // src/app/status/page.tsx and src/app/api/health/route.ts do, and it means
+    // relaxing the guarantee takes two deliberate edits rather than one.
+    expect(sitemapRoute.revalidate).toBe(0);
   });
 });


### PR DESCRIPTION
## Summary

Two fixes, both found while continuing the SEC-104 sitemap work.

**SEC-130 — `/sitemap.xml` was prerendered at BUILD time.** The route read no dynamic API, so Next prerendered it and served one snapshot until the next deploy. Suspending a member did **not** remove their slug from the sitemap, even though their profile page 404s and `/search` drops them immediately.

This is *not* the defect SEC-100 or SEC-104 fixed, and the distinction is the point:

| | fixes | still broken after |
|---|---|---|
| SEC-100 | the missing `is_suspended` filter at 5 call sites | the query runs once, at build |
| SEC-104 | moved both predicates into the `public_profiles` view | the query runs once, at build |
| **SEC-130** | **when the query runs** | — |

SEC-104 fixed *what* the query filters; this fixes *when it runs*. **A correct query executed once at build time is still a stale answer.** Pre-existing — the old code had the identical property.

**SEC-131 — all three schema snapshots understated their own live database.** Every one was missing `profile_items.group_label` and `profile_conversation_starters.custom_prompt`, which exist on dev, staging **and** prod. This is exactly the blind spot CTL-048 was built for: three snapshots stale the *same way*, so CTL-036 compares stale-to-stale and passes. **Found by dry-running CTL-048 against the live databases before dispatching the promote** — left alone it would have blocked that promote, correctly, mid-release.

## Jira Ticket

SEC-130, SEC-131 (both In Progress). Unblocks the pending SEC-104 / CTL-048 promote.

## Evidence

**SEC-130 — measured, not inferred.** Same tree, `next build` twice:

| | `/sitemap.xml` |
|---|---|
| pre-fix | **`○` Static** — prerendered as static content |
| post-fix | **`ƒ` Dynamic** — server-rendered on demand |

The marker discriminates: `/terms`, `/safe`, `/suspended` are `○` in the same table.

Mutation proof (each reverted, file confirmed byte-identical after):

| mutation | result |
|---|---|
| delete `export const dynamic` | 1 failed, 7 passed |
| delete `export const revalidate` | 1 failed, 7 passed |
| weaken to `revalidate = 3600` (the plausible wrong fix) | 1 failed, 7 passed |

**SEC-131 — verified per database**, by md5 of each table's sorted column list computed from the committed snapshot and compared inside Postgres. Read from `pg_class`/`pg_attribute`, not `information_schema`, because the latter omits materialized views and `relationship_signals` is one — a proxy that cannot see it would be blind exactly where the real checker (PostgREST's OpenAPI document) is not.

| | before | after |
|---|---|---|
| dev | `profile_conversation_starters`, `profile_items` | **NONE — all shared tables match** |
| staging | `profile_conversation_starters`, `profile_items` | **NONE — all shared tables match** |
| prod | `profile_conversation_starters`, `profile_items` | **NONE — all shared tables match** |

## Design decisions worth not re-litigating

- **A bounded `revalidate` was considered and rejected.** It trades an unbounded staleness window for a merely smaller one, with no load argument for the trade — production has **27** published profiles. If crawl volume ever makes that untrue, a bounded `revalidate` is the knob, not a return to build-time caching. Recorded at the call site.
- **The snapshots were hand-patched, not regenerated.** They carry no header precisely so they stay byte-identical to `supabase gen types` output; a correct patch of two nullable-text columns is exactly what the generator emits, so this moves them *closer* to that invariant.
- **`supabase/schema-drift-baseline.json` is deliberately untouched** — this is not new drift *between* environments, it is the snapshots catching up with all three at once. CTL-036 still reports its 8 baselined declarations, unchanged.

## Findings raised, not fixed here

- `gift_suggestion_dismissals` (a whole table) and `public_profiles` (the SEC-104 view itself) are absent from all three snapshots. Neither fails CTL-048 — it only compares the *intersection* of live and snapshot table names.
- ⚠️ `createServiceRoleClient()` returns a bare `SupabaseClient` with **no `<Database>` generic**, so `.from('public_profiles')` type-checks against nothing. The SEC-104 read path has no compile-time schema checking at all. Adding the view to the snapshots would not change that; typing the client would — a much wider change (~40 call sites).
- **CTL-048 only runs on a promote**, so a snapshot can go stale indefinitely between promotes with nothing looking wrong. Running it on the daily `db-invariants.yml` schedule (which already holds all six credentials) would surface drift within a day rather than at the door of a release.

## Checklist

- [x] Unit tests added/updated for new/changed functionality — invariant 5 in `sitemap-suspension-behaviour.test.ts`, plus the `C1-sitemap-fresh` soak probe
- [x] All existing tests pass (`npm run test:unit`) — **278 suites / 3632 tests**, all green
- [x] Lint passes (`npm run lint`) — 0 errors, 35 warnings (unchanged baseline)
- [x] Type check passes (`npm run type-check`)
- [x] Build succeeds (`npm run build`)
- [x] Coverage has not decreased — net-new tests only, nothing removed or weakened
- [x] No eslint-disable or ts-ignore without KAN-XX reference — none added
- [x] Dependency-rule gate reviewed (`npm run depcruise`) — 0 errors, the same 2 pre-existing `no-cross-segment-app` warnings; no new violation
- [x] ARCHITECTURE.md updated if architectural changes were made — **N/A**: no architectural change; two route-config constants and six type-declaration lines
- [x] Ops routine / Control-Room registry updated — **N/A**: the soak gains a probe, but its cadence, ownership and contract are unchanged
- [x] Docs / system map updated — **N/A with reason**: no new service, table, env var, route, scheduled job or security boundary. SEC-131 corrects committed type declarations to match databases already in that state, so the drift recorded on *Data Model & Security* is unaffected
- [x] Design loop (KAN-441) — **N/A**: no user-facing look or wording changes. `src/app/sitemap.ts` is not in `is_protected` (it is `.ts`, not `.tsx`, and matches no named copy module); `check-ui-copy-ownership.sh` confirms *"no founder-owned UI/copy paths changed"* against a real committed diff, so no trailer is required

## Verification of the gates themselves

`check-extraction-dod.sh` correctly reports **not an extraction PR** (no file under `src/` moved), so its section is omitted rather than filled with `n/a` noise. All nine PR-check guards run locally and pass, including `check-live-schema-parity.py --self-test` (9/9) and `check-bash-portability.py` (the soak probe is bash-3.2 clean, and uses `grep -E` rather than a BRE `\|` alternation — gotcha #30).

## MCP coverage

Not applicable — `/sitemap.xml` is a crawler surface, not user data, and no MCP tool exposes it. The schema snapshots are a repo artefact with no MCP surface.

---
_Generated by [Claude Code](https://claude.ai/code/session_015ztw7gfb4CLL2LGvsvMCZq)_