### PR TITLE
fix(SEC-137): send a User-Agent — CTL-049 could never have worked without one

### DIFF
--- a/scripts/check-migration-ledger-parity.py
+++ b/scripts/check-migration-ledger-parity.py
@@ -121,6 +121,32 @@ BASELINE_PATH = REPO_ROOT / "supabase" / "migration-ledger-baseline.json"
 TIMEOUT_SECONDS = 30
 API_ROOT = "https://api.supabase.com"
 
+# ⚠️ THIS HEADER IS LOAD-BEARING. Without it CTL-049 CANNOT WORK, with any
+# token, from any IP.
+#
+# `api.supabase.com` sits behind Cloudflare, and Cloudflare bans Python's
+# default `User-Agent: Python-urllib/3.x` by browser signature — **error 1010**,
+# returned as a bare `403 Forbidden`. The request never reaches Supabase's auth
+# layer at all.
+#
+# That 403 is indistinguishable at a glance from "your token lacks permission",
+# and it cost real time on 2026-08-14: a freshly minted PAT was blamed and
+# nearly regenerated. The tell was the Supabase dashboard still reporting the
+# token as **"Never used"** after two CI runs — a token that had been presented
+# and REFUSED would have registered a use. Measured, no credentials, from a
+# residential IP:
+#
+#   default python-urllib UA  -> 403  Cloudflare error 1010
+#   browser-like UA           -> 401  Unauthorized   <- reached Supabase
+#   bogus bearer + python UA  -> 403  Cloudflare error 1010
+#
+# So a 401 is the HEALTHY failure here and a 403 is the infrastructure one.
+# This is CLAUDE.md gotcha #7 ("Cloudflare 403 from CI") one layer deeper: it is
+# not only the runner's IP, it is the user agent, and it reproduces anywhere.
+#
+# Pinned by `--self-test` so the header cannot be dropped as tidying.
+USER_AGENT = "lyra-ci-migration-ledger-parity/1.0 (+https://github.com/luisa-sys/lyra; CTL-049)"
+
 # Project refs per CLAUDE.md gotcha #19. Not secrets — they appear in every
 # project URL — but overridable so a fork or a restored project can be pointed
 # elsewhere without editing the script.
@@ -190,7 +216,13 @@ def fetch_ledger(project_ref: str, token: str) -> list[dict]:
     endpoint = f"{API_ROOT}/v1/projects/{project_ref}/database/migrations"
     request = urllib.request.Request(
         endpoint,
-        headers={"Authorization": f"Bearer {token}", "Accept": "application/json"},
+        headers={
+            "Authorization": f"Bearer {token}",
+            "Accept": "application/json",
+            # See USER_AGENT above — without this Cloudflare 403s the request
+            # before Supabase ever sees the token.
+            "User-Agent": USER_AGENT,
+        },
         method="GET",
     )
     try:
@@ -445,6 +477,28 @@ def self_test() -> int:
     methods = set(re.findall(r'method\s*=\s*"([A-Z]+)"', code))
     check("the file issues at least one request", len(methods) > 0, True)
     check("every request method is GET", methods, {"GET"})
+
+    # --- the User-Agent is load-bearing, not decoration --------------------
+    # Cloudflare fronts api.supabase.com and bans Python's default UA by
+    # browser signature (error 1010), returning a bare 403 BEFORE Supabase
+    # sees the token. Dropping this header does not degrade the check — it
+    # makes it impossible, while producing a failure that reads exactly like
+    # a credential problem. It cost a nearly-regenerated PAT on 2026-08-14.
+    #
+    # Asserted on the header actually sent, and on the request wiring, so
+    # deleting either the constant or its use reddens this.
+    check("a User-Agent constant is defined", bool(re.search(r'^USER_AGENT\s*=', code, re.M)), True)
+    check(
+        "the outbound request sends that User-Agent",
+        bool(re.search(r'"User-Agent"\s*:\s*USER_AGENT', code)),
+        True,
+    )
+    check(
+        "the User-Agent is not Python's default",
+        USER_AGENT.lower().startswith("python-urllib"),
+        False,
+    )
+    check("the User-Agent identifies this control", "CTL-049" in USER_AGENT, True)
 
     if failures:
         print("SELF-TEST FAILED")


### PR DESCRIPTION
## CTL-049 has never run successfully, and it was never the token

`api.supabase.com` is behind Cloudflare, which bans Python's default `User-Agent: Python-urllib/3.x` by browser signature — **error 1010**, returned as a bare **403 Forbidden**. The request never reaches Supabase's auth layer, so no token of any type or scope could have fixed it.

Measured, **no credentials**, from a residential IP — so this is not a runner-IP problem:

| request | result |
|---|---|
| default `python-urllib` UA | **403 — Cloudflare 1010** |
| browser-like UA | **401 Unauthorized** ← reached Supabase |
| bogus bearer + `python-urllib` UA | **403 — Cloudflare 1010** |
| **the UA this PR adds** | **401 Unauthorized** ✅ |

A 401 is the *healthy* failure here; the 403 was infrastructure.

## ⚠️ The diagnostic worth keeping

A 403 is indistinguishable from "your token lacks permission", and a freshly minted PAT was blamed and nearly regenerated. **The tell was the Supabase dashboard still reporting the token as "Never used" after two CI runs.** A token that had been presented and *refused* would have registered a use — 403-but-never-used is contradictory, and that contradiction is what pointed away from the credential.

This is CLAUDE.md gotcha #7 one layer deeper: not only the runner's IP, but the user agent, and it reproduces anywhere.

## Verification

Four new `--self-test` cases pin the header — on the constant, the request wiring, it not being Python's default, and it naming the control. **Mutation-proven, 3 mutations, 0 survivors**, each verified applied then reverted:

- remove the User-Agent from the request (the actual bug) → **RED**
- revert the UA to Python's default → **RED**
- smuggle a `DELETE` onto the same path → **RED**

That last is the pre-existing GET-only guard, re-confirmed because this PR touches the same request — `DELETE /v1/projects/{ref}/database/migrations` rolls migrations out of the history table on the very path this GETs.

Self-test **29 cases**; `tests/scripts/check-migration-ledger-parity.test.js` **10/10**.

Prevention: CTL-049 — the control's own self-test now covers its **transport**, not only its comparison logic. The blind spot was that every existing case exercised parsing and ratcheting against fixtures, so the one part that had never worked in production was the one part nothing tested.

Docs-N/A: SEC-137 — the rationale lives in the header comment beside the constant, where anyone tempted to simplify the headers dict will be standing.

Refs: SEC-137, CTL-049