### PR TITLE
fix(SEC-96): readiness probe that can report the database degraded

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -383,6 +383,28 @@ All operations run via GitHub Actions — no local machine needed:
 | Claude Design | Design source of truth for UI changes — tokens + per-ticket before/after cards (KAN-441) | Projects `e4682889-…` (Lyra Design System) and `c179aa52-…` (Lyra Web Design) |
 
 
+## Health & status surfaces (SEC-96)
+
+Three distinct surfaces, deliberately answering different questions. Conflating
+them is what SEC-96 was about — a surface that cannot express failure reports
+green forever.
+
+| Surface | Question it answers | Can it report failure? |
+|---|---|---|
+| `GET /api/health` | *liveness + config* — is a Next.js server responding, and how is this environment wired? Echoes `siteUrl`, `isBetaDeploy`, `vercelEnv`. | **No, by design.** Returns a hardcoded `ok: true` and touches no dependency. Its response shape is pinned by an exact `toEqual` and consumed by CI smoke checks — do not widen it. |
+| `GET /api/health/ready` | *readiness* — can the site serve a request that needs the database? One `head`-only round trip to PostgREST on the anon key. | **Yes.** `200 {ok:true}` / `503 {ok:false}`. `detail` is a fixed token, never exception text (a public probe leaks nothing — SEC-96 §4). Logic lives in `src/modules/observability/readiness.ts`; the route stays thin per CTL-056. |
+| `/status` (public page) | *human-visible service status* — the surface `docs/UPTIMEROBOT_SETUP.md` positions as the signal for members. | **Partially.** The Agent-API row is a live probe of `mcp.checklyra.com/health`. |
+
+⚠️ **Known gap, stated rather than implied.** The `/status` page's **Website row
+is still the literal `{ ok: true, detail: 'Serving' }`**, so the public banner
+still cannot say the website is degraded — the site is "up" by virtue of having
+served the page that says so. `/api/health/ready` exists to close that, and
+wiring it in is a one-line change to the Website row.
+
+That wiring is **founder-owned under KAN-411** (`src/app/*.tsx`) and is
+deliberately not done by automation: it alters what a user-facing page displays.
+Until it lands, treat a green `/status` as evidence about the MCP API only.
+
 ## Security Posture (updated 29 March 2026)
 
 ### Application Security — implemented

--- a/modules.json
+++ b/modules.json
@@ -770,12 +770,13 @@
       "layer": 1,
       "paths": [
         "src/modules/observability/metrics.ts",
+        "src/modules/observability/readiness.ts",
         "src/modules/observability/sentry-scrub.ts",
         "src/app/api/health/",
         "src/app/status/"
       ],
       "owns": {
-        "files": 4,
+        "files": 6,
         "tables": [],
         "rpcs": [
           "get_metrics_for_window"

--- a/src/app/api/health/ready/route.ts
+++ b/src/app/api/health/ready/route.ts
@@ -1,0 +1,48 @@
+import { NextResponse } from 'next/server';
+import { checkReadiness } from '@/modules/observability/readiness';
+
+/**
+ * SEC-96 instance 3 — the readiness endpoint the public `/status` page needs
+ * so its Website row can stop being a literal `ok: true`.
+ *
+ * Liveness vs readiness, and why this is a sibling of `/api/health` rather
+ * than a change to it: `/api/health` answers "is a Next.js server responding
+ * and how is it configured" — it echoes three public env values and returns a
+ * hardcoded `ok: true`. That is green during exactly the outage a status page
+ * exists to report. This route answers "can the site actually serve a
+ * request that needs the database", which is the question behind the word
+ * "operational".
+ *
+ * Contract, so callers can rely on it:
+ *   200 + { ok: true,  detail }  — dependency reachable
+ *   503 + { ok: false, detail }  — dependency degraded or timed out
+ *
+ * The non-200 status is the load-bearing half: it means an uptime monitor
+ * pointed here alarms without parsing a body, and a `fetch(...).ok` check —
+ * which is how `src/app/status/page.tsx` already evaluates its MCP probe —
+ * reads degraded correctly with no new client logic.
+ *
+ * `detail` is one of a fixed set of tokens from the readiness module; no
+ * exception text, hostname or key fragment ever reaches this response (SEC-96
+ * §4 — a public probe returns ok/degraded only).
+ *
+ * Unauthenticated by design and safe to be so: it returns no data, only a
+ * boolean, and its underlying query runs on the anon key with `head: true`.
+ */
+export const dynamic = 'force-dynamic';
+export const revalidate = 0;
+
+export async function GET() {
+  const { ok, detail } = await checkReadiness();
+
+  return NextResponse.json(
+    { ok, detail },
+    {
+      status: ok ? 200 : 503,
+      headers: {
+        'Cache-Control': 'private, no-cache, no-store, must-revalidate',
+        'X-Robots-Tag': 'noindex, nofollow',
+      },
+    }
+  );
+}

--- a/src/modules/observability/readiness.ts
+++ b/src/modules/observability/readiness.ts
@@ -1,0 +1,114 @@
+/**
+ * SEC-96 instance 3 — a readiness probe that is *able to say no*.
+ *
+ * WHY THIS EXISTS
+ * ---------------
+ * The public `/status` page renders its Website row from a literal:
+ *
+ *     { name: 'Website (checklyra.com)', ok: true, detail: 'Serving' }
+ *
+ * so `allOk` turns solely on the MCP `/health` fetch, and the banner reads
+ * "All systems operational" for a site whose database is down — the site is
+ * "up" by virtue of having served the status page that says so. That is the
+ * false-positive shape the Workflow & Backup Integrity Policy forbids, and the
+ * same family as SEC-79 (workflows reporting green while disabled) and BUGS-81.
+ *
+ * The existing `/api/health` route cannot stand in for this. It is a *config
+ * echo* — it returns a hardcoded `ok: true` alongside three public env values
+ * and touches no dependency at all, so it is green in exactly the outage this
+ * probe needs to catch. Its response shape is pinned by an exact `toEqual` in
+ * `tests/unit/health-endpoint.test.ts` and consumed by CI smoke checks, so it
+ * is deliberately left alone rather than widened; readiness is a separate
+ * question from liveness and gets a separate endpoint.
+ *
+ * WHAT "READY" MEANS HERE
+ * -----------------------
+ * One round trip to PostgREST. That is the dependency whose loss makes the
+ * site non-functional while still serving static pages — sign-in, dashboard
+ * and every profile read go through it. A `head` count is used so the request
+ * returns *no rows*: this endpoint is public and unauthenticated, and it must
+ * prove reachability without becoming a data surface. It runs on the anon key,
+ * not the service role, so it can never read more than an anonymous visitor.
+ *
+ * WHY THE FAILURE DETAIL IS GENERIC
+ * ---------------------------------
+ * SEC-96 §4: a public probe must return ok/degraded only, with no internal
+ * detail leak. A raw PostgREST/undici error can carry hostnames, ports, key
+ * fragments and driver internals. So the real error is logged server-side and
+ * the caller is handed a fixed string. `detail` is a stable enum-like token,
+ * never interpolated from an exception.
+ */
+
+import { createClient } from '@supabase/supabase-js';
+import { env } from '@/modules/platform/env';
+import type { Database } from '@/types/database';
+
+/** Fixed, non-leaking detail tokens. Never interpolate an exception into these. */
+export const READY_DETAIL = {
+  ok: 'Reachable',
+  degraded: 'Database unreachable',
+  timeout: 'Database timed out',
+} as const;
+
+export type ReadinessResult = {
+  ok: boolean;
+  /** One of READY_DETAIL — safe to render publicly. */
+  detail: string;
+};
+
+/**
+ * The probe, narrowed to the only thing readiness cares about: did a trivial
+ * round trip to the database succeed? Injectable so tests can drive the
+ * degraded and timeout branches without a live database — the real client is
+ * built lazily inside the default so importing this module never requires
+ * Supabase env vars to be present.
+ */
+export type DatabaseProbe = (signal: AbortSignal) => Promise<{ failed: boolean }>;
+
+const DEFAULT_TIMEOUT_MS = 3000;
+
+const defaultProbe: DatabaseProbe = async (signal) => {
+  const supabase = createClient<Database>(env.supabaseUrl(), env.supabaseAnonKey(), {
+    auth: { persistSession: false, autoRefreshToken: false },
+  });
+
+  // `head: true` returns no rows — reachability only, never data. An RLS-empty
+  // result is still a successful round trip and therefore still "ready".
+  const { error } = await supabase
+    .from('profiles')
+    .select('id', { head: true, count: 'exact' })
+    .abortSignal(signal);
+
+  return { failed: Boolean(error) };
+};
+
+/**
+ * Probes the database and reports readiness.
+ *
+ * Never throws: an unreachable dependency is a *result*, not an exception, or
+ * the caller would 500 and the status page would lose the distinction between
+ * "degraded" and "the probe itself broke".
+ */
+export async function checkReadiness(
+  probe: DatabaseProbe = defaultProbe,
+  timeoutMs: number = DEFAULT_TIMEOUT_MS
+): Promise<ReadinessResult> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+
+  try {
+    const { failed } = await probe(controller.signal);
+    if (failed) {
+      console.error('[readiness] database probe reported an error');
+      return { ok: false, detail: READY_DETAIL.degraded };
+    }
+    return { ok: true, detail: READY_DETAIL.ok };
+  } catch (e) {
+    // Deliberately not surfaced to the caller — see the header note on leaks.
+    console.error('[readiness] database probe threw', e);
+    const timedOut = controller.signal.aborted;
+    return { ok: false, detail: timedOut ? READY_DETAIL.timeout : READY_DETAIL.degraded };
+  } finally {
+    clearTimeout(timer);
+  }
+}

--- a/tests/support/test-floor-baseline.json
+++ b/tests/support/test-floor-baseline.json
@@ -1,6 +1,6 @@
 {
   "$comment": "GENERATED — regenerate with `npm run gen:test-floor`. The enforced test floor. The guard fails if the counts DROP (a test was deleted) and also if they RISE (this baseline is stale and is overstating how much of the estate is actually protected). The rise case is the one that matters: the previous hand-maintained floor sat at 29 files / 320 blocks against an actual 260 / 2963, so ~89% of the tests could have been deleted silently. Raise it in the SAME commit as any net-new test.",
-  "measured_at": "2026-08-14",
-  "test_files": 295,
-  "test_blocks": 3399
+  "measured_at": "2026-08-15",
+  "test_files": 296,
+  "test_blocks": 3409
 }

--- a/tests/unit/readiness-endpoint.test.ts
+++ b/tests/unit/readiness-endpoint.test.ts
@@ -1,0 +1,166 @@
+/**
+ * SEC-96 instance 3 — readiness probe contract tests.
+ *
+ * These drive the REAL module and the REAL route handler (no reimplementation
+ * of the logic under test — see CTL-038 / gotcha #29). The probe itself is the
+ * one injected seam, because the alternative is a live database; everything
+ * downstream of it — the ok/degraded decision, the status code mapping and the
+ * leak guard — is the actual shipped code.
+ *
+ * The assertions that matter most are the negative ones: that a *failing*
+ * dependency produces a non-ok result and a 503. A readiness endpoint that
+ * cannot go red is the defect this ticket is about, so each red path is
+ * asserted explicitly rather than inferred from the green one.
+ */
+
+import {
+  checkReadiness,
+  READY_DETAIL,
+  type DatabaseProbe,
+} from '@/modules/observability/readiness';
+
+describe('checkReadiness', () => {
+  let errorSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    // The module logs the real error server-side on purpose; keep it out of
+    // the test output without asserting on console as a side channel.
+    errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    errorSpy.mockRestore();
+  });
+
+  test('reports ready when the probe round-trips', async () => {
+    const probe: DatabaseProbe = async () => ({ failed: false });
+
+    await expect(checkReadiness(probe)).resolves.toEqual({
+      ok: true,
+      detail: READY_DETAIL.ok,
+    });
+  });
+
+  test('reports DEGRADED when the probe returns an error', async () => {
+    const probe: DatabaseProbe = async () => ({ failed: true });
+
+    await expect(checkReadiness(probe)).resolves.toEqual({
+      ok: false,
+      detail: READY_DETAIL.degraded,
+    });
+  });
+
+  test('reports DEGRADED when the probe throws', async () => {
+    const probe: DatabaseProbe = async () => {
+      throw new Error('connection refused');
+    };
+
+    await expect(checkReadiness(probe)).resolves.toEqual({
+      ok: false,
+      detail: READY_DETAIL.degraded,
+    });
+  });
+
+  test('reports TIMEOUT when the probe outlives the deadline', async () => {
+    const probe: DatabaseProbe = (signal) =>
+      new Promise((_resolve, reject) => {
+        signal.addEventListener('abort', () => reject(new Error('aborted')));
+      });
+
+    await expect(checkReadiness(probe, 10)).resolves.toEqual({
+      ok: false,
+      detail: READY_DETAIL.timeout,
+    });
+  });
+
+  test('never leaks the underlying error into the public detail', async () => {
+    const SECRET = 'postgres://user:hunter2@db.internal.example:5432/lyra';
+    const probe: DatabaseProbe = async () => {
+      throw new Error(`getaddrinfo ENOTFOUND ${SECRET}`);
+    };
+
+    const result = await checkReadiness(probe);
+
+    expect(result.ok).toBe(false);
+    expect(result.detail).not.toContain('hunter2');
+    expect(result.detail).not.toContain('db.internal.example');
+    expect(result.detail).not.toContain('ENOTFOUND');
+    // Positive counterpart: the detail is one of the fixed tokens, so this
+    // cannot pass merely because `detail` is undefined (gotcha #31 —
+    // a negative assertion against undefined is vacuously true).
+    expect(Object.values(READY_DETAIL)).toContain(result.detail);
+  });
+
+  test('does not throw when the probe rejects — degraded is a result, not an exception', async () => {
+    const probe: DatabaseProbe = async () => {
+      throw new Error('boom');
+    };
+
+    await expect(checkReadiness(probe)).resolves.toBeDefined();
+  });
+});
+
+describe('GET /api/health/ready', () => {
+  const readiness = '@/modules/observability/readiness';
+
+  beforeEach(() => {
+    jest.resetModules();
+  });
+
+  afterEach(() => {
+    jest.unmock(readiness);
+  });
+
+  test('returns 200 and ok=true when the database is reachable', async () => {
+    jest.doMock(readiness, () => ({
+      READY_DETAIL: { ok: 'Reachable', degraded: 'Database unreachable', timeout: 'Database timed out' },
+      checkReadiness: async () => ({ ok: true, detail: 'Reachable' }),
+    }));
+
+    const { GET } = await import('@/app/api/health/ready/route');
+    const res = await GET();
+
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toEqual({ ok: true, detail: 'Reachable' });
+  });
+
+  test('returns 503 and ok=false when the database is degraded', async () => {
+    jest.doMock(readiness, () => ({
+      READY_DETAIL: { ok: 'Reachable', degraded: 'Database unreachable', timeout: 'Database timed out' },
+      checkReadiness: async () => ({ ok: false, detail: 'Database unreachable' }),
+    }));
+
+    const { GET } = await import('@/app/api/health/ready/route');
+    const res = await GET();
+
+    // The status code is the load-bearing half: a monitor or a `fetch().ok`
+    // check must read degraded without parsing the body.
+    expect(res.status).toBe(503);
+    await expect(res.json()).resolves.toEqual({ ok: false, detail: 'Database unreachable' });
+  });
+
+  test('exposes only ok and detail — no internal fields', async () => {
+    jest.doMock(readiness, () => ({
+      READY_DETAIL: { ok: 'Reachable', degraded: 'Database unreachable', timeout: 'Database timed out' },
+      checkReadiness: async () => ({ ok: false, detail: 'Database unreachable' }),
+    }));
+
+    const { GET } = await import('@/app/api/health/ready/route');
+    const body = await (await GET()).json();
+
+    expect(Object.keys(body).sort()).toEqual(['detail', 'ok']);
+  });
+
+  test('is uncacheable and unindexed', async () => {
+    jest.doMock(readiness, () => ({
+      READY_DETAIL: { ok: 'Reachable', degraded: 'Database unreachable', timeout: 'Database timed out' },
+      checkReadiness: async () => ({ ok: true, detail: 'Reachable' }),
+    }));
+
+    const { GET } = await import('@/app/api/health/ready/route');
+    const res = await GET();
+
+    expect(res.headers.get('Cache-Control')).toContain('no-store');
+    expect(res.headers.get('X-Robots-Tag')).toContain('noindex');
+  });
+});

--- a/tests/unit/sec4-status-page.test.js
+++ b/tests/unit/sec4-status-page.test.js
@@ -1,9 +1,23 @@
 /**
  * SEC-4 — public status page.
  *
- * Structural guards: the page does a LIVE probe (not a hard-coded "operational"),
- * and it is reachable on every environment (exempt from the beta gate + allow-listed
- * in the maintenance worker).
+ * Structural guards: the page probes the MCP API live, and it is reachable on
+ * every environment (exempt from the beta gate + allow-listed in the
+ * maintenance worker).
+ *
+ * ⚠️ SCOPE — read before trusting this file as cover for "the status page is
+ * honest". It is NOT. The header here used to claim the page "does a LIVE probe
+ * (not a hard-coded 'operational')", which is true of the MCP row and false of
+ * the Website row — the one SEC-96 instance 3 is about, which is still the
+ * literal `{ ok: true, detail: 'Serving' }`. Prose asserting a property the code
+ * does not have is exactly the shape CTL-039 exists to catch, and it read as
+ * cover for the defect while the defect was live.
+ *
+ * Stated plainly rather than quietly fixed: nothing in this file asserts the
+ * Website row. The readiness endpoint that lets it stop being a literal now
+ * exists and is tested in `tests/unit/readiness-endpoint.test.ts`; wiring it
+ * into this page is founder-owned under KAN-411 (`src/app/*.tsx`) and is
+ * deliberately not done here.
  */
 const fs = require('fs');
 const path = require('path');


### PR DESCRIPTION
## Summary

SEC-96 **instance 3**. The public `/status` page renders its Website row from a literal:

```ts
{ name: 'Website (checklyra.com)', ok: true, detail: 'Serving' }
```

so `allOk` turns solely on the MCP probe, and the banner reads "All systems operational" for a site whose database is down — up by virtue of having served the page that says so. Same family as SEC-79 and BUGS-81: a surface that cannot express failure reports green forever.

**This PR lands the half that automation owns — the probe. It does not touch the page.**

### What's here

- **`src/modules/observability/readiness.ts`** — one `head`-only round trip to PostgREST on the **anon** key. Returns no rows: the endpoint is public and unauthenticated, so it must prove reachability without becoming a data surface. Never throws — a dead dependency is a *result*, not an exception, or the caller 500s and "degraded" becomes indistinguishable from "the probe broke". The failure `detail` is a **fixed token, never exception text**: a raw driver error carries hostnames, ports and key fragments, and §4 requires ok/degraded only.
- **`src/app/api/health/ready/route.ts`** — `200 {ok:true}` / `503 {ok:false}`. The status code is the load-bearing half: a monitor alarms without parsing a body, and a `fetch().ok` check — which is how `status/page.tsx` already evaluates its MCP probe — reads degraded with no new client logic. Thin per CTL-056 (verified: 100 route files now, still 48 with direct DB calls).

### Why not just change `/api/health`

It is a *config echo* — hardcoded `ok: true` plus three public env values, touching no dependency, so it is green in exactly the outage this catches. Its shape is pinned by an exact `toEqual` and consumed by CI smoke checks. Liveness and readiness are different questions and get different endpoints.

### ⚠️ What is deliberately NOT done

Wiring the `/status` Website row to this endpoint. That changes what a user-facing page displays, and `src/app/*.tsx` is founder-owned under **KAN-411**. Verified against `scripts/check-ui-copy-ownership.sh --describe` (read at runtime, not recalled): every path in this diff is a carve-out (`src/app/api/*`, `*/route.ts`) or unprotected. **No UI trailer is claimed and none is needed** — the guard confirms `no founder-owned UI/copy paths changed`.

It is a one-line change to the Website row when Luisa wants it.

### Test-header correction

`tests/unit/sec4-status-page.test.js` opened with *"the page does a LIVE probe (not a hard-coded 'operational')"* — true of the MCP row, **false of the Website row**, i.e. prose reading as cover for the live defect (the CTL-039 shape the ticket itself flags). Header corrected to state the remaining gap. **No assertion changed.**

### Mutation proof

Each applied-then-verified (file confirmed modified before trusting the result), then restored:

| Mutation | Result |
|---|---|
| degraded branch returns `ok: true` | 1 red |
| route always returns 200 | 1 red |
| exception text into `detail` | 3 red |

## Jira Ticket

SEC-96 (stays **In Progress** — instance 3 is split; Luisa's half remains, as does the independent §1 founder action to verify `IS_SENTRY_ENABLED` on prod Vercel)

## Checklist

- [x] Unit tests added/updated for new/changed functionality — `tests/unit/readiness-endpoint.test.ts`, 10 tests
- [x] All existing tests pass (`npm run test:unit`) — **296 suites / 3936 tests green** (+10, +1 suite)
- [x] Lint passes (`npm run lint`) — 0 errors, 36 pre-existing warnings, none in new files
- [x] Type check passes (`npm run type-check`) — clean
- [x] Build succeeds (`npm run build`) — `/api/health/ready` registered dynamic (ƒ)
- [x] Coverage has not decreased — net-new code ships with tests; CI enforces the F5 floor
- [x] No eslint-disable or ts-ignore without KAN-XX reference — none added
- [x] Dependency-rule gate reviewed — `npm run depcruise` clean, 313 modules / 633 dependencies, no new violation
- [x] ARCHITECTURE.md updated — new "Health & status surfaces" section
- [x] Ops routine / Control-Room registry updated — N/A: no scheduled-routine behaviour, cadence or ownership changed
- [x] Docs / system map updated — `docs/ARCHITECTURE.md` gains the three-surface table **and states the remaining `/status` gap explicitly** rather than implying coverage
- [x] Design loop (KAN-441) — N/A: no look or wording of a user-facing page changes. The page edit that would is deliberately excluded (see above)

Ratchets re-run and green: CTL-035, CTL-037, CTL-041, CTL-051, CTL-053, CTL-055, CTL-056. `modules.json` `observability` updated (paths + `owns.files` 4→6); test-floor baseline regenerated in this commit.

MCP coverage: N/A — monitoring/ops route, explicitly outside the KAN-222 lockstep scope.

---
_Generated by [Claude Code](https://claude.ai/code/session_01C35ySVcpooiyWHtZqDGj2r)_