### PR TITLE
fix(SEC-143, SEC-23): repair the two failing routines, and close the blind spot each was hiding

### DIFF
--- a/.github/absent-secrets.txt
+++ b/.github/absent-secrets.txt
@@ -64,3 +64,31 @@ ATLASSIAN_DOMAIN              # explicit -z guard -> DATA UNAVAILABLE with reaso
 # via pr-checks.yml and exercises the normaliser, the two-way ratchet and the
 # fail-closed paths without credentials.
 SUPABASE_ACCESS_TOKEN       # CTL-049 fails loudly until the founder provisions it; self-test half runs on every PR (SEC-137)
+
+# --- SEC-143 admin schema-contract check: cross-repo read -------------------
+# NOT benign, and it is why that step has never once succeeded — see SEC-150.
+#
+# db-invariants.yml reads lyra-admin-mcp-server's committed schema contract to
+# prove it still matches production (the BUGS-101 defect: the admin server wrote
+# against dropped columns for 47 days with nothing watching). The step was built
+# using the workflow's built-in GITHUB_TOKEN, citing CTL-043 as precedent.
+#
+# CTL-043 works because ITS target is PUBLIC — shared-code-manifest.json records
+# that precondition beside the repo it names. lyra-admin-mcp-server is PRIVATE,
+# and a workflow's built-in token is scoped to its own repository, so it can
+# never read that repo. The mechanism was copied without the condition that made
+# it valid, and the step went red the day it reached main.
+#
+# The workflow now reads ADMIN_CONTRACT_READ_TOKEN when present and falls back
+# to GITHUB_TOKEN when not — so the absence changes nothing today, and the step
+# keeps failing CLOSED with a message naming the real cause. It starts working
+# the moment the secret exists, with no further code change.
+#
+# ⚠️ NAG, not an expected red — same distinction SUPABASE_ACCESS_TOKEN draws
+# above. Provision a FINE-GRAINED token with Contents:read on
+# luisa-sys/lyra-admin-mcp-server ONLY (no write, no other repo), add it as
+# ADMIN_CONTRACT_READ_TOKEN, and refresh .github/known-secrets.txt. A classic
+# broad-scope PAT here would be a real downgrade and must not be used. If this
+# is still absent weeks from now, the honest move is to disable the step and say
+# so, not to leave a permanent red teaching people to scroll past the job.
+ADMIN_CONTRACT_READ_TOKEN   # SEC-143 step fails closed naming the cause until provisioned (SEC-150)

--- a/.github/workflows/backup-restore-test.yml
+++ b/.github/workflows/backup-restore-test.yml
@@ -132,6 +132,59 @@ jobs:
           SQL
           echo "✓ shim ready"
 
+      - name: Seed auth.users so the dump's FK constraints can validate
+        run: |
+          set -euo pipefail
+          # WHY THIS EXISTS (added 2026-08-16, first red drill since June).
+          #
+          # The dump is public-schema-only, so every FK pointing at
+          # auth.users(id) has no target row. `session_replication_role =
+          # replica` in the restore step defers TRIGGER firing on DML — it does
+          # NOT defer constraint validation, and `ALTER TABLE ... ADD CONSTRAINT
+          # ... FOREIGN KEY` runs a full validation scan regardless. So the
+          # seven FK constraints below simply FAILED TO BE CREATED:
+          #
+          #   profiles, api_keys, moderation_logs, oauth_access_tokens,
+          #   oauth_authorization_codes, oauth_consents, oauth_refresh_tokens
+          #
+          # The drill passed every week from June to 2026-08-09 anyway, because
+          # nothing ever asserted that constraints survive a restore — it went
+          # red on 08-16 only once enough referencing rows accumulated to also
+          # disturb one of the counts. A restore that silently dropped EVERY
+          # foreign key would have reported success. That blind spot is the real
+          # finding; the assertion added below closes it.
+          #
+          # Seeding stands in for what a real recovery does: auth.users is
+          # restored from Supabase's own auth backup, not from this dump. The
+          # shim's own comment already calls itself "what a clean-room restore
+          # must provide beyond the public dump" — this is that, made true.
+          #
+          # ⚠️ It does NOT close the SEC-23 gap. This dump still contains no
+          # auth data, and that remains tracked there. Seeding makes the drill
+          # measure what it claims to measure; it does not make the backup
+          # complete.
+          #
+          # Every UUID in the dump is seeded rather than only the FK columns:
+          # over-seeding a throwaway auth.users cannot mask a public-schema
+          # defect (nothing asserts auth.users' contents), whereas parsing
+          # per-column would be fragile against dump layout changes.
+          grep -oEi '[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}' "$SQL_FILE" \
+            | sort -u > /tmp/uuids.txt
+          SEEDED=$(wc -l < /tmp/uuids.txt | tr -d ' ')
+          if [ "$SEEDED" -eq 0 ]; then
+            echo "::error::No UUIDs found in the dump — it is empty or malformed, so the"
+            echo "::error::  drill cannot prove anything. Failing rather than seeding nothing."
+            exit 1
+          fi
+          {
+            echo "BEGIN;"
+            echo "CREATE TEMP TABLE _seed(id uuid);"
+            echo "\\copy _seed(id) FROM '/tmp/uuids.txt'"
+            echo "INSERT INTO auth.users(id) SELECT id FROM _seed ON CONFLICT DO NOTHING;"
+            echo "COMMIT;"
+          } | psql "$PGURL" -v ON_ERROR_STOP=1 >/dev/null
+          echo "✓ seeded $SEEDED candidate auth.users ids so FK constraints can validate"
+
       - name: Restore the backup
         run: |
           set -euo pipefail
@@ -192,6 +245,33 @@ jobs:
             echo "- ✅ tables: $GOT_TABLES restored (dump declares $EXPECT_TABLES)" >> "$GITHUB_STEP_SUMMARY"
           else
             echo "- ❌ tables: restored $GOT_TABLES but dump declares $EXPECT_TABLES" >> "$GITHUB_STEP_SUMMARY"
+            FAIL=1
+          fi
+
+          # Foreign keys must survive a restore (added 2026-08-16).
+          #
+          # Nothing checked this until now, and that is exactly how the drill
+          # reported success for months while SEVEN FK constraints were failing
+          # to be created on every single run. Referential integrity is not a
+          # detail of a backup — a restored database that has lost its foreign
+          # keys will happily accept orphaned rows, and the damage is silent and
+          # cumulative. A drill that does not check the constraints is not
+          # proving the backup is restorable, only that the bytes load.
+          # Match the statement pg_dump actually emits, not the bare words:
+          #   ALTER TABLE ONLY public.x
+          #       ADD CONSTRAINT x_fkey FOREIGN KEY (col) REFERENCES ...;
+          # `ADD CONSTRAINT … FOREIGN KEY` is one line and is unambiguous. A
+          # looser 'FOREIGN KEY' would also match prose in comments and any
+          # inline table definition, and an over-count here would invent a red
+          # drill — the precise failure this change exists to remove.
+          EXPECT_FK=$(grep -cE 'ADD CONSTRAINT .* FOREIGN KEY' "$SQL_FILE" || true)
+          GOT_FK=$(psql "$PGURL" -X -t -A -c \
+            "SELECT count(*) FROM pg_constraint c JOIN pg_namespace n ON n.oid=c.connamespace WHERE c.contype='f' AND n.nspname='public'")
+          if [ "${EXPECT_FK:-0}" -gt 0 ] && [ "$GOT_FK" -eq "$EXPECT_FK" ]; then
+            echo "- ✅ foreign keys: $GOT_FK restored (dump declares $EXPECT_FK)" >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "- ❌ foreign keys: restored $GOT_FK but dump declares ${EXPECT_FK:-0} — the restored" >> "$GITHUB_STEP_SUMMARY"
+            echo "  database has lost referential integrity and would accept orphaned rows." >> "$GITHUB_STEP_SUMMARY"
             FAIL=1
           fi
 

--- a/.github/workflows/db-invariants.yml
+++ b/.github/workflows/db-invariants.yml
@@ -177,9 +177,21 @@ jobs:
         env:
           PROD_SUPABASE_URL: ${{ secrets.PROD_SUPABASE_URL }}
           PROD_SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.PROD_SUPABASE_SERVICE_ROLE_KEY }}
-          # Same mechanism CTL-043 uses for its cross-repo reads — the built-in
-          # token, no new secret provisioned anywhere.
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # ⚠️ CORRECTED 2026-08-16. This said "same mechanism CTL-043 uses for
+          # its cross-repo reads — the built-in token, no new secret provisioned
+          # anywhere", and that is why this step had never once succeeded.
+          #
+          # CTL-043's target (lyra-mcp-server) is PUBLIC, which is the whole
+          # reason the built-in token reaches it — shared-code-manifest.json
+          # records that precondition explicitly. lyra-admin-mcp-server is
+          # PRIVATE, and a workflow's GITHUB_TOKEN is scoped to its own
+          # repository, so it can never read it. The mechanism was copied
+          # without the precondition that made it valid.
+          #
+          # ADMIN_CONTRACT_READ_TOKEN is the fix. Until it exists the step fails
+          # closed and names the gap — which is honest, but is not the control
+          # running. Tracked in SEC-150.
+          GH_TOKEN: ${{ secrets.ADMIN_CONTRACT_READ_TOKEN || secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
           rc=0

--- a/docs/RUNBOOK.md
+++ b/docs/RUNBOOK.md
@@ -390,8 +390,25 @@ reconstruct user accounts (`auth`) — restoring it alone leaves profiles whose
   GitHub Artifacts, 90-day retention.
 - **Weekly real restore drill**: `backup-restore-test.yml` (Sun 05:00 UTC) now
   restores the latest backup into a throwaway Postgres and asserts the data
-  round-trips (table count + RLS + per-table row counts) — it is no longer a
-  schema-only check, and no longer silently passes on a missing secret.
+  round-trips (table count + RLS + per-table row counts + **foreign keys**) — it
+  is no longer a schema-only check, and no longer silently passes on a missing
+  secret.
+
+  ⚠️ **The FK assertion was added 2026-08-16, and it closed a real blind spot.**
+  The dump is public-schema-only, so every FK pointing at `auth.users(id)` had
+  no target row, and `ALTER TABLE … ADD CONSTRAINT … FOREIGN KEY` validates on
+  creation — `session_replication_role = replica` defers trigger firing on DML
+  but *not* constraint validation. So seven constraints (`profiles`, `api_keys`,
+  `moderation_logs`, and the four `oauth_*` tables) failed to be created on
+  **every run**, and the drill passed anyway from June to 2026-08-09 because
+  nothing checked. A restore that dropped every foreign key would have reported
+  success. The drill now seeds `auth.users` from the UUIDs the dump references —
+  standing in for restoring auth from Supabase's own backup, which is what a
+  real recovery does — and then asserts the constraint count matches the dump.
+
+  This does **not** close the SEC-23 gap: the dump still contains no auth data.
+  Seeding makes the drill measure what it claims to measure; it does not make
+  the backup complete.
 - Manually trigger any of these: GitHub → Actions → select workflow → Run.
 
 ### Supabase built-in backups
@@ -549,6 +566,26 @@ columns were live on all three databases and absent from all three snapshots.
 | **CTL-036** (`check-schema-type-parity.py`, every PR) | the three snapshots **to each other** | all three stale the same way — no *relative* drift to find |
 | **CTL-048 full** (`promote-to-staging.yml`) | the databases to each other **and** each snapshot to its own database | nothing, but it only runs on a promote |
 | **CTL-048 `--snapshot-only`** (`db-invariants.yml`, daily 06:15 UTC) | each snapshot to **its own** database | cross-environment drift — deliberately, see below |
+
+> ⚠️ **The SEC-143 admin schema-contract step in this same workflow is currently
+> INERT, and its daily red is not a schema finding.** It reads
+> `lyra-admin-mcp-server`'s committed contract with the workflow's built-in
+> `GITHUB_TOKEN` — which is scoped to *this* repository and can never read
+> another **private** repo. The step cites CTL-043 as precedent, but CTL-043
+> works precisely because *its* target is public, a precondition
+> `shared-code-manifest.json` records explicitly. So the check has never once
+> succeeded, and it has been red every day since it reached `main` on
+> 2026-08-15.
+>
+> **If you are triaging a red `db-invariants` run, read the step name before the
+> job name.** The job is called *"Committed schema snapshots match their
+> databases (CTL-048, daily)"*, so this failure looks like schema drift and is
+> not. CTL-048's own comparison passes; the admin-contract step is a separate
+> control sharing the job. Splitting them is tracked in
+> [SEC-150](https://checklyra.atlassian.net/browse/SEC-150), along with the fix:
+> provision `ADMIN_CONTRACT_READ_TOKEN` (fine-grained, contents-read, admin repo
+> only). The workflow already reads it when present, so no code change is
+> needed once it exists.
 
 The daily job runs only the snapshot half on purpose. During a staged migration
 rollout the three databases genuinely differ, so the cross-database half would

--- a/scripts/check-live-schema-parity.py
+++ b/scripts/check-live-schema-parity.py
@@ -189,9 +189,25 @@ ADMIN_CONTRACT_ENV = "prod"
 def fetch_admin_contract() -> str:
     """Read the admin repo's committed schema contract. Fails CLOSED.
 
-    Uses `gh api` for the same reason CTL-043 does: it needs no new secret, the
-    built-in GITHUB_TOKEN covers it, and the alternative (a PAT) would add a
-    credential to buy nothing.
+    ⚠️ CORRECTED 2026-08-16. This docstring previously said the check "needs no
+    new secret, the built-in GITHUB_TOKEN covers it, and the alternative (a PAT)
+    would add a credential to buy nothing", citing CTL-043 as precedent.
+
+    **That was wrong, and it is why this check has never once succeeded.**
+    CTL-043 works because its target is PUBLIC — `shared-code-manifest.json`
+    records exactly that precondition next to the repo it names:
+
+        "public": true,
+        "note": "Public, so CI reads it with the built-in GITHUB_TOKEN."
+
+    `lyra-admin-mcp-server` is PRIVATE, and a workflow's built-in GITHUB_TOKEN is
+    scoped to the repository it runs in — it cannot read a different private
+    repo, ever. The mechanism was copied without the precondition that made it
+    valid, so the step went red the day it reached `main` and stayed red.
+
+    Set `ADMIN_CONTRACT_READ_TOKEN` (a token that can read the admin repo's
+    contents) to make this work. Until then it fails closed and says so, which
+    is correct but is NOT the same as the control running.
     """
     try:
         res = subprocess.run(
@@ -204,6 +220,19 @@ def fetch_admin_contract() -> str:
         raise AdminContractUnavailable(f"{type(exc).__name__}: {exc}") from exc
     if res.returncode != 0 or not res.stdout.strip():
         detail = res.stderr.strip()[:300] or f"exit {res.returncode}"
+        # Distinguish "not authorised to read a private repo" from every other
+        # read failure. GitHub returns 404 (not 403) for a private repo the
+        # credential cannot see, so "Not Found" here does NOT mean the file was
+        # deleted — and sending the operator to look for a missing file, or at
+        # the PROD_SUPABASE_* secrets, is the wrong direction entirely.
+        if "404" in detail or "Not Found" in detail or "403" in detail:
+            raise AdminContractUnavailable(
+                f"cannot read {ADMIN_REPO} ({detail.splitlines()[0][:120]}). That repo is "
+                "PRIVATE, and a workflow's built-in GITHUB_TOKEN is scoped to its own "
+                "repository — it can never read another private repo. Provide a token that "
+                "can (ADMIN_CONTRACT_READ_TOKEN). This is an authorisation gap, not a "
+                "missing file and not a database problem."
+            )
         raise AdminContractUnavailable(detail)
     try:
         return base64.b64decode(res.stdout.strip()).decode("utf-8")
@@ -618,7 +647,12 @@ def main() -> int:
                 "::error::  This is NOT a drift finding. Nothing has been compared, so do "
                 "not go looking for a stale column: the file could not be fetched at all."
             )
-            print("::error::  Check `gh auth status` and that GITHUB_TOKEN can read that repo.")
+            print(
+                "::error::  Fix: set ADMIN_CONTRACT_READ_TOKEN to a token that can read "
+                f"{ADMIN_REPO} contents. The built-in GITHUB_TOKEN cannot — it is scoped to "
+                "this repository, and that repo is private. CTL-043 gets away with the same "
+                "mechanism only because ITS target is public, which its manifest records."
+            )
             return 2
         violations += compare_admin_contract(contract_text, prod)
 


### PR DESCRIPTION
## Summary

Reviewed every scheduled routine. **12 of 14 are green.** The two red ones were investigated to root cause — neither is flaky, and both were reporting correctly on something genuinely wrong. In each case the interesting part is not the red but what the red revealed.

| routine | state | finding |
|---|---|---|
| Database Security Invariants | red daily since 08-15 | the SEC-143 admin-contract check **has never once worked** |
| Weekly Backup Restore Drill | first red since June | **7 FK constraints have never restored** — and nothing checked |
| other 12 | green | — |

## 1. Database Security Invariants — a misread precedent

SEC-143 ([#797](https://github.com/luisa-sys/lyra/pull/797)) added a step reading `lyra-admin-mcp-server`'s schema contract with the workflow's built-in `GITHUB_TOKEN`, with the comment *"Same mechanism CTL-043 uses for its cross-repo reads — the built-in token, no new secret provisioned anywhere."*

**CTL-043 works because its target is public**, and `shared-code-manifest.json` records that precondition right next to the repo it names:

```json
"lyra-mcp-server": { "public": true,
  "note": "Public, so CI reads it with the built-in GITHUB_TOKEN. No new secret." }
```

Verified via the API: `lyra` and `lyra-mcp-server` are **public**; `lyra-admin-mcp-server` is **private**. A workflow's `GITHUB_TOKEN` is scoped to its own repository and can never read another private repo. The mechanism was copied without the condition that made it valid, so the step went red the day it reached `main` and cannot self-heal.

**Worse than the red was the misdirection.** GitHub returns **404**, not 403, for a private repo a credential cannot see — so the generic handler read it as a deleted file, and the operator guidance said *"check gh auth and the `PROD_SUPABASE_*` secrets"*. Nothing about the database is involved.

Fixed: the false claim corrected in both the docstring and the workflow comment; the 404/403 case classified and explained precisely; the step now reads `ADMIN_CONTRACT_READ_TOKEN` when present. Until that secret exists it **still fails closed** — honest, but not the control running. Tracked as **SEC-150**.

## 2. Weekly Backup Restore Drill — and the blind spot is the real finding

The dump is public-schema-only, so every FK pointing at `auth.users(id)` has no target row. `session_replication_role = replica` defers **trigger** firing on DML but does **not** defer constraint validation, and `ALTER TABLE … ADD CONSTRAINT … FOREIGN KEY` runs a validation scan regardless. So these failed to be created on **every run**:

`profiles` · `api_keys` · `moderation_logs` · `oauth_access_tokens` · `oauth_authorization_codes` · `oauth_consents` · `oauth_refresh_tokens`

> ⚠️ **The drill passed anyway, weekly, from June to 2026-08-09.** Nothing asserted that constraints survive a restore, so **a restore that dropped every foreign key would have reported success**. It only turned red on 08-16 once enough referencing rows accumulated to also disturb one of the counts. The red is not the problem; it is what finally exposed the problem.

Two changes:

**(a) Seed `auth.users` from the UUIDs the dump references, before restore.** This is what a real recovery does — auth is restored from Supabase's own auth backup, not from this dump — and the shim already describes itself as *"what a clean-room restore must provide beyond the public dump"*. This makes that true. It **does not** close the SEC-23 gap: the dump still carries no auth data, which stays tracked there. Fails loudly if the dump yields zero UUIDs, rather than seeding nothing and proving nothing.

**(b) Assert FK constraints survive the restore**, comparing `pg_constraint` against the dump. Referential integrity is not a detail of a backup — a restored database missing its foreign keys accepts orphaned rows, silently and cumulatively.

## Verification

- Both YAML files parse; `check-workflow-integrity`, `check-bash-portability`, `check-live-schema-parity --self-test` all exit 0.
- Each shell fragment exercised against a realistic pg_dump sample rather than reasoned about:
  - UUID extraction recovers **exactly the two user ids from the live failure** (`43ac6e86…`, `bbc4fce3…`).
  - FK count: the precise `ADD CONSTRAINT .* FOREIGN KEY` pattern counts **2**; a bare `FOREIGN KEY` counts **3**, because it also matches a comment. **An over-count would have invented a red drill** — the exact failure this change exists to remove.
  - The empty-dump guard fires on an empty file.

## Also checked, and not a problem

The **08-14** db-invariants failure was a *different* cause — CTL-049 ledger parity, the already-tracked intermittent 403 — and has since self-resolved (08-15 and 08-16 both pass that job). I nearly conflated the two into one story; they are unrelated.

I also nearly reported this as a promotion-lag issue (gotcha #1), on the reasoning that it fails on `main` and succeeded on `develop`. **That was wrong** — the workflow file is byte-identical on both branches, and the `develop` run simply predated the commit that added the step.

## ⚠️ Not done here, deliberately

The admin-contract step still lives inside the CTL-048 job, so its red reads as *"schema snapshots don't match"* when CTL-048's own checks passed. Splitting it into its own job is right, but a larger edit than this fix warrants. Noted on SEC-150.

## Jira Ticket

SEC-143, SEC-23 (and SEC-150, raised from this work)

## Checklist

- [x] Unit tests added/updated — **N/A**: the changes are workflow shell and one script's error classification. Each fragment was instead exercised against a sample dump (results above); `check-live-schema-parity --self-test` covers the script and passes
- [x] All existing tests pass — guards re-run: workflow-integrity, bash-portability, schema-parity self-test all exit 0
- [x] Lint / type check — **N/A**: no `src/` change
- [ ] Build succeeds — **N/A**: no application code touched
- [x] Coverage has not decreased — no test removed or weakened; the drill gains an assertion it never had
- [x] No eslint-disable or ts-ignore — none added
- [x] Dependency-rule gate reviewed — **N/A**, no imports change
- [x] ARCHITECTURE.md updated — **N/A**: no service, route, env var or schedule changes. One new *optional* secret (`ADMIN_CONTRACT_READ_TOKEN`) is documented inline where it is read and on SEC-150
- [x] Ops routine / Control-Room registry updated — **N/A**: no routine's behaviour, cadence or ownership changes. Both keep their schedules; one stops misdirecting and one stops overstating
- [x] Docs / system map updated — **N/A with reason**: CI-only. The corrections live next to the code that was wrong, which is where the next reader will be
- [x] Design loop (KAN-441) — **N/A**: touches no founder-owned UI/copy path

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015ztw7gfb4CLL2LGvsvMCZq

---
_Generated by [Claude Code](https://claude.ai/code/session_015ztw7gfb4CLL2LGvsvMCZq)_