### PR TITLE
fix(types): type the service-role Supabase client so RLS-bypassing reads are schema-checked (SEC-132)

### DIFF
--- a/docs/compliance/ROPA.md
+++ b/docs/compliance/ROPA.md
@@ -161,6 +161,7 @@ recording it here is a red build.
 | `oauth_refresh_tokens` | P8 | `user_id` | **withheld** — live credential (SEC-71) |
 | `oauth_authorization_codes` | P8 | `user_id` | **withheld** — short-lived credential (SEC-71) |
 | `oauth_connect_state` | P8 | `user_id` | **withheld** — transient CSRF state, not personal data |
+| `public_profiles` | P1 | `user_id` | **withheld** — redundant: a view over `profiles`, already exported in full (SEC-132) |
 
 ### On the withheld rows
 
@@ -172,6 +173,15 @@ Two are retained under **Art. 17(3)(b)**. `moderation_logs` is
 `ON DELETE RESTRICT` precisely so it survives an erasure, and
 `erasure_obligations` is the record that the erasure happened. Erasing either on
 request would defeat its purpose.
+
+One — `public_profiles` (SEC-132) — is withheld for a different reason from the
+other six, and the distinction matters when reading this table. It is not a
+lawful-basis carve-out and **nothing in it is kept from the subject**. It is a
+*view* over `profiles`, so all 17 of its columns are a strict subset of the
+`profiles` row the export already returns in full. Listing it would hand back a
+second copy of data already supplied. If it is ever the case that the view gains
+a column `profiles` does not have, this row must change — a view that is no
+longer a strict subset is no longer redundant.
 
 **If a subject disputes a withholding**, the answer is not to widen the export —
 it is to confirm the lawful basis above still applies to their specific case, and

--- a/src/app/dashboard/convene/gatherings/[id]/actions.ts
+++ b/src/app/dashboard/convene/gatherings/[id]/actions.ts
@@ -21,6 +21,10 @@ import { getConnectionForUser } from '@/lib/convene/oauth-connections';
 import { generateRsvpToken, persistQueuedInvite, setInviteeRsvpToken } from '@/lib/convene/invites/repository';
 import { dispatchQueuedInvites } from '@/lib/convene/invites/dispatch';
 import { getAccountStanding, shouldRefuseIssuance } from '@/lib/account-status';
+// SEC-132: type-only import. `'use server'` files may export only async
+// functions (gotcha #18) — a type import is erased at build, so it adds no
+// runtime export and cannot trip that rule.
+import type { Json } from '@/types/database';
 
 type Result = { ok: true } | { ok: false; error: string };
 type SendSummary = { queued: number; sent: number; blocked_by_allowlist: number; failed: number };
@@ -40,7 +44,7 @@ async function appendEvent(
   gatheringId: string,
   actorUserId: string,
   eventType: string,
-  metadata: Record<string, unknown> = {}
+  metadata: Json = {}
 ) {
   const sb = admin();
   // ownership-ok: caller has already verified host_user_id matches (KAN-236)

--- a/src/app/dashboard/settings/actions.ts
+++ b/src/app/dashboard/settings/actions.ts
@@ -321,7 +321,15 @@ export async function deleteAccount() {
   try {
     const { error: obligationError } = await admin.rpc('record_erasure_obligation', {
       p_subject_user_id: userId,
-      p_subject_email: user.email ?? null,
+      // SEC-132: the generated Args type says `p_subject_email: string`, because
+      // typegen marks any parameter without a SQL DEFAULT as required and
+      // non-null. Verified against the database: `record_erasure_obligation` is
+      // NOT STRICT and `erasure_obligations.subject_email` is nullable, so NULL
+      // is accepted and stored. Passing `''` instead would type-check and be
+      // WRONG — it would record an erasure obligation carrying an email address
+      // that is not merely unknown but affirmatively empty, which is what an ops
+      // follow-up would then try to chase through Resend and Didit.
+      p_subject_email: (user.email ?? null) as string,
       p_processors: ERASURE_PROCESSORS,
       p_notes: 'Account hard-deleted; external processor / KV copies pending erasure (SEC-75 leg b).',
     });

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -59,12 +59,27 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
       .from('public_profiles')
       .select('slug, updated_at');
 
-    profilePages = (profiles || []).map((profile) => ({
-      url: `${baseUrl}/${profile.slug}`,
-      lastModified: new Date(profile.updated_at),
-      changeFrequency: 'weekly' as const,
-      priority: 0.8,
-    }));
+    profilePages = (profiles || [])
+      // SEC-132: `public_profiles` is a VIEW, and a view does not carry the base
+      // table's NOT NULL guarantees — every column comes back nullable even
+      // though `profiles.slug` is NOT NULL. Guard rather than assert, because
+      // both failure modes here are SILENT and get published to crawlers:
+      // a null slug renders the literal string `https://checklyra.com/null`,
+      // and `new Date(null)` is 1970-01-01 rather than an error.
+      //
+      // This was invisible until the service-role client gained its <Database>
+      // generic — with an untyped client `profile.slug` was `any`.
+      .filter((p): p is typeof p & { slug: string } => typeof p.slug === 'string' && p.slug !== '')
+      .map((profile) => ({
+        url: `${baseUrl}/${profile.slug}`,
+        // `updated_at` is genuinely nullable on the base table too, so this one
+        // is not merely a view artefact. Omit the hint rather than invent a
+        // date — `lastModified` is optional, and a wrong date is worse than an
+        // absent one because crawlers act on it.
+        ...(profile.updated_at ? { lastModified: new Date(profile.updated_at) } : {}),
+        changeFrequency: 'weekly' as const,
+        priority: 0.8,
+      }));
   } catch {
     // If Supabase is unavailable, return static pages only
   }

--- a/src/lib/access-model/access-transitions.ts
+++ b/src/lib/access-model/access-transitions.ts
@@ -18,6 +18,7 @@
  */
 
 import type { ModerationAction } from '@/lib/admin';
+import type { Database } from '@/types/database';
 
 /** The two axes of the access model (KAN-326). */
 export type UserStatus = 'not_applied' | 'waitlist' | 'live';
@@ -40,8 +41,22 @@ export type AccessAction =
   | 'unsuspend';
 
 export interface AccessTransition {
-  /** The partial `profiles` update to apply. */
-  update: Record<string, unknown>;
+  /**
+   * The partial `profiles` update to apply.
+   *
+   * SEC-132: typed as the generated `profiles` Update row, not
+   * `Record<string, unknown>`. This is the single source of truth for how a
+   * user moves between access states — including `suspend` — and every value
+   * here is written straight to the profiles table by three callers (the admin
+   * console, the waitlist action, and the beta-access flow).
+   *
+   * As `Record<string, unknown>` a misspelled column was accepted by the
+   * compiler AND by PostgREST-via-an-untyped-client, so `user_staus: 'live'`
+   * would have been a silent no-op: the update succeeds, affects the columns it
+   * recognises, and the account simply never transitions. Naming the real row
+   * type makes that a build error.
+   */
+  update: Database['public']['Tables']['profiles']['Update'];
   /** The moderation_logs action string to audit. */
   moderationAction: ModerationAction;
   /** Whether a "you're in" approval email is appropriate for this transition. */

--- a/src/lib/admin.ts
+++ b/src/lib/admin.ts
@@ -22,6 +22,7 @@
 
 import { createClient as createSupabaseServerClient } from '@/modules/platform/supabase-server';
 import { createServiceRoleClient } from '@/modules/platform/supabase-service';
+import type { Database, Json } from '@/types/database';
 
 /**
  * The set of action strings we accept in moderation_logs. The DB column
@@ -108,13 +109,25 @@ export function getAdminServiceClient() {
   return createServiceRoleClient();
 }
 
+/**
+ * SEC-132: the generated Insert row for `moderation_logs`. Named once here
+ * because both writers below have to state the same trigger-managed omission.
+ */
+type ModerationLogInsert = Database['public']['Tables']['moderation_logs']['Insert'];
+
 export interface LogModerationActionInput {
   admin: AdminUser;
   action: ModerationAction;
   targetProfileId?: string | null;
   targetItemId?: string | null;
   reason?: string | null;
-  metadata?: Record<string, unknown>;
+  /**
+   * SEC-132: `Json`, not `Record<string, unknown>`. This value is written to a
+   * `jsonb` column, and `unknown` values are not necessarily serialisable — a
+   * `Date`, a `Map` or a `undefined` survives `Record<string, unknown>` and
+   * then lands in the audit log as `{}` or an error.
+   */
+  metadata?: Json;
 }
 
 /**
@@ -128,16 +141,20 @@ export interface LogModerationActionInput {
  */
 export async function logModerationAction(input: LogModerationActionInput): Promise<string> {
   const client = getAdminServiceClient();
+  // SEC-132: `row_hash` / `seq` omitted deliberately — see the note in
+  // logModerationActionsBatch below. They are written by the hash-chain trigger,
+  // and a caller able to supply its own would be able to forge the audit chain.
+  const row: Omit<ModerationLogInsert, 'row_hash' | 'seq'> = {
+    actor_user_id: input.admin.userId,
+    action: input.action,
+    target_profile_id: input.targetProfileId ?? null,
+    target_item_id: input.targetItemId ?? null,
+    reason: input.reason ?? null,
+    metadata: input.metadata ?? {},
+  };
   const { data, error } = await client
     .from('moderation_logs')
-    .insert({
-      actor_user_id: input.admin.userId,
-      action: input.action,
-      target_profile_id: input.targetProfileId ?? null,
-      target_item_id: input.targetItemId ?? null,
-      reason: input.reason ?? null,
-      metadata: input.metadata ?? {},
-    })
+    .insert(row as ModerationLogInsert)
     .select('id')
     .single();
 
@@ -152,7 +169,8 @@ export interface LogModerationActionsBatchInput {
   action: ModerationAction;
   targetProfileIds: string[];
   reason?: string | null;
-  metadata?: Record<string, unknown>;
+  /** SEC-132: see the note on `LogModerationActionInput.metadata`. */
+  metadata?: Json;
 }
 
 /**
@@ -167,15 +185,27 @@ export async function logModerationActionsBatch(
 ): Promise<void> {
   if (input.targetProfileIds.length === 0) return;
   const client = getAdminServiceClient();
-  const rows = input.targetProfileIds.map((profileId) => ({
-    actor_user_id: input.admin.userId,
-    action: input.action,
-    target_profile_id: profileId,
-    target_item_id: null,
-    reason: input.reason ?? null,
-    metadata: input.metadata ?? {},
-  }));
-  const { error } = await client.from('moderation_logs').insert(rows);
+  // SEC-132: `row_hash` and `seq` are NOT NULL with no column default, so the
+  // generated Insert type marks them REQUIRED. Supplying them from here would
+  // be wrong, not merely redundant: they are computed by the BEFORE INSERT
+  // trigger `moderation_logs_hash_chain_trg`, which is what makes this table
+  // tamper-evident. A caller that could set its own `row_hash` could forge the
+  // chain. Typegen cannot see triggers, so this is the one place the generated
+  // type is narrower than the database — the omission is named in an `Omit`
+  // rather than hidden behind a blanket cast, so the other columns stay checked.
+  const rows: Omit<ModerationLogInsert, 'row_hash' | 'seq'>[] = input.targetProfileIds.map(
+    (profileId) => ({
+      actor_user_id: input.admin.userId,
+      action: input.action,
+      target_profile_id: profileId,
+      target_item_id: null,
+      reason: input.reason ?? null,
+      metadata: input.metadata ?? {},
+    }),
+  );
+  const { error } = await client
+    .from('moderation_logs')
+    .insert(rows as ModerationLogInsert[]);
   if (error) {
     throw new Error(`Failed to write ${rows.length} moderation_logs rows: ${error.message}`);
   }

--- a/src/lib/gdpr/person-keyed-tables.ts
+++ b/src/lib/gdpr/person-keyed-tables.ts
@@ -96,4 +96,12 @@ export const DELIBERATELY_EXCLUDED: Record<string, string> = {
   // would be self-defeating to erase or hand back on request.
   moderation_logs: 'Art.17(3)(b) — moderation audit trail, ON DELETE RESTRICT',
   erasure_obligations: 'Art.17(3)(b) — the record of erasure itself',
+
+  // SEC-132: a VIEW over `profiles`, not independent storage. All 17 of its
+  // columns are a strict subset of the `profiles` row the same export already
+  // returns in full, so including it would hand the subject a second copy of
+  // data they have already been given rather than anything new. Excluded as
+  // REDUNDANT, not withheld — unlike the entries above, nothing here is absent
+  // from the response. Art.15 is satisfied by the `profiles` row itself.
+  public_profiles: 'SEC-132 — view over profiles; every column already exported via the profiles row',
 };

--- a/src/modules/observability/metrics.ts
+++ b/src/modules/observability/metrics.ts
@@ -104,5 +104,16 @@ export async function getAnomalyWindowAdmin(window: AnomalyWindowKey): Promise<M
   if (error) {
     throw new Error(`get_metrics_for_window(${window}) [admin] failed: ${error.message}`);
   }
-  return data as MetricsSnapshot;
+  // SEC-132: `get_metrics_for_window` returns `jsonb`, so with the now-typed
+  // service-role client the Returns type is `Json` — a union that does not
+  // overlap MetricsSnapshot, hence the explicit widen-then-narrow rather than a
+  // direct assertion. The cast is what lets a jsonb payload cross into a named
+  // type at all; it does not verify the shape.
+  //
+  // Note the two sibling functions above still read `data as MetricsSnapshot`
+  // directly. That is not an inconsistency to tidy — they use the SERVER client,
+  // which has no <Database> generic yet, so their `data` is still `any` and the
+  // cast is unchecked. The difference between these three lines is exactly the
+  // difference this ticket is about.
+  return data as unknown as MetricsSnapshot;
 }

--- a/src/modules/platform/supabase-service.ts
+++ b/src/modules/platform/supabase-service.ts
@@ -26,13 +26,35 @@
 
 import { createClient, type SupabaseClient } from '@supabase/supabase-js';
 import { env } from '@/modules/platform/env';
+import type { Database } from '@/types/database';
 
 /**
  * Returns a fresh service-role Supabase client with the hardened options above.
  * Callers must have already authorised the request — this client sees every row.
+ *
+ * SEC-132: the `<Database>` generic is load-bearing, not decoration.
+ *
+ * Until this was added the factory returned a BARE `SupabaseClient`, whose
+ * `.from()` accepts any string and whose rows are `any`. So every service-role
+ * read in the app — the ~40 modules that bypass RLS entirely — type-checked
+ * against nothing. `.from('pubic_profiles')` would have compiled.
+ *
+ * That is what made the SEC-104 read path unchecked. The `public_profiles` view
+ * is the mechanism that stops a suspended member reaching a public surface, and
+ * a typo in its name would have failed at RUNTIME, on a public page, rather than
+ * at build time. Worth stating plainly because the committed schema made it look
+ * covered: `src/types/database/` is ~6,300 generated lines guarded by two
+ * blocking controls (CTL-036, CTL-048), and before this commit **no application
+ * code imported it at all**. It was generated, committed, drift-gated, and wired
+ * to nothing.
+ *
+ * Note the generic is applied to `createClient` as well as the return type. The
+ * return annotation alone would be a cast over an untyped value — it would
+ * silence the compiler rather than inform it, which is the same failure in a new
+ * costume.
  */
-export function createServiceRoleClient(): SupabaseClient {
-  return createClient(env.supabaseUrl(), env.supabaseServiceRoleKey(), {
+export function createServiceRoleClient(): SupabaseClient<Database> {
+  return createClient<Database>(env.supabaseUrl(), env.supabaseServiceRoleKey(), {
     auth: { persistSession: false, autoRefreshToken: false },
   });
 }

--- a/src/types/database/dev.ts
+++ b/src/types/database/dev.ts
@@ -750,6 +750,32 @@ export type Database = {
           },
         ]
       }
+      gift_suggestion_dismissals: {
+        Row: {
+          dismissed_at: string
+          profile_id: string
+          suggestion_key: string
+        }
+        Insert: {
+          dismissed_at?: string
+          profile_id: string
+          suggestion_key: string
+        }
+        Update: {
+          dismissed_at?: string
+          profile_id?: string
+          suggestion_key?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "gift_suggestion_dismissals_profile_id_fkey"
+            columns: ["profile_id"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       global_feature_switches: {
         Row: {
           created_at: string
@@ -1973,6 +1999,28 @@ export type Database = {
           ip: string | null
           last_seen: string | null
           request_count: number | null
+        }
+        Relationships: []
+      }
+      public_profiles: {
+        Row: {
+          avatar_url: string | null
+          bio_short: string | null
+          city: string | null
+          country: string | null
+          delivery_country_code: string | null
+          display_name: string | null
+          gift_voucher_hint: string | null
+          headline: string | null
+          homepage_example_order: number | null
+          id: string | null
+          is_homepage_example: boolean | null
+          is_published: boolean | null
+          is_suspended: boolean | null
+          section_visibility: Json | null
+          slug: string | null
+          updated_at: string | null
+          user_id: string | null
         }
         Relationships: []
       }

--- a/src/types/database/prod.ts
+++ b/src/types/database/prod.ts
@@ -753,6 +753,32 @@ export type Database = {
           },
         ]
       }
+      gift_suggestion_dismissals: {
+        Row: {
+          dismissed_at: string
+          profile_id: string
+          suggestion_key: string
+        }
+        Insert: {
+          dismissed_at?: string
+          profile_id: string
+          suggestion_key: string
+        }
+        Update: {
+          dismissed_at?: string
+          profile_id?: string
+          suggestion_key?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "gift_suggestion_dismissals_profile_id_fkey"
+            columns: ["profile_id"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       global_feature_switches: {
         Row: {
           created_at: string
@@ -1964,6 +1990,28 @@ export type Database = {
           ip: string | null
           last_seen: string | null
           request_count: number | null
+        }
+        Relationships: []
+      }
+      public_profiles: {
+        Row: {
+          avatar_url: string | null
+          bio_short: string | null
+          city: string | null
+          country: string | null
+          delivery_country_code: string | null
+          display_name: string | null
+          gift_voucher_hint: string | null
+          headline: string | null
+          homepage_example_order: number | null
+          id: string | null
+          is_homepage_example: boolean | null
+          is_published: boolean | null
+          is_suspended: boolean | null
+          section_visibility: Json | null
+          slug: string | null
+          updated_at: string | null
+          user_id: string | null
         }
         Relationships: []
       }

--- a/src/types/database/staging.ts
+++ b/src/types/database/staging.ts
@@ -753,6 +753,32 @@ export type Database = {
           },
         ]
       }
+      gift_suggestion_dismissals: {
+        Row: {
+          dismissed_at: string
+          profile_id: string
+          suggestion_key: string
+        }
+        Insert: {
+          dismissed_at?: string
+          profile_id: string
+          suggestion_key: string
+        }
+        Update: {
+          dismissed_at?: string
+          profile_id?: string
+          suggestion_key?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "gift_suggestion_dismissals_profile_id_fkey"
+            columns: ["profile_id"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       global_feature_switches: {
         Row: {
           created_at: string
@@ -1976,6 +2002,28 @@ export type Database = {
           ip: string | null
           last_seen: string | null
           request_count: number | null
+        }
+        Relationships: []
+      }
+      public_profiles: {
+        Row: {
+          avatar_url: string | null
+          bio_short: string | null
+          city: string | null
+          country: string | null
+          delivery_country_code: string | null
+          display_name: string | null
+          gift_voucher_hint: string | null
+          headline: string | null
+          homepage_example_order: number | null
+          id: string | null
+          is_homepage_example: boolean | null
+          is_published: boolean | null
+          is_suspended: boolean | null
+          section_visibility: Json | null
+          slug: string | null
+          updated_at: string | null
+          user_id: string | null
         }
         Relationships: []
       }

--- a/tests/support/test-floor-baseline.json
+++ b/tests/support/test-floor-baseline.json
@@ -2,5 +2,5 @@
   "$comment": "GENERATED — regenerate with `npm run gen:test-floor`. The enforced test floor. The guard fails if the counts DROP (a test was deleted) and also if they RISE (this baseline is stale and is overstating how much of the estate is actually protected). The rise case is the one that matters: the previous hand-maintained floor sat at 29 files / 320 blocks against an actual 260 / 2963, so ~89% of the tests could have been deleted silently. Raise it in the SAME commit as any net-new test.",
   "measured_at": "2026-08-12",
   "test_files": 278,
-  "test_blocks": 3181
+  "test_blocks": 3184
 }

--- a/tests/unit/access-model-transitions.test.ts
+++ b/tests/unit/access-model-transitions.test.ts
@@ -73,8 +73,17 @@ describe('computeAccessTransition (KAN-309 / KAN-326)', () => {
       suspended_at: NOW,
       suspension_reason: 'spam',
     });
-    expect(t.update.access_stage).toBeUndefined();
-    expect(t.update.is_beta_eligible).toBeUndefined();
+    // SEC-132: `AccessTransition.update` is now the generated `profiles` Update
+    // row rather than `Record<string, unknown>`, and `access_stage` /
+    // `is_beta_eligible` are LEGACY columns dropped in Phase C — so they can no
+    // longer be *named* on the typed value at all. The two assertions are
+    // preserved verbatim by reading through a Record view: same matcher, same
+    // expected value, same runtime check. Nothing is weakened — the compiler now
+    // enforces this more strongly than the test can, because writing either
+    // column into a transition is a build error rather than a caught mistake.
+    const legacy = t.update as Record<string, unknown>;
+    expect(legacy.access_stage).toBeUndefined();
+    expect(legacy.is_beta_eligible).toBeUndefined();
     expect(t.update.user_status).toBeUndefined();
     expect(t.update.access_tier).toBeUndefined();
     expect(t.moderationAction).toBe('suspend');
@@ -87,7 +96,9 @@ describe('computeAccessTransition (KAN-309 / KAN-326)', () => {
       suspended_at: null,
       suspension_reason: null,
     });
-    expect(t.update.access_stage).toBeUndefined();
+    // SEC-132: see the note above — `access_stage` is a Phase-C legacy column
+    // and cannot be named on the typed Update row. Assertion unchanged.
+    expect((t.update as Record<string, unknown>).access_stage).toBeUndefined();
     expect(t.update.user_status).toBeUndefined();
     expect(t.update.access_tier).toBeUndefined();
     expect(t.moderationAction).toBe('unsuspend');

--- a/tests/unit/sitemap-suspension-behaviour.test.ts
+++ b/tests/unit/sitemap-suspension-behaviour.test.ts
@@ -75,7 +75,13 @@ import type { MetadataRoute } from 'next';
 
 const BASE = 'https://checklyra.com';
 
-type Row = { slug: string; updated_at: string; is_suspended?: boolean };
+// SEC-132: `slug` and `updated_at` are nullable here on purpose. `public_profiles`
+// is a VIEW, and a view does not carry the base table's NOT NULL guarantees, so
+// the real query can hand back either as null. Widening the fixture type is what
+// lets invariant 6 below construct that row at all — with the old
+// `{ slug: string; updated_at: string }` the case could not be expressed, which
+// is why it went untested through SEC-100, SEC-104 and SEC-130.
+type Row = { slug: string | null; updated_at: string | null; is_suspended?: boolean };
 type EqCall = [string, unknown];
 
 const eqCalls: EqCall[] = [];
@@ -228,6 +234,47 @@ describe('sitemap (behavioural, KAN-414 F4 / SEC-100)', () => {
     for (const e of entries) {
       expect(e.changeFrequency).toBeDefined();
       expect(typeof e.priority).toBe('number');
+    }
+  });
+});
+
+describe('sitemap nullability of the public_profiles VIEW (SEC-132)', () => {
+  // These three cases became REACHABLE only once the service-role client gained
+  // its <Database> generic. Before that `profile.slug` was `any`, so neither the
+  // compiler nor this suite had any reason to ask what happens when the view
+  // returns null — and both failure modes below are silent and get published to
+  // search engines.
+  const published = (r: Partial<Row>) =>
+    ({ is_published: true, is_suspended: false, ...r }) as unknown as Row;
+
+  it('drops a null-slug row instead of emitting the literal URL /null', async () => {
+    rows = [published({ slug: 'ada', updated_at: '2026-01-01T00:00:00.000Z' }), published({ slug: null, updated_at: '2026-01-01T00:00:00.000Z' })];
+
+    const out = urls(await sitemap());
+
+    expect(out).toContain(`${BASE}/ada`);
+    expect(out.some((u) => u.endsWith('/null'))).toBe(false);
+  });
+
+  it('still emits a row whose updated_at is null, but with no lastModified', async () => {
+    rows = [published({ slug: 'no-date', updated_at: null })];
+
+    const entry = (await sitemap()).find((e) => e.url === `${BASE}/no-date`);
+
+    // The page belongs in the sitemap; only the freshness hint is unknown.
+    expect(entry).toBeDefined();
+    expect(entry?.lastModified).toBeUndefined();
+  });
+
+  it('never dates an entry 1970 — the new Date(null) trap', async () => {
+    rows = [published({ slug: 'no-date', updated_at: null })];
+
+    for (const e of await sitemap()) {
+      if (e.lastModified) {
+        // `new Date(null)` is not an error, it is 1970-01-01 — so the old code
+        // would have told crawlers this profile was last modified 56 years ago.
+        expect(new Date(e.lastModified).getUTCFullYear()).toBeGreaterThan(2000);
+      }
     }
   });
 });


### PR DESCRIPTION
## Summary

`createServiceRoleClient()` returned a bare `SupabaseClient` — **no `<Database>` generic**. A bare client's `.from()` accepts any string and yields `any` rows, so every service-role read — the ~40 modules that **bypass RLS entirely** — was unchecked by the compiler.

Concretely: **`.from('pubic_profiles')` compiled.**

That is what left the SEC-104 read path unchecked. `public_profiles` is the mechanism keeping a suspended member off a public surface; a typo in its name would have failed at **runtime, on a public page**, not at build time.

### Measured, both directions — same typo, same tree

| client state | `.from('pubic_profiles')` |
|---|---|
| **before** (untyped) | **0 errors — compiled clean** |
| **after** (typed) | **5 errors** |

A typo'd *column* is caught too: `user_status:` → `user_staus:` in the access-transition matrix is now 1 error, where `Record<string, unknown>` accepted it — and PostgREST would have accepted the write, updating the columns it recognised and simply never transitioning the account.

## The bigger finding, which is not what I went looking for

`src/types/database/` is **~6,300 generated lines** guarded by **two blocking controls** (CTL-036, CTL-048). Before this PR, **no application code imported it.** The only match for `Database` anywhere in `src/` was the word in privacy-policy prose.

Generated, committed, drift-gated — and wired to nothing. That also makes `index.ts`'s own header inaccurate: it argues at length about *"WHY `dev` IS THE ONE THE APP COMPILES AGAINST"*, while the app compiled against none of them. **A file can document its load-bearing role convincingly and still be inert** — the header reads identically either way, which is why nobody noticed.

## Jira Ticket

SEC-132 (In Progress). Closes the follow-up raised on SEC-131; completes the finding flagged when shipping SEC-130.

## The fallout was worth reading, not silencing

9 errors, 8 files:

| site | verdict |
|---|---|
| 3× `profiles` update | **one root cause** — `AccessTransition.update` was `Record<string, unknown>`. Fixed at source, not three times locally |
| `sitemap.ts` | **a real latent bug — see below** |
| `moderation_logs` ×2 | typegen limit, **verified against the DB**: `row_hash`/`seq` are trigger-written by `moderation_logs_hash_chain_trg`. Supplying them would be *wrong* — a caller that could set its own `row_hash` could forge the tamper-evident chain. Named in an `Omit` so other columns stay checked |
| `record_erasure_obligation` | typegen limit, **verified** NOT STRICT + nullable column. Passing `''` would type-check and be *worse* — an obligation carrying an affirmatively empty address for ops to chase |
| 3× `metadata` | `Record<string, unknown>` → `Json`; those land in `jsonb` and `unknown` is not necessarily serialisable |

### The real bug it surfaced

`public_profiles` is a **VIEW**, so it loses the base table's NOT NULL guarantees — every column returns nullable even though `profiles.slug` is NOT NULL. With an untyped client `profile.slug` was `any`, so nothing ever asked what happens on null. Both failure modes are **silent and published to crawlers**:

- a null slug renders the literal URL `https://checklyra.com/null`;
- **`new Date(null)` is 1970-01-01**, not an error — telling crawlers a profile was last modified 56 years ago.

Now guarded, with the `lastModified` hint **omitted rather than invented** — a wrong date is worse than an absent one because crawlers act on it.

## Two compliance controls fired correctly, and were answered

Adding `public_profiles` to the schema made it visible to two SEC-117 controls:

- **SAR completeness** demanded an explicit decision → `DELIBERATELY_EXCLUDED` as **redundant, not withheld**. All 17 columns are a strict subset of the `profiles` row the export already returns in full.
- **ROPA inventory** demanded a matching row → added to `docs/compliance/ROPA.md`, with prose distinguishing it from the six lawful-basis carve-outs and naming the condition that revokes the decision (a view that stops being a strict subset is no longer redundant).

`gift_suggestion_dismissals` was **already** registered and already queried by the export — no SAR gap existed there.

## Test changes — please read this bit

Two existing assertions in `access-model-transitions.test.ts` named `access_stage` / `is_beta_eligible`, Phase-C legacy columns that can no longer be *named* on a typed Update row. **Preserved verbatim through a `Record` view** — same matcher, same expected value, same runtime check. Nothing weakened; the compiler now enforces the invariant more strongly than the test can, since writing either column is a build error.

**Three net-new tests**, each mutation-proven: restoring the slug guard reddens 1; restoring `new Date(null)` reddens 2. The fixture type had to be widened to `string | null` first — with the old `{ slug: string; updated_at: string }` **the case could not be expressed**, which is why it went untested through SEC-100, SEC-104 and SEC-130.

## Checklist

- [x] Unit tests added/updated — 3 net-new, mutation-proven; 2 existing assertions preserved verbatim
- [x] All existing tests pass — **278 suites / 3635 tests**
- [x] Lint passes — 0 errors, 35 warnings (unchanged baseline)
- [x] Type check passes — 0 errors
- [x] Build succeeds — `/sitemap.xml` still `ƒ` dynamic (SEC-130 preserved)
- [x] Coverage has not decreased — net-new tests only
- [x] No eslint-disable or ts-ignore without a ticket reference — none added
- [x] Dependency-rule gate reviewed — 0 errors, same 2 pre-existing `no-cross-segment-app` warnings
- [x] ARCHITECTURE.md updated if architectural changes were made — **N/A**: no new service, boundary or dependency; a type generic plus call-site fixes
- [x] Ops routine / Control-Room registry updated — **N/A**: no routine, cadence or ownership change
- [x] Docs / system map updated — **`docs/compliance/ROPA.md` updated**, required by `ropa-table-inventory.test.ts`. No Confluence change needed: the view and table already existed on all three databases, so no new table, env var, route, job or security boundary
- [x] Design loop (KAN-441) — **N/A**: no user-facing look or wording change. `check-ui-copy-ownership.sh` confirms *"no founder-owned UI/copy paths changed"* against a real committed diff

`check-extraction-dod.sh` correctly reports **not an extraction PR** (no file under `src/` moved), so that section is omitted rather than filled with `n/a` noise. All 12 PR-check guards run locally and pass.

## Known gap, stated rather than buried

**There is no gate asserting the generic stays applied.** Delete `<Database>` tomorrow and the build goes green, because a bare client type-checks everything. The mutation table above is evidence it works *today*, not a control that keeps it working — and a convention with no gate erodes (gotcha #28's lesson). Candidate control recorded on the ticket.

**The browser and server clients are still untyped**, so most authenticated reads remain unchecked. `metrics.ts` now shows all three cases in one file: two sibling functions still cast `data as MetricsSnapshot` directly because their `data` is `any`, while the service-role one needs `as unknown as`. That difference in one file is exactly the remaining gap.

## MCP coverage

Not applicable — no new user-facing data or route; `lyra-mcp-server` has its own client and schema handling.

---
_Generated by [Claude Code](https://claude.ai/code/session_015ztw7gfb4CLL2LGvsvMCZq)_