### PR TITLE
docs(KAN-466): put lyra-admin-mcp-server on the system map, with a control that keeps it there

### DIFF
--- a/controls/registry.json
+++ b/controls/registry.json
@@ -1202,6 +1202,22 @@
       ],
       "escape_hatch": "none for the --local arm - a required context nothing produces is never acceptable; either restore the job name, or change .github/expected-protection.json AND the live branch protection together, which is the point (protection becomes reviewable). The --live arm's only 'hatch' is exit 2 UNVERIFIED when no token with administration:read is present, which is a loud daily red rather than a pass, and is cleared by provisioning BRANCH_PROTECTION_READ_TOKEN.",
       "added": "2026-08-15"
+    },
+    {
+      "id": "CTL-068",
+      "name": "security-lockdown inventory agrees with itself and with its checklist",
+      "defect_class": "estate-inventory-drift",
+      "summary": "KAN-466: lyra-admin-mcp-server - a deployed Railway service holding the PROD Supabase service-role key, able to suspend users and override age status - appeared in no inventory in docs/ at all. Two independent things made that invisible. (1) The enumeration of lockdown services and the '7 services to verify (KAN-24)' count are written in two different places by hand and nothing compared them, so adding a service and forgetting the count, or the reverse, reads as complete. (2) A provider entry can claim coverage its checklist does not deliver: docs/CYBER_LOCKDOWN.md SS Railway named lyra-mcp-server as THE service while three exist, so the highest-privilege surface on the platform sat inside the inventory entry that was supposed to cover it and outside every checklist item. That is the SEC-79 presence-badge shape one level down - the badge is on the provider and the hole is inside it, which is exactly what a per-entry existence check would miss. The control parses the enumeration rather than restating it (a copy in the test is a copy that drifts), asserts the corpus is non-empty before iterating it (catalogue failure mode 4), requires a checklist section per enumerated provider, and requires SS Railway to name all three deployed services plus the admin-specific edge controls (admin-mcp.checklyra.com, ALLOW_CF_ACCESS_OFF) - so 'covered under Railway' is a claim the build can check. Mutation-proven in three directions: reverting SS Railway to one service, bumping the stated count without touching the enumeration, and dropping the repo name from the ARCHITECTURE.md heading each redden exactly one case.",
+      "implementation": "tests/unit/lockdown-inventory-consistency.test.js",
+      "kind": "test",
+      "wired_in": [
+        ".github/workflows/pr-checks.yml"
+      ],
+      "prevents": [
+        "KAN-466"
+      ],
+      "escape_hatch": "none - the inventory, its count and its checklist are three statements of one fact; if they disagree one of them is wrong. A service that genuinely needs no checklist belongs outside the inventory, recorded with its reason (the Claude Design / KAN-441 precedent in ARCHITECTURE.md).",
+      "added": "2026-08-16"
     }
   ]
 }

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -164,6 +164,21 @@ reachable only through a denylisted action.
 - **Endpoint**: https://mcp.checklyra.com/mcp
 - **Dev Endpoint**: https://mcp-dev.checklyra.com/mcp (points to dev Supabase)
 
+### Admin MCP Server (lyra-admin-mcp-server)
+- **Framework**: TypeScript, Express, @modelcontextprotocol/sdk
+- **Hosting**: Railway — its **own service**, separate from the user-facing MCP for blast-radius isolation (KAN-323)
+- **Repository**: https://github.com/luisa-sys/lyra-admin-mcp-server (**private**, branch `main`)
+- **Endpoint**: https://admin-mcp.checklyra.com/mcp — points at **prod** Supabase
+- **Purpose**: the high-privilege admin surface — suspend/unpublish users, per-user feature entitlements, beta approval, access stage, age-status override. Every mutation is audited to `moderation_logs` **before** it is applied; if the audit write fails, the action aborts.
+- **Access control**, four layers deep, because the server holds the Supabase service-role key and so bypasses RLS:
+  1. **Cloudflare Access + IP allow-list** at the edge. Verified live: an unauthenticated `GET /health` returns `401` with `WWW-Authenticate: Bearer realm="OAuth" … resource_metadata=…/cloudflare-access-protected-resource/health`.
+  2. **App-layer Access verification** (`src/cf-access.ts`) — the origin re-verifies the `Cf-Access-Jwt-Assertion` JWT against the team JWKS, so a request that reaches Railway directly is still refused. In production the server **refuses to boot** with this off unless `ALLOW_CF_ACCESS_OFF=true` is set (first deploy only).
+  3. **Admin gate** (`src/admin-auth.ts`) — a live DB read requiring `is_admin = true` and not suspended, mirroring the web `getCurrentAdmin()`.
+  4. **Audit-first wrapper**, asserted by a positive registry test: a new mutating tool that forgets the wrapper fails that repo's CI.
+- **Deploy**: push to `main` → Railway auto-deploys (same model as `lyra-mcp-server`; "Wait for CI" must stay **OFF** — BUGS-18/BUGS-54). Its Railway project is `resilient-commitment`.
+- **Lockdown scope**: covered under **Railway** in `docs/CYBER_LOCKDOWN.md`, not as a separate inventory entry — see "Service inventory for security lockdown" below.
+- ⚠️ **The repo's own `README.md` still says "It is not deployed yet"**. That is stale as of 2026-08-16: the endpoint is live behind Cloudflare Access (evidence above). Fixing that line is a change in the admin repo, tracked separately (KAN-466).
+
 ### Database
 - **Provider**: Supabase Pro (PostgreSQL 17)
 - **Region**: EU West (Ireland)
@@ -183,7 +198,7 @@ reachable only through a denylisted action.
 ### DNS & CDN
 - **Provider**: Cloudflare
 - **Domain**: checklyra.com
-- **Subdomains**: dev.checklyra.com, stage.checklyra.com, mcp.checklyra.com, mcp-dev.checklyra.com, **admin.checklyra.com**
+- **Subdomains**: dev.checklyra.com, stage.checklyra.com, mcp.checklyra.com, mcp-dev.checklyra.com, **admin.checklyra.com**, **admin-mcp.checklyra.com** (Cloudflare Access in front — see "Admin MCP Server")
 
 ## Environments
 
@@ -348,9 +363,17 @@ All operations run via GitHub Actions — no local machine needed:
 - Cloud workflows: fail the job and do not proceed; manual intervention required
 
 ### MCP Server Deployment
-- Railway auto-deploys on push to lyra-mcp-server main branch
-- No staging environment for MCP server (single environment)
-- Health check: GET https://mcp.checklyra.com/health
+There are **three** Railway services deploying MCP code, not one:
+
+| Service | Repo | Supabase | Health check |
+|---|---|---|---|
+| `lyra-mcp-server` (prod) | `luisa-sys/lyra-mcp-server` `main` | prod-lyra | `GET https://mcp.checklyra.com/health` → 200 |
+| `lyra-mcp-dev` | `luisa-sys/lyra-mcp-server` `main` | dev-lyra | `GET https://mcp-dev.checklyra.com/health` → 200 |
+| `lyra-admin-mcp-server` | `luisa-sys/lyra-admin-mcp-server` `main` | prod-lyra | `GET https://admin-mcp.checklyra.com/health` → **401** (Cloudflare Access) |
+
+- All three auto-deploy on push to `main`. **"Wait for CI" must stay OFF on every one of them** — turning it on wedges the deploy on unresolved third-party check suites (BUGS-18, recurred as BUGS-54).
+- No staging environment for any MCP service (single environment each).
+- ⚠️ The admin service's health check is **401 by design**, not a failure: Cloudflare Access refuses the unauthenticated request before it reaches the origin. A monitor that treats non-200 as down will report it permanently red.
 
 ## Database Schema
 
@@ -418,7 +441,7 @@ All operations run via GitHub Actions — no local machine needed:
 | Vercel | Web hosting, CDN, serverless | luisa-sys-projects |
 | Supabase | Database, auth | ilprytcrnqyrsbsrfujj |
 | Cloudflare | DNS, SSL, CDN proxy | checklyra.com zone |
-| Railway | MCP server hosting | lyra-mcp-server |
+| Railway | MCP server hosting — **three** services: `lyra-mcp-server` (prod), `lyra-mcp-dev`, `lyra-admin-mcp-server` (admin surface, project `resilient-commitment`) | luisa-sys |
 | GitHub | Source code, CI/CD, secrets | luisa-sys |
 | Atlassian/Jira | Project management | checklyra.atlassian.net |
 | Claude Design | Design source of truth for UI changes — tokens + per-ticket before/after cards (KAN-441) | Projects `e4682889-…` (Lyra Design System) and `c179aa52-…` (Lyra Web Design) |
@@ -499,6 +522,25 @@ gap recorded above.
 > projects) and record any credential it holds in `docs/SECURITY_ROTATION.md`;
 > then add it here and move the KAN-24 count to 8. **No ticket tracks this yet —
 > one needs raising.**
+
+**`lyra-admin-mcp-server` is covered by the `Railway` entry, and the count stays
+7 (KAN-466).** The decision, recorded so it is not re-litigated: this inventory
+enumerates **providers** — the accounts whose console holds a 2FA setting, an
+access list and an API token — not individual deployed services. Supabase is one
+entry for three projects; Railway is one entry for three services. The admin MCP
+adds no new provider, so adding a row would inflate the KAN-24 count without
+adding a console to audit.
+
+That is only honest if the Railway checklist actually covers all three services,
+which is the gap this ticket found: `docs/CYBER_LOCKDOWN.md` §Railway named
+`lyra-mcp-server` as *the* service and scoped its auto-deploy check to that repo
+alone, so the **highest-privilege surface on the platform** sat outside the
+checklist behind the inventory entry that claimed to cover it. §Railway now
+enumerates all three and carries the admin-specific items (sealed prod
+service-role key, Cloudflare Access + IP allow-list, `ALLOW_CF_ACCESS_OFF`
+removed after first deploy). Coverage-by-provider is the rule; a provider entry
+whose checklist names one of its services is the same presence badge in a
+different shape.
 
 
 ### Token rotation

--- a/docs/CYBER_LOCKDOWN.md
+++ b/docs/CYBER_LOCKDOWN.md
@@ -96,14 +96,34 @@ For each project:
 
 ## Railway
 
-**Console:** <https://railway.com/dashboard>  •  **Service:** `lyra-mcp-server`
+**Console:** <https://railway.com/dashboard>  •  **Services (3):** `lyra-mcp-server` (prod, project `elegant-tranquility`), `lyra-mcp-dev` (project `overflowing-laughter`), `lyra-admin-mcp-server` (project `resilient-commitment`)
+
+Railway is one provider entry covering three deployed services — see
+`docs/ARCHITECTURE.md` → "Service inventory for security lockdown" for why the
+inventory counts providers rather than services. **Every item below is per
+service**; tick it three times, not once.
 
 - [ ] **2FA on the owning Railway account**
-- [ ] **Project access reviewed**
-- [ ] **Env vars sealed** — `SUPABASE_URL`, `SUPABASE_SERVICE_ROLE_KEY` for prod-lyra MUST be marked sealed (one-way write)
-- [ ] **Auto-deploy source restricted** — only from `main` of `luisa-sys/lyra-mcp-server`, no fork PRs
+- [ ] **Project access reviewed** — on all three projects
+- [ ] **Env vars sealed** — `SUPABASE_URL`, `SUPABASE_SERVICE_ROLE_KEY` for prod-lyra MUST be marked sealed (one-way write) on **both** prod-pointing services (`lyra-mcp-server`, `lyra-admin-mcp-server`)
+- [ ] **Auto-deploy source restricted** — only from `main` of the service's own repo (`luisa-sys/lyra-mcp-server` for the two user-facing services, `luisa-sys/lyra-admin-mcp-server` for the admin one), no fork PRs
+- [ ] **"Wait for CI" is OFF on all three** — on means Railway waits for third-party check suites that may never resolve, and deploys silently report `SKIPPED` (BUGS-18, recurred as BUGS-54). Verify per service; it is a per-service trigger setting.
 - [ ] **API token rotated** quarterly per `SECURITY_ROTATION.md`
 - [ ] **Cost / usage alert** set so a runaway loop doesn't silently bill out
+
+### `lyra-admin-mcp-server` — additional items (KAN-323 / KAN-466)
+
+This is the **highest-privilege surface on the platform**: it holds the prod
+service-role key (so it bypasses RLS) and can suspend users, unpublish profiles,
+grant feature entitlements and override age status. It is a separate Railway
+service specifically so its blast radius is separate.
+
+- [ ] **Cloudflare Access application** exists in front of `admin-mcp.checklyra.com`, with an explicit allowed-identity list (not "anyone in the org")
+- [ ] **IP allow-list** attached to that Access policy
+- [ ] **`ALLOW_CF_ACCESS_OFF` is absent** from the service's variables — it is a first-deploy-only escape hatch, and while it is set the origin accepts requests that never passed the CF edge
+- [ ] **`CF_ACCESS_TEAM_DOMAIN` + `CF_ACCESS_AUD` are set**, so app-layer Access verification is ON (boot log reads `Cloudflare Access app-layer verification: ON`)
+- [ ] **Verified from outside**: `curl -sS -o /dev/null -w '%{http_code}' https://admin-mcp.checklyra.com/health` returns **401**, not 200. A 200 means the edge is not enforcing.
+- [ ] **`admin.checklyra.com` and `admin-mcp.checklyra.com` are distinct surfaces** — the first is the web back-office, the second this MCP service; confirm each has its own Access policy
 
 ## Google Cloud Console
 
@@ -195,7 +215,8 @@ Append a row each time the full pass is completed:
 
 - KAN-36 — Cybersecurity (broad backlog)
 - KAN-90 — Google Cloud + Apple OAuth dashboards (this doc's primary trigger)
-- KAN-24 — 2FA audit across all services
+- KAN-24 — 2FA audit across all services (7 providers — see `docs/ARCHITECTURE.md` → "Service inventory for security lockdown")
+- KAN-323 / KAN-466 — `lyra-admin-mcp-server`: the admin MCP service and its lockdown coverage under §Railway
 - KAN-125 — Move Google OAuth consent screen to Production (gated by removing Cloudflare lockdown)
 - KAN-85 — Replace staging Vercel SSO with Cloudflare Access
 - `docs/SECURITY_ROTATION.md` — secrets inventory + rotation cadence + emergency playbook

--- a/tests/support/test-floor-baseline.json
+++ b/tests/support/test-floor-baseline.json
@@ -1,6 +1,6 @@
 {
   "$comment": "GENERATED — regenerate with `npm run gen:test-floor`. The enforced test floor. The guard fails if the counts DROP (a test was deleted) and also if they RISE (this baseline is stale and is overstating how much of the estate is actually protected). The rise case is the one that matters: the previous hand-maintained floor sat at 29 files / 320 blocks against an actual 260 / 2963, so ~89% of the tests could have been deleted silently. Raise it in the SAME commit as any net-new test.",
   "measured_at": "2026-08-16",
-  "test_files": 304,
-  "test_blocks": 3512
+  "test_files": 305,
+  "test_blocks": 3517
 }

--- a/tests/unit/lockdown-inventory-consistency.test.js
+++ b/tests/unit/lockdown-inventory-consistency.test.js
@@ -1,0 +1,111 @@
+/**
+ * KAN-466 — the security-lockdown inventory must agree with itself.
+ *
+ * The drift this ticket was raised from: `lyra-admin-mcp-server` is a deployed,
+ * prod-service-role-holding, highest-privilege service that appeared in NO
+ * inventory in docs/. Two failures made that possible and neither could go red:
+ *
+ *  1. The inventory line in ARCHITECTURE.md and the "N services to verify
+ *     (KAN-24)" count are written in two places, by hand, and nothing compared
+ *     them. A ticket adding one and forgetting the other reads as complete.
+ *  2. A provider entry claimed coverage that its CYBER_LOCKDOWN.md checklist did
+ *     not deliver — §Railway named `lyra-mcp-server` as *the* service while three
+ *     exist. That is the SEC-79 presence-badge shape one level down: the badge is
+ *     on the provider, and the hole is inside it.
+ *
+ * So this asserts both directions of the claim ARCHITECTURE.md now makes:
+ * the inventory enumerates PROVIDERS, its stated count matches its enumeration,
+ * every enumerated provider has a checklist section, and the provider that
+ * absorbs an extra deployed service actually names that service.
+ *
+ * Mutation-proven (see the PR): reverting §Railway's service list to
+ * `lyra-mcp-server` alone reddens the coverage case; changing "7 services" to 8
+ * without touching the enumeration reddens the count case.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const ROOT = path.resolve(__dirname, '../..');
+const ARCH = fs.readFileSync(path.join(ROOT, 'docs/ARCHITECTURE.md'), 'utf8');
+const LOCKDOWN = fs.readFileSync(path.join(ROOT, 'docs/CYBER_LOCKDOWN.md'), 'utf8');
+
+/**
+ * The enumeration is the line immediately following the inventory heading.
+ * Parsed rather than restated here — a copy in the test is a copy that drifts.
+ */
+function inventoryEntries() {
+  const m = ARCH.match(
+    /^### Service inventory for security lockdown\n(.+)$/m
+  );
+  if (!m) throw new Error('inventory heading or its enumeration line not found in docs/ARCHITECTURE.md');
+  return m[1]
+    .split(',')
+    .map((s) => s.trim())
+    .filter(Boolean);
+}
+
+/** "Supabase (x3)" -> "Supabase"; "Atlassian/Jira" -> "Atlassian". */
+function providerName(entry) {
+  return entry.replace(/\s*\(.*?\)\s*/g, '').split('/')[0].trim();
+}
+
+const lockdownHeadings = LOCKDOWN.split('\n')
+  .filter((l) => l.startsWith('## '))
+  .map((l) => l.slice(3).trim());
+
+describe('security-lockdown inventory (KAN-466)', () => {
+  const entries = inventoryEntries();
+
+  // Failure mode 4: a parameterised test over an empty list registers nothing
+  // and an empty suite is green. Assert the corpus before iterating it.
+  test('the inventory enumerates a plausible number of providers', () => {
+    expect(entries.length).toBeGreaterThanOrEqual(5);
+  });
+
+  test('the stated KAN-24 count equals the number of enumerated providers', () => {
+    const m = ARCH.match(/2FA audit incomplete — (\d+) services to verify \(KAN-24\)/);
+    expect(m).not.toBeNull();
+    expect(Number(m[1])).toBe(entries.length);
+  });
+
+  test.each(entries)('provider %s has a checklist section in CYBER_LOCKDOWN.md', (entry) => {
+    const name = providerName(entry);
+    expect(name.length).toBeGreaterThan(0);
+    const matched = lockdownHeadings.filter((h) => h.startsWith(name));
+    expect(matched.length).toBeGreaterThan(0);
+  });
+
+  test('§Railway covers all three deployed Railway services, not just the user-facing one', () => {
+    const start = LOCKDOWN.indexOf('\n## Railway\n');
+    expect(start).toBeGreaterThan(-1);
+    const rest = LOCKDOWN.slice(start + 1);
+    const end = rest.indexOf('\n## ', 1);
+    const section = end === -1 ? rest : rest.slice(0, end);
+
+    // The admin MCP is in the lockdown estate BY BEING INSIDE THIS SECTION.
+    // If it is not named here, ARCHITECTURE.md's "covered under Railway"
+    // decision is a presence badge and the count of 7 is not honest.
+    for (const service of ['lyra-mcp-server', 'lyra-mcp-dev', 'lyra-admin-mcp-server']) {
+      expect(section).toContain(service);
+    }
+    // The admin service holds the prod service-role key and sits behind
+    // Cloudflare Access; a checklist that names it but never checks the edge
+    // is coverage in name only.
+    expect(section).toContain('admin-mcp.checklyra.com');
+    expect(section).toContain('ALLOW_CF_ACCESS_OFF');
+  });
+});
+
+describe('ARCHITECTURE.md knows lyra-admin-mcp-server exists (KAN-466)', () => {
+  test('it is a System Components entry with its own heading, not a passing mention', () => {
+    const headings = ARCH.split('\n').filter((l) => /^#{2,3} /.test(l));
+    expect(headings.some((h) => h.includes('lyra-admin-mcp-server'))).toBe(true);
+  });
+
+  test('the External Services Railway row names it', () => {
+    const row = ARCH.split('\n').find((l) => /^\| Railway \|/.test(l));
+    expect(row).toBeDefined();
+    expect(row).toContain('lyra-admin-mcp-server');
+  });
+});


### PR DESCRIPTION
## Summary

`lyra-admin-mcp-server` is a deployed Railway service holding the **prod** Supabase service-role key — it can suspend users, unpublish profiles, grant feature entitlements and override age status — and it appeared in **no inventory in `docs/` at all**. `grep -c admin-mcp docs/ARCHITECTURE.md` returned 0.

**Confirmed live before writing** (ticket step 1, which Luisa's 2026-08-14 review flagged as still outstanding): `GET https://admin-mcp.checklyra.com/health` returns **401** with `WWW-Authenticate: Bearer realm="OAuth" … resource_metadata=…/cloudflare-access-protected-resource/health`, served by Cloudflare. So the service is deployed **and** the Access edge is enforcing.

**`docs/ARCHITECTURE.md`**
- **System Components** gains an "Admin MCP Server" entry — repo, host, endpoint, the four access layers, the Railway project, the deploy path.
- **DNS & CDN** gains `admin-mcp.checklyra.com`.
- **External Services** — the Railway row named one service where three exist.
- **MCP Server Deployment** — a table of all three. Its health check is **401 by design**; a monitor treating non-200 as down reads it permanently red.

**Lockdown scope (ticket step 4) — the decision, recorded so it is not re-litigated.** The inventory enumerates **providers**, not services: Supabase is one entry for three projects, Railway one for three services. The admin MCP adds no new console to audit, so the **KAN-24 count stays 7** and no row is added.

That is only honest if the Railway checklist covers all three — and it did not. `CYBER_LOCKDOWN.md` §Railway named `lyra-mcp-server` as *the* service and scoped its auto-deploy item to that repo alone, so the highest-privilege surface sat **inside** the inventory entry claiming to cover it and **outside** every checklist item. That is the SEC-79 presence badge one level down: the badge is on the provider, the hole is inside it. §Railway now enumerates all three and carries admin-specific items (sealed prod key, CF Access + IP allow-list, `ALLOW_CF_ACCESS_OFF` removed after first deploy, an external 401 check).

**Acceptance criterion 3 was already met** — `SECURITY_ROTATION.md:24` records the `NPM_TOKEN` and already names this service. Not touched, so `check-secret-rotation.test.ts:63` is unaffected.

**Control: CTL-068** (`tests/unit/lockdown-inventory-consistency.test.js`, +12 tests). The count and the enumeration were two hand-written statements of one fact with nothing comparing them. It parses the enumeration rather than restating it, asserts the corpus is non-empty before iterating (catalogue failure mode 4), requires a checklist section per provider, and requires §Railway to name all three services plus the admin edge controls — so "covered under Railway" is a claim the build can check.

**Mutation-proven**, each mutation asserted to have applied before trusting the result:

| mutation | result |
|---|---|
| revert §Railway to one service | 1 red |
| bump "7 services" → 8 without touching the enumeration | 1 red |
| drop the repo name from the ARCHITECTURE.md heading | 1 red |
| restored | 12/12 green |

CTL-068 verified free by a positive-control scan across all **71** remote branch tips (`CTL-066` → 40 hits, `CTL-067` → 9, `CTL-068` → 0) — a registry uniqueness check cannot see a collision that exists only across unmerged branches.

**Two findings raised rather than fixed here** (both recorded on KAN-466):
1. The admin repo's own `README.md` still says *"It is not deployed yet"*. Stale — fixing it is a change in `luisa-sys/lyra-admin-mcp-server`, and merging there is a production Railway deploy.
2. The Confluence *Architecture & Infrastructure* mirror is outstanding (Documentation DoD).

## Jira Ticket

KAN-466

## Checklist

- [x] Unit tests added/updated for new/changed functionality — CTL-068, +12, mutation-proven three ways
- [x] All existing tests pass — targeted: `test-regression-guard`, `doc-dod`, `source-path-manifest-integrity`, CTL-068 → 255/255 green; CTL-038, CTL-039, CTL-047, control-registry and guard-path-drift guards all clean. Full `npm run test:unit` left to CI.
- [ ] Lint passes — not run locally (docs + one new test file, no `src/` change); CI is the check
- [ ] Type check passes — not run locally; no `.ts` source touched
- [ ] Build succeeds — not run locally; no `src/` change
- [x] Coverage has not decreased — net-new tests only; test floor regenerated in the same commit (305 files / 3517 blocks)
- [x] No eslint-disable or ts-ignore without KAN-XX reference — none added
- [x] Dependency-rule gate reviewed — N/A, no import graph change
- [x] ARCHITECTURE.md updated if architectural changes were made — this PR *is* that change
- [x] Ops routine / Control-Room registry updated — N/A: no scheduled-routine behaviour, cadence or ownership changed
- [x] Docs / system map updated — Architecture & Infrastructure changed here; **the Confluence mirror is outstanding and named on KAN-466**, stated rather than ticked silently
- [x] Design loop (KAN-441) — N/A: no user-facing page, look or wording touched. `check-ui-copy-ownership.sh --describe` was read at claim; nothing in this diff matches a PROTECTED glob (`docs/**` is outside the surface entirely), so no UI trailer is claimed.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Aithms4vGC8QRPfHg1ntMg)_