### PR TITLE
docs: correct the KAN transition IDs, which silently no-op when wrong

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -168,7 +168,20 @@ git worktree prune
 All work must be tracked in Jira. **KAN** for design/deployment, **BUGS** for bug tracking, and **SEC** (Security & Risk — team-managed) for all security and risk findings: vulnerabilities, data-protection/compliance, ops-resilience and governance. Route any security or risk-audit work to **SEC**, not KAN/BUGS.
 
 - The second-line **Lyra Risk Register** (Confluence space TWC) is the index of findings; the Jira epic **SEC-1** ("2026-06 Second-line Risk & Security Audit") is their tracking home.
-- **SEC transition IDs** (for `transitionJiraIssue`): `11` = To Do, `21` = In Progress, `31` = Done. (cf. KAN `21`/`41`, BUGS `21`/`31`/`41`.)
+- **Transition IDs** (for `transitionJiraIssue`) — ⚠️ **they differ per project, and a wrong id fails SILENTLY**:
+
+  | project | To Do | In Progress | In Review | Done |
+  |---|---|---|---|---|
+  | **SEC** | `11` | `21` | — | `31` |
+  | **BUGS** | `21` | `31` | — | `41` |
+  | **KAN** | `11` | `21` | `31` | `41` |
+
+  **Verify every transition by reading the status back.** `transitionJiraIssue` returns HTTP
+  success for an id that is valid-but-not-the-one-you-meant, so passing KAN `21` to a ticket
+  that is already In Progress transitions In Progress → In Progress and changes nothing. No
+  error, no warning, and the ticket silently stays where it was. Corrected 2026-08-14, after
+  this line's previous text (`cf. KAN 21/41`) caused exactly that no-op during the backlog
+  audit — `21` is KAN's **In Progress**, not its To Do.
 
 Every KAN/SEC Task/Story description MUST include all six sections:
 


### PR DESCRIPTION
## Summary

`CLAUDE.md` carried `(cf. KAN 21/41, BUGS 21/31/41)`. The BUGS half is right. **The KAN half is not** — `21` is KAN's **In Progress**, not its To Do.

| project | To Do | In Progress | In Review | Done |
|---|---|---|---|---|
| SEC | `11` | `21` | — | `31` |
| BUGS | `21` | `31` | — | `41` |
| **KAN** | **`11`** | `21` | `31` | `41` |

## Why this is worth a commit rather than a quiet edit

`transitionJiraIssue` returns **HTTP success** for an id that is valid but not the one you meant. Passing KAN `21` to a ticket already In Progress transitions In Progress → In Progress: no error, no warning, nothing changes, and the caller reports success.

**That happened today.** During the backlog audit a ticket was "moved" to To Do and stayed In Progress. It was caught only because the agent **read the status back** instead of trusting the call's return value.

That is the same habit this repo already applies in two other places:
- `git add` — verify with `git diff --cached`, not "I typed the command" (the SEC-141 stash incident)
- mutation testing — assert the file actually changed before believing what the suite says

Same failure shape, third context. So the fix is not just the number: the table states every project's full mapping side by side, and the note says to verify by reading the status back, **because a wrong id is indistinguishable from a correct one at the call site**.

## Scope

- `CLAUDE.md`
- `lyra-mcp-server/CLAUDE.md` carried the identical line — mirrored there, shipping as a separate PR in that repo

## Verification

- `tests/unit/doc-dod.test.js` + `tests/scripts/` — **51 suites / 733 tests** green
- Documentation-only; no code, workflow or config change

## Checklist

- [x] Unit tests pass
- [ ] ARCHITECTURE.md updated — **N/A**: no service, table, env var, route, job or security boundary changed
- [x] Docs / system map updated — this *is* the doc fix
- [ ] Design loop (KAN-441) — **N/A**: no user-facing look or wording changed

---
_Generated by [Claude Code](https://claude.ai/code/session_015ztw7gfb4CLL2LGvsvMCZq)_