### PR TITLE
feat(KAN-474): derive the founder-owned surface so the autopilot cannot drift from it

### DIFF
--- a/controls/registry.json
+++ b/controls/registry.json
@@ -170,7 +170,8 @@
         "KAN-411"
       ],
       "escape_hatch": null,
-      "added": "2026-07-24"
+      "added": "2026-07-24",
+      "notes": "KAN-474: the script also exposes `--describe`, which emits the founder-owned surface DERIVED from is_protected() itself (parsed from the function body, not restated). The Backlog Autopilot routine reads that at runtime instead of carrying its own copy of the list. Two prior drifts \u2014 KAN-415 moving two copy modules, KAN-473 adding src/modules/*.tsx \u2014 were invisible to CI because a SaaS routine prompt is not readable from CI, so the fix was removing the second copy rather than adding a third checker. tests/scripts/check-ui-copy-ownership.test.js pins it, including a count ratchet: silently deleting a rule keeps guard and description in agreement, so equality alone cannot catch it."
     },
     {
       "id": "CTL-010",

--- a/scripts/check-ui-copy-ownership.sh
+++ b/scripts/check-ui-copy-ownership.sh
@@ -35,6 +35,74 @@
 #   overridable via env so the unit tests can drive crafted histories.
 set -euo pipefail
 
+# ---------------------------------------------------------------------------
+# --describe : emit the founder-owned surface, DERIVED from is_protected()
+# ---------------------------------------------------------------------------
+#
+# KAN-474. This exists because the surface was maintained in TWO places — this
+# guard, and the Backlog Autopilot's prompt, which is a SaaS routine no CI job
+# can read. They are supposed to be 1:1 mirrors. They drifted twice:
+#
+#   * KAN-415 moved `src/lib/invite-text.ts` and `src/lib/beta-access/email.ts`
+#     into `src/modules/`. The guard was updated; the prompt was not, so two
+#     copy modules were protected by CI and unprotected by the robot.
+#   * KAN-473 added `src/modules/*.tsx`. Again the guard only. The autopilot
+#     would have read three founder-owned components as fair game.
+#
+# Neither drift could go red, because nothing in CI can see a routine prompt.
+# So the fix is not another checker — it is removing the second copy. The
+# autopilot now reads this at runtime instead of restating it, and the guard
+# becomes the single source of truth.
+#
+# ⚠️ THE OUTPUT IS PARSED OUT OF is_protected() ITSELF, not hand-written
+# alongside it. That distinction is the whole point: a hand-written
+# description is a third copy and would drift exactly like the second one did.
+# Add a rule to the function and it appears here with no further edit —
+# `tests/scripts/check-ui-copy-ownership.test.js` proves that by adding one.
+#
+# Contract: line-oriented and stable, because a routine prompt parses it.
+#   PROTECTED <glob>     founder-owned; autopilot must not touch
+#   CARVE-OUT <glob>     explicitly NOT founder-owned; checked first, wins
+# Carve-outs are printed FIRST because that is the order they are evaluated in.
+describe_surface() {
+  local body
+  body="$(sed -n '/^is_protected()/,/^}/p' "$0")"
+
+  echo "# Founder-owned UI/copy surface — KAN-411."
+  echo "# Derived from is_protected() in scripts/check-ui-copy-ownership.sh."
+  echo "# Do not restate this list anywhere; read it."
+  echo "#"
+  echo "# CARVE-OUT lines are evaluated FIRST and win over PROTECTED lines."
+  echo
+
+  # ⚠️ The extraction must tolerate a TRAILING COMMENT and arbitrary internal
+  # whitespace, because the function is written for humans and several rules
+  # carry both. The first cut of this anchored on `]] && return N$` and
+  # silently emitted 1 carve-out instead of 4, dropping `src/*.css` — a list
+  # that LOOKS right while omitting rules is the exact failure mode KAN-474
+  # exists to end, so the parser is strict about the shape it matches and the
+  # test below pins the counts rather than trusting the output looks sensible.
+  extract_rules() {  # $1 = return code to select
+    printf '%s\n' "$body" \
+      | sed -n "s/^[[:space:]]*\[\[[[:space:]]*\\\$f[[:space:]]*==[[:space:]]*\(.*[^[:space:]]\)[[:space:]]*\]\][[:space:]]*\&\&[[:space:]]*return[[:space:]]*$1[[:space:]]*\(#.*\)\{0,1\}\$/\1/p"
+  }
+
+  # `return 1` inside the function = explicitly not protected.
+  while IFS= read -r line; do
+    [ -n "$line" ] && printf 'CARVE-OUT %s\n' "$line"
+  done < <(extract_rules 1)
+
+  # `return 0` = founder-owned.
+  while IFS= read -r line; do
+    [ -n "$line" ] && printf 'PROTECTED %s\n' "$line"
+  done < <(extract_rules 0)
+}
+
+if [ "${1:-}" = "--describe" ]; then
+  describe_surface
+  exit 0
+fi
+
 BASE_REF="${BASE_REF:-origin/develop}"
 HEAD_REF="${HEAD_REF:-HEAD}"
 

--- a/tests/scripts/check-ui-copy-ownership.test.js
+++ b/tests/scripts/check-ui-copy-ownership.test.js
@@ -185,4 +185,103 @@ describe(SRC.checkUiCopyOwnership, () => {
     expect(output).toMatch(/::warning::/);
     expect(output).toMatch(/not found/);
   });
+  // ─── KAN-474: --describe is DERIVED from is_protected(), not restated ───
+  //
+  // The surface used to live in two places — this guard and the Backlog
+  // Autopilot's prompt, a SaaS routine no CI job can read. They drifted twice
+  // (KAN-415 moved two copy modules; KAN-473 added src/modules/*.tsx), and
+  // neither drift could go red because nothing in CI can see a prompt.
+  //
+  // The fix is removing the second copy: the autopilot reads --describe at
+  // runtime. These cases exist to keep that promise honest — a hand-written
+  // description would be a THIRD copy and would drift exactly as the second
+  // did, so the load-bearing assertion is the last one, which adds a rule to
+  // the function and requires it to appear with no other edit.
+  describe('--describe (KAN-474)', () => {
+    const describeOut = () =>
+      execSync(`bash ${JSON.stringify(SCRIPT)} --describe`, { encoding: 'utf-8' });
+
+    /** Every `[[ $f == X ]] && return N` in is_protected(), read from source. */
+    function rulesInFunction() {
+      const src = fs.readFileSync(SCRIPT, 'utf-8');
+      const body = src.slice(src.indexOf('\nis_protected()')).split('\n}\n')[0];
+      return [...body.matchAll(/^\s*\[\[\s*\$f\s*==\s*(.*?)\s*\]\]\s*&&\s*return\s*([01])/gm)]
+        .map((m) => ({ glob: m[1], protected: m[2] === '0' }));
+    }
+
+    function emitted() {
+      return describeOut()
+        .split('\n')
+        .filter((l) => l.startsWith('PROTECTED ') || l.startsWith('CARVE-OUT '))
+        .map((l) => ({ glob: l.slice(l.indexOf(' ') + 1), protected: l.startsWith('PROTECTED ') }));
+    }
+
+    // Two-way ratchet on the SIZE of the surface. The equality case above
+    // proves guard and description agree; it cannot tell "a rule was removed
+    // deliberately" from "a rule was removed silently", because deleting it
+    // from is_protected() removes it from BOTH and they still agree. Measured
+    // by mutation: dropping `src/components/*` left all other cases green.
+    //
+    // So the count is pinned. RAISE it when you add a protection. If you are
+    // LOWERING it you are removing founder ownership from a surface, which is
+    // Luisa's call (KAN-411) and should not pass on a green diff.
+    const EXPECTED_RULES = { carveOuts: 4, protected: 17 };
+
+    it('emits a non-empty surface', () => {
+      // Guards the vacuous case: a parser that matched nothing would make
+      // every assertion below pass over an empty set.
+      expect(emitted().length).toBeGreaterThanOrEqual(15);
+    });
+
+    it('⚠️ the surface has not SHRUNK — removing a protection must be deliberate', () => {
+      const got = emitted();
+      expect({
+        carveOuts: got.filter((r) => !r.protected).length,
+        protected: got.filter((r) => r.protected).length,
+      }).toEqual(EXPECTED_RULES);
+    });
+
+    it('emits EXACTLY the rules in is_protected() — none missing, none invented', () => {
+      const key = (r) => `${r.protected ? 'P' : 'C'} ${r.glob}`;
+      const declared = rulesInFunction().map(key).sort();
+      const got = emitted().map(key).sort();
+      expect(got).toEqual(declared);
+    });
+
+    it('tolerates trailing comments and irregular spacing', () => {
+      // The first cut anchored on `]] && return N$` and silently emitted 1
+      // carve-out instead of 4, dropping src/*.css — several rules carry a
+      // trailing comment. These three are the ones it missed.
+      const globs = emitted().map((r) => r.glob);
+      expect(globs).toContain('src/app/admin/*');   // trailing comment
+      expect(globs).toContain('*/route.ts');        // comment + extra spacing
+      expect(globs).toContain('src/*.css');         // trailing comment
+    });
+
+    it('carve-outs are emitted BEFORE protected rules, matching evaluation order', () => {
+      const lines = emitted();
+      const lastCarveOut = lines.map((r) => r.protected).lastIndexOf(false);
+      const firstProtected = lines.map((r) => r.protected).indexOf(true);
+      expect(lastCarveOut).toBeLessThan(firstProtected);
+    });
+
+    it('⚠️ a NEW rule appears with no other edit — this is what makes it derived', () => {
+      // The whole claim of KAN-474 in one case. Add a rule to is_protected()
+      // in a scratch copy; if --describe is truly parsed from the function it
+      // shows up untouched. If anyone later replaces the parser with a
+      // hand-written list, this goes red.
+      const tmp = path.join(fs.mkdtempSync(path.join(os.tmpdir(), 'kan474-')), 'guard.sh');
+      const src = fs.readFileSync(SCRIPT, 'utf-8');
+      const sentinel = 'src/kan474-sentinel/*.tsx';
+      const mutated = src.replace(
+        '  [[ $f == src/modules/*.tsx ]] && return 0',
+        `  [[ $f == ${sentinel} ]] && return 0\n  [[ $f == src/modules/*.tsx ]] && return 0`,
+      );
+      expect(mutated).not.toBe(src); // the mutation actually applied
+      fs.writeFileSync(tmp, mutated, { mode: 0o755 });
+
+      const out = execSync(`bash ${JSON.stringify(tmp)} --describe`, { encoding: 'utf-8' });
+      expect(out).toContain(`PROTECTED ${sentinel}`);
+    });
+  });
 });

--- a/tests/support/test-floor-baseline.json
+++ b/tests/support/test-floor-baseline.json
@@ -2,5 +2,5 @@
   "$comment": "GENERATED — regenerate with `npm run gen:test-floor`. The enforced test floor. The guard fails if the counts DROP (a test was deleted) and also if they RISE (this baseline is stale and is overstating how much of the estate is actually protected). The rise case is the one that matters: the previous hand-maintained floor sat at 29 files / 320 blocks against an actual 260 / 2963, so ~89% of the tests could have been deleted silently. Raise it in the SAME commit as any net-new test.",
   "measured_at": "2026-08-14",
   "test_files": 287,
-  "test_blocks": 3280
+  "test_blocks": 3286
 }


### PR DESCRIPTION
## The second copy is the bug

The KAN-411 protected surface lived in **two** places — `is_protected()` in `check-ui-copy-ownership.sh`, and the Backlog Autopilot's prompt, a SaaS routine **no CI job can read**. They are meant to be 1:1 mirrors. They drifted twice:

| when | what moved | result |
|---|---|---|
| KAN-415 | `src/lib/invite-text.ts`, `src/lib/beta-access/email.ts` → `src/modules/` | two copy modules protected by CI, **unprotected by the robot** |
| KAN-473 | added `src/modules/*.tsx` | autopilot would read three founder-owned components as fair game |

**Neither drift could go red**, because nothing in CI can see a routine prompt. So this is not a third checker — it removes the second copy. `--describe` emits the surface; the routine reads it at runtime.

## ⚠️ The output is parsed out of `is_protected()` itself

A hand-written description would be a **third** copy and would drift exactly as the second did. So the extraction reads the function body — add a rule and it appears with no further edit. One test proves that by adding a sentinel rule to a scratch copy and requiring it in the output.

## ⚠️ My first cut was wrong in the dangerous direction

It anchored on `]] && return N$`, which several rules don't match because they carry trailing comments and irregular spacing. It emitted **1 carve-out instead of 4** and dropped `src/*.css` entirely.

A list that *looks* right while silently omitting rules is precisely the failure this ticket exists to end. Caught by running it and cross-checking against the function — not by reading the output and nodding. The parser now tolerates comments and whitespace, and a test pins the three rules it missed.

## Mutation proof — 5 mutations, 0 survivors

| mutation | result |
|---|---|
| replace the derivation with a hand-written list | **RED** (4 cases) |
| revert to the comment-intolerant anchor | **RED** (2 cases) |
| silently drop a protection rule | **RED** |
| silently drop a carve-out | **RED** |
| add a rule to a scratch copy (must *appear*) | asserted green |

⚠️ **The third and fourth needed a new test, and that's the interesting part.** Deleting a rule removes it from *both* the function and the description, so they still agree — the equality case cannot see it. Measured: it survived. The surface size is now a **two-way ratchet**. Raise it when adding a protection; lowering it removes founder ownership from a surface and is Luisa's call.

## Verification

**286 suites / 3781 tests.** Floor regenerated in this commit. `--describe` emits all 21 rules, cross-checked against the function: none missing, none invented.

## ⚠️ Sequencing — read before re-enabling the routine

The autopilot prompt has **already been updated** to call `--describe`, and it's instructed to **STOP** rather than fall back to a remembered list if the command fails. The routine is currently **disabled** (paused 2026-07-29), so nothing can run against a `develop` that lacks this. **This PR must land before the routine is re-enabled.**

Prevention: CTL-009 — the control now publishes its own surface, so the copy that drifted twice no longer exists to drift.

Docs-N/A: KAN-474 — no module boundary, workflow, control script or migration added; the rationale lives above `describe_surface()`, where anyone tempted to hand-write the list will be standing.

Refs: KAN-474, KAN-411, KAN-415, KAN-473