### PR TITLE
docs(BUGS-105): accept the build-time Google Fonts dependency, and record why

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1165,6 +1165,33 @@ These have caused real bugs. Read before making related changes:
 
     ⚠️ **The `--files` mode still fires on every workflow path**, because it has no diff to classify. That is the conservative answer, not an oversight — an undecidable file is never treated as exempt.
 
+34. **`Failed to fetch \`Inter\` from Google Fonts` means Google, not you — every build needs `fonts.gstatic.com`, and we have DECIDED to accept that (BUGS-105)**: `src/app/layout.tsx` uses `next/font/google`, which downloads the font files **at build time** and then self-hosts them. The self-hosting is the point of the API and it works — but the *build* has a hard dependency on `fonts.gstatic.com`, with no local fallback and no waiver mechanism.
+
+    When it fires you get eight URLs, three retries each, then:
+
+    ```
+    Failed to fetch font file from `https://fonts.gstatic.com/s/inter/v20/….woff2`.
+    Retrying 1/3...  Retrying 2/3...  Retrying 3/3...
+
+    Failed to compile.
+    src/app/layout.tsx
+    `next/font` error:
+    Failed to fetch `Inter` from Google Fonts.
+    > Build failed because of webpack errors
+    ```
+
+    The job dies in ~90 seconds having run no tests and uploaded no report. **Next's own retry budget is already exhausted, so a longer timeout does not help — re-run the job.** Observed once, 2026-08-16, on PR [#827](https://github.com/luisa-sys/lyra/pull/827) run [31971422543](https://github.com/luisa-sys/lyra/actions/runs/31971422543); green on re-run.
+
+    **DECIDED 2026-08-17 (Luisa): accept and document, do NOT self-host.** That is option (b) of BUGS-105, chosen *after* measuring what option (a) actually costs — the ticket's own premise turned out to be wrong in three ways, and all three are the reason:
+
+    - **`subsets: ["latin"]` controls PRELOADING, not downloading.** A baseline production build emits **7 woff2 files (224 KB) and 28 `@font-face` blocks** — all seven subsets, one per subset per weight — of which exactly one carries `.p` (preloaded). So `ł`, `ő`, `ğ`, Cyrillic and Greek all render in Inter today. Anyone "faithfully" self-hosting the latin subset would silently drop six subsets and regress how members' names render, which on this product is the worst possible thing to get wrong quietly.
+    - **Next generates a metric-matched fallback that hand-rolled CSS does not**: `@font-face{font-family:Inter Fallback;src:local("Arial");ascent-override:90.44%;descent-override:22.52%;line-gap-override:0.00%;size-adjust:107.12%}`. That is what stops text reflowing while the webfont loads. Losing it is a visible layout shift on every page — a real visual change, on founder-owned output.
+    - **`next/font/local` has no `unicode-range` support** (checked in the installed package), so the 7-subset arrangement cannot be expressed through it at all.
+
+    Self-hosting faithfully therefore means hand-writing 28 `@font-face` blocks plus those four override percentages into `globals.css` — replacing framework-generated output with hand-maintained constants, which is catalogue failure mode 8 wearing a different hat. Against a defect observed **once** and cleared by a re-run, that trade is not worth making.
+
+    **If this starts recurring, reopen BUGS-105 — but reopen it as a design card, not a build fix.** The work is 7 committed files, 28 blocks and 4 override values copied verbatim, before/after `@font-face` sets diffed, and the rendered output actually compared. ⚠️ It must **not** ride a `UI-No-Visual-Change:` trailer: on the evidence above that trailer would be false, and the whole point of SEC-152 adding that trailer was to stop people asserting things they had not checked.
+
 ## Supabase Migration Rules
 
 - Always test migrations on dev first, then staging, then production


### PR DESCRIPTION
## Summary

**Founder decision 2026-08-17 (Luisa): option (b) — accept and document.** Chosen *after* measuring what option (a) actually costs, which turned out to invalidate the ticket's own premise.

### The defect is real and stays

`next/font/google` downloads **at build time**, so `fonts.gstatic.com` is a hard precondition of every CI and Vercel build — no local fallback, no waiver mechanism. Observed once, on PR #827 run [31971422543](https://github.com/luisa-sys/lyra/actions/runs/31971422543): eight URLs, three retries each, build dead in ~90s having run no tests. Green on re-run.

Gotcha **#34** now names the exact error string — ``Failed to fetch `Inter` from Google Fonts`` — so the next person matches it in seconds instead of debugging webpack, and knows to re-run rather than chase a timeout (Next's own retry budget is already spent).

### Why not self-host — measured from a baseline production build

| finding | measured |
|---|---|
| `subsets: ["latin"]` controls **preloading**, not downloading | **7 woff2 files (224 KB), 28 `@font-face` blocks** — all seven subsets. Exactly one carries `.p` |
| Next generates a metric-matched fallback | `ascent-override:90.44%; descent-override:22.52%; line-gap-override:0.00%; size-adjust:107.12%; src:local("Arial")` |
| `next/font/local` unicode-range support | **none** — checked in the installed package |

**I had earlier claimed the opposite on the first point.** Acting on that belief would have shipped a four-file replacement that silently dropped six subsets — regressing how `ł`, `ő`, `ğ`, Cyrillic and Greek names render, on a product whose entire purpose is people's names. That is the worst possible thing to get wrong quietly, and it is why the baseline build happened before any code changed.

The fallback face is the other blocker: it's what stops text reflowing while the webfont loads. Hand-rolled `@font-face` doesn't produce it, so naive self-hosting introduces a **visible layout shift on every page**.

Faithful self-hosting therefore means hand-writing 28 `@font-face` blocks plus four override percentages into `globals.css` — framework-generated output replaced by hand-maintained constants, i.e. catalogue failure mode 8 in a new hat. Against a defect seen **once** and cleared by a re-run, that trade isn't worth making.

### What the gotcha commits us to

Reopening this is a **design card, not a build fix** — 7 committed files, 28 blocks and 4 override values copied verbatim, before/after `@font-face` sets diffed, rendered output actually compared.

⚠️ And explicitly: it must **not** ride a `UI-No-Visual-Change:` trailer. On this evidence that trailer would be false — which is exactly the assert-without-checking that SEC-152 added the trailer to prevent.

## Jira Ticket

BUGS-105

## Checklist

- [x] Unit tests added/updated — N/A, docs-only
- [x] All existing tests pass — **4100 / 306, unchanged**
- [x] Lint / type-check / build pass
- [x] Coverage has not decreased — no code changed
- [x] No eslint-disable or ts-ignore
- [x] Dependency-rule gate — no `src/` imports changed
- [x] ARCHITECTURE.md — N/A: no service, table, env var, route or security boundary change
- [x] Ops routine / Control-Room registry — N/A: no routine cadence or ownership change
- [x] Docs / system map — `CLAUDE.md` gotcha #34; commit carries `Docs-Updated: BUGS-105`
- [x] Design loop (KAN-441) — N/A, and deliberately so: this PR **declines** to touch founder-owned typography. No `src/` file is modified

---
_Generated by [Claude Code](https://claude.ai/code/session_015ztw7gfb4CLL2LGvsvMCZq)_