### PR TITLE
fix(SEC-119): CTL-026 accepted a comment as proof a control is invoked

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -530,7 +530,14 @@ jobs:
         # control to its invoker in controls/registry.json; `npm run lint` alone
         # reaches it only by convention, and a convention is precisely what the
         # registry exists to stop us relying on.
-        run: npm run lint  # uses eslint.config.mjs
+        #
+        # SEC-119: that name used to live in a trailing `# uses eslint.config.mjs`
+        # comment, and check-control-registry.py's substring scan was satisfied by
+        # it — so the registry's proof that this control is invoked was a comment.
+        # --config is the SAME file eslint would load by convention (flat config
+        # default), so behaviour is unchanged; it is now an argument rather than a
+        # remark, which is the difference between a claim and a wiring.
+        run: npm run lint -- --config eslint.config.mjs
       - name: Run type check
         run: npm run type-check
       - name: Dependency-rule gate (KAN-425)

--- a/controls/registry.json
+++ b/controls/registry.json
@@ -23,12 +23,11 @@
       "id": "CTL-001",
       "name": "Workflow integrity check",
       "defect_class": "false-green-ci",
-      "summary": "Static scan for workflow patterns that report SUCCESS while doing nothing \u2014 GITHUB_TOKEN pushes that suppress downstream triggers, --limit 1 deploy verification, 401 acceptance without SHA verification, rollback steps that never roll back.",
+      "summary": "Static scan for workflow patterns that report SUCCESS while doing nothing \u2014 GITHUB_TOKEN pushes that suppress downstream triggers, --limit 1 deploy verification, 401 acceptance without SHA verification, rollback steps that never roll back. SEC-119: promote-to-production.yml was listed as a second wiring and never ran it \u2014 the only two occurrences of the script's name in that file are inside # comment blocks explaining the SEC-86 and SEC-66 residuals its Patterns 5 and 6 pin. That file is a SUBJECT of this scan (pr-checks.yml runs the script over every workflow, this one included), not an invoker of it, and wired_in means 'the control RUNS here'. Dropped rather than wired in: adding a gate to the production promote is a release-control change under SEC-98, and the coverage already exists from pr-checks.yml.",
       "implementation": "scripts/check-workflow-integrity.sh",
       "kind": "ci-gate",
       "wired_in": [
-        ".github/workflows/pr-checks.yml",
-        ".github/workflows/promote-to-production.yml"
+        ".github/workflows/pr-checks.yml"
       ],
       "prevents": [
         "BUGS-4",

--- a/docs/DEFECT_FEEDBACK_LOOP.md
+++ b/docs/DEFECT_FEEDBACK_LOOP.md
@@ -164,12 +164,27 @@ Each entry records: `id`, `name`, `defect_class`, `summary`, `implementation`,
 `kind` (`ci-gate` / `test` / `scheduled` / `policy`), `wired_in`, `prevents`,
 optional `self_test`, and its `escape_hatch`.
 
+**`wired_in` means "the control RUNS here" — every entry, not just one of
+them.** A file that is merely *relevant* to a control (scanned by it,
+documented alongside it, mentioned in a comment near it) does not belong in the
+list. SEC-119 fixed two ways that distinction used to blur:
+
+- A `#` comment naming the control satisfied the invocation test, because it
+  was a bare substring scan over whole file text. Comments are now stripped
+  first, reusing CTL-039's helper. If a control's implementation is a **tool
+  config** rather than a script named on a command line, name it as an argument
+  (`npm run lint -- --config eslint.config.mjs`), not in a remark — an argument
+  is a wiring, a remark is a claim.
+- Satisfaction was ANY-of across `wired_in`, so one live target proved the
+  whole list and a rotted entry could never be reported by name. It is now
+  per-target.
+
 `scripts/check-control-registry.py` runs on **every PR** and fails if:
 
 1. a registered control's implementation file is missing;
-2. nothing actually invokes it — *the SEC-79 failure mode, where
-   `health-check.yml` and `weekly-report.yml` sat disabled for over a month
-   while still reporting green*;
+2. **any** `wired_in` target does not invoke it — *the SEC-79 failure mode,
+   where `health-check.yml` and `weekly-report.yml` sat disabled for over a
+   month while still reporting green*;
 3. a `scripts/check-*.{sh,py}` exists in the repo but is not registered;
 4. a control cites no Jira key, or its declared `self_test` names a missing file.
 

--- a/scripts/check-control-registry.py
+++ b/scripts/check-control-registry.py
@@ -18,9 +18,28 @@ false confidence in exactly the audits that are supposed to catch drift.
 WHAT THIS ENFORCES
 ------------------
   1. Every registered control's `implementation` file EXISTS.
-  2. Every control is REFERENCED by at least one file it claims to be wired
-     into, and each `wired_in` file exists. A control nobody invokes is the
-     SEC-79 failure mode.
+  2. EVERY `wired_in` file exists AND actually invokes the implementation.
+     A control nobody invokes is the SEC-79 failure mode.
+
+     SEC-119 changed two things here, and both matter more than they look.
+
+     (a) COMMENTS ARE STRIPPED BEFORE MATCHING. The test used to be a bare
+         substring scan over the whole file, so a `#` comment MENTIONING a
+         control satisfied "this file invokes it". CTL-001 declared
+         `promote-to-production.yml` as a wiring on the strength of two
+         explanatory comments; neutering its one real `run:` line in
+         pr-checks.yml left this checker green at exit 0. That is CTL-039's
+         defect class — "the comment satisfies the assertion" — landing on
+         the meta-control that exists to catch exactly this.
+
+     (b) SATISFACTION IS PER-TARGET, NOT ANY-OF. A single flag was raised by
+         whichever target happened to match and tested once at the end, so a
+         control wired into five files was proven by one. A stale entry could
+         never be reported, because a live sibling always covered for it.
+         `wired_in` means "the control RUNS here" — that is what the error
+         text has always claimed and what the SEC-79 failure mode is about.
+         A file that is merely RELEVANT to a control (scanned by it,
+         documented alongside it) does not belong in the list.
   3. Every control names at least one real Jira key in `prevents` — a control
      with no defect behind it is speculative, and speculative gates are the
      ones that get switched off.
@@ -39,6 +58,7 @@ Process: docs/DEFECT_FEEDBACK_LOOP.md
 from __future__ import annotations
 
 import argparse
+import importlib.util
 import json
 import re
 import sys
@@ -51,6 +71,33 @@ CONTROL_ID_RE = re.compile(r"^CTL-\d{3}$")
 
 REQUIRED_FIELDS = ("id", "name", "defect_class", "summary", "implementation", "kind", "wired_in", "prevents")
 VALID_KINDS = {"ci-gate", "test", "scheduled", "policy"}
+
+# CTL-039 owns the comment-stripping semantics (per-file-type syntax, string-aware
+# line markers, characters blanked rather than deleted so offsets stay stable).
+# SEC-119 REUSES it rather than writing a second implementation: two copies of a
+# comment parser drift, and the drift is invisible until one of them wrongly
+# reports a control as invoked. The module name has hyphens, so it cannot be a
+# plain `import` — load it by path.
+COMMENT_STRIPPER_PATH = Path(__file__).resolve().parent / "check-comment-only-assertions.py"
+
+
+def _load_strip_comments():
+    """Return CTL-039's `strip_comments`, or raise.
+
+    Deliberately NOT wrapped in a try/except that falls back to a local copy or
+    to raw text. Either fallback would silently restore the defect this control
+    was fixed for — a comment satisfying the invocation test — and it would do
+    so while printing a clean result.
+    """
+    spec = importlib.util.spec_from_file_location("_ctl039_comments", COMMENT_STRIPPER_PATH)
+    if spec is None or spec.loader is None:
+        raise ImportError(f"cannot load {COMMENT_STRIPPER_PATH}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module.strip_comments
+
+
+strip_comments = _load_strip_comments()
 
 
 def validate(registry: dict, repo_root: Path) -> list[str]:
@@ -106,7 +153,6 @@ def validate(registry: dict, repo_root: Path) -> list[str]:
         wired_in = control.get("wired_in") or []
         impl_basename = Path(impl).name if impl else None
         kind = control.get("kind")
-        referenced_anywhere = kind == "policy"
 
         for target in wired_in:
             target_path = repo_root / target
@@ -116,33 +162,54 @@ def validate(registry: dict, repo_root: Path) -> list[str]:
 
             if target == impl:
                 # A workflow that IS the control (e.g. main-chain-guard.yml).
-                referenced_anywhere = True
+                continue
+
+            if kind == "policy":
+                # No executable form; existence is the proof.
                 continue
 
             try:
-                content = target_path.read_text(encoding="utf-8")
+                raw = target_path.read_text(encoding="utf-8")
             except (UnicodeDecodeError, OSError):
                 continue
 
+            # SEC-119(a): a MENTION is not an INVOCATION.
+            content = strip_comments(raw, target_path.suffix)
+            if content is None:
+                # Unknown file type: a comment cannot be told from code, so the
+                # question "does this file invoke the control?" is undecidable.
+                # Say so rather than guessing — guessing raw text is how the
+                # comment-satisfies-the-assertion defect returns.
+                problems.append(
+                    f"::error::{cid}: wired_in target '{target}' has a file type with no known "
+                    f"comment syntax, so an invocation cannot be distinguished from a mention "
+                    f"of one. Add '{target_path.suffix}' to SYNTAX in "
+                    f"scripts/check-comment-only-assertions.py."
+                )
+                continue
+
+            # SEC-119(b): every target must carry its own proof.
             if kind == "test":
                 runs_runner = bool(re.search(r"\b(npm run test:unit|npm test|npx jest|jest)\b", content))
-                discoverable = impl and (impl.startswith("tests/") or impl.startswith("src/"))
-                if runs_runner and discoverable:
-                    referenced_anywhere = True
-            elif impl_basename and impl_basename in content:
-                referenced_anywhere = True
-
-        if wired_in and not referenced_anywhere:
-            detail = (
-                f"no wired_in target runs the test suite, or '{impl}' is outside the "
-                f"runner's discovery roots (tests/, src/)"
-                if kind == "test"
-                else f"none of its wired_in targets reference '{impl_basename}'"
-            )
-            problems.append(
-                f"::error::{cid}: {detail}. The control exists but nothing invokes it — "
-                f"this is the SEC-79 'silently disabled' failure mode."
-            )
+                discoverable = bool(impl and (impl.startswith("tests/") or impl.startswith("src/")))
+                if not (runs_runner and discoverable):
+                    detail = (
+                        f"wired_in target '{target}' does not run the test suite"
+                        if not runs_runner
+                        else f"'{impl}' is outside the runner's discovery roots (tests/, src/)"
+                    )
+                    problems.append(
+                        f"::error::{cid}: {detail}, so that wiring does not invoke the control — "
+                        f"this is the SEC-79 'silently disabled' failure mode. Either fix the "
+                        f"wiring or drop the target from wired_in."
+                    )
+            elif impl_basename and impl_basename not in content:
+                problems.append(
+                    f"::error::{cid}: wired_in target '{target}' does not reference "
+                    f"'{impl_basename}' outside comments, so it does not invoke the control — "
+                    f"this is the SEC-79 'silently disabled' failure mode. wired_in means "
+                    f"'the control RUNS here'; either wire it in or drop the target."
+                )
 
         # 3. prevents must cite real Jira keys
         prevents = control.get("prevents") or []
@@ -263,6 +330,91 @@ def self_test() -> int:
         (root / "scripts/check-orphan.py").unlink()
 
         cases.append(("empty registry fails", len(validate({"controls": []}, root)) == 1))
+
+        # --- SEC-119 -------------------------------------------------------
+        # (a) A MENTION inside a comment is not an INVOCATION. This is the
+        # defect that let CTL-001 claim promote-to-production.yml as a wiring
+        # on the strength of two `#` comments, and it is CTL-039's own class
+        # landing on the meta-control.
+        (root / ".github/workflows/comment-only.yml").write_text(
+            "# this workflow used to run scripts/check-thing.sh\n"
+            "jobs:\n  x:\n    steps:\n      - run: echo hi\n"
+        )
+        comment_only = json.loads(json.dumps(good))
+        comment_only["controls"][0]["wired_in"] = [".github/workflows/comment-only.yml"]
+        problems_co = validate(comment_only, root)
+        cases.append(
+            ("control named only in a comment fails", len(problems_co) >= 1)
+        )
+        cases.append(
+            (
+                "…and the failure names the comment-only target",
+                any("comment-only.yml" in p for p in problems_co),
+            )
+        )
+
+        # Same file, same basename, but on a real `run:` line — must pass. The
+        # contrast is what proves the stripping is what did the work, rather
+        # than the check having simply become stricter about everything.
+        (root / ".github/workflows/comment-plus-run.yml").write_text(
+            "# scripts/check-thing.sh is explained here\n"
+            "jobs:\n  x:\n    steps:\n      - run: bash scripts/check-thing.sh\n"
+        )
+        comment_plus_run = json.loads(json.dumps(good))
+        comment_plus_run["controls"][0]["wired_in"] = [".github/workflows/comment-plus-run.yml"]
+        cases.append(
+            ("a real run: line passes even when a comment also names it",
+             validate(comment_plus_run, root) == [])
+        )
+
+        # (b) Satisfaction is PER-TARGET. A live sibling used to cover for a
+        # stale entry, so a wiring that had rotted could never be reported.
+        stale_sibling = json.loads(json.dumps(good))
+        stale_sibling["controls"][0]["wired_in"] = [
+            ".github/workflows/pr.yml",              # genuinely invokes it
+            ".github/workflows/unrelated.yml",       # does not
+        ]
+        problems_ss = validate(stale_sibling, root)
+        cases.append(("a stale wired_in target fails despite a live sibling", len(problems_ss) == 1))
+        cases.append(
+            (
+                "…and the stale target is named",
+                any("unrelated.yml" in p for p in problems_ss),
+            )
+        )
+
+        # Per-target for kind: test as well — one workflow runs the runner, one
+        # does not, and the one that does not must be reported by name.
+        stale_test = json.loads(json.dumps(test_control))
+        stale_test["controls"][0]["wired_in"] = [
+            ".github/workflows/tests.yml",
+            ".github/workflows/unrelated.yml",
+        ]
+        problems_st = validate(stale_test, root)
+        cases.append(("a test wiring that never runs the runner fails per-target", len(problems_st) == 1))
+        cases.append(
+            ("…and that target is named", any("unrelated.yml" in p for p in problems_st))
+        )
+
+        # An undecidable file type is reported, never assumed clean. Guessing
+        # raw text is exactly how the comment-satisfies-the-assertion defect
+        # comes back.
+        (root / ".github/workflows/config.ini").write_text("; scripts/check-thing.sh\n")
+        unknown_type = json.loads(json.dumps(good))
+        unknown_type["controls"][0]["wired_in"] = [".github/workflows/config.ini"]
+        problems_ut = validate(unknown_type, root)
+        cases.append(("an undecidable file type fails rather than passing", len(problems_ut) == 1))
+        cases.append(
+            ("…and says which suffix it could not decide",
+             any(".ini" in p for p in problems_ut))
+        )
+
+        # `policy` controls have no executable form — existence is the proof —
+        # and that exemption must survive the per-target rewrite.
+        policy = json.loads(json.dumps(good))
+        policy["controls"][0]["kind"] = "policy"
+        policy["controls"][0]["wired_in"] = [".github/workflows/unrelated.yml"]
+        cases.append(("a policy control needs no invocation", validate(policy, root) == []))
 
     failures = 0
     for label, ok in cases:

--- a/tests/scripts/check-control-registry.test.js
+++ b/tests/scripts/check-control-registry.test.js
@@ -1,0 +1,231 @@
+/**
+ * Guard test for CTL-026 (scripts/check-control-registry.py) — SEC-119.
+ *
+ * CTL-026 is the META-control: it is what notices that some OTHER control has
+ * stopped being invoked. Until SEC-119 it had no test of its own at all, which
+ * is a slightly uncomfortable thing to write down — the artefact whose job is
+ * to catch "a control nobody runs" was itself a control nobody tested.
+ *
+ * Two defects were fixed, and this file exists to keep both fixed:
+ *
+ *   (a) The invocation test was a bare substring scan over whole file text, so
+ *       a `#` comment MENTIONING a control satisfied "this file invokes it".
+ *       CTL-001 claimed promote-to-production.yml as a wiring on the strength
+ *       of two explanatory comments, and neutering its one real `run:` line
+ *       left this checker green at exit 0.
+ *
+ *   (b) Satisfaction was ANY-of across `wired_in` — one flag, raised by
+ *       whichever target matched, tested once at the end. A live sibling
+ *       covered for a stale entry, so a wiring that had rotted could never be
+ *       reported by name.
+ *
+ * The load-bearing cases here are the two that run the REAL
+ * `.github/workflows/pr-checks.yml` through the checker with one line
+ * neutered. A fixture can prove the logic; only the real file can prove the
+ * logic is pointed at the thing we care about. Both assert the unmutated file
+ * passes first, so a case cannot go green because the mutation silently
+ * matched nothing.
+ *
+ * The checker is driven as a subprocess (the tests/scripts convention) rather
+ * than reimplemented — see CLAUDE.md "Writing a test that can actually fail",
+ * failure mode 1. It resolves `controls/registry.json` and every path relative
+ * to its CWD, so a sandbox directory is all that is needed to drive it.
+ */
+const { spawnSync } = require('node:child_process');
+const { resolve, dirname } = require('node:path');
+const fs = require('node:fs');
+const os = require('node:os');
+const { SRC } = require('../support/source-paths.json');
+
+const ROOT = resolve(__dirname, '../..');
+// scripts/check-control-registry.py
+const SCRIPT = resolve(ROOT, SRC.checkControlRegistry);
+const PR_CHECKS = resolve(ROOT, SRC.prChecks);
+
+// Sandbox fixture paths are COMPOSED rather than written as path literals.
+// They name files that exist only inside a throwaway directory, so they are
+// not repo source paths and must not enter the `SRC` manifest — but the F4
+// raw-literal ratchet cannot tell the two apart, and raising a shrink-only
+// baseline to accommodate fixtures is how a ratchet decays into a suppression
+// list. Composing them keeps the ratchet honest without pretending these are
+// manifest-worthy paths. `SRC.prChecks` is used for the one path that IS a
+// real repo file.
+const WORKFLOW_DIR = ['.github', 'workflows'].join('/');
+const SCRIPT_DIR = 'scripts';
+const wf = (name) => `${WORKFLOW_DIR}/${name}`;
+const scriptPath = (name) => `${SCRIPT_DIR}/${name}`;
+
+const PR_YML = wf('pr.yml');
+const STALE_YML = wf('stale.yml');
+const PR_INI = wf('pr.ini');
+const THING_SH = scriptPath('check-thing.sh');
+const INTEGRITY_SH = scriptPath('check-workflow-integrity.sh');
+
+const run = (cwd, args = []) =>
+  spawnSync('python3', [SCRIPT, ...args], { cwd, encoding: 'utf-8' });
+
+/** A throwaway repo root containing only what a case needs. */
+const sandbox = () => {
+  const dir = fs.mkdtempSync(resolve(os.tmpdir(), 'ctl026-'));
+  fs.mkdirSync(resolve(dir, 'controls'), { recursive: true });
+  fs.mkdirSync(resolve(dir, SCRIPT_DIR), { recursive: true });
+  fs.mkdirSync(resolve(dir, WORKFLOW_DIR), { recursive: true });
+  return dir;
+};
+
+const writeRegistry = (dir, controls) =>
+  fs.writeFileSync(resolve(dir, 'controls/registry.json'), JSON.stringify({ controls }, null, 2));
+
+const control = (over = {}) => ({
+  id: 'CTL-001',
+  name: 'Thing',
+  defect_class: 'x',
+  summary: 's',
+  implementation: THING_SH,
+  kind: 'ci-gate',
+  wired_in: [PR_YML],
+  prevents: ['BUGS-1'],
+  ...over,
+});
+
+describe('CTL-026 — control-registry integrity (SEC-119)', () => {
+  it('passes its own self-test, over a corpus that has not shrunk', () => {
+    const r = run(ROOT, ['--self-test']);
+    expect(r.status).toBe(0);
+    // A count floor, not an equality: the number may only grow, and an
+    // "N/N passed" tally that nobody re-derives is failure mode 8.
+    const m = /all (\d+) case\(s\) behave as specified/.exec(r.stdout);
+    expect(m).not.toBeNull();
+    expect(Number(m[1])).toBeGreaterThanOrEqual(21);
+    expect(r.stdout).not.toMatch(/^\s*FAIL\s/m);
+  });
+
+  it('is green against the committed registry', () => {
+    const r = run(ROOT);
+    expect(r.status).toBe(0);
+    expect(r.stdout).toContain('Every registered control exists, is invoked');
+  });
+
+  describe('(a) a mention inside a comment is not an invocation', () => {
+    it('fails a control whose only reference is in a comment, and names the file', () => {
+      const dir = sandbox();
+      fs.writeFileSync(resolve(dir, THING_SH), '#!/bin/bash\n');
+      fs.writeFileSync(
+        resolve(dir, PR_YML),
+        '# this used to run scripts/check-thing.sh\njobs:\n  x:\n    steps:\n      - run: echo hi\n',
+      );
+      writeRegistry(dir, [control()]);
+
+      const r = run(dir);
+      expect(r.status).toBe(1);
+      expect(r.stdout).toContain(PR_YML);
+      expect(r.stdout).toContain("does not reference 'check-thing.sh' outside comments");
+    });
+
+    it('passes the same file once the name is on a real run: line', () => {
+      const dir = sandbox();
+      fs.writeFileSync(resolve(dir, THING_SH), '#!/bin/bash\n');
+      fs.writeFileSync(
+        resolve(dir, PR_YML),
+        '# scripts/check-thing.sh is explained here\n' +
+          'jobs:\n  x:\n    steps:\n      - run: bash scripts/check-thing.sh\n',
+      );
+      writeRegistry(dir, [control()]);
+
+      const r = run(dir);
+      expect(r.status).toBe(0);
+    });
+
+    it('reports a wired_in file type it cannot decide, rather than assuming it clean', () => {
+      const dir = sandbox();
+      fs.writeFileSync(resolve(dir, THING_SH), '#!/bin/bash\n');
+      fs.writeFileSync(resolve(dir, PR_INI), '; scripts/check-thing.sh\n');
+      writeRegistry(dir, [control({ wired_in: [PR_INI] })]);
+
+      const r = run(dir);
+      expect(r.status).toBe(1);
+      expect(r.stdout).toContain('no known comment syntax');
+      expect(r.stdout).toContain('.ini');
+    });
+  });
+
+  describe('(b) every wired_in target carries its own proof', () => {
+    it('reports a stale target by name even when a live sibling invokes the control', () => {
+      const dir = sandbox();
+      fs.writeFileSync(resolve(dir, THING_SH), '#!/bin/bash\n');
+      fs.writeFileSync(
+        resolve(dir, PR_YML),
+        'jobs:\n  x:\n    steps:\n      - run: bash scripts/check-thing.sh\n',
+      );
+      fs.writeFileSync(resolve(dir, STALE_YML), 'jobs:\n  x:\n    steps:\n      - run: echo hi\n');
+      writeRegistry(dir, [
+        control({ wired_in: [PR_YML, STALE_YML] }),
+      ]);
+
+      const r = run(dir);
+      expect(r.status).toBe(1);
+      expect(r.stdout).toContain('stale.yml');
+      // The live sibling is not the finding — only the rotted wiring is.
+      expect(r.stdout).not.toContain(`target '${PR_YML}' does not reference`);
+    });
+  });
+
+  describe('the real pr-checks.yml wiring', () => {
+    /**
+     * Copy the genuine pr-checks.yml into a sandbox, optionally replacing one
+     * line, and run the checker against a registry of exactly that control.
+     */
+    const againstRealPrChecks = (registryControl, mutate) => {
+      const dir = sandbox();
+      const impl = registryControl.implementation;
+      fs.mkdirSync(resolve(dir, dirname(impl)), { recursive: true });
+      fs.writeFileSync(resolve(dir, impl), '# stub\n');
+      let yaml = fs.readFileSync(PR_CHECKS, 'utf-8');
+      if (mutate) {
+        const mutated = mutate(yaml);
+        // Failure mode: a replace that matches nothing produces a green run
+        // indistinguishable from a real one. Prove the edit landed.
+        expect(mutated).not.toBe(yaml);
+        yaml = mutated;
+      }
+      fs.writeFileSync(resolve(dir, SRC.prChecks), yaml);
+      writeRegistry(dir, [registryControl]);
+      return run(dir);
+    };
+
+    const CTL_001 = control({
+      implementation: INTEGRITY_SH,
+      wired_in: [SRC.prChecks],
+    });
+
+    const CTL_046 = control({
+      id: 'CTL-046',
+      implementation: 'eslint.config.mjs',
+      wired_in: [SRC.prChecks],
+    });
+
+    it('accepts CTL-001 today, and goes red if its run: line is neutered', () => {
+      expect(againstRealPrChecks(CTL_001).status).toBe(0);
+
+      const r = againstRealPrChecks(CTL_001, (y) =>
+        y.replace('run: bash scripts/check-workflow-integrity.sh', "run: echo 'guard removed'"),
+      );
+      expect(r.status).toBe(1);
+      expect(r.stdout).toContain("does not reference 'check-workflow-integrity.sh' outside comments");
+    });
+
+    it('accepts CTL-046 today, and goes red if the config stops being named on the command line', () => {
+      expect(againstRealPrChecks(CTL_046).status).toBe(0);
+
+      // CTL-046's implementation is a tool CONFIG, not a script named on a
+      // command line, so `npm run lint` reaches it only by convention. Until
+      // SEC-119 the registry's proof that it was invoked was a trailing
+      // comment; drop the argument and the wiring is unproven again.
+      const r = againstRealPrChecks(CTL_046, (y) =>
+        y.replace('run: npm run lint -- --config eslint.config.mjs', 'run: npm run lint'),
+      );
+      expect(r.status).toBe(1);
+      expect(r.stdout).toContain("does not reference 'eslint.config.mjs' outside comments");
+    });
+  });
+});

--- a/tests/support/source-path-seeds.ts
+++ b/tests/support/source-path-seeds.ts
@@ -116,6 +116,11 @@ export const SEEDED_PATHS = [
   // infer it from. Two suites reach it by path; seeded so neither needs a raw
   // literal, which the F4 ratchet correctly refuses to let rise.
   'scripts/depcruise-severity.cjs',
+  // CTL-026's own implementation. SEC-119 gave the meta-control its first
+  // test; that suite reaches the checker by path and nothing else names it as
+  // a literal, so without this seed the key would not come back on the next
+  // regeneration and SRC.checkControlRegistry would go `undefined`.
+  'scripts/check-control-registry.py',
   // D8 moved the profile domain core out of the editor's app tree. All three
   // keys were DROPPED by the regeneration — read only via SRC, hard-coded
   // nowhere that counts — which is the self-sustaining loop breaking exactly as

--- a/tests/support/source-paths.json
+++ b/tests/support/source-paths.json
@@ -1,7 +1,7 @@
 {
   "$comment": "GENERATED — regenerate with `npm run gen:test-paths`. Mirror of tests/support/source-paths.ts for .cjs and shell consumers (KAN-414 F4).",
   "generated_from": "literals referenced by tracked files under tests/",
-  "count": 246,
+  "count": 247,
   "SRC": {
     "codeowners": ".github/CODEOWNERS",
     "pullRequestTemplate": ".github/PULL_REQUEST_TEMPLATE.md",
@@ -43,6 +43,7 @@
     "checkActionPinning": "scripts/check-action-pinning.sh",
     "checkCommentOnlyAssertions": "scripts/check-comment-only-assertions.py",
     "checkCompleteBackup": "scripts/check-complete-backup.sh",
+    "checkControlRegistry": "scripts/check-control-registry.py",
     "checkDependencyRules": "scripts/check-dependency-rules.sh",
     "checkDesignBaseline": "scripts/check-design-baseline.py",
     "checkDocMirrorContent": "scripts/check-doc-mirror-content.sh",

--- a/tests/support/source-paths.ts
+++ b/tests/support/source-paths.ts
@@ -13,7 +13,7 @@
 // cannot drift from reality — a hand-maintained list is what let BUGS-74's
 // first fix miss the legacy editor.
 //
-// 246 entries.
+// 247 entries.
 
 export const SRC = {
   codeowners: '.github/CODEOWNERS',
@@ -56,6 +56,7 @@ export const SRC = {
   checkActionPinning: 'scripts/check-action-pinning.sh',
   checkCommentOnlyAssertions: 'scripts/check-comment-only-assertions.py',
   checkCompleteBackup: 'scripts/check-complete-backup.sh',
+  checkControlRegistry: 'scripts/check-control-registry.py',
   checkDependencyRules: 'scripts/check-dependency-rules.sh',
   checkDesignBaseline: 'scripts/check-design-baseline.py',
   checkDocMirrorContent: 'scripts/check-doc-mirror-content.sh',

--- a/tests/support/test-floor-baseline.json
+++ b/tests/support/test-floor-baseline.json
@@ -1,6 +1,6 @@
 {
   "$comment": "GENERATED — regenerate with `npm run gen:test-floor`. The enforced test floor. The guard fails if the counts DROP (a test was deleted) and also if they RISE (this baseline is stale and is overstating how much of the estate is actually protected). The rise case is the one that matters: the previous hand-maintained floor sat at 29 files / 320 blocks against an actual 260 / 2963, so ~89% of the tests could have been deleted silently. Raise it in the SAME commit as any net-new test.",
-  "measured_at": "2026-08-17",
-  "test_files": 308,
-  "test_blocks": 3565
+  "measured_at": "2026-08-19",
+  "test_files": 309,
+  "test_blocks": 3573
 }


### PR DESCRIPTION
## Summary

`scripts/check-control-registry.py` (**CTL-026**) is the meta-control: it is what notices that some *other* control has stopped being invoked. Two defects made it unable to do that, and it had no test of its own at all.

**(a) A mention inside a comment counted as an invocation.** The wiring test was a bare substring scan over whole file text, so a `#` comment naming a control satisfied "this file invokes it". That is CTL-039's own defect class — *the comment satisfies the assertion* — landing on the meta-control. Comments are now stripped first, **reusing** CTL-039's `strip_comments` by path import rather than writing a second comment parser. A file type with no known comment syntax is reported as undecidable, never assumed clean.

**(b) Satisfaction was ANY-of across `wired_in`.** One flag, raised by whichever target happened to match, tested once after the loop — so a live sibling covered for a stale entry and a rotted wiring could never be reported by name. It is now per-target, and the error names the target.

### Two live findings, both fixed

| control | what was wrong | resolution |
|---|---|---|
| **CTL-001** | declared `promote-to-production.yml` as a second wiring; the script's name appears there **only inside two `#` comment blocks** (the SEC-86 and SEC-66 residuals its Patterns 5 and 6 pin). That file is a **subject** of the scan — `pr-checks.yml` runs the script over every workflow, this one included — not an invoker. | dropped from `wired_in`. **Not** wired in: adding a gate to the production promote is a release-control change under SEC-98, and the coverage already exists from `pr-checks.yml`. |
| **CTL-046** *(not in the ticket — surfaced by the fix)* | its implementation is `eslint.config.mjs`, a tool **config** that `npm run lint` reaches only by convention. The registry's entire proof that it was invoked was a trailing `# uses eslint.config.mjs` comment — which that step's own comment block says was the point. | the name moved onto the command line: `npm run lint -- --config eslint.config.mjs`. Same file eslint loads by default; **lint output verified byte-identical to base** (96 lines, identical). |

### Mutation proof — five ways, each with the edit asserted to have applied

| mutation | result |
|---|---|
| `content = raw` (drop comment stripping) | 4 self-test + 4 jest cases red |
| ANY-of restored | 2 self-test + 2 jest cases red |
| neuter CTL-001's real `run:` line in `pr-checks.yml` | checker exit 1 |
| restore CTL-001's stale `wired_in` target | checker exit 1 |
| drop `--config` from the lint step | checker exit 1 |

The third is the ticket's acceptance criterion 3. **Before this change it left the checker green at exit 0.**

### Tests

`--self-test` **11 → 21** cases. New suite `tests/scripts/check-control-registry.test.js` (8 tests) drives the real checker as a subprocess — no reimplementation. Its two load-bearing cases run the **real `pr-checks.yml`** through the checker with one line neutered, and assert the *unmutated* file passes first so a case cannot go green on a replace that matched nothing.

Sandbox fixture paths are **composed** rather than written as path literals: they name files that exist only in a throwaway directory, the F4 ratchet cannot tell them from repo source paths, and raising a shrink-only baseline to accommodate fixtures is how a ratchet decays into a suppression list.

Measured standing alone on `develop` `81f8f2e`: **308 suites / 4151 tests**. Here: **309 / 4160** — +8 hand-written, +1 from `source-path-manifest-integrity` being parameterised over `SRC` (246 → 247 entries). Test-floor baseline regenerated in the same commit after correctly failing STALE.

## Jira Ticket

SEC-119

## Checklist

- [x] Unit tests added/updated for new/changed functionality
- [x] All existing tests pass (`npm run test:unit`) — 309 suites / 4160 tests, green
- [x] Lint passes (`npm run lint`) — output byte-identical to base
- [x] Type check passes (`npm run type-check`)
- [ ] Build succeeds (`npm run build`) — not run; no `src/` file is touched by this PR
- [x] Coverage has not decreased — net-new tests only, no assertion changed or removed
- [x] No eslint-disable or ts-ignore without KAN-XX reference — none added
- [x] Dependency-rule gate reviewed — no `src/` import graph change
- [ ] ARCHITECTURE.md updated if architectural changes were made — N/A, no architectural change
- [ ] Ops routine / Control-Room registry updated — N/A, no scheduled-routine behaviour, cadence or ownership changed
- [x] Docs / system map updated — `docs/DEFECT_FEEDBACK_LOOP.md` §4 now states what `wired_in` means and what SEC-119 changed. No Confluence system-map surface: no service, table, env var, route, scheduled job or security boundary changed
- [ ] Design loop (KAN-441) — N/A. No user-facing page. `check-ui-copy-ownership.sh --describe` re-run at claim; nothing touched is protected (`scripts/`, `controls/`, `tests/`, `docs/`, `.github/workflows/`)

**MCP coverage:** N/A — CI control tooling, no user-facing data surface.

## Notes for review

- **`wired_in` now means "the control RUNS here", per-target.** If a file is merely *relevant* to a control it does not belong in the list. That reading is what the error text has always claimed and what the SEC-79 failure mode is about, but the code allowed the two readings to be silently confused (the ticket's own open question). Both live findings resolved cleanly under it.
- The comment-stripping import is deliberately **not** wrapped in a fallback. Either falling back to a local copy or to raw text would silently restore the defect while printing a clean result.
- Opened as a **draft**: the autopilot does not self-merge, and the `pr-checks.yml` lint-step change is worth one human glance even though its output is proven unchanged.

---
_Generated by [Claude Code](https://claude.ai/code/session_0195bBPxWwAUZLr3ZamEZVdV)_