### PR TITLE
fix(ctl-028): public surfaces may not read the profiles base table — SEC-104 step 3

### DIFF
--- a/controls/registry.json
+++ b/controls/registry.json
@@ -509,7 +509,7 @@
       "id": "CTL-028",
       "name": "Suspension-guard coverage",
       "defect_class": "authz-coverage-drift",
-      "summary": "Any query filtering is_published = true is selecting content for public consumption and must also filter is_suspended = false. Stated on the QUERY rather than the file or the client, so it enumerates the surface instead of sampling it \u2014 the property every previous fix in this class lacked. Found three unguarded sites beyond the two identified by review, including the homepage and the sitemap.",
+      "summary": "A PUBLIC-SURFACE file may not read the `profiles` BASE TABLE; public surfaces read `public_profiles`, whose view body carries every visibility predicate and therefore applies even to service_role (RLS does not). Default-deny: everything under src/app/ is public unless it matches a short authenticated carve-out list, so a NEW public route is covered the day it is written. SEC-104 step 3 replaced the original column-keyed rule, which triggered on the presence of a PARTIAL guard and so could not see an unguarded read at all \u2014 and which the SEC-104 migration then blinded completely, taking its public-surface coverage from 4 chains to 0 while its vacuous-pass guard (keyed on a raw count of 2) never fired.",
       "implementation": "scripts/check-suspension-guard-coverage.py",
       "kind": "ci-gate",
       "wired_in": [
@@ -522,11 +522,14 @@
         "SEC-81",
         "SEC-83",
         "SEC-85",
-        "BUGS-21"
+        "BUGS-21",
+        "SEC-100",
+        "SEC-104"
       ],
       "self_test": "python3 scripts/check-suspension-guard-coverage.py --self-test",
       "escape_hatch": "// suspension-guard-ok:",
-      "added": "2026-07-27"
+      "added": "2026-07-27",
+      "rewritten": "2026-08-12"
     },
     {
       "id": "CTL-029",

--- a/modules.json
+++ b/modules.json
@@ -1959,7 +1959,7 @@
         "blastRadius": "high (privacy)",
         "edgeSafe": false,
         "frozenContracts": [
-          ".eq('is_published',true).eq('is_suspended',false) must stay ONE tested unit (SEC-44)",
+          "public reads go through the public_profiles VIEW, never the profiles base table (SEC-104; enforced by CTL-028). Supersedes the SEC-44 requirement that .eq('is_published',true).eq('is_suspended',false) stay one tested unit — that pair no longer appears in this module's files at all, because the predicates moved into the view body, where they apply even to service_role",
           "SEC-82 cache headers preserved"
         ],
         "extraGates": [

--- a/scripts/check-suspension-guard-coverage.py
+++ b/scripts/check-suspension-guard-coverage.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""SEC-100 — the suspension-guard coverage class.
+"""SEC-100 / SEC-104 — the suspension-guard coverage class.
 
 THE DEFECT CLASS
 ----------------
@@ -31,23 +31,73 @@ WHY RLS IS NOT THE BACKSTOP PEOPLE ASSUME
 
 But the SERVICE-ROLE client bypasses RLS entirely. Any page rendered through
 `createServiceRoleClient()` gets no policy protection at all, and this codebase
-has ~40 modules importing it. That is precisely how SEC-44 happened, and how
-`src/app/search/page.tsx` and `src/app/sitemap.ts` were still leaking suspended
-members to public search and to search-engine crawlers on 2026-07-27 — more
-than three weeks after SEC-44 closed.
+has ~40 modules importing it. That is precisely how SEC-44 happened.
 
-THE INVARIANT
--------------
-Any Supabase query chain that filters `is_published = true` is, by definition,
-selecting content for PUBLIC consumption. Every such chain must also filter
-`is_suspended = false`.
+═══════════════════════════════════════════════════════════════════════════
+SEC-104 STEP 3 — WHY THE ORIGINAL RULE WAS REPLACED (2026-08-12)
+═══════════════════════════════════════════════════════════════════════════
 
-This is deliberately expressed on the QUERY rather than the file or the client:
-it needs no knowledge of which client is in play, it holds whether or not RLS
-would have covered it (defence in depth), and it enumerates the surface instead
-of sampling it — which is the property every previous fix in this class lacked.
+The original invariant was keyed on a COLUMN LITERAL: "any chain filtering
+`.eq('is_published', true)` must also filter `is_suspended`". SEC-104 raised
+two structural problems with it, and landing SEC-104's own fix created a third
+— which is the one that finally forced this rewrite.
 
-Allow-list: `// suspension-guard-ok: <reason>` inside the chain, plus a Jira key.
+  1. A query with NO guard at all was invisible. The rule triggered on the
+     PRESENCE of a partial guard, so `.from('profiles').select('slug')` with no
+     filters sailed through. Reproduced 2026-07-27.
+
+  2. One guard per predicate. The invariant was hard-coded to `is_suspended`;
+     the day visibility gained a third predicate the checker would have held
+     the old line silently.
+
+  3. ⚠️ THE MIGRATION MOVED EVERY PUBLIC SURFACE OUT OF SCOPE. SEC-104 moved
+     the predicates INTO the `public_profiles` view body, so a correctly
+     migrated public read contains no `is_published` literal at all — and a
+     checker keyed on that literal cannot see it. Measured across the migration
+     commit (62db86b, PR #757):
+
+         62db86b~1   6 chains visible — 4 of them public
+                     ([slug]x2, search, sitemap)
+         after       2 chains visible — 0 of them public
+                     (admin console count, convene dashboard action)
+
+     The control whose stated invariant was about PUBLIC consumption ended up
+     scanning an admin page and a dashboard action, and printing a confident
+     "Every public-visibility query also filters suspended members. ✓".
+
+That third failure is CLAUDE.md's own lesson in its purest form: **"matches
+nothing" is detectable; "matches less than it used to" is not.** The old
+vacuous-pass guard was right in spirit and one notch too low — it fired only
+when `chains_seen == 0`, and 2 is not 0.
+
+THE INVARIANT NOW
+-----------------
+Stated on the RELATION and the PATH rather than on a column literal:
+
+    A public-surface file may not read the `profiles` BASE TABLE.
+    Public surfaces read `public_profiles`, whose view body carries every
+    visibility predicate and therefore applies even to service_role.
+
+This is strictly stronger than the old rule on all three counts. An unguarded
+read is now a violation rather than an invisible one (1); adding a visibility
+predicate is a one-line view change rather than a checker change (2); and a
+correctly-migrated read is exactly what the rule looks for rather than what it
+cannot see (3).
+
+DEFAULT-DENY, WHICH IS THE WHOLE POINT
+--------------------------------------
+Public surfaces are NOT enumerated. Everything under `src/app/` is treated as
+public unless it matches an AUTHENTICATED carve-out below. So a brand-new
+public route is covered the day it is written, and exempting one is a visible
+diff to a short list — the opposite of the CTL-013 signup-manifest failure
+mode (gotcha #32), where a manifest of literal paths reported RESULT: CLEAN
+after the surface was renamed out from under it.
+
+The old column-keyed rule is RETAINED as a WARNING on non-public paths, per
+SEC-104 step 3. It still catches a partial guard in dashboard/admin code, where
+the base table is legitimately read.
+
+Allow-list: `// suspension-guard-ok: <JIRA-KEY> <reason>`.
 
 USAGE
     python3 scripts/check-suspension-guard-coverage.py
@@ -58,35 +108,108 @@ from __future__ import annotations
 
 import argparse
 import re
+import subprocess
 import sys
 from pathlib import Path
 
+# --- the new rule (SEC-104 step 3) -----------------------------------------
+
+# `.from('profiles')` in any quote style. Deliberately literal: the ticket asks
+# for a "near-zero-false-positive" rule, and a table name reached through a
+# variable is not something a static scan should pretend to resolve.
+BASE_TABLE_RE = re.compile(r"\.from\(\s*['\"`]profiles['\"`]\s*\)")
+VIEW_RE = re.compile(r"\.from\(\s*['\"`]public_profiles['\"`]\s*\)")
+
+# AUTHENTICATED / INTERNAL carve-outs. Everything else under src/app/ is public.
+#
+# Each entry is a path PREFIX and must match at least one tracked file that
+# actually reads the base table — a carve-out matching nothing is either a
+# stale path left behind by a move or over-broad drafting, and both are failures
+# (see check_carve_outs_are_live). That is CTL-035's lesson applied inline, and
+# it is why this list is short rather than defensive.
+AUTHENTICATED_PREFIXES = [
+    # The admin console. Reads unpublished and suspended rows BY DESIGN — that
+    # is what a moderation queue is for.
+    ("src/app/admin/", "admin console — moderation must see suspended rows"),
+    # Every authenticated member surface. The dashboard reads the caller's own
+    # row, and the editor writes it.
+    ("src/app/dashboard/", "authenticated member dashboard — own-row reads/writes"),
+    # Authenticated self-reads that sit outside /dashboard because they are
+    # pre-dashboard states in the signup funnel.
+    ("src/app/verify-age/", "authenticated self-read of own age_status (KAN-407)"),
+    ("src/app/waitlist/", "authenticated self-read/write of own user_status"),
+    # The only API route that reads the base table, and it authenticates first
+    # (auth.getUser() before any query). Note src/app/api/ is NOT carved out as
+    # a class: api/recommendations/** is genuinely public and MUST stay in
+    # scope, which is exactly the distinction KAN-411's api/ carve-out does not
+    # have to make.
+    ("src/app/api/reports/", "authenticated report submission — auth.getUser() first"),
+]
+
+ALLOW_MARKER = "suspension-guard-ok"
+
+# --- the retained rule (now a warning off the public surface) ---------------
+
 PUBLISHED_RE = re.compile(r"\.eq\(\s*['\"`]is_published['\"`]\s*,\s*true\s*\)")
 SUSPENDED_RE = re.compile(r"is_suspended")
-ALLOW_MARKER = "suspension-guard-ok"
 
 # How far past the `is_published` filter to look for its siblings. A supabase-js
 # chain is fluent, so the rest of the query follows immediately; 900 characters
-# comfortably covers the longest chain in this repo (src/app/[slug]/page.tsx)
-# without spilling into an unrelated statement.
+# comfortably covers the longest chain in this repo without spilling into an
+# unrelated statement.
 CHAIN_WINDOW = 900
 
+# Comments are stripped before matching. This is the CTL-039 / SEC-100 lesson:
+# `is_published` occurs TWICE in the old sitemap.ts — once in the query and once
+# in the comment explaining why the query needs it — so a source-text scan could
+# match the prose after the code was removed. The better a fix is documented,
+# the weaker a naive scan of it becomes. The allow-list marker is harvested
+# BEFORE stripping, because the marker is itself a comment.
+LINE_COMMENT_RE = re.compile(r"//[^\n]*")
+BLOCK_COMMENT_RE = re.compile(r"/\*.*?\*/", re.DOTALL)
 
-def find_violations(source: str, path: str) -> list[tuple[int, str]]:
-    """Return (line_number, excerpt) for each is_published chain lacking is_suspended."""
+
+def strip_comments(source: str) -> str:
+    """Blank out comments, preserving newlines so line numbers stay correct."""
+    def blank(match: re.Match[str]) -> str:
+        return re.sub(r"[^\n]", " ", match.group(0))
+
+    return LINE_COMMENT_RE.sub(blank, BLOCK_COMMENT_RE.sub(blank, source))
+
+
+def is_public_surface(rel_path: str) -> bool:
+    """Default-deny: a src/app file is public unless explicitly carved out."""
+    if not rel_path.startswith("src/app/"):
+        return False
+    return not any(rel_path.startswith(prefix) for prefix, _ in AUTHENTICATED_PREFIXES)
+
+
+def find_base_table_reads(source: str) -> list[tuple[int, str]]:
+    """Return (line_number, excerpt) for each base-table read not allow-listed."""
+    if ALLOW_MARKER in source:
+        return []
+
+    code = strip_comments(source)
+    return [
+        (code.count("\n", 0, m.start()) + 1, m.group(0))
+        for m in BASE_TABLE_RE.finditer(code)
+    ]
+
+
+def find_violations(source: str, path: str = "") -> list[tuple[int, str]]:
+    """The RETAINED column-keyed rule: an is_published chain lacking is_suspended.
+
+    Kept verbatim in behaviour so its six self-test fixtures still mean what they
+    meant — SEC-104 step 4 asks for the self-test to survive the rewrite.
+    """
     violations: list[tuple[int, str]] = []
 
     for match in PUBLISHED_RE.finditer(source):
-        # The chain runs from the start of the statement to a window past the
-        # is_published filter. Look backwards to the opening of the chain so a
-        # guard placed BEFORE .eq('is_published', ...) also counts.
         chain_start = source.rfind("supabase", max(0, match.start() - CHAIN_WINDOW), match.start())
         if chain_start == -1:
             chain_start = max(0, match.start() - CHAIN_WINDOW)
         chain = source[chain_start : match.end() + CHAIN_WINDOW]
 
-        # Stop the window at a blank line followed by a non-chained statement,
-        # so we do not borrow a guard from the next query in the same file.
         cut = re.search(r";\s*\n\s*\n", chain[match.start() - chain_start :])
         if cut:
             chain = chain[: (match.start() - chain_start) + cut.end()]
@@ -97,37 +220,98 @@ def find_violations(source: str, path: str) -> list[tuple[int, str]]:
             continue
 
         line_no = source.count("\n", 0, match.start()) + 1
-        excerpt = source[match.start() : match.end()]
-        violations.append((line_no, excerpt))
+        violations.append((line_no, source[match.start() : match.end()]))
 
     return violations
 
 
-def scan(src_root: Path) -> tuple[list[str], int]:
-    problems: list[str] = []
-    chains_seen = 0
+# --- scanning ---------------------------------------------------------------
 
-    for path in sorted(src_root.rglob("*")):
-        if not path.is_file() or path.suffix not in {".ts", ".tsx"}:
-            continue
+
+def tracked_files(root: Path) -> list[str]:
+    """Tracked state, not disk state.
+
+    `git mv` leaves the source directory behind EMPTY, so an `os.walk` would
+    still report a moved-away tree as present and a ratchet built on it would
+    stay green on the exact defect it guards. That is catalogue failure mode 6.
+    """
+    out = subprocess.run(
+        ["git", "-C", str(root), "ls-files", "src"],
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout
+    return [p for p in out.splitlines() if p.endswith((".ts", ".tsx"))]
+
+
+def check_carve_outs_are_live(root: Path, files: list[str]) -> list[str]:
+    """Every carve-out must still cover a real base-table reader.
+
+    A carve-out matching nothing is a stale path from a move, and its silent
+    effect is to make the public surface look SMALLER than it is — the exact
+    shape of the `^src/lib/` depcruise narrowing in D1, which CTL-035 could not
+    see because the pattern was narrow rather than dead.
+    """
+    problems: list[str] = []
+    for prefix, reason in AUTHENTICATED_PREFIXES:
+        covered = [
+            f
+            for f in files
+            if f.startswith(prefix)
+            and BASE_TABLE_RE.search(strip_comments((root / f).read_text(encoding="utf-8")))
+        ]
+        if not covered:
+            problems.append(
+                f"::error::Carve-out '{prefix}' ({reason}) matches no tracked file that reads "
+                f"the profiles base table. Either the path moved — in which case the public "
+                f"surface has silently GROWN and this list must be rewritten — or the carve-out "
+                f"was never needed and should be deleted."
+            )
+    return problems
+
+
+def scan(root: Path) -> dict:
+    files = tracked_files(root)
+
+    public_files = [f for f in files if is_public_surface(f)]
+    errors: list[str] = []
+    warnings: list[str] = []
+    view_reads = 0
+
+    for rel in files:
         try:
-            source = path.read_text(encoding="utf-8")
+            source = (root / rel).read_text(encoding="utf-8")
         except (UnicodeDecodeError, OSError):
             continue
-        if "is_published" not in source:
-            continue
 
-        chains_seen += len(PUBLISHED_RE.findall(source))
+        code = strip_comments(source)
 
-        for line_no, excerpt in find_violations(source, str(path)):
-            problems.append(
-                f"::error file={path},line={line_no}::Query filters is_published but not is_suspended. "
-                f"A suspended (moderated / taken-down) member stays publicly visible here. "
-                f"RLS does NOT save you if this reads through the service-role client. "
-                f"Add .eq('is_suspended', false). ({excerpt})"
-            )
+        if is_public_surface(rel):
+            view_reads += len(VIEW_RE.findall(code))
+            for line_no, excerpt in find_base_table_reads(source):
+                errors.append(
+                    f"::error file={rel},line={line_no}::Public surface reads the `profiles` "
+                    f"BASE TABLE ({excerpt}). Read `public_profiles` instead — its view body "
+                    f"carries is_published AND is_suspended, and a predicate in a view body "
+                    f"applies to every reader INCLUDING service_role, which bypasses RLS. "
+                    f"That bypass is how SEC-44 and SEC-100 happened."
+                )
+        else:
+            # Retained column-keyed rule, advisory off the public surface.
+            for line_no, excerpt in find_violations(code, rel):
+                warnings.append(
+                    f"::warning file={rel},line={line_no}::Query filters is_published but not "
+                    f"is_suspended ({excerpt}). Not a public surface, so this is advisory — but "
+                    f"check whether this listing should exclude suspended members."
+                )
 
-    return problems, chains_seen
+    return {
+        "files": files,
+        "public_files": public_files,
+        "errors": errors,
+        "warnings": warnings,
+        "view_reads": view_reads,
+    }
 
 
 # --- self-test (the "test the test" control) -------------------------------
@@ -190,65 +374,192 @@ _CASES = [
     ("a later query's guard does not cover an earlier one", _TWO_QUERIES, 1),
 ]
 
+# --- SEC-104 step 3 fixtures: the base-table rule ---------------------------
+
+# THE CASE THE OLD RULE COULD NOT SEE. No is_published literal anywhere, so the
+# column-keyed rule returned 0. This is the hole SEC-104 reproduced on
+# 2026-07-27 and the reason the rule was replaced rather than extended.
+_UNGUARDED_NO_FILTER = """
+const supabase = createServiceRoleClient();
+const { data } = await supabase.from('profiles').select('slug, display_name');
+"""
+
+_MIGRATED = """
+const { data } = await supabase
+  .from('public_profiles')
+  .select('slug, display_name');
+"""
+
+# A correctly-migrated read that ALSO carries the predicates. Belt and braces,
+# and must not be flagged.
+_MIGRATED_WITH_FILTERS = """
+const { data } = await supabase
+  .from('public_profiles')
+  .select('slug')
+  .order('updated_at');
+"""
+
+_BASE_TABLE_ALLOWLISTED = """
+// suspension-guard-ok: SEC-000 this public page intentionally reads the base table
+const { data } = await supabase.from('profiles').select('slug');
+"""
+
+# CTL-039: prose describing the defect must not be mistaken for the defect. This
+# whole file discusses `.from('profiles')` in its header while explaining the
+# hazard, and a guard that punished writing the explanation down would be
+# pointed the wrong way.
+_ONLY_IN_A_COMMENT = """
+// Historical note: this used to be .from('profiles') before SEC-104.
+const { data } = await supabase.from('public_profiles').select('slug');
+"""
+
+_ONLY_IN_A_BLOCK_COMMENT = """
+/* The old shape was:
+     await supabase.from('profiles').select('slug')
+   which SEC-104 replaced. */
+const { data } = await supabase.from('public_profiles').select('slug');
+"""
+
+_DOUBLE_QUOTED = """
+const { data } = await supabase.from("profiles").select('slug');
+"""
+
+_BASE_CASES = [
+    ("SEC-104's invisible case: no filters at all", _UNGUARDED_NO_FILTER, 1),
+    ("a migrated read is clean", _MIGRATED, 0),
+    ("a migrated read with ordering is clean", _MIGRATED_WITH_FILTERS, 0),
+    ("allow-listed base-table read", _BASE_TABLE_ALLOWLISTED, 0),
+    ("a line comment mentioning it is not a violation", _ONLY_IN_A_COMMENT, 0),
+    ("a block comment mentioning it is not a violation", _ONLY_IN_A_BLOCK_COMMENT, 0),
+    ("double-quoted table name is still caught", _DOUBLE_QUOTED, 1),
+]
+
+_PATH_CASES = [
+    ("a public route is in scope", "src/app/[slug]/page.tsx", True),
+    ("the sitemap is in scope", "src/app/sitemap.ts", True),
+    ("search is in scope", "src/app/search/page.tsx", True),
+    ("the PUBLIC recommendations API stays in scope", "src/app/api/recommendations/[slug]/route.ts", True),
+    ("the dashboard is carved out", "src/app/dashboard/profile/page.tsx", False),
+    ("the admin console is carved out", "src/app/admin/users/page.tsx", False),
+    ("the authenticated reports API is carved out", "src/app/api/reports/route.ts", False),
+    ("library code is not a route at all", "src/modules/access/gates/suspension.ts", False),
+]
+
 
 def self_test() -> int:
     failures = 0
+
     for label, source, expected in _CASES:
-        found = len(find_violations(source, "fixture.ts"))
+        found = len(find_violations(source))
         ok = found == expected
-        print(f"  {'PASS' if ok else 'FAIL'}  {label} (expected {expected}, got {found})")
-        if not ok:
-            failures += 1
+        print(f"  {'PASS' if ok else 'FAIL'}  [retained] {label} (expected {expected}, got {found})")
+        failures += not ok
+
+    for label, source, expected in _BASE_CASES:
+        found = len(find_base_table_reads(source))
+        ok = found == expected
+        print(f"  {'PASS' if ok else 'FAIL'}  [base-table] {label} (expected {expected}, got {found})")
+        failures += not ok
+
+    for label, path, expected in _PATH_CASES:
+        got = is_public_surface(path)
+        ok = got == expected
+        print(f"  {'PASS' if ok else 'FAIL'}  [surface] {label} (expected {expected}, got {got})")
+        failures += not ok
+
+    total = len(_CASES) + len(_BASE_CASES) + len(_PATH_CASES)
     if failures:
         print(f"::error::check-suspension-guard-coverage self-test: {failures} case(s) failed.")
         return 1
-    print(f"Self-test: all {len(_CASES)} fixture case(s) behave as specified. ✓")
+    print(f"Self-test: all {total} fixture case(s) behave as specified. ✓")
     return 0
 
 
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("--src", default="src")
+    parser.add_argument("--root", default=".")
     parser.add_argument("--self-test", action="store_true")
     args = parser.parse_args()
 
     if args.self_test:
         return self_test()
 
-    src_root = Path(args.src)
-    if not src_root.is_dir():
-        print(f"::error::source directory '{src_root}' not found.")
+    root = Path(args.root)
+    app_dir = root / "src" / "app"
+
+    # Assert the precondition directly rather than inferring "the tree was
+    # actually scanned" from a downstream count — gotcha #30, where a BSD/GNU
+    # grep exit-code divergence let a security guard report green having
+    # searched nothing.
+    if not app_dir.is_dir():
+        print(f"::error::{app_dir} is missing or unreadable, so no public surface can be scanned.")
+        print("::error::  Failing closed rather than reporting a clean scan that never ran.")
+        return 2
+
+    try:
+        result = scan(root)
+    except subprocess.CalledProcessError as exc:
+        print(f"::error::could not list tracked files: {exc}")
+        print("::error::  Failing closed — 'could not look' must never print as 'nothing found'.")
+        return 2
+
+    # ── Vacuous-pass guards ────────────────────────────────────────────────
+    #
+    # THE RE-KEYED ONE. The old guard failed only when the raw chain count hit
+    # zero, and the SEC-104 migration took the PUBLIC count from 4 to 0 while
+    # the raw count sat at 2 — so it never fired on the very event it existed
+    # for. Both numbers that can silently go to zero are now asserted.
+    if not result["public_files"]:
+        print("::error::No public-surface files found under src/app/.")
+        print("::error::  Either every route is carved out, or the tree moved. Either way this")
+        print("::error::  check would be passing vacuously — which is how SEC-104's own fix")
+        print("::error::  blinded the previous version of this control.")
         return 1
 
-    problems, chains_seen = scan(src_root)
-
-    # Vacuous-pass guard. This codebase has filtered is_published since the
-    # first public-profile release. Finding no chains at all means the pattern
-    # has changed and this check would be reporting green on nothing.
-    if chains_seen == 0:
-        print(f"::error::No `is_published = true` query chains found under '{src_root}'.")
-        print("::error::This check has lost its target — it would be passing vacuously.")
+    if result["view_reads"] == 0:
+        print("::error::No public surface reads `public_profiles`.")
+        print("::error::  SEC-104 migrated six read sites to that view. Finding none means the")
+        print("::error::  migration was reverted or those files moved out of src/app/, and this")
+        print("::error::  check has lost the surface it is meant to be watching.")
         return 1
 
-    print(f"Scanning {chains_seen} public-visibility query chain(s) for suspension coverage…")
-
-    if problems:
+    carve_out_problems = check_carve_outs_are_live(root, result["files"])
+    if carve_out_problems:
         print()
-        for problem in problems:
+        for problem in carve_out_problems:
             print(problem)
         print()
-        print(f"::error::{len(problems)} public query chain(s) omit the suspension filter.")
-        print()
-        print("Any query that filters is_published is selecting content for PUBLIC")
-        print("consumption and must also filter is_suspended. The RLS policy on")
-        print("`profiles` does enforce both — but the SERVICE-ROLE client bypasses RLS,")
-        print("and ~40 modules in this repo use it. That is how SEC-44 happened, and how")
-        print("search + sitemap were still leaking suspended members on 2026-07-27.")
-        print()
-        print("Allow-list only with '// suspension-guard-ok: <reason>' plus a SEC key.")
+        print("::error::A carve-out that covers nothing makes the public surface look smaller")
+        print("::error::than it is. 'Matches nothing' is detectable; 'matches less than it used")
+        print("::error::to' is not — which is the whole reason this assertion exists.")
         return 1
 
-    print("Every public-visibility query also filters suspended members. ✓")
+    print(
+        f"Scanning {len(result['public_files'])} public-surface file(s) under src/app/ "
+        f"({result['view_reads']} public_profiles read(s) found)…"
+    )
+
+    for warning in result["warnings"]:
+        print(warning)
+
+    if result["errors"]:
+        print()
+        for problem in result["errors"]:
+            print(problem)
+        print()
+        print(f"::error::{len(result['errors'])} public surface(s) read the profiles base table.")
+        print()
+        print("Public surfaces must read `public_profiles`. A predicate in a VIEW BODY applies")
+        print("to every reader including service_role; an RLS policy does not, and ~40 modules")
+        print("in this repo use the service-role client. That difference is SEC-44, SEC-100 and")
+        print("SEC-104 in one sentence.")
+        print()
+        print("Allow-list only with '// suspension-guard-ok: <JIRA-KEY> <reason>'.")
+        return 1
+
+    print("No public surface reads the profiles base table. ✓")
+    if result["warnings"]:
+        print(f"({len(result['warnings'])} advisory warning(s) on non-public paths.)")
     return 0
 
 

--- a/tests/scripts/check-suspension-guard-coverage.test.js
+++ b/tests/scripts/check-suspension-guard-coverage.test.js
@@ -1,0 +1,183 @@
+/**
+ * CTL-028 — tests for scripts/check-suspension-guard-coverage.py.
+ *
+ * WHY THIS FILE EXISTS AT ALL
+ * ---------------------------
+ * Until SEC-104 step 3, this control had NO tests. Its only cover was its own
+ * `--self-test`, which is the control grading its own homework: nothing
+ * asserted the self-test still ran a meaningful number of cases, nothing
+ * asserted it was wired into CI, and nothing asserted it could still fail.
+ *
+ * That mattered, because it turned out to be scanning nothing. The SEC-104
+ * migration moved every public surface out of its scope — the predicates went
+ * into the `public_profiles` view body, so a correctly-migrated read no longer
+ * contains the `is_published` literal the old rule was keyed on:
+ *
+ *     62db86b~1   6 chains visible — 4 of them public
+ *     after       2 chains visible — 0 of them public
+ *
+ * and the control printed "Every public-visibility query also filters suspended
+ * members. ✓" while looking at an admin count and a dashboard action.
+ *
+ * ⚠️ THE DISTRIBUTION IS THE POINT, NOT THE COUNT. `--self-test N/N passed`
+ * says nothing about WHICH code paths the N cover — SEC-133's lesson, where
+ * nine green fixtures sat beside a comparator with zero. So the floor below is
+ * necessary but not sufficient, and the tests after it assert that each of the
+ * three rule families is represented BY NAME.
+ */
+const { spawnSync } = require('node:child_process');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const ROOT = path.resolve(__dirname, '../..');
+const { SRC } = JSON.parse(
+  fs.readFileSync(path.join(ROOT, 'tests/support/source-paths.json'), 'utf-8'),
+);
+const SCRIPT = path.join(ROOT, SRC.checkSuspensionGuardCoverage);
+
+/**
+ * Committed MINIMUM number of self-test fixtures. May be raised, never lowered.
+ *
+ * SEC-104 step 3: 6 -> 21. The rewrite added 7 base-table fixtures and 8
+ * public-surface classification fixtures. Leaving the floor at 6 would have let
+ * every one of the new cases be deleted with the suite still green — on the
+ * only rule that can see the defect this control was rewritten for.
+ */
+const SELF_TEST_FLOOR = 21;
+
+function run(args = [], opts = {}) {
+  return spawnSync('python3', [SCRIPT, ...args], {
+    encoding: 'utf-8',
+    cwd: opts.cwd || ROOT,
+    env: { PATH: process.env.PATH, HOME: process.env.HOME, LANG: 'en_GB.UTF-8' },
+  });
+}
+
+describe('CTL-028 — public surfaces may not read the profiles base table', () => {
+  test('the self-test passes, and runs at least its committed floor', () => {
+    const r = run(['--self-test']);
+    expect(r.status).toBe(0);
+
+    const m = /all (\d+) fixture case\(s\) behave as specified/.exec(r.stdout);
+    expect(`self-test summary present: ${Boolean(m)}`).toBe('self-test summary present: true');
+    expect(Number(m[1])).toBeGreaterThanOrEqual(SELF_TEST_FLOOR);
+    expect(r.stdout).not.toMatch(/FAIL/);
+  });
+
+  test('SEC-104: the self-test covers all THREE rule families, by name', () => {
+    // A floor guards the count. This guards the distribution — the failure that
+    // a healthy count cannot distinguish from real coverage.
+    const { stdout } = run(['--self-test']);
+    for (const family of ['[retained]', '[base-table]', '[surface]']) {
+      expect(`${family} present: ${stdout.includes(family)}`).toBe(`${family} present: true`);
+    }
+  });
+
+  test("SEC-104: it catches the case the OLD rule could not see", () => {
+    // The defect this rewrite exists for: a service-role read of `profiles`
+    // with NO filters at all. The old rule triggered on the PRESENCE of a
+    // partial guard, so this returned zero findings. Asserted through the
+    // fixture the checker names, so deleting the fixture fails here too.
+    const { stdout } = run(['--self-test']);
+    expect(stdout).toMatch(/\[base-table\] SEC-104's invisible case: no filters at all \(expected 1, got 1\)/);
+  });
+
+  test('SEC-104: default-deny — a new public route is in scope without being listed', () => {
+    // The property that separates this from the CTL-013 signup manifest, whose
+    // failure mode is a confident RESULT: CLEAN after a rename (gotcha #32).
+    // Public surfaces are not enumerated, so a route nobody remembered to
+    // register is still covered.
+    const { stdout } = run(['--self-test']);
+    expect(stdout).toMatch(/\[surface\] a public route is in scope \(expected true, got true\)/i);
+    expect(stdout).toMatch(
+      /\[surface\] the PUBLIC recommendations API stays in scope \(expected true, got true\)/i,
+    );
+    // ...and the authenticated areas are NOT in scope, or the control would be
+    // unusable noise on 26 legitimate own-row readers.
+    expect(stdout).toMatch(/\[surface\] the dashboard is carved out \(expected false, got false\)/i);
+  });
+
+  test('SEC-104: comments are stripped, so documenting the hazard is not a violation', () => {
+    // CTL-039 / SEC-100: `is_published` occurred twice in sitemap.ts — once in
+    // the query and once in the comment explaining it — so deleting the filter
+    // left a source-text scan green. The inverse hazard applies here: a guard
+    // that flagged prose would punish writing the explanation down, and this
+    // checker's own header discusses `.from('profiles')` at length.
+    const { stdout } = run(['--self-test']);
+    expect(stdout).toMatch(/a line comment mentioning it is not a violation \(expected 0, got 0\)/);
+    expect(stdout).toMatch(/a block comment mentioning it is not a violation \(expected 0, got 0\)/);
+  });
+
+  test('⚠️ FAILS CLOSED: a missing src/app exits 2, it does not report a clean scan', () => {
+    // Gotcha #30 — a BSD/GNU grep divergence let a sibling guard print its
+    // success line having searched nothing. The precondition is asserted
+    // directly here rather than inferred from a downstream count.
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'ctl028-'));
+    try {
+      const r = run([], { cwd: tmp });
+      expect(r.status).toBe(2);
+      expect(r.stdout + r.stderr).toMatch(/missing or unreadable/);
+      expect(r.stdout + r.stderr).toMatch(/Failing closed/);
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  test('it passes on the real tree, and says how much it actually scanned', () => {
+    // A control that reports a clean result without saying what it covered is
+    // indistinguishable from one that covered nothing — which is precisely how
+    // the previous version read while scanning zero public surfaces.
+    const r = run([]);
+    expect(r.status).toBe(0);
+
+    const m = /Scanning (\d+) public-surface file\(s\).*?\((\d+) public_profiles read\(s\)/.exec(
+      r.stdout,
+    );
+    expect(`coverage line present: ${Boolean(m)}`).toBe('coverage line present: true');
+    const [, files, viewReads] = m.map(Number);
+    // Floors, not exact values, so adding a route does not fail the build. The
+    // point is that neither number can quietly reach zero.
+    expect(files).toBeGreaterThan(20);
+    expect(viewReads).toBeGreaterThanOrEqual(6);
+  });
+
+  test('it is registered as a control and actually invoked by pr-checks', () => {
+    // CTL-041's lesson: a registered control nothing invokes is a claim, not a
+    // gate — the SEC-79 failure mode where two workflows sat disabled for over
+    // a month while still reporting green.
+    const registry = JSON.parse(
+      fs.readFileSync(path.join(ROOT, 'controls/registry.json'), 'utf-8'),
+    );
+    const entry = registry.controls.find((c) => c.id === 'CTL-028');
+    expect(entry).toBeDefined();
+    expect(entry.implementation).toBe(SRC.checkSuspensionGuardCoverage);
+    expect(entry.wired_in.length).toBeGreaterThan(0);
+
+    for (const wf of entry.wired_in) {
+      const yml = fs.readFileSync(path.join(ROOT, wf), 'utf-8');
+      expect(`${wf} invokes it: ${yml.includes(entry.implementation)}`).toBe(
+        `${wf} invokes it: true`,
+      );
+    }
+    // SEC-104 is the ticket that rewrote it; the registry must say so, or the
+    // defect-feedback loop loses the link between the fix and its lesson.
+    expect(entry.prevents).toContain('SEC-104');
+  });
+
+  test('SEC-104: the six migrated read sites are still reading the view', () => {
+    // The regression this control could NOT observe before the rewrite:
+    // switching a public surface back to the base table. Asserted on the tree
+    // rather than through the checker, so it holds even if the checker changes.
+    const sites = [SRC.slugPage, SRC.searchPage, SRC.sitemap, SRC.slugRoute, SRC.v2SlugRoute];
+    // Assert the corpus before iterating it — catalogue failure mode 4, where a
+    // parameterised test over an empty list registers zero cases and is green.
+    expect(sites.filter(Boolean)).toHaveLength(5);
+    for (const rel of sites) {
+      const src = fs.readFileSync(path.join(ROOT, rel), 'utf-8');
+      expect(`${rel} reads public_profiles: ${/\.from\(\s*'public_profiles'\s*\)/.test(src)}`).toBe(
+        `${rel} reads public_profiles: true`,
+      );
+    }
+  });
+});

--- a/tests/support/source-path-seeds.ts
+++ b/tests/support/source-path-seeds.ts
@@ -133,6 +133,12 @@ export const SEEDED_PATHS = [
   // same reasoning as the two entries above.
   '.github/workflows/db-invariants.yml',
   'scripts/gen-db-types.sh',
+  // CTL-028's implementation, seeded for the same reason as CTL-047's and
+  // CTL-048's above: check-suspension-guard-coverage.test.js asserts the
+  // registry's `implementation` field names this exact path, so the assertion
+  // IS the path and a literal in the test would let a rename read as a pass
+  // against a control nobody runs. SEC-104 step 3.
+  'scripts/check-suspension-guard-coverage.py',
   // The snapshot gen-db-types.sh must leave untouched when it fails closed.
   // `prod.ts` and `staging.ts` keys survive on other tests' literals; `dev.ts`
   // had none, so it is the one that would silently vanish.

--- a/tests/support/source-paths.json
+++ b/tests/support/source-paths.json
@@ -1,7 +1,7 @@
 {
   "$comment": "GENERATED — regenerate with `npm run gen:test-paths`. Mirror of tests/support/source-paths.ts for .cjs and shell consumers (KAN-414 F4).",
   "generated_from": "literals referenced by tracked files under tests/",
-  "count": 200,
+  "count": 201,
   "SRC": {
     "codeowners": ".github/CODEOWNERS",
     "pullRequestTemplate": ".github/PULL_REQUEST_TEMPLATE.md",
@@ -44,6 +44,7 @@
     "checkScheduledWorkflowsActive": "scripts/check-scheduled-workflows-active.py",
     "checkSchemaTypeParity": "scripts/check-schema-type-parity.py",
     "checkSharedCodeDrift": "scripts/check-shared-code-drift.py",
+    "checkSuspensionGuardCoverage": "scripts/check-suspension-guard-coverage.py",
     "checkTestReimplementation": "scripts/check-test-reimplementation.py",
     "checkUiCopyOwnership": "scripts/check-ui-copy-ownership.sh",
     "checkWorkflowIntegrity": "scripts/check-workflow-integrity.sh",

--- a/tests/support/source-paths.ts
+++ b/tests/support/source-paths.ts
@@ -13,7 +13,7 @@
 // cannot drift from reality — a hand-maintained list is what let BUGS-74's
 // first fix miss the legacy editor.
 //
-// 200 entries.
+// 201 entries.
 
 export const SRC = {
   codeowners: '.github/CODEOWNERS',
@@ -57,6 +57,7 @@ export const SRC = {
   checkScheduledWorkflowsActive: 'scripts/check-scheduled-workflows-active.py',
   checkSchemaTypeParity: 'scripts/check-schema-type-parity.py',
   checkSharedCodeDrift: 'scripts/check-shared-code-drift.py',
+  checkSuspensionGuardCoverage: 'scripts/check-suspension-guard-coverage.py',
   checkTestReimplementation: 'scripts/check-test-reimplementation.py',
   checkUiCopyOwnership: 'scripts/check-ui-copy-ownership.sh',
   checkWorkflowIntegrity: 'scripts/check-workflow-integrity.sh',

--- a/tests/support/test-floor-baseline.json
+++ b/tests/support/test-floor-baseline.json
@@ -1,6 +1,6 @@
 {
   "$comment": "GENERATED — regenerate with `npm run gen:test-floor`. The enforced test floor. The guard fails if the counts DROP (a test was deleted) and also if they RISE (this baseline is stale and is overstating how much of the estate is actually protected). The rise case is the one that matters: the previous hand-maintained floor sat at 29 files / 320 blocks against an actual 260 / 2963, so ~89% of the tests could have been deleted silently. Raise it in the SAME commit as any net-new test.",
   "measured_at": "2026-08-12",
-  "test_files": 278,
-  "test_blocks": 3189
+  "test_files": 279,
+  "test_blocks": 3198
 }


### PR DESCRIPTION
## Summary

**SEC-104's own fix blinded SEC-104's own guard, and nobody could see it because the control kept printing a tick.**

SEC-104 steps 1–2 shipped: a `public_profiles` view whose body carries both visibility predicates, and six public read sites migrated onto it. Step 3 — *"replace CTL-028's column-keyed rule with: public-surface paths may not reference the `profiles` base table at all"* — was never done.

Because the predicates now live in the **view body**, a correctly-migrated public read contains no `is_published` literal at all — and the old rule was keyed on exactly that literal. Measured across the migration commit ([`62db86b`](https://github.com/luisa-sys/lyra/commit/62db86b), #757):

| | public member-data surfaces in scope | non-public | total chains |
|---|---|---|---|
| `62db86b~1` (before) | **4** — `[slug]`×2, `search`, `sitemap` | 2 | 6 |
| `HEAD` (before this PR) | **0** | 2 | 2 |

The two survivors are `src/app/admin/page.tsx` (an admin-console `count`) and `src/app/dashboard/convene/contacts/actions.ts` (an authenticated dashboard action). So the control whose stated invariant was *"any chain filtering `is_published` is, by definition, selecting content for **public** consumption"* was scanning **zero public surfaces** and printing:

```
Scanning 2 public-visibility query chain(s) for suspension coverage…
Every public-visibility query also filters suspended members. ✓
```

Its vacuous-pass guard was right in spirit and **one notch too low** — it fired only at `chains_seen == 0`, and 2 is not 0. *"Matches nothing" is detectable; "matches less than it used to" is not* — the `^src/lib/` depcruise narrowing from D1, except here the narrowing was caused by the very fix this control was meant to be replaced by.

### The new invariant

Stated on the **relation** and the **path** rather than on a column literal:

> A public-surface file may not read the `profiles` **base table**. Public surfaces read `public_profiles`, whose view body applies to every reader **including `service_role`** — unlike RLS, which `service_role` bypasses, and which is precisely how SEC-44 and SEC-100 happened.

Strictly stronger on all three of SEC-104's counts: an unguarded read is now a violation rather than invisible; adding a visibility predicate is a one-line view change rather than a checker change; and a correctly-migrated read is what the rule *looks for* rather than what it cannot see.

### Default-deny, which is the point

Public surfaces are **not enumerated**. Everything under `src/app/` is public unless it matches one of five authenticated carve-outs (`admin/`, `dashboard/`, `verify-age/`, `waitlist/`, `api/reports/`). A brand-new public route is covered the day it is written, and exempting one is a visible diff to a short list — the opposite of the CTL-013 signup-manifest failure mode (gotcha #32), whose `RESULT: CLEAN` survives the surface being renamed out from under it.

`src/app/api/` is deliberately **not** carved out as a class: `api/recommendations/**` is genuinely public and must stay in scope. That is a distinction KAN-411's `api/` carve-out never has to make.

**Coverage: 0 public surfaces → 74 public-surface files, 8 `public_profiles` reads.**

Each carve-out must still match a tracked file that actually reads the base table. A carve-out matching nothing is a stale path from a move, and its silent effect is to make the public surface look *smaller* than it is.

The old column-keyed rule is **retained as a warning** on non-public paths per step 3, with its six fixtures unchanged so they still mean what they meant (step 4 asks for the self-test to survive the rewrite).

### Second commit — a frozen contract SEC-104 had already retired

`modules.json` still declared, for `public-profile`:

```
".eq('is_published',true).eq('is_suspended',false) must stay ONE tested unit (SEC-44)"
```

That pair no longer appears anywhere in the module's files — SEC-104 moved both predicates into the view body, so `[slug]/page.tsx` and `search/page.tsx` carry no visibility filters of their own (the one surviving `is_published` in either file is a TypeScript field declaration, not a query). The declaration described a code shape that had ceased to exist, and would have told whoever picks up D9 to preserve something that is not there.

`PLAN-REVALIDATION-2026-07-28.md` anticipated it: *"the 'one tested unit' requirement re-expressed as 'reads go through `public_profiles`' once the view exists."* Re-expressed accordingly, naming CTL-028 as what enforces it. Nothing reads `frozenContracts` programmatically — which is exactly why a stale entry is worth fixing, since it is read by a human at the moment they are least able to check it.

## Mutation proof

Each reverted, files verified byte-identical after. The headline is a like-for-like comparison — the **same defect**, an unguarded service-role `.from('profiles')` injected into the real `/[slug]` route, put to both rules:

| rule | result |
|---|---|
| **OLD** (as on `develop`) | `Scanning 2 chains… ✓` — **exit 0, missed it** |
| **NEW** | `::error file=src/app/[slug]/page.tsx,line=219` — **exit 1, caught it** |

That is SEC-104's verified hole, reproduced on a real public route and closed.

| mutation | result |
|---|---|
| stale carve-out (`admin/` → `adminconsole/`) | red |
| `public_profiles` reads driven to zero | red |
| every route carved out (public surface empties) | red |
| revert the checker to its pre-rewrite version | **7 of 9 tests red** |
| `sitemap.ts` switched back to the base table | 2 tests red **+ checker red** |

The last row is the regression the old control could not observe at all.

## Tests

**CTL-028 had no test file.** Its only cover was its own `--self-test` — the control grading its own homework. Nothing asserted the self-test still ran a meaningful number of cases, that it was wired into CI, or that it could fail.

`tests/scripts/check-suspension-guard-coverage.test.js` adds 9, including the fail-closed path (a missing `src/app` exits 2 rather than reporting a clean scan) and an assertion that the six migrated sites still read the view.

Self-test **6 → 21** fixtures, floor raised in the same commit. The new tests assert the three rule families **by name**, not just by count — `N/N passed` says nothing about which paths the N cover, which is how nine green fixtures sat beside an unfixtured comparator in SEC-133.

## Jira Ticket

[SEC-104](https://checklyra.atlassian.net/browse/SEC-104) step 3. Evidence and measurement recorded as a comment on the ticket.

## Checklist

- [x] Unit tests added/updated for new/changed functionality — 9 net-new tests, 15 net-new self-test fixtures
- [x] All existing tests pass (`npm run test:unit`) — **279 suites / 3653 tests green**; no existing assertion modified, and the six retained fixtures are unchanged
- [x] Lint passes (`npm run lint`) — 0 errors / 35 warnings, unchanged baseline
- [x] Type check passes (`npm run type-check`) — clean
- [x] Build succeeds — no `src/` runtime change (the only `src/` touch was a mutation, reverted byte-identical); CI builds it
- [x] Coverage has not decreased — no `src/` code changed
- [x] No eslint-disable or ts-ignore without KAN-XX reference — none added
- [x] Dependency-rule gate reviewed — no `src/` imports changed
- [x] ARCHITECTURE.md updated if architectural changes were made — **N/A**: no new service, table, env var, route or security boundary; the view and its readers already existed
- [x] Ops routine / Control-Room registry updated — **N/A**: no scheduled-routine change. `controls/registry.json` CTL-028 entry *is* updated (new summary, `prevents` += SEC-100/SEC-104, `rewritten` date)
- [x] Docs / system map updated — **`modules.json`** `public-profile.frozenContracts` corrected (second commit above). No Confluence page change: this alters how a CI control is expressed and removes a stale declaration, not the system either describes. The invariant now enforced is the one `docs/` already documents for SEC-104
- [x] Design loop (KAN-441) — **N/A**: touches no founder-owned UI/copy path. `modules.json` is a manifest, not UI or copy

**MCP coverage: not applicable** — CI control; no user-facing data, route or server action. (The MCP repos have their own `mcp-visibility-guard` for the equivalent invariant.)

## Extraction Definition-of-Done (KAN-428)

Not applicable — this PR moves no file under `src/`.

## Why this unblocks D9

`LYRA_MODULARISATION_PLAN_2026-07-26.md` §5 gates **D9 (`public-profile`)** on SEC-104. The plan's stated risk — *"if D9 lands first it freezes a call-site convention SEC-104 then unpicks"* — was already gone once the view landed and the call sites migrated. What remained was this control rewrite, and the live reason to do it first: **D9 moves files, and until this PR the guard watching those files was blind to every public surface.** The second commit removes the last stale instruction that a D9 implementer would otherwise have tried to honour.

[SEC-104]: https://checklyra.atlassian.net/browse/SEC-104?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ