### PR TITLE
fix(SEC-115): mask raw error.message on the Convene OAuth initiate routes

### DIFF
--- a/controls/registry.json
+++ b/controls/registry.json
@@ -1257,6 +1257,23 @@
       ],
       "escape_hatch": "none - regenerate with `npm run gen:db-types -- --env <env>` and commit the result. There is no annotation, because an accepted difference between a snapshot and its own database is exactly the defect this control exists to find.",
       "added": "2026-08-17"
+    },
+    {
+      "id": "CTL-074",
+      "name": "Convene OAuth route error-masking coverage",
+      "defect_class": "guard-names-its-targets-so-siblings-go-uncovered",
+      "summary": "Asserts that NO Convene OAuth route returns internal error text to the caller, over a corpus DISCOVERED with `git ls-files` rather than listed. SEC-76 masked the two callback routes and shipped a guard whose targets were a hand-written two-entry array, so both INITIATE routes carried the identical `{ error: 'state_persist_failed', detail: error.message }` leak - on the same line number, for both providers - while that guard reported green. SEC-115. Same shape as the eight-ticket suspension-guard family: a fix applied at one call site and not its siblings. THE FIX IS THE ORACLE, NOT THE ASSERTION: the assertions are unchanged, the corpus is what changed, so a fifth provider route is covered on the day it is committed with nobody remembering to add it. Three properties are asserted per discovered route - no `detail:` in any response, the raw message still reaches logStep server-side (masking must not merely discard it), and the stable error codes survive. CORPUS IS ASSERTED BEFORE IT IS ITERATED, because `describe.each([])` registers zero tests and an empty suite is green (catalogue failure mode 4) - a discovery glob that silently stopped matching would otherwise turn the file into a no-op with a tick. COMMENTS ARE STRIPPED before matching, both directions of CTL-039: the prose explaining why `detail:` must not appear would otherwise redden the fix's own documentation, and a positive assertion could otherwise be satisfied by a comment whose code was deleted. Mutation-proven five ways - reintroducing the leak on the google initiate route reddens it (the route SEC-76's guard could not see), reintroducing it on the microsoft callback reddens it, deleting the logStep call reddens it, narrowing discovery back to callbacks reddens it, and removing the comment-stripping reddens a comment-only reintroduction (so the stripping is load-bearing, not decoration). STATED GAP: this is a source-text scan, not a behavioural test - Convene is dark in every environment (CONVENE_ENABLED false, routes 404) so there is no reachable endpoint to exercise, which also bounds the live exposure of the original leak to zero.",
+      "implementation": "tests/unit/convene/oauth-callback-error-masking.test.ts",
+      "kind": "test",
+      "wired_in": [
+        ".github/workflows/pr-checks.yml"
+      ],
+      "prevents": [
+        "SEC-76",
+        "SEC-115"
+      ],
+      "escape_hatch": "none - a route that must return internal error text is not a case this codebase has; log it server-side via logStep and return the stable code.",
+      "added": "2026-08-19"
     }
   ]
 }

--- a/src/app/api/convene/oauth/google/initiate/route.ts
+++ b/src/app/api/convene/oauth/google/initiate/route.ts
@@ -13,6 +13,14 @@ import { createServiceRoleClient } from '@/modules/platform/supabase-service';
 import { isConveneEnabled } from '@/lib/convene/flags';
 import { buildAuthorizeUrl } from '@/lib/convene/google/oauth';
 
+function logStep(step: string, extra?: Record<string, unknown>) {
+  // Single-line JSON so Vercel runtime logs are searchable — same shape as the
+  // callback route's logStep, minus the reqId (initiate has no request chain).
+  console.log(
+    JSON.stringify({ at: 'convene/oauth/google/initiate', step, ...extra })
+  );
+}
+
 export async function GET(req: NextRequest) {
   if (!isConveneEnabled()) {
     return NextResponse.json({ error: 'convene_disabled' }, { status: 404 });
@@ -35,10 +43,12 @@ export async function GET(req: NextRequest) {
     provider: 'google',
   });
   if (error) {
-    return NextResponse.json(
-      { error: 'state_persist_failed', detail: error.message },
-      { status: 500 }
-    );
+    // SEC-115: error.message can carry Supabase/PostgREST internal text — log it
+    // server-side (above) but return only the stable error code to the caller.
+    // Same contract SEC-76 settled on for the callback routes.
+    const msg = error.message;
+    logStep('state_persist_failed', { msg });
+    return NextResponse.json({ error: 'state_persist_failed' }, { status: 500 });
   }
 
   // Support both browser redirect (default) and JSON response (for MCP).

--- a/src/app/api/convene/oauth/microsoft/initiate/route.ts
+++ b/src/app/api/convene/oauth/microsoft/initiate/route.ts
@@ -13,6 +13,14 @@ import { createServiceRoleClient } from '@/modules/platform/supabase-service';
 import { isConveneEnabled } from '@/lib/convene/flags';
 import { buildAuthorizeUrl } from '@/lib/convene/microsoft/oauth';
 
+function logStep(step: string, extra?: Record<string, unknown>) {
+  // Single-line JSON so Vercel runtime logs are searchable — same shape as the
+  // callback route's logStep, minus the reqId (initiate has no request chain).
+  console.log(
+    JSON.stringify({ at: 'convene/oauth/microsoft/initiate', step, ...extra })
+  );
+}
+
 export async function GET(req: NextRequest) {
   if (!isConveneEnabled()) {
     return NextResponse.json({ error: 'convene_disabled' }, { status: 404 });
@@ -35,10 +43,12 @@ export async function GET(req: NextRequest) {
     provider: 'microsoft',
   });
   if (error) {
-    return NextResponse.json(
-      { error: 'state_persist_failed', detail: error.message },
-      { status: 500 }
-    );
+    // SEC-115: error.message can carry Supabase/PostgREST internal text — log it
+    // server-side (above) but return only the stable error code to the caller.
+    // Same contract SEC-76 settled on for the callback routes.
+    const msg = error.message;
+    logStep('state_persist_failed', { msg });
+    return NextResponse.json({ error: 'state_persist_failed' }, { status: 500 });
   }
 
   const wantsJson = req.headers.get('accept')?.includes('application/json');

--- a/tests/support/test-floor-baseline.json
+++ b/tests/support/test-floor-baseline.json
@@ -1,6 +1,6 @@
 {
   "$comment": "GENERATED — regenerate with `npm run gen:test-floor`. The enforced test floor. The guard fails if the counts DROP (a test was deleted) and also if they RISE (this baseline is stale and is overstating how much of the estate is actually protected). The rise case is the one that matters: the previous hand-maintained floor sat at 29 files / 320 blocks against an actual 260 / 2963, so ~89% of the tests could have been deleted silently. Raise it in the SAME commit as any net-new test.",
-  "measured_at": "2026-08-17",
+  "measured_at": "2026-08-19",
   "test_files": 308,
-  "test_blocks": 3565
+  "test_blocks": 3570
 }

--- a/tests/unit/convene/oauth-callback-error-masking.test.ts
+++ b/tests/unit/convene/oauth-callback-error-masking.test.ts
@@ -1,32 +1,123 @@
 /**
- * SEC-76 (web-oauth-6) — Convene OAuth callbacks don't echo internal error detail.
+ * SEC-76 (web-oauth-6) + SEC-115 — no Convene OAuth route echoes internal
+ * error detail to the caller.
  *
- * Both the Google and Microsoft callback routes previously returned
+ * WHAT HAPPENED
+ * -------------
+ * SEC-76 fixed the two CALLBACK routes: they previously returned
  * `{ error: '<code>', detail: msg }` where `msg` could carry an upstream
- * provider response body or a Supabase/DB error string. That leaks internal
- * detail to the browser. The routes must now log `msg` server-side (via
- * logStep) but return only the stable error code. These source-string guards
- * pin that no error response re-introduces a `detail:` field.
+ * provider response body or a Supabase/DB error string. They now log `msg`
+ * server-side (via logStep) and return only the stable error code.
+ *
+ * The guard written alongside that fix listed its two targets by hand:
+ *
+ *     const callbacks = [SRC.callbackRoute, SRC.microsoftCallbackRoute];
+ *
+ * so it could only ever see the routes that happened to be in front of its
+ * author. Both INITIATE routes carried the identical
+ * `{ error: 'state_persist_failed', detail: error.message }` leak, on the same
+ * line number, for the whole time this file reported green — SEC-115. That is
+ * the same shape as the eight-ticket suspension-guard family in CLAUDE.md: a
+ * fix applied at one call site and not its siblings.
+ *
+ * WHY THIS FILE IS SHAPED THE WAY IT IS
+ * -------------------------------------
+ *  1. **The corpus is DISCOVERED, never listed.** `git ls-files` over the
+ *     Convene OAuth route directory is the corpus. A guard that names its
+ *     targets will drift; a guard that discovers them cannot. A fifth provider
+ *     added tomorrow is covered on the day its route file is committed, with
+ *     nobody remembering to add it here.
+ *  2. **The corpus is asserted non-empty and complete before it is iterated.**
+ *     `describe.each([])` registers ZERO tests and an empty suite is green
+ *     (catalogue failure mode 4) — so a discovery glob that silently stopped
+ *     matching would turn this file into a no-op that still reports a tick.
+ *  3. **Comments are stripped before matching.** `detail:` appears in the
+ *     prose of the routes explaining why it must not appear in the code, so an
+ *     unstripped `not.toMatch(/detail\s*:/)` would go red on the documentation
+ *     of its own fix — and the mirror hazard, CTL-039, is that prose can
+ *     SATISFY a positive assertion whose code has been deleted.
+ *
+ * The directory is derived from `SRC.callbackRoute` rather than written as a
+ * fresh path literal, so a move of these routes is caught by the SRC manifest
+ * integrity guard rather than silently narrowing this scan (gotcha #31).
+ * Convene is permanently out of the KAN-415 modularisation, so in practice
+ * these four paths are stable.
  */
 
 import fs from 'fs';
 import path from 'path';
+import { execFileSync } from 'child_process';
 import { SRC } from '../../support/source-paths';
+import { stripComments } from '../../support/strip-comments';
 
 const ROOT = path.join(__dirname, '..', '..', '..');
 
-const callbacks = [
-  SRC.callbackRoute,
-  SRC.microsoftCallbackRoute,
-];
+// src/app/api/convene/oauth — three levels up from <provider>/<leg>/route.ts.
+const OAUTH_DIR = path.dirname(path.dirname(path.dirname(SRC.callbackRoute)));
 
-describe.each(callbacks)('%s error masking', (rel) => {
-  const src = fs.readFileSync(path.join(ROOT, rel), 'utf8');
+/** Every tracked route file under the Convene OAuth tree. */
+function discoverRoutes(): string[] {
+  const out = execFileSync('git', ['ls-files', '--', `${OAUTH_DIR}/`], {
+    cwd: ROOT,
+    encoding: 'utf8',
+  });
+  return out
+    .split('\n')
+    .map((l) => l.trim())
+    .filter((l) => l.endsWith('/route.ts'))
+    .sort();
+}
+
+const routes = discoverRoutes();
+const callbacks = routes.filter((r) => r.includes('/callback/'));
+const initiates = routes.filter((r) => r.includes('/initiate/'));
+
+function read(rel: string): string {
+  return stripComments(fs.readFileSync(path.join(ROOT, rel), 'utf8'), '.ts');
+}
+
+describe('Convene OAuth route corpus', () => {
+  // Assert the corpus BEFORE iterating it: an empty describe.each is green.
+  test('discovers every Convene OAuth route', () => {
+    expect(routes.length).toBeGreaterThanOrEqual(4);
+    expect(callbacks.length).toBeGreaterThanOrEqual(2);
+    expect(initiates.length).toBeGreaterThanOrEqual(2);
+  });
+
+  test('covers both legs of both providers', () => {
+    for (const provider of ['google', 'microsoft']) {
+      for (const leg of ['initiate', 'callback']) {
+        expect(routes).toContain(`${OAUTH_DIR}/${provider}/${leg}/route.ts`);
+      }
+    }
+  });
+
+  test('the routes SEC-76 hand-listed are still in the discovered set', () => {
+    expect(routes).toContain(SRC.callbackRoute);
+    expect(routes).toContain(SRC.microsoftCallbackRoute);
+    expect(routes).toContain(SRC.initiateRoute);
+  });
+});
+
+describe.each(routes)('%s error masking', (rel) => {
+  const src = read(rel);
 
   test('no error response includes a detail field', () => {
     // Catches `detail: msg`, `detail: e`, `detail:msg`, etc. in any response.
     expect(src).not.toMatch(/detail\s*:/);
   });
+
+  test('the raw message is still logged server-side, not merely dropped', () => {
+    // Masking must not lose the detail operationally — every route captures the
+    // message and hands it to logStep. `reqId` is present on the callbacks and
+    // absent on the initiates, so the arg list is matched loosely; `{ msg }` is
+    // the part that matters.
+    expect(src).toMatch(/logStep\([^)]*'\w+_failed',\s*\{\s*msg\s*[,}]/);
+  });
+});
+
+describe.each(callbacks)('%s stable error codes', (rel) => {
+  const src = read(rel);
 
   test('still returns the stable error codes', () => {
     expect(src).toMatch(/error:\s*'token_exchange_failed'/);
@@ -35,7 +126,14 @@ describe.each(callbacks)('%s error masking', (rel) => {
   });
 
   test('still logs the raw message server-side', () => {
-    // msg is captured and passed to logStep so detail is not lost operationally.
     expect(src).toMatch(/logStep\(reqId, '\w+_failed', \{ msg \}\)/);
+  });
+});
+
+describe.each(initiates)('%s stable error codes', (rel) => {
+  const src = read(rel);
+
+  test('still returns the stable state_persist_failed code', () => {
+    expect(src).toMatch(/error:\s*'state_persist_failed'/);
   });
 });


### PR DESCRIPTION
## Summary

SEC-76 introduced error masking for the Convene OAuth flow and fixed the two **callback** routes. Both **initiate** routes carried the identical leak — the same `{ error: 'state_persist_failed', detail: error.message }` payload, on the same line number, for both providers — and the guard SEC-76 shipped alongside the fix could not see them, because it listed its two targets by hand:

```ts
const callbacks = [SRC.callbackRoute, SRC.microsoftCallbackRoute];
```

Same shape as the eight-ticket suspension-guard family in `CLAUDE.md`: a fix applied at one call site and not its siblings.

**Routes.** `google/initiate` and `microsoft/initiate` now capture the message, hand it to a `logStep` matching the callbacks' shape, and return only the stable `state_persist_failed` code. Nothing is lost operationally; nothing internal reaches the caller.

**Guard (CTL-074).** The corpus is now *discovered* with `git ls-files` over the Convene OAuth tree instead of listed, so a fifth route is covered the day it is committed. Every existing assertion is preserved and now runs over the discovered set rather than the hand-list — this is a coverage expansion, not a weakening. Three properties per route: no `detail:` in any response, the raw message still reaches `logStep`, the stable codes survive.

Two shapes the file deliberately guards against:
- the corpus is asserted non-empty **and** complete *before* it is iterated, because `describe.each([])` registers zero tests and an empty suite is green (catalogue failure mode 4);
- comments are stripped before matching, so the prose explaining why `detail:` must not appear cannot redden the fix's own documentation, and a positive assertion cannot be satisfied by a comment whose code was deleted (CTL-039).

**Mutation-proven five ways**, each with the edit confirmed applied first (a `sed` that matches nothing produces a green run indistinguishable from a green run):

| # | mutation | result |
|---|---|---|
| 1 | reintroduce the leak on `google/initiate` | 1 red — the route SEC-76's guard could not see |
| 2 | reintroduce the leak on `microsoft/callback` | 1 red |
| 3 | delete the `logStep` call on `microsoft/initiate` | 1 red |
| 4 | narrow discovery back to callbacks only | suite red at collection |
| 5 | drop comment-stripping, reintroduce the leak in a *comment only* | 1 red — so the stripping is load-bearing, not decoration |

**Acceptance.** Criterion 1 (enumerate, don't sample) was satisfied by the ticket's 2026-08-14 correction note — exactly four routes, two leaking. Criteria 2–4 are closed here.

**Prevention: CTL-074** — SEC-101 outcome (a). A control existed and its scope was too narrow; the control is fixed and its blind spot is now unreachable by construction rather than by remembering. `CTL-074` was verified free by scanning all remote branch tips (`CTL-072` → 11 refs, `CTL-073` → 19, `CTL-074` → 0), since the registry's uniqueness check cannot see a collision that exists only across unmerged branches.

**Stated gap.** This is a source-text scan, not a behavioural test. Convene is dark in every environment (`CONVENE_ENABLED` false, routes 404), so there is no reachable endpoint to exercise — which is also what bounds the live exposure of the original leak to zero. It becomes reachable the moment the flag flips, which is an argument for fixing it now rather than deferring.

**LOOK AND TEXT.** No founder-owned surface is touched. `scripts/check-ui-copy-ownership.sh --describe` was re-run at claim: `src/app/api/*` and `*/route.ts` are both CARVE-OUTs, so the two changed routes are outside the protected surface twice over; the guard test lives under `tests/` and is not protected. No `UI-*` trailer is claimed, because none would be true.

## Jira Ticket

SEC-115

## Checklist

- [x] Unit tests added/updated for new/changed functionality — the existing masking guard widened; test floor regenerated in the same commit (308 files / 3570 blocks, was 3565)
- [x] All existing tests pass (`npm run test:unit`) — **308 suites / 4162 tests green**
- [x] Lint passes (`npm run lint`) — 0 errors; the 36 warnings are pre-existing on `develop` and `npx eslint src/app/api/convene/oauth/` is silent
- [x] Type check passes (`npm run type-check`)
- [x] Build succeeds (`npm run build`)
- [x] Coverage has not decreased — net-new assertions only, no assertion removed or relaxed
- [x] No eslint-disable or ts-ignore without KAN-XX reference — none added
- [x] Dependency-rule gate reviewed — `npm run depcruise` clean: no violations, 313 modules / 635 dependencies cruised
- [x] ARCHITECTURE.md updated if architectural changes were made — N/A: no new service, table, env var, route or boundary; two existing route error payloads changed
- [x] Ops routine / Control-Room registry updated — N/A: no scheduled-routine behaviour, cadence or ownership changed. `controls/registry.json` gains CTL-074 and `scripts/check-control-registry.py` passes
- [x] Docs / system map updated — **N/A with reason**: no doc in this repo records these route error payloads. The contract now lives in the guard test and in `controls/registry.json`, both updated here. Carried as `Docs-N/A: SEC-115` on the commit
- [x] Design loop (KAN-441) — N/A: no user-facing page changes look or wording. See the LOOK AND TEXT note above

## Extraction Definition-of-Done (KAN-428)

N/A — this PR moves no file under `src/`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FsFKUaxKAWX9SSehVmUs47)_