### PR TITLE
fix(BUGS-109): default CI dummy env vars for the e2e phase in weekly-health-regression.sh

### DIFF
--- a/scripts/weekly-health-regression.sh
+++ b/scripts/weekly-health-regression.sh
@@ -22,6 +22,18 @@
 #               dependency gate that blocks all PRs + the deploy chain is surfaced
 #               by the runner itself, not discovered by hand (SEC-91, 2026-07-22).
 #
+# The `e2e` phase defaults CI, E2E_LOCAL_SERVER and four dummy Supabase vars
+# (only when unset) to the exact values .github/workflows/e2e-tests.yml sets
+# for its "Playwright E2E (local build)" gate. Without them, `playwright.config.ts`
+# falls back to `npm run dev` and any route that calls `requireEnv()`
+# (src/modules/platform/env.ts) 500s with "Missing required environment
+# variable" — a local-environment gap, not a product regression, but one that
+# reads exactly like a real E2E FAIL until you notice the missing env vars.
+# Found the hard way during the 2026-08-19 weekly run: public-pages.spec.ts's
+# waitlist test failed locally on both browsers and passed 12/12 once these
+# were exported to match CI. Real secrets, if already exported, are never
+# overridden — these are non-secret CI dummies, safe to inline.
+#
 # Exit: 2 if any phase FAILs; 1 if any UNVERIFIED and no FAIL; 0 if all PASS.
 #
 # NB: `set -e` is off — we run EVERY phase and aggregate; nothing is swallowed.
@@ -49,7 +61,16 @@ cmd_for() {
   scripts)     echo "npm run test:scripts" ;;
   audit)       echo "npm audit --audit-level=high" ;;
   integration) echo "npm run test:integration" ;;
-  e2e)         echo "npm run test:e2e" ;;
+  # NB: no quotes around these values — $c is executed unquoted below ($c, not
+  # "$c"), so word-splitting is what tokenises this into argv for `env`. A
+  # quoted "${VAR:-default}" here would pass its literal quote characters
+  # through as PART OF THE VALUE (env sees NEXT_PUBLIC_SUPABASE_URL=`"https:...`"`,
+  # an invalid URL) rather than stripping them — quote-stripping only happens
+  # when a variable is *expanded*, not when it is merely word-split. Found by
+  # a webServer timeout that reproduced 100% via this script and 0% calling
+  # `npx playwright test` directly with the same values exported normally.
+  # Safe here because none of the six defaults contain whitespace.
+  e2e)         echo "env CI=${CI:-true} E2E_LOCAL_SERVER=${E2E_LOCAL_SERVER:-1} NEXT_PUBLIC_SUPABASE_URL=${NEXT_PUBLIC_SUPABASE_URL:-https://e2e-dummy.supabase.co} NEXT_PUBLIC_SUPABASE_ANON_KEY=${NEXT_PUBLIC_SUPABASE_ANON_KEY:-e2e-dummy-anon-key} SUPABASE_SERVICE_ROLE_KEY=${SUPABASE_SERVICE_ROLE_KEY:-e2e-dummy-service-role-key} NEXT_PUBLIC_SITE_URL=${NEXT_PUBLIC_SITE_URL:-http://localhost:3000} npm run test:e2e" ;;
   build)       echo "npm run build" ;;
   *)           echo "" ;;
 esac; }


### PR DESCRIPTION
## Summary

Found during the 2026-08-19 Weekly Health + Regression routine: `RUN_E2E=1 bash scripts/weekly-health-regression.sh` reported a FAIL on `public-pages.spec.ts`'s waitlist test that was actually a local-environment gap, not a product regression.

**Root cause 1.** `.github/workflows/e2e-tests.yml`'s "Playwright E2E (local build)" gate sets `CI=true`, `E2E_LOCAL_SERVER=1`, and four non-secret dummy Supabase vars before running Playwright. `weekly-health-regression.sh`'s `e2e` phase ran `npm run test:e2e` with none of these set, so `requireEnv()` throws and `/waitlist` 500s at render time instead of rendering.

**Root cause 2 (self-inflicted, caught before merge).** My first cut of this fix quoted the defaulted values (`env CI=\"${CI:-true}\" ...`). `run_phase()` executes the resulting string via unquoted `$c`, which relies on word-splitting — and word-splitting does not strip quote characters, only expansion does. So `env` received `NEXT_PUBLIC_SUPABASE_URL="https://e2e-dummy.supabase.co"` **with the literal quote characters as part of the value**, an invalid URL. This reproduced a `Timed out waiting 120000ms from config.webServer` 3/3 through the wrapper script, while the identical values passed directly to `npx playwright test` (bypassing the `env`-based word-splitting) passed 2/2 — including the full 44-test suite (34 passed / 10 skipped / 0 failed). Fixed by dropping the inner quotes (safe: none of the six defaults contain whitespace) and re-validating through the real script, not an isolated bypass.

Both root causes reproduced and fixed; see BUGS-109 for the full evidence trail.

## Jira Ticket

BUGS-109

## Checklist

- [x] Unit tests added/updated for new/changed functionality — none needed; `tests/scripts/weekly-health-regression.test.js` doesn't pin the literal `e2e` command string
- [x] All existing tests pass (`npm run test:unit`) — full suite re-run clean (see below)
- [x] Lint passes (`npm run lint`) — PASS
- [x] Type check passes (`npm run type-check`) — PASS
- [x] Build succeeds (`npm run build`) — PASS
- [x] Coverage has not decreased — no test removed or weakened, `tests/scripts/weekly-health-regression.test.js` 14/14 green
- [x] No eslint-disable or ts-ignore without KAN-XX reference — none added
- [x] Dependency-rule gate reviewed — N/A, no `src/` file touched (bash script only)
- [x] ARCHITECTURE.md updated if architectural changes were made — N/A, no service/table/env var/route/security boundary changed; this only affects how the routine invokes its own local run
- [x] Ops routine / Control-Room registry updated — N/A, `weekly-health-regression.sh`'s cadence/ownership is unchanged; this is a bugfix to the script's own e2e-phase invocation
- [x] Docs / system map updated — N/A with reason: CI-tooling-only change, no system-map impact
- [x] Design loop (KAN-441) — N/A, no founder-owned UI/copy path touched (`scripts/**` is explicitly carved out)

Full regression suite re-run end-to-end through the actual script after both fixes: `PASS=7 FAIL=0 UNVERIFIED=1` (the one UNVERIFIED is the pre-existing, documented `tests/integration` directory gap — BUGS-51 — unrelated to this change).

---
_Generated by [Claude Code](https://claude.ai/code/session_01CaVDeMhiS2WUB3rZop7UYW)_