### PR TITLE
fix(ctl-048): run the schema-parity check DAILY, and give it a remediation that exists (SEC-133)

### DIFF
--- a/.github/workflows/db-invariants.yml
+++ b/.github/workflows/db-invariants.yml
@@ -115,3 +115,74 @@ jobs:
           echo "3. Raise a SEC ticket and record it in the Risk Register."
           echo "4. If the finding is accepted, add a waiver with an owner, a Jira key"
           echo "   and a date to supabase/security-invariants-waivers.json."
+
+  snapshot-freshness:
+    name: Committed schema snapshots match their databases (CTL-048, daily)
+    # SEC-133 — CTL-048's live-vs-snapshot half, run DAILY.
+    #
+    # WHY A SEPARATE JOB, not another step on `invariants`: that job's
+    # `if: failure()` handler prints a SECURITY DEFINER / storage-bucket
+    # message. A stale snapshot is not that, and a finding that describes
+    # itself wrongly is how an operator learns to skim the annotations.
+    #
+    # WHY DAILY AT ALL: CTL-048 previously ran only during a promote, so drift
+    # could sit undetected indefinitely and then surface at the worst possible
+    # moment — at the door of a release. SEC-131 was found only because someone
+    # chose to dry-run the gate before dispatching; how long those two columns
+    # had been missing is unknown, because nothing was looking.
+    #
+    # WHY ONLY THE SNAPSHOT HALF: the two halves behave oppositely during a
+    # staged migration rollout, and rollouts here span days. live-vs-live
+    # compares the three databases to each other, so mid-rollout it is red for
+    # the whole window — noise, daily. live-vs-snapshot compares each env to its
+    # OWN database and is unaffected, provided <env>.ts is regenerated when
+    # <env> is migrated.
+    #
+    # And the evidence settles it: SEC-131 was INVISIBLE to live-vs-live,
+    # because all three databases agreed perfectly. Only this half could see it.
+    # Both halves still run on the promote; that path is unchanged.
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6
+
+      - name: Self-test the checker
+        # Prove the comparators can still fail before trusting a clean report.
+        # The six compare_snapshots() fixtures added under SEC-133 are the ones
+        # that matter here — this job runs nothing else.
+        run: python3 scripts/check-live-schema-parity.py --self-test
+
+      - name: Compare each committed snapshot with its own database
+        # Fail-closed on a missing credential: the script exits 2 and says which
+        # one, rather than reporting a clean scan it never performed.
+        env:
+          NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.NEXT_PUBLIC_SUPABASE_URL }}
+          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+          STAGING_SUPABASE_URL: ${{ secrets.STAGING_SUPABASE_URL }}
+          STAGING_SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.STAGING_SUPABASE_SERVICE_ROLE_KEY }}
+          PROD_SUPABASE_URL: ${{ secrets.PROD_SUPABASE_URL }}
+          PROD_SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.PROD_SUPABASE_SERVICE_ROLE_KEY }}
+        run: python3 scripts/check-live-schema-parity.py --snapshot-only
+
+      - name: Raise the finding
+        if: failure()
+        run: |
+          set -euo pipefail
+          echo "::error::A committed schema snapshot no longer matches its own database."
+          echo ""
+          echo "src/types/database/ is what the app's \`Database\` type is built from,"
+          echo "so a stale snapshot means the compiler is reasoning about a schema that"
+          echo "does not exist. CTL-036 cannot see this: it compares the three snapshots"
+          echo "to EACH OTHER, so three files stale in the same way look identical and"
+          echo "pass. That is exactly how SEC-131 stayed green in every gate."
+          echo ""
+          echo "Fix, naming the environment the annotations above identify:"
+          echo "    npm run gen:db-types -- --env dev"
+          echo "then commit the regenerated file."
+          echo ""
+          echo "Full steps: docs/RUNBOOK.md -> 'Regenerating a database type snapshot'."
+          echo ""
+          echo "If this is red because a migration is mid-rollout, that is the control"
+          echo "working: regenerate the snapshot for the environment you migrated. Do"
+          echo "NOT leave it red across days — a red you learn to expect is a control"
+          echo "you have switched off."

--- a/controls/registry.json
+++ b/controls/registry.json
@@ -846,17 +846,20 @@
       "id": "CTL-048",
       "name": "Live schema parity",
       "defect_class": "schema-parity-drift",
-      "summary": "Asks the three LIVE Supabase databases for their columns and asserts (a) every table present on more than one database exposes the same columns, except where supabase/schema-drift-baseline.json records a ticketed difference, and (b) each committed src/types/database/<env>.ts matches its own database. Exists because CTL-036 - the repo-side half - compares the three committed SNAPSHOTS to each other and therefore cannot see all three going stale the same way, which is the state they were in on 2026-08-11: every snapshot was missing gift_voucher_hint while all three databases had it, and CTL-036 was green. Runs in the promotion chain because a promotion is when a column gap becomes an outage - code written against one schema reaching a database with another. Detects drift in BOTH directions; dev is behind staging and prod on gathering_invite_messages.claimed_at (BUGS-62), so a prod-is-missing-only check would sail past it. Fails closed with exit 2 when a credential is absent rather than skipping.",
+      "summary": "Asks the three LIVE Supabase databases for their columns and asserts (a) every table present on more than one database exposes the same columns, except where supabase/schema-drift-baseline.json records a ticketed difference, and (b) each committed src/types/database/<env>.ts matches its own database. Exists because CTL-036 - the repo-side half - compares the three committed SNAPSHOTS to each other and therefore cannot see all three going stale the same way, which is the state they were in on 2026-08-11: every snapshot was missing gift_voucher_hint while all three databases had it, and CTL-036 was green. Runs in the promotion chain because a promotion is when a column gap becomes an outage - code written against one schema reaching a database with another. Detects drift in BOTH directions; dev is behind staging and prod on gathering_invite_messages.claimed_at (BUGS-62), so a prod-is-missing-only check would sail past it. Fails closed with exit 2 when a credential is absent rather than skipping. SEC-133: the live-vs-snapshot half ALSO runs daily via db-invariants.yml (--snapshot-only), because running only on a promote meant drift surfaced at the door of a release and nothing looked for it in between. Only that half runs daily: the cross-database half is red for the whole of any staged migration rollout, and SEC-131 proved the snapshot half is the one that matters - all three databases agreed perfectly while all three snapshots were wrong, so live-vs-live was blind to it. Remediation is one command: npm run gen:db-types -- --env <env>.",
       "implementation": "scripts/check-live-schema-parity.py",
       "kind": "ci-gate",
       "wired_in": [
         ".github/workflows/promote-to-staging.yml",
-        ".github/workflows/pr-checks.yml"
+        ".github/workflows/pr-checks.yml",
+        ".github/workflows/db-invariants.yml"
       ],
       "prevents": [
         "SEC-107",
         "BUGS-62",
-        "KAN-420"
+        "KAN-420",
+        "SEC-131",
+        "SEC-133"
       ],
       "escape_hatch": "none - apply the missing migration, or record the difference in supabase/schema-drift-baseline.json with a ticket",
       "added": "2026-08-11"

--- a/docs/RUNBOOK.md
+++ b/docs/RUNBOOK.md
@@ -512,6 +512,51 @@ supabase migration repair <VERSION> --status reverted
 ./scripts/restore-database.sh ./backups/latest_backup.sql
 ```
 
+### Regenerating a database type snapshot (SEC-133)
+
+**Do this in the SAME change that applies a migration to an environment.** The
+committed snapshots in `src/types/database/{dev,staging,prod}.ts` are what the
+app's `Database` type is built from, so one that has gone stale means the
+compiler is reasoning about a schema that does not exist.
+
+```bash
+npm run gen:db-types -- --env dev        # or staging, or prod
+```
+
+Then commit the regenerated file, and verify:
+
+```bash
+python3 scripts/check-live-schema-parity.py --snapshot-only --env dev
+```
+
+Requires `SUPABASE_ACCESS_TOKEN`. Without it the script **fails loud and writes
+nothing** — a truncated or error-body snapshot is worse than a stale one,
+because the drift gates would then compare against garbage. If you have no CLI
+token, the Supabase MCP tool `generate_typescript_types` returns identical
+output for a project ref; write it to the same path.
+
+**Why this procedure exists at all.** Until 2026-08-12 the checker's own error
+message told you to *"regenerate a stale snapshot with the documented step in
+`docs/RUNBOOK.md`"* — and that step did not exist anywhere in `docs/` or
+`scripts/`. The remediation instruction was a dangling reference, which is why
+[SEC-131](https://checklyra.atlassian.net/browse/SEC-131) sat undetected: two
+columns were live on all three databases and absent from all three snapshots.
+
+**Which gate catches what — they are not interchangeable:**
+
+| gate | compares | blind to |
+|---|---|---|
+| **CTL-036** (`check-schema-type-parity.py`, every PR) | the three snapshots **to each other** | all three stale the same way — no *relative* drift to find |
+| **CTL-048 full** (`promote-to-staging.yml`) | the databases to each other **and** each snapshot to its own database | nothing, but it only runs on a promote |
+| **CTL-048 `--snapshot-only`** (`db-invariants.yml`, daily 06:15 UTC) | each snapshot to **its own** database | cross-environment drift — deliberately, see below |
+
+The daily job runs only the snapshot half on purpose. During a staged migration
+rollout the three databases genuinely differ, so the cross-database half would
+be red for the whole multi-day window — and a red you learn to expect is a
+control you have switched off. The snapshot half is unaffected by a rollout,
+*provided you follow the procedure above*. It is also the only half that could
+see SEC-131, because there all three databases agreed perfectly.
+
 ## Scheduled Workflows (GitHub Actions)
 
 DayTime (UTC)WorkflowDescriptionSunday02:00backup-database.ymlDatabase backup to GitHub Artifacts (90-day retention)Sunday02:30backup-platform.ymlFull platform backup (repos, DNS, schema) to Cloudflare R2Sunday04:00mutation-testing.ymlStryker mutation testingSunday05:00backup-restore-test.ymlAutomated backup restore verificationMonday07:00weekly-report.ymlWeekly status report emailed via ResendMonday—DependabotDependency update PRs (npm + GitHub Actions)Wednesday07:00security-audit.ymlnpm audit scan; emails alert if high/critical vulns found

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "uptimerobot:bootstrap": "node scripts/uptimerobot/bootstrap.js",
     "gen:test-paths": "node scripts/gen-test-paths.mjs",
     "gen:test-floor": "node scripts/gen-test-floor.mjs",
+    "gen:db-types": "bash scripts/gen-db-types.sh",
     "qa:preflight": "python3 qa-sweep/preflight.py",
     "qa:inventory": "python3 qa-sweep/inventory.py",
     "qa:coverage": "python3 qa-sweep/coverage.py"

--- a/scripts/check-live-schema-parity.py
+++ b/scripts/check-live-schema-parity.py
@@ -191,11 +191,19 @@ def compare_live(live: dict[str, dict[str, set[str]]], baseline) -> list[str]:
     return violations
 
 
-def compare_snapshots(live: dict[str, dict[str, set[str]]]) -> list[str]:
+def compare_snapshots(
+    live: dict[str, dict[str, set[str]]],
+    snapshot_reader=columns_from_snapshot,
+) -> list[str]:
+    """SEC-133: `snapshot_reader` is injectable ONLY so the self-test can reach
+    this comparator. Until now all nine self-test cases exercised compare_live()
+    and NONE touched this function — and this is the half that runs daily and
+    the half that caught SEC-131. A comparator with no fixture is the thing this
+    file's own docstring warns about, one level in."""
     violations: list[str] = []
     for env, tables in live.items():
         try:
-            snap = columns_from_snapshot(env)
+            snap = snapshot_reader(env)
         except FileNotFoundError:
             violations.append(f"{env}: no committed snapshot at src/types/database/{env}.ts")
             continue
@@ -267,6 +275,45 @@ def self_test() -> int:
         ("gathering_invite_messages", "claimed_at", "*") in real_baseline,
     ))
 
+    # ------------------------------------------------------------------
+    # SEC-133: compare_snapshots() fixtures. Added when this half started
+    # running daily (--snapshot-only). Every case above tests compare_live();
+    # before this, the snapshot comparator had NO coverage at all — despite
+    # being the half that found SEC-131, and the only half that can see a
+    # snapshot which has gone stale against its own database.
+    # ------------------------------------------------------------------
+    def reader(mapping):
+        def _read(env):
+            if env not in mapping:
+                raise FileNotFoundError(env)
+            return mapping[env]
+        return _read
+
+    # THE SEC-131 SHAPE: the database has a column the committed snapshot does
+    # not. This is invisible to compare_live() when every database agrees —
+    # which is exactly how group_label and custom_prompt survived.
+    live_one = {"dev": {"profile_items": {"id", "group_label"}}}
+    v = compare_snapshots(live_one, reader({"dev": {"profile_items": {"id"}}}))
+    checks.append(("a STALE snapshot is detected", len(v) == 1 and "group_label" in v[0]))
+    checks.append(("the stale snapshot names its env", v and v[0].startswith("dev:")))
+
+    # The reverse: the snapshot claims a column the database does not have.
+    # This is how a type asserts a column exists on a database it does not.
+    v = compare_snapshots(live_one, reader({"dev": {"profile_items": {"id", "group_label", "ghost"}}}))
+    checks.append(("an OVERSTATING snapshot is detected", len(v) == 1 and "ghost" in v[0]))
+
+    v = compare_snapshots(live_one, reader({"dev": {"profile_items": {"id", "group_label"}}}))
+    checks.append(("a matching snapshot produces no violation", v == []))
+
+    # Intersection-only, deliberately: a relation absent from the snapshot is
+    # not a violation (that is how public_profiles sat unlisted without failing).
+    v = compare_snapshots(live_one, reader({"dev": {"other_table": {"id"}}}))
+    checks.append(("a relation absent from the snapshot is not a violation", v == []))
+
+    # A missing snapshot FILE must be reported, not swallowed.
+    v = compare_snapshots(live_one, reader({}))
+    checks.append(("a missing snapshot file is reported", len(v) == 1 and "no committed snapshot" in v[0]))
+
     passed = sum(1 for _, ok in checks if ok)
     for name, ok in checks:
         print(f"  {'ok  ' if ok else 'FAIL'} {name}")
@@ -278,6 +325,14 @@ def main() -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument("--self-test", action="store_true")
     parser.add_argument("--env", action="append", help="limit to one or more environments")
+    parser.add_argument(
+        "--snapshot-only",
+        action="store_true",
+        help=(
+            "SEC-133: run ONLY the live-vs-snapshot half (each committed snapshot "
+            "against its own database). This is the daily mode. See the note in main()."
+        ),
+    )
     args = parser.parse_args()
 
     if args.self_test:
@@ -308,31 +363,80 @@ def main() -> int:
         print("A control that cannot run must not report success.")
         return 2
 
-    if len(live) < 2:
-        print("::error::check-live-schema-parity: fewer than two databases read; nothing to compare")
+    # SEC-133 — WHY --snapshot-only EXISTS, AND WHY IT IS THE DAILY MODE.
+    #
+    # The two halves behave OPPOSITELY during a staged migration rollout, and
+    # rollouts here span days (dev, then staging, then production):
+    #
+    #   live-vs-live      compares the three databases to each other. Mid-rollout
+    #                     they genuinely differ, so it is RED for the whole window
+    #                     until the divergence is baselined. Correct on a promote —
+    #                     you should not promote mid-rollout — and pure noise daily.
+    #   live-vs-snapshot  compares each env to its OWN database. Unaffected by a
+    #                     rollout, provided <env>.ts is regenerated when <env> is
+    #                     migrated. Red exactly when a snapshot has gone stale.
+    #
+    # And the half worth running daily is settled by evidence, not preference:
+    # SEC-131 (two columns missing from all three snapshots) was COMPLETELY
+    # INVISIBLE to live-vs-live, because all three databases agreed perfectly.
+    # Only the snapshot half could see it. Running the cross-database half daily
+    # would have caught nothing and gone red for days at a time — and a red you
+    # learn to expect is a control you have switched off.
+    #
+    # So: snapshot half daily, both halves on the promote. The promote path is
+    # unchanged by this flag.
+    minimum = 1 if args.snapshot_only else 2
+    if len(live) < minimum:
+        print(
+            f"::error::check-live-schema-parity: fewer than {minimum} database(s) read; "
+            "nothing to compare"
+        )
         return 2
 
-    baseline = load_baseline()
-    violations = compare_live(live, baseline) + compare_snapshots(live)
+    if args.snapshot_only:
+        violations = compare_snapshots(live)
+    else:
+        violations = compare_live(live, load_baseline()) + compare_snapshots(live)
 
     if violations:
         for v in violations:
             print(f"::error::check-live-schema-parity: {v}")
         print()
-        print("Column parity is a promotion precondition: code written against one")
-        print("schema is about to reach a database with a different one, and the")
-        print("first symptom is a 500 on whatever page reads the missing column.")
-        print()
-        print("Fix by applying the missing migration, or — if the difference is")
-        print("known and ticketed — record it in supabase/schema-drift-baseline.json.")
-        print("Regenerate a stale snapshot with the documented step in docs/RUNBOOK.md.")
+        if args.snapshot_only:
+            print("A committed snapshot no longer matches its own database.")
+            print()
+            print("This is not cosmetic. src/types/database/ is what the app's")
+            print("`Database` type is built from, so a stale snapshot means the")
+            print("compiler is reasoning about a schema that does not exist — and")
+            print("CTL-036 cannot see it, because it only compares the snapshots to")
+            print("EACH OTHER. That is how SEC-131 stayed green in every gate.")
+            print()
+            print("Fix it in one command, naming the environment that drifted:")
+            print("    npm run gen:db-types -- --env dev")
+            print("and commit the regenerated file. Full steps: docs/RUNBOOK.md")
+            print("-> 'Regenerating a database type snapshot'.")
+        else:
+            print("Column parity is a promotion precondition: code written against one")
+            print("schema is about to reach a database with a different one, and the")
+            print("first symptom is a 500 on whatever page reads the missing column.")
+            print()
+            print("Fix by applying the missing migration, or — if the difference is")
+            print("known and ticketed — record it in supabase/schema-drift-baseline.json.")
+            print("Regenerate a stale snapshot with `npm run gen:db-types -- --env <env>`")
+            print("(docs/RUNBOOK.md -> 'Regenerating a database type snapshot').")
         return 1
 
     tables = len({t for env in live.values() for t in env})
-    print(
-        f"check-live-schema-parity OK — {len(live)} database(s), {tables} table(s), "
-        "columns agree and every committed snapshot matches its database."
-    )
+    if args.snapshot_only:
+        print(
+            f"check-live-schema-parity OK (snapshot-only) — {len(live)} database(s), "
+            f"{tables} relation(s); every committed snapshot matches its own database."
+        )
+    else:
+        print(
+            f"check-live-schema-parity OK — {len(live)} database(s), {tables} table(s), "
+            "columns agree and every committed snapshot matches its database."
+        )
     return 0
 
 

--- a/scripts/gen-db-types.sh
+++ b/scripts/gen-db-types.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+#
+# gen-db-types.sh — regenerate ONE environment's committed schema snapshot
+# (`src/types/database/<env>.ts`).
+#
+# SEC-133. This exists because the remediation instruction was a dangling
+# reference: `check-live-schema-parity.py` told you to "regenerate a stale
+# snapshot with the documented step in docs/RUNBOOK.md", and that step did not
+# exist — nothing in docs/ or scripts/ mentioned `supabase gen types` at all.
+# The daily snapshot-freshness check now depends on this being a one-command
+# fix, because a red that is awkward to clear becomes a red people learn to
+# expect, and this repo has paid for that lesson twice (gotcha #30, and the 18
+# "expected" macOS failures).
+#
+# USAGE
+#     npm run gen:db-types -- --env dev
+#     bash scripts/gen-db-types.sh --env staging
+#
+# The project ref is read from `src/types/database/index.ts` (SCHEMA_PROJECT_REFS)
+# rather than repeated here. Two copies of a project ref is one copy too many —
+# and that file is already the place the drift gates read.
+#
+# REQUIRES `SUPABASE_ACCESS_TOKEN`. If it is absent this FAILS LOUD and exits
+# non-zero; it never writes a partial file and never reports success. Per the
+# Workflow & Backup Integrity Policy, a step that cannot run must not be green.
+#
+# ALTERNATIVE, when you have no CLI token: the Supabase MCP tool
+# `generate_typescript_types` returns the identical output for a project ref.
+# Paste it into the same path. Same result, different transport.
+#
+# Portability: bash 3.2-clean (no mapfile/readarray, no declare -A, no ${v,,})
+# — macOS ships bash 3.2 and this runs by hand far more often than in CI.
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+INDEX="$REPO_ROOT/src/types/database/index.ts"
+
+ENV_NAME=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --env) ENV_NAME="${2:-}"; shift 2 ;;
+    --env=*) ENV_NAME="${1#--env=}"; shift ;;
+    -h|--help) sed -n '2,32p' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;;
+    *) echo "::error::gen-db-types: unknown argument '$1'"; exit 2 ;;
+  esac
+done
+
+case "$ENV_NAME" in
+  dev|staging|prod) ;;
+  "") echo "::error::gen-db-types: --env is required (dev | staging | prod)"; exit 2 ;;
+  *)  echo "::error::gen-db-types: unknown environment '$ENV_NAME' (expected dev | staging | prod)"; exit 2 ;;
+esac
+
+# Assert the input exists rather than inferring it from a grep exit code —
+# gotcha #30: never conclude "the file was searched" from an exit status.
+if [ ! -f "$INDEX" ] || [ ! -r "$INDEX" ]; then
+  echo "::error::gen-db-types: $INDEX is missing or unreadable, so the project ref cannot be resolved."
+  echo "::error::  Failing closed rather than guessing a ref and overwriting a snapshot."
+  exit 2
+fi
+
+PROJECT_REF=$(grep -E "^[[:space:]]*${ENV_NAME}:[[:space:]]*'[a-z]+'" "$INDEX" \
+  | head -1 | sed -E "s/^[^']*'([a-z]+)'.*/\1/")
+
+if [ -z "$PROJECT_REF" ]; then
+  echo "::error::gen-db-types: no project ref for '$ENV_NAME' in $INDEX (SCHEMA_PROJECT_REFS)."
+  exit 2
+fi
+
+if [ -z "${SUPABASE_ACCESS_TOKEN:-}" ]; then
+  echo "::error::gen-db-types: SUPABASE_ACCESS_TOKEN is not set."
+  echo "::error::  Cannot reach the Supabase Management API, so the snapshot cannot be"
+  echo "::error::  regenerated. NOT writing anything — a truncated or error-body snapshot"
+  echo "::error::  is worse than a stale one, because the drift gates would then compare"
+  echo "::error::  against garbage and report a difference nobody can interpret."
+  echo "::error::"
+  echo "::error::  Either export SUPABASE_ACCESS_TOKEN, or use the Supabase MCP tool"
+  echo "::error::  generate_typescript_types with project ref $PROJECT_REF and write the"
+  echo "::error::  output to src/types/database/${ENV_NAME}.ts."
+  exit 2
+fi
+
+TARGET="$REPO_ROOT/src/types/database/${ENV_NAME}.ts"
+TMP="$(mktemp)"
+trap 'rm -f "$TMP"' EXIT
+
+echo "gen-db-types: regenerating $ENV_NAME ($PROJECT_REF) -> src/types/database/${ENV_NAME}.ts"
+if ! npx --yes supabase gen types typescript --project-id "$PROJECT_REF" > "$TMP" 2>"$TMP.err"; then
+  echo "::error::gen-db-types: 'supabase gen types' failed for $ENV_NAME ($PROJECT_REF):"
+  sed 's/^/::error::  /' "$TMP.err" | head -20
+  rm -f "$TMP.err"
+  exit 1
+fi
+rm -f "$TMP.err"
+
+# Validate before overwriting. The whole point of this script is that a bad
+# write is worse than no write: these files are the input to two blocking gates.
+if ! grep -q "export type Database" "$TMP"; then
+  echo "::error::gen-db-types: output does not contain 'export type Database' — refusing to write."
+  echo "::error::  First 5 lines of what came back:"
+  head -5 "$TMP" | sed 's/^/::error::  /'
+  exit 1
+fi
+
+LINES=$(wc -l < "$TMP" | tr -d ' ')
+if [ "$LINES" -lt 200 ]; then
+  echo "::error::gen-db-types: output is only $LINES lines — implausibly short for a full schema."
+  echo "::error::  Refusing to write. Suspect an auth or project-ref problem."
+  exit 1
+fi
+
+mv "$TMP" "$TARGET"
+trap - EXIT
+echo "gen-db-types: wrote $LINES lines to src/types/database/${ENV_NAME}.ts"
+echo "gen-db-types: now run  python3 scripts/check-live-schema-parity.py --snapshot-only --env $ENV_NAME"
+echo "gen-db-types: and commit the regenerated file."

--- a/tests/scripts/check-live-schema-parity.test.js
+++ b/tests/scripts/check-live-schema-parity.test.js
@@ -31,8 +31,16 @@ const { SRC } = JSON.parse(
 );
 const SCRIPT = path.join(ROOT, SRC.checkLiveSchemaParity);
 
-/** Committed MINIMUM number of self-test fixtures. May be raised, never lowered. */
-const SELF_TEST_FLOOR = 9;
+/**
+ * Committed MINIMUM number of self-test fixtures. May be raised, never lowered.
+ *
+ * SEC-133: raised 9 -> 15. Six compare_snapshots() fixtures were added when the
+ * snapshot half started running daily. Leaving the floor at 9 would have let all
+ * six be deleted with the suite still green — which is the precise failure this
+ * constant exists to prevent, and it would have applied to the only half that
+ * could see SEC-131.
+ */
+const SELF_TEST_FLOOR = 15;
 
 /** Run with an explicitly constructed env so an ambient credential cannot leak in. */
 function run(args, extraEnv = {}) {
@@ -120,6 +128,88 @@ describe('CTL-048 — live schema parity', () => {
     // edge satisfiable by a failing job.
     const jobBlock = yml.slice(yml.indexOf('  schema-parity:'), yml.indexOf('  merge-and-deploy:'));
     expect(jobBlock).not.toMatch(/continue-on-error/);
+  });
+
+  test('SEC-133: the self-test covers the SNAPSHOT half, not just the live half', () => {
+    // Before SEC-133 all nine fixtures exercised compare_live() and NONE
+    // touched compare_snapshots() — the half that runs daily, and the only half
+    // that could see SEC-131. A floor alone would not have caught that: the
+    // count was healthy while an entire comparator was unfixtured.
+    const { stdout } = run(['--self-test']);
+    for (const fixture of [
+      'a STALE snapshot is detected',
+      'an OVERSTATING snapshot is detected',
+      'a matching snapshot produces no violation',
+      'a missing snapshot file is reported',
+    ]) {
+      expect(`${fixture}: ${stdout.includes(fixture)}`).toBe(`${fixture}: true`);
+    }
+  });
+
+  test('SEC-133: --snapshot-only is wired into the DAILY job and blocks it', () => {
+    const yml = require('node:fs').readFileSync(path.join(ROOT, SRC.dbInvariants), 'utf-8');
+
+    // Invoked, with the flag — not merely mentioned.
+    expect(yml).toMatch(/check-live-schema-parity\.py --snapshot-only/);
+    // Daily, and its own job so a stale snapshot does not report itself as a
+    // SECURITY DEFINER finding.
+    expect(yml).toMatch(/^\s{2}snapshot-freshness:/m);
+    expect(yml).toMatch(/cron:\s*'15 6 \* \* \*'/);
+    // A step that cannot fail the job is decoration.
+    const job = yml.slice(yml.indexOf('  snapshot-freshness:'));
+    expect(job).not.toMatch(/continue-on-error/);
+    expect(job).not.toMatch(/if:\s*env\./); // the KAN-167 silent-skip shape
+  });
+
+  test('SEC-133: the remediation the checker names actually exists', () => {
+    // THE DEFECT THIS PINS. The checker used to tell you to "regenerate a stale
+    // snapshot with the documented step in docs/RUNBOOK.md" — and no such step
+    // existed anywhere in docs/ or scripts/. An instruction pointing at nothing
+    // is worse than none: it reads as a procedure and stops the reader looking.
+    const fs = require('node:fs');
+    const script = fs.readFileSync(SCRIPT, 'utf-8');
+    const runbook = fs.readFileSync(path.join(ROOT, 'docs/RUNBOOK.md'), 'utf-8');
+    const pkg = JSON.parse(fs.readFileSync(path.join(ROOT, 'package.json'), 'utf-8'));
+
+    // The command the checker tells you to run must exist as a script...
+    expect(script).toMatch(/npm run gen:db-types/);
+    expect(pkg.scripts['gen:db-types']).toBeDefined();
+    // ...and resolve to a real file.
+    const target = pkg.scripts['gen:db-types'].replace(/^bash\s+/, '').trim();
+    expect(`${target} exists: ${fs.existsSync(path.join(ROOT, target))}`).toBe(
+      `${target} exists: true`,
+    );
+    // ...and the RUNBOOK section it cites must be present, by its exact heading.
+    expect(runbook).toMatch(/^### Regenerating a database type snapshot/m);
+  });
+
+  test('SEC-133: gen:db-types fails closed without a token rather than writing', () => {
+    // A truncated or error-body snapshot is worse than a stale one: the drift
+    // gates would then compare against garbage. Assert it refuses, and that the
+    // committed snapshot is untouched.
+    const fs = require('node:fs');
+    const snapshot = path.join(ROOT, SRC.dev);
+    const before = fs.readFileSync(snapshot, 'utf-8');
+
+    const res = spawnSync('bash', [path.join(ROOT, SRC.genDbTypes), '--env', 'dev'], {
+      encoding: 'utf-8',
+      cwd: ROOT,
+      env: { PATH: process.env.PATH, HOME: process.env.HOME }, // no SUPABASE_ACCESS_TOKEN
+    });
+
+    expect(res.status).not.toBe(0);
+    expect(res.stdout + res.stderr).toMatch(/SUPABASE_ACCESS_TOKEN is not set/);
+    expect(fs.readFileSync(snapshot, 'utf-8')).toBe(before);
+  });
+
+  test('SEC-133: gen:db-types rejects an unknown environment', () => {
+    const res = spawnSync('bash', [path.join(ROOT, SRC.genDbTypes), '--env', 'staging-2'], {
+      encoding: 'utf-8',
+      cwd: ROOT,
+      env: { PATH: process.env.PATH, HOME: process.env.HOME },
+    });
+    expect(res.status).not.toBe(0);
+    expect(res.stdout + res.stderr).toMatch(/unknown environment/);
   });
 
   test('git is not required — the subject reads files and HTTP only', () => {

--- a/tests/support/source-path-seeds.ts
+++ b/tests/support/source-path-seeds.ts
@@ -124,4 +124,17 @@ export const SEEDED_PATHS = [
   // rename look like a passing test against a script nobody runs.
   'scripts/check-live-schema-parity.py',
   'scripts/check-docs-updated.py',
+  // SEC-133 gave CTL-048 a DAILY half, and these three are the residue: no
+  // counted test hard-codes any of them, so all three exist only as `SRC.*`.
+  // check-live-schema-parity.test.js asserts that the daily job invokes the
+  // checker with --snapshot-only, and that gen-db-types.sh refuses to write
+  // without a token. Both assertions are ABOUT the paths, so a literal in the
+  // test would let a rename read as a pass against a job nobody runs — the
+  // same reasoning as the two entries above.
+  '.github/workflows/db-invariants.yml',
+  'scripts/gen-db-types.sh',
+  // The snapshot gen-db-types.sh must leave untouched when it fails closed.
+  // `prod.ts` and `staging.ts` keys survive on other tests' literals; `dev.ts`
+  // had none, so it is the one that would silently vanish.
+  'src/types/database/dev.ts',
 ] as const;

--- a/tests/support/source-paths.json
+++ b/tests/support/source-paths.json
@@ -1,7 +1,7 @@
 {
   "$comment": "GENERATED — regenerate with `npm run gen:test-paths`. Mirror of tests/support/source-paths.ts for .cjs and shell consumers (KAN-414 F4).",
   "generated_from": "literals referenced by tracked files under tests/",
-  "count": 197,
+  "count": 200,
   "SRC": {
     "codeowners": ".github/CODEOWNERS",
     "pullRequestTemplate": ".github/PULL_REQUEST_TEMPLATE.md",
@@ -12,6 +12,7 @@
     "backupComplete": ".github/workflows/backup-complete.yml",
     "backupDatabase": ".github/workflows/backup-database.yml",
     "backupRestoreTest": ".github/workflows/backup-restore-test.yml",
+    "dbInvariants": ".github/workflows/db-invariants.yml",
     "prChecks": ".github/workflows/pr-checks.yml",
     "promoteToStaging": ".github/workflows/promote-to-staging.yml",
     "securityAudit": ".github/workflows/security-audit.yml",
@@ -48,6 +49,7 @@
     "checkWorkflowIntegrity": "scripts/check-workflow-integrity.sh",
     "dailySecurityCheck": "scripts/daily-security-check.sh",
     "docSyncHealthcheck": "scripts/doc-sync-healthcheck.sh",
+    "genDbTypes": "scripts/gen-db-types.sh",
     "genTestPaths": "scripts/gen-test-paths.mjs",
     "lyraMaintenanceWorker": "scripts/lyra-maintenance-worker.js",
     "restoreDatabase": "scripts/restore-database.sh",
@@ -185,6 +187,7 @@
     "sectionVisibility": "src/modules/profile/section-visibility.ts",
     "profileTypes": "src/modules/profile/types.ts",
     "database": "src/types/database",
+    "dev": "src/types/database/dev.ts",
     "index": "src/types/database/index.ts",
     "prod": "src/types/database/prod.ts",
     "staging": "src/types/database/staging.ts",

--- a/tests/support/source-paths.ts
+++ b/tests/support/source-paths.ts
@@ -13,7 +13,7 @@
 // cannot drift from reality — a hand-maintained list is what let BUGS-74's
 // first fix miss the legacy editor.
 //
-// 197 entries.
+// 200 entries.
 
 export const SRC = {
   codeowners: '.github/CODEOWNERS',
@@ -25,6 +25,7 @@ export const SRC = {
   backupComplete: '.github/workflows/backup-complete.yml',
   backupDatabase: '.github/workflows/backup-database.yml',
   backupRestoreTest: '.github/workflows/backup-restore-test.yml',
+  dbInvariants: '.github/workflows/db-invariants.yml',
   prChecks: '.github/workflows/pr-checks.yml',
   promoteToStaging: '.github/workflows/promote-to-staging.yml',
   securityAudit: '.github/workflows/security-audit.yml',
@@ -61,6 +62,7 @@ export const SRC = {
   checkWorkflowIntegrity: 'scripts/check-workflow-integrity.sh',
   dailySecurityCheck: 'scripts/daily-security-check.sh',
   docSyncHealthcheck: 'scripts/doc-sync-healthcheck.sh',
+  genDbTypes: 'scripts/gen-db-types.sh',
   genTestPaths: 'scripts/gen-test-paths.mjs',
   lyraMaintenanceWorker: 'scripts/lyra-maintenance-worker.js',
   restoreDatabase: 'scripts/restore-database.sh',
@@ -198,6 +200,7 @@ export const SRC = {
   sectionVisibility: 'src/modules/profile/section-visibility.ts',
   profileTypes: 'src/modules/profile/types.ts',
   database: 'src/types/database',
+  dev: 'src/types/database/dev.ts',
   index: 'src/types/database/index.ts',
   prod: 'src/types/database/prod.ts',
   staging: 'src/types/database/staging.ts',

--- a/tests/support/test-floor-baseline.json
+++ b/tests/support/test-floor-baseline.json
@@ -2,5 +2,5 @@
   "$comment": "GENERATED — regenerate with `npm run gen:test-floor`. The enforced test floor. The guard fails if the counts DROP (a test was deleted) and also if they RISE (this baseline is stale and is overstating how much of the estate is actually protected). The rise case is the one that matters: the previous hand-maintained floor sat at 29 files / 320 blocks against an actual 260 / 2963, so ~89% of the tests could have been deleted silently. Raise it in the SAME commit as any net-new test.",
   "measured_at": "2026-08-12",
   "test_files": 278,
-  "test_blocks": 3184
+  "test_blocks": 3189
 }


### PR DESCRIPTION
## Summary

CTL-048 is the **only** control that can see a schema snapshot going stale — CTL-036 diffs the three committed files against each other and never talks to a database, so all three stale in the same way is structurally invisible to it. CTL-048 was wired into exactly one place: `promote-to-staging.yml`.

Two consequences, and the second is the worse one.

**(a) The finding always arrived at the worst moment.** A snapshot could drift the day after a release and nothing looked wrong for a week. SEC-131 was found only because that promote happened to be dry-run first; dispatched normally, CTL-048 would have blocked it and the diagnosis would have happened mid-release. The gate would have been right; the timing would have been worse.

**(b) The snapshot half had ZERO test coverage.** The checker has two comparators — `compare_live()` (cross-database) and `compare_snapshots()` (each env vs its own DB). All nine `--self-test` fixtures exercised `compare_live()`. **None touched `compare_snapshots()`** — the half that now runs daily, and the only half that could have seen SEC-131. The fixture count was healthy while an entire comparator was unfixtured: `--self-test N/N passed` says nothing about *which* paths the N cover.

### The second defect, found while fixing the first

The checker told you to regenerate a stale snapshot using *"the documented step in `docs/RUNBOOK.md`"*. **No such step existed** — nothing in `docs/` or `scripts/` mentioned `supabase gen types` at all.

An instruction pointing at nothing is worse than no instruction: it reads as a procedure and stops the reader looking. It matters specifically here because a red that is awkward to clear becomes a red people learn to expect, and this repo has paid for that twice (gotcha #30's grep divergence, and the 18 "expected" macOS failures that were two real defects). A daily gate with an unclearable remediation is a switched-off control within a fortnight.

### What changed

- **`--snapshot-only` flag** — runs the snapshot half alone and lowers the credential floor from 2 databases to 1, because the cross-database comparison needs a pair and the snapshot comparison does not. Error text now names `npm run gen:db-types -- --env dev`.
- **`snapshot-freshness` job** in `db-invariants.yml`, daily at 06:15 UTC. Its own job rather than a step in the invariants job — a stale snapshot is not a SECURITY DEFINER finding and should not report itself as one. The workflow already holds all six credentials.
- **`scripts/gen-db-types.sh`** — the missing remediation. Reads the project ref from `src/types/database/index.ts` (`SCHEMA_PROJECT_REFS`) rather than repeating it; that file is already what the drift gates read.
- **`docs/RUNBOOK.md`** gains the section the checker cites, under that exact heading.
- **Six `compare_snapshots()` fixtures**, and `SELF_TEST_FLOOR` raised 9 → 15 in the same commit.

`compare_snapshots()` read the snapshot files directly, which is why it had no fixtures — one would have needed a real 2,000-line file on disk. It now takes `snapshot_reader=columns_from_snapshot` as a default argument. The production path is unchanged and is still proven end-to-end; the seam exists only so a fixture can reach the logic.

`gen-db-types.sh` fails closed without `SUPABASE_ACCESS_TOKEN` and validates output before `mv` (must contain `export type Database`, must be ≥200 lines). **A truncated or error-body snapshot is worse than a stale one** — a stale snapshot is wrong in a bounded, diagnosable way, whereas one holding an HTML error page makes both drift gates compare against garbage. That is the Workflow & Backup Integrity Policy's `pg_dump ... || echo "failed" > $FILE` pattern in a different costume.

### Mutation proof

Each reverted, files confirmed byte-identical after. Per the D7 lesson, the file was verified changed before trusting any run — every mutation below asserts it applied.

| mutation | result |
|---|---|
| delete the RUNBOOK `### Regenerating a database type snapshot` section | **1 red** |
| remove `--snapshot-only` from `db-invariants.yml` | **1 red** |
| delete one `compare_snapshots` fixture | **2 red** (floor *and* named-fixture assertion) |
| strip `genDbTypes` from both manifest mirrors **and** remove its seed | key **MISSING** |
| restore the seed alone, manifest still lacking the key | key **RETURNS** |

The last two rows prove the seed is load-bearing rather than decorative.

**End-to-end proof against a stub, not only through the injected seam:** a stub snapshot matching the stub DB exits 0; adding `newly_added_column` to the DB stub exits 1, naming `profile_items has newly_added_column on the database but not in the snapshot`.

**The flag proven load-bearing:** with one database's credentials `--snapshot-only` exits 0 while the default invocation exits 2 with `fewer than 2 database(s) read`. Without that contrast the flag could have been a no-op sitting beside a passing run.

### The F4 ratchet went 35 → 39, and was NOT raised

The four new path literals tripped the shrink-only raw-literal ratchet. It fails in both directions on purpose, so the baseline was left alone and the literals were routed through `SRC` instead — which is the move the ratchet exists to force. All three keys are the residue no counted test hard-codes (verified, not assumed), so all three are **seeded** per `source-path-seeds.ts`'s own "when to add a seed" rule.

### Honest gaps

- **27 of 30 `pr-checks` guards pass locally.** `check-scheduled-workflows-active.py` and `check-shared-code-drift.py` require the `gh` CLI, which is absent in this environment. Both **fail closed** (exit 2) rather than reporting green, and they run in CI.
- The daily job's *live* behaviour cannot be proven until it runs with real credentials — the same limitation `check-live-schema-parity.test.js`'s header already states about the live half. What is proven here is the comparator, the wiring, and the fail-closed path.

## Jira Ticket

[SEC-133](https://checklyra.atlassian.net/browse/SEC-133) — follows [SEC-131](https://checklyra.atlassian.net/browse/SEC-131) (whose Prevention line raised this) and [SEC-132](https://checklyra.atlassian.net/browse/SEC-132).

## Checklist

- [x] Unit tests added/updated for new/changed functionality — 5 net-new tests, 6 net-new self-test fixtures
- [x] All existing tests pass (`npm run test:unit`) — **278 suites / 3643 tests green**; no existing assertion modified. `SELF_TEST_FLOOR` was *raised*, which its docstring permits and which is the opposite of weakening
- [x] Lint passes (`npm run lint`) — 0 errors / 35 warnings, unchanged baseline
- [x] Type check passes (`npm run type-check`) — clean
- [x] Build succeeds — no `src/` runtime change in this PR (scripts, workflow, docs, tests only); CI builds it
- [x] Coverage has not decreased — no `src/` code changed
- [x] No eslint-disable or ts-ignore without KAN-XX reference — none added
- [x] Dependency-rule gate reviewed — no `src/` imports changed; `depcruise` unchanged at 0 errors / 2 warnings
- [x] ARCHITECTURE.md updated if architectural changes were made — **N/A**: no new service, table, env var, route or security boundary
- [ ] Ops routine / Control-Room registry updated — **N/A with reason**: this adds a *GitHub Actions* scheduled job, not a claude.ai routine, so it has no Control-Room heartbeat row and no watchdog entry. The GitHub-Actions cron schedule is documented in `docs/RUNBOOK.md`, which this PR updates
- [x] Docs / system map updated — `docs/RUNBOOK.md` gains both the new daily job and the "Regenerating a database type snapshot" procedure. A new scheduled job is explicitly a Documentation Definition-of-Done trigger, so this is **not** N/A
- [x] Design loop (KAN-441) — **N/A**: touches no founder-owned UI/copy path. Verified by listing the changed files against `is_protected` (workflow, scripts, docs, tests, `package.json`, `controls/registry.json` — none match)

**MCP coverage: not applicable** — CI control and ops tooling; no user-facing data, route or server action.

## Extraction Definition-of-Done (KAN-428)

Not applicable — this PR moves no file under `src/`. `scripts/check-extraction-dod.sh` is inert here (confirmed: it passes on this tree).

---
_Generated by [Claude Code](https://claude.ai/code/session_015ztw7gfb4CLL2LGvsvMCZq)_

[SEC-133]: https://checklyra.atlassian.net/browse/SEC-133?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ