### PR TITLE
docs(KAN-415/SEC-105): fix stale npm-audit gate description in ARCHITECTURE.md

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -399,7 +399,7 @@ All operations run via GitHub Actions — no local machine needed:
 ### Pipeline Security — implemented
 - **CodeQL**: security-extended analysis on every push/PR + weekly Sunday 03:00 UTC
 - **GitHub Actions SHA-pinned**: All 9 workflows use full SHA hashes (no tag-based supply chain risk)
-- **npm audit**: Blocking at high/critical level on all 3 deployment pipelines
+- **npm audit**: rescoped 2026-08-13 (SEC-105/CTL-052) — blocking, production-dependency-tree-only (`--omit=dev`) in the PR gate (`pr-checks.yml`); removed entirely from all four deploy workflows (redundant given the SEC-98 chain guard — every commit reaching them already passed the PR gate); weekly full-tree scan (`security-audit.yml`, includes dev deps) opens/updates a GitHub issue instead of blocking. Known-unfixable advisories are recorded in `security/npm-audit-waivers.json` (advisory+package+severity+ticket+owner+dated `expires`, two-way, fails closed on expiry).
 - **Dependabot**: Weekly scans for npm and GitHub Actions dependencies
 - **Secret scanning**: GitHub secret scanning with push protection enabled
 - **PR quality gate**: Scans for eslint-disable/ts-ignore without Jira reference


### PR DESCRIPTION
## What & Why

Daily Confluence doc-sync routine (KAN-249) found `docs/ARCHITECTURE.md`'s "Pipeline Security" section still describing the pre-SEC-105 npm-audit gate: "Blocking at high/critical level on all 3 deployment pipelines."

Commit `0cdd20a5` (SEC-105/CTL-052, 2026-08-13) rescoped this gate:
- `pr-checks.yml` now runs `npm audit --omit=dev --audit-level=high` (production-tree only) — blocking.
- All four `deploy-*.yml` workflows had the audit step removed entirely (redundant given the SEC-98 chain guard).
- `security-audit.yml` runs the full tree (incl. dev deps) weekly and opens/updates a GitHub issue instead of blocking.
- New waiver file `security/npm-audit-waivers.json` for known-unfixable advisories (dated, two-way, fails closed on lapse).

Also corrected the stale "3 deployment pipelines" count — there are four (dev/staging/beta/production).

## Changes

- `docs/ARCHITECTURE.md` — rewrote the `npm audit` bullet under "Pipeline Security — implemented" to match the current gate shape.

## Test plan

- [x] Documentation-only change, no code/test impact.
- [x] Verified against the SEC-105 commit (`0cdd20a5`) and Jira ticket SEC-105 (status: Done).

Linked: [KAN-477](https://checklyra.atlassian.net/browse/KAN-477) (Confluence doc sync — 2026-08-14)

[KAN-477]: https://checklyra.atlassian.net/browse/KAN-477?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ