### PR TITLE
fix(SEC-118): admin moderation writes must refuse a self-target

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -364,6 +364,21 @@ jobs:
           set -euo pipefail
           python3 scripts/check-absent-secret-probe.py --self-test
           python3 scripts/check-absent-secret-probe.py
+      - name: Admin moderation writes refuse a self-target (SEC-118 / CTL-075)
+        # SEC-118: three of four writers of a member's `profiles` row carried a
+        # self-moderation guard and one did not, so an admin reviewing a report
+        # filed against their OWN profile was shown a live Suspend button that
+        # locked them out of the product with no in-app way back.
+        #
+        # Keyed on the ADMIN MODERATION SIGNATURE (writes `profiles` AND logs a
+        # moderation action), deliberately NOT on the column name: the bulk
+        # path passes an opaque payload built in another module, so a
+        # column-keyed matcher reports clean over the highest-volume moderation
+        # path in the product. Same lesson as CTL-055's `opaque-builder`.
+        run: |
+          set -euo pipefail
+          python3 scripts/check-self-moderation-guard.py --self-test
+          python3 scripts/check-self-moderation-guard.py
       - name: Soak verdicts are extracted and testable (BUGS-103 / CTL-069)
         # BUGS-103: the C1-sitemap-fresh probe asserted a header Next hardcodes
         # to the OTHER value, so it could never return PASS and could not have

--- a/controls/registry.json
+++ b/controls/registry.json
@@ -1274,6 +1274,22 @@
       ],
       "escape_hatch": "none - a route that must return internal error text is not a case this codebase has; log it server-side via logStep and return the stable code.",
       "added": "2026-08-19"
+    },
+    {
+      "id": "CTL-075",
+      "name": "Admin moderation writes refuse a self-target",
+      "defect_class": "guard-added-at-one-call-site-but-not-its-siblings",
+      "summary": "Fails any PR in which a function BOTH writes the profiles table and records a moderation action, yet performs no self-moderation check. SEC-118: three of four such writers had the guard and suspendProfileFromReport did not, so an admin reviewing a report filed against their own profile was shown a live Suspend button; one click locked them out of dev/staging on every path with no self-unsuspend route anywhere, recoverable only by a second admin or direct SQL. docs/DEFECT_FEEDBACK_LOOP.md counts EIGHT prior tickets in this family, so fixing the ninth call site without a control produces a tenth. CTL-028 named this class in its prevents list and could never fire on it (it matched .eq(is_published,true) READ chains); that claim was removed on 2026-08-12 by an unrelated rewrite, leaving the class with no control at all until this one. KEYED ON THE MODERATION SIGNATURE, NOT THE COLUMN NAME, and that is the load-bearing design decision: bulkUserAction writes svc.from(profiles).update(transition.update) where the payload is built in another module, so is_suspended appears nowhere in the writing function and a column-keyed matcher would report clean over the highest-volume moderation path in the product (CTL-055 opaque-builder lesson). FUNCTION-SCOPED, not file-scoped, per gotcha #27: a guard in a sibling function must not cover its neighbour, which is the entire defect class. COMMENTS ARE STRIPPED before matching (catalogue failure mode 2) and the case is live - the fixed file names isSelfModeration in a header paragraph explaining the defect, so raw matching would let the prose satisfy the guard. A guard-the-guard self-test case proves the stripper actually removes that token, and a second proves it does not remove one in executable code. FAILS CLOSED on a short corpus or an unreadable file rather than reporting a clean scan that never ran (gotcha #30). FOUND A LIVE FIFTH WRITER the ticket did not list: approveBetaUser in src/app/admin/beta-queue/actions.ts, where an admin could grant themselves beta access - already refused via the bulk path, so the two routes to one outcome disagreed. Mutation-proven: removing the guard from suspendProfileFromReport, from approveBetaUser, or from bulkUserAction each reddens the scan; moving a guard into a comment reddens it; and the behavioural suites redden independently. STATED GAPS: deleteProfileItem logs a moderation action with no self-guard but writes profile_items, not profiles, so it is out of the predicate by design (SEC-118 section D - a product decision with an owner, not a defect); and this is a static scan, so it proves a check is PRESENT, not that it is correct - the behavioural contract is pinned by tests/unit/trust-safety-report-actions.test.ts and tests/unit/beta-queue-approve.test.ts.",
+      "implementation": "scripts/check-self-moderation-guard.py",
+      "kind": "ci-gate",
+      "wired_in": [
+        ".github/workflows/pr-checks.yml"
+      ],
+      "prevents": [
+        "SEC-118"
+      ],
+      "escape_hatch": "// self-moderation-ok: <JIRA-KEY> <reason> inside the function. A bare marker with no ticket key does NOT satisfy it.",
+      "added": "2026-08-20"
     }
   ]
 }

--- a/scripts/check-self-moderation-guard.py
+++ b/scripts/check-self-moderation-guard.py
@@ -1,0 +1,399 @@
+#!/usr/bin/env python3
+"""CTL-075 — every admin moderation write to `profiles` must refuse a self-target.
+
+SEC-118. Of the four code paths that moderate a member's `profiles` row, three
+carried a self-moderation guard and one did not: `suspendProfileFromReport`.
+The consequence was not privilege escalation — an admin can already suspend a
+peer through the sanctioned UI — it was an unrecoverable SELF-lockout, because
+any member can report an admin and the report page rendered a live "Suspend"
+button with nothing behind it.
+
+WHY THIS CONTROL EXISTS AT ALL
+------------------------------
+`docs/DEFECT_FEEDBACK_LOOP.md` counts EIGHT prior tickets in one family: "a
+suspension guard added to one call site but not its siblings". SEC-118 is the
+ninth. Fixing the ninth call site without changing a control produces a tenth.
+
+CTL-028 named this class in its `prevents` list and could not fire on it — its
+implementation only matched `.eq('is_published', true)` READ chains. That claim
+was removed on 2026-08-12 by an unrelated rewrite, which is honest but leaves
+the class with NO control at all. This is that control.
+
+WHAT IT MATCHES, AND WHY IT IS NOT KEYED ON THE COLUMN NAME
+----------------------------------------------------------
+The obvious predicate — "a function whose update payload mentions
+`is_suspended`" — is WRONG here, and measurably so. `bulkUserAction` writes
+`svc.from('profiles').update(transition.update)`, where `transition.update` is
+built by `computeAccessTransition` in another module entirely. The column name
+appears nowhere in the writing function. A column-keyed gate would report clean
+over the highest-volume moderation path in the product (it suspends up to
+BULK_MAX members in one statement), which is the CTL-055 `opaque-builder`
+lesson: a matcher that needs a literal cannot see a variable.
+
+So the predicate is the ADMIN MODERATION SIGNATURE instead — a function that
+BOTH:
+  1. writes `profiles` (`.from('profiles')` … `.update(`/`.upsert(`), AND
+  2. records the act in the tamper-evident trail (`logModerationAction` or
+     `logModerationActionsBatch`).
+
+Writing a member's row *and* logging it as a moderation action is what makes a
+function a moderation path, whatever columns it happens to touch. That pairing
+is also what keeps the owner's own `is_published` write in
+`src/app/dashboard/profile/actions.ts` out of scope: a member publishing their
+own profile is self-targeting BY DEFINITION and must not be refused. Excluding
+it by "does it log a moderation action" is a statement about what the code IS,
+where excluding it by path would only be a statement about where it lives.
+
+COMMENTS ARE STRIPPED BEFORE MATCHING
+-------------------------------------
+Catalogue failure mode 2, and it is live in this very repo: the file this
+control was written for has a header paragraph naming `isSelfModeration` while
+explaining the defect. Matching raw source would let that PROSE satisfy the
+guard requirement — the better the fix is documented, the weaker the scan
+becomes. Annotations are read from the raw text (they are comments by
+construction); everything else is matched post-strip.
+
+STATED GAPS — read these before trusting a clean result
+-------------------------------------------------------
+* `deleteProfileItem` (`src/modules/trust-safety/user-actions.ts`) logs a
+  moderation action and has no self-guard, but deletes from `profile_items`,
+  not `profiles`, so it is OUT of this predicate. That is deliberate: whether
+  an admin may delete an item from their own profile is a product decision
+  with an owner, not a defect (SEC-118 §D). It is recorded here so a clean
+  run is not misread as covering it.
+* A moderation path that neither writes `profiles` nor logs would be invisible.
+  Such a path would be a worse defect than this one and is not currently
+  reachable — every writer in the tree does both.
+* This is a static scan. It proves a self-check is PRESENT in the function, not
+  that it is correct. The behavioural contract is pinned by
+  `tests/unit/trust-safety-report-actions.test.ts` and
+  `tests/unit/trust-safety-user-actions.test.ts`, which are mutation-proven.
+
+Escape hatch: `// self-moderation-ok: <JIRA-KEY> <reason>` inside the function.
+
+Usage:
+  python3 scripts/check-self-moderation-guard.py
+  python3 scripts/check-self-moderation-guard.py --self-test
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+import sys
+
+# A floor, not an exact count. Asserted BEFORE iterating, because a
+# parameterised scan over an empty corpus is green and says nothing
+# (catalogue failure mode 4). If the tree genuinely drops below this, the
+# scan is not finding the files it used to and that is the finding.
+MIN_FILES_SCANNED = 200
+MIN_MODERATION_WRITERS = 3
+
+WRITE_RE = re.compile(r"\.from\(\s*['\"]profiles['\"]\s*\)")
+MUTATE_RE = re.compile(r"\.(update|upsert)\s*\(")
+LOG_RE = re.compile(r"\blogModerationAction(sBatch)?\s*\(")
+
+# Either the shared helper, or an explicit comparison against the acting
+# admin's own profile id. `bulkUserAction` uses the second form — a filter over
+# a list — and rewriting it to use the helper is a refactor this control has no
+# business forcing.
+GUARD_RE = re.compile(
+    r"isSelfModeration\s*\(|[!=]==?\s*admin\.profileId|admin\.profileId\s*[!=]==?"
+)
+
+ANNOTATION_RE = re.compile(r"//\s*self-moderation-ok:\s*([A-Z][A-Z0-9]+-[0-9]+)\s+\S")
+
+FUNC_START_RE = re.compile(
+    r"^(?:export\s+)?(?:async\s+)?function\s+([A-Za-z_$][\w$]*)\s*\(", re.M
+)
+
+
+def strip_comments(src: str) -> str:
+    """Remove // and /* */ comments, preserving line structure.
+
+    Deliberately naive about strings containing "//": the cost of a false
+    strip here is a guard that reads as ABSENT (a loud, investigable failure),
+    where the cost of not stripping is a guard that reads as PRESENT because
+    a comment mentioned it — silent, and the defect this repo keeps hitting.
+    Fail in the direction that is visible.
+    """
+    src = re.sub(r"/\*.*?\*/", lambda m: "\n" * m.group(0).count("\n"), src, flags=re.S)
+    src = re.sub(r"//[^\n]*", "", src)
+    return src
+
+
+def split_functions(src: str) -> list[tuple[str, str]]:
+    """Split a module into (name, body) for each top-level function.
+
+    Function-scoped rather than file-scoped for the reason gotcha #27 records:
+    a file-scoped cut of `check-partial-write-safety.py` passed `actions.ts`
+    because an UNRELATED function in the same file contained the token it was
+    looking for. A guard present in one function says nothing about its sibling
+    — which is the entire defect class this control exists for.
+    """
+    starts = [(m.start(), m.group(1)) for m in FUNC_START_RE.finditer(src)]
+    if not starts:
+        return []
+    out = []
+    for i, (pos, name) in enumerate(starts):
+        end = starts[i + 1][0] if i + 1 < len(starts) else len(src)
+        out.append((name, src[pos:end]))
+    return out
+
+
+def tracked_sources() -> list[str]:
+    out = subprocess.run(
+        ["git", "ls-files", "src/"], capture_output=True, text=True, check=True
+    ).stdout.splitlines()
+    return [p for p in out if p.endswith((".ts", ".tsx"))]
+
+
+def analyse(raw: str) -> list[tuple[str, bool, bool]]:
+    """Return (function name, is a moderation writer, is guarded-or-annotated)."""
+    stripped = strip_comments(raw)
+    results = []
+    raw_funcs = dict(split_functions(raw))
+    for name, body in split_functions(stripped):
+        writes = bool(WRITE_RE.search(body)) and bool(MUTATE_RE.search(body))
+        if not (writes and LOG_RE.search(body)):
+            continue
+        guarded = bool(GUARD_RE.search(body))
+        # The annotation is a comment, so it is read from the RAW body.
+        annotated = bool(ANNOTATION_RE.search(raw_funcs.get(name, "")))
+        results.append((name, True, guarded or annotated))
+    return results
+
+
+def run_scan() -> int:
+    files = tracked_sources()
+    if len(files) < MIN_FILES_SCANNED:
+        print(
+            f"::error::CTL-075: scanned only {len(files)} tracked source files "
+            f"(floor {MIN_FILES_SCANNED}). The scan did not run over the tree it "
+            "is supposed to cover; failing closed rather than reporting clean."
+        )
+        return 2
+
+    writers: list[str] = []
+    violations: list[str] = []
+    for path in files:
+        try:
+            with open(path, encoding="utf-8") as fh:
+                raw = fh.read()
+        except OSError as exc:  # unreadable file => fail closed, never "clean"
+            print(f"::error::CTL-075: could not read {path}: {exc}")
+            return 2
+        for name, _, ok in analyse(raw):
+            writers.append(f"{path}::{name}")
+            if not ok:
+                violations.append(f"{path}::{name}")
+
+    if len(writers) < MIN_MODERATION_WRITERS:
+        print(
+            f"::error::CTL-075: found only {len(writers)} admin moderation "
+            f"writer(s) (floor {MIN_MODERATION_WRITERS}). Either the detector "
+            "stopped matching or the moderation paths moved. Both are findings."
+        )
+        for w in writers:
+            print(f"    matched: {w}")
+        return 2
+
+    for v in violations:
+        print(
+            f"::error::CTL-075: {v} writes `profiles` and logs a moderation "
+            "action, but performs no self-moderation check."
+        )
+    if violations:
+        print(
+            "\n  An admin server action is reachable by anyone who can post a "
+            "form, so it must defend itself — hiding the button is not enough.\n"
+            "  Fix: call isSelfModeration(admin.profileId, targetProfileId) and "
+            "bail BEFORE the audit write.\n"
+            "  Or annotate: // self-moderation-ok: <JIRA-KEY> <reason>\n"
+            "  See SEC-118 and docs/DEFECT_FEEDBACK_LOOP.md."
+        )
+        return 1
+
+    print(
+        f"CTL-075: {len(writers)} admin moderation writer(s) across "
+        f"{len(files)} files, all self-guarded. ✓"
+    )
+    for w in writers:
+        print(f"    ok: {w}")
+    return 0
+
+
+# ── self-test ────────────────────────────────────────────────────────────
+
+GUARDED = """
+export async function setSuspendState(profileId: string): Promise<void> {
+  const admin = await getCurrentAdmin();
+  if (isSelfModeration(admin.profileId, profileId)) { redirect('/x'); }
+  await logModerationAction({ admin, action: 'suspend' });
+  await supabase.from('profiles').update({ is_suspended: true }).eq('id', profileId);
+}
+"""
+
+# The SEC-118 defect, verbatim in shape.
+UNGUARDED = """
+export async function suspendProfileFromReport(profileId: string): Promise<void> {
+  const admin = await getCurrentAdmin();
+  await logModerationAction({ admin, action: 'suspend' });
+  await supabase.from('profiles').update({ is_suspended: true }).eq('id', profileId);
+}
+"""
+
+# The reason this control is not keyed on the column name: the payload is
+# opaque and `is_suspended` appears nowhere in the writing function.
+OPAQUE_GUARDED = """
+export async function bulkUserAction(formData: FormData): Promise<void> {
+  const admin = await getCurrentAdmin();
+  ids = ids.filter((id) => id !== admin.profileId);
+  await logModerationActionsBatch({ admin, targetProfileIds: ids });
+  await svc.from('profiles').update(transition.update).in('id', ids);
+}
+"""
+
+OPAQUE_UNGUARDED = """
+export async function bulkUserAction(formData: FormData): Promise<void> {
+  const admin = await getCurrentAdmin();
+  await logModerationActionsBatch({ admin, targetProfileIds: ids });
+  await svc.from('profiles').update(transition.update).in('id', ids);
+}
+"""
+
+# Catalogue failure mode 2: prose naming the guard must NOT satisfy it.
+COMMENT_ONLY = """
+/**
+ * Historically this called isSelfModeration(admin.profileId, profileId)
+ * before the audit write. See SEC-118.
+ */
+export async function suspendProfileFromReport(profileId: string): Promise<void> {
+  // isSelfModeration is the shared helper used by the sibling actions.
+  const admin = await getCurrentAdmin();
+  await logModerationAction({ admin, action: 'suspend' });
+  await supabase.from('profiles').update({ is_suspended: true }).eq('id', profileId);
+}
+"""
+
+ANNOTATED = """
+export async function suspendProfileFromReport(profileId: string): Promise<void> {
+  // self-moderation-ok: SEC-999 target is always a third party by construction
+  const admin = await getCurrentAdmin();
+  await logModerationAction({ admin, action: 'suspend' });
+  await supabase.from('profiles').update({ is_suspended: true }).eq('id', profileId);
+}
+"""
+
+# A bare marker with no ticket key must NOT satisfy the hatch.
+ANNOTATION_NO_KEY = """
+export async function suspendProfileFromReport(profileId: string): Promise<void> {
+  // self-moderation-ok: because I said so
+  const admin = await getCurrentAdmin();
+  await logModerationAction({ admin, action: 'suspend' });
+  await supabase.from('profiles').update({ is_suspended: true }).eq('id', profileId);
+}
+"""
+
+# The member publishing their OWN profile. Self-targeting by definition, and
+# no moderation log — must never be flagged.
+OWNER_SELF_PUBLISH = """
+export async function publishProfile(profileId: string): Promise<void> {
+  await supabase.from('profiles').update({ is_published: true }).eq('id', profileId);
+}
+"""
+
+# Reads the table but does not mutate it.
+READ_ONLY = """
+export async function loadProfile(profileId: string): Promise<void> {
+  await logModerationAction({ admin, action: 'view' });
+  await supabase.from('profiles').select('id').eq('id', profileId);
+}
+"""
+
+# Gotcha #27's lesson: a guard in a SIBLING function must not cover this one.
+SIBLING_LEAK = """
+export async function setSuspendState(profileId: string): Promise<void> {
+  if (isSelfModeration(admin.profileId, profileId)) { redirect('/x'); }
+  await logModerationAction({ admin, action: 'suspend' });
+  await supabase.from('profiles').update({ is_suspended: true }).eq('id', profileId);
+}
+
+export async function suspendProfileFromReport(profileId: string): Promise<void> {
+  await logModerationAction({ admin, action: 'suspend' });
+  await supabase.from('profiles').update({ is_suspended: true }).eq('id', profileId);
+}
+"""
+
+# A moderation write to a DIFFERENT table is out of scope (the stated gap).
+OTHER_TABLE = """
+export async function deleteProfileItem(itemId: string): Promise<void> {
+  await logModerationAction({ admin, action: 'delete_item' });
+  await supabase.from('profile_items').delete().eq('id', itemId);
+}
+"""
+
+CASES = [
+    ("guarded", GUARDED, [("setSuspendState", True)]),
+    ("unguarded — the SEC-118 defect", UNGUARDED, [("suspendProfileFromReport", False)]),
+    ("opaque payload, guarded by filter", OPAQUE_GUARDED, [("bulkUserAction", True)]),
+    ("opaque payload, unguarded", OPAQUE_UNGUARDED, [("bulkUserAction", False)]),
+    ("comment naming the guard does NOT satisfy it", COMMENT_ONLY,
+     [("suspendProfileFromReport", False)]),
+    ("annotation with a ticket key satisfies it", ANNOTATED,
+     [("suspendProfileFromReport", True)]),
+    ("annotation without a ticket key does NOT", ANNOTATION_NO_KEY,
+     [("suspendProfileFromReport", False)]),
+    ("owner self-publish is not a moderation write", OWNER_SELF_PUBLISH, []),
+    ("read-only access is not a write", READ_ONLY, []),
+    ("a sibling's guard does not cover this function", SIBLING_LEAK,
+     [("setSuspendState", True), ("suspendProfileFromReport", False)]),
+    ("a write to another table is out of scope", OTHER_TABLE, []),
+]
+
+
+def self_test() -> int:
+    failures: list[str] = []
+    checked = 0
+
+    def check(cond: bool, label: str) -> None:
+        nonlocal checked
+        checked += 1
+        if not cond:
+            failures.append(label)
+
+    for label, src, expected in CASES:
+        got = [(n, ok) for n, _, ok in analyse(src)]
+        check(got == expected, f"{label}: expected {expected}, got {got}")
+
+    # Guard-the-guard: prove strip_comments actually removes the token the
+    # COMMENT_ONLY case depends on. Without this, that case could be passing
+    # because the regex never matched for some other reason.
+    check(
+        "isSelfModeration" in COMMENT_ONLY
+        and "isSelfModeration" not in strip_comments(COMMENT_ONLY),
+        "strip_comments must remove a guard token that appears only in prose",
+    )
+    # ...and that it does NOT remove one in real code.
+    check(
+        "isSelfModeration" in strip_comments(GUARDED),
+        "strip_comments must preserve a guard token in executable code",
+    )
+
+    # The corpus floor is asserted, not assumed (catalogue failure mode 4).
+    check(len(CASES) >= 11, f"case corpus shrank to {len(CASES)}")
+
+    # Read the verdict AFTER every case has run (catalogue failure mode 9 —
+    # assertions appended to a list nothing consumes report a rising count and
+    # never fail).
+    if failures:
+        for f in failures:
+            print(f"::error::CTL-075 self-test FAILED — {f}")
+        print(f"Self-test FAILED ({len(failures)} of {checked} checks)")
+        return 1
+    print(f"CTL-075 self-test passed ({checked} checks over {len(CASES)} fixtures). ✓")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(self_test() if "--self-test" in sys.argv else run_scan())

--- a/src/app/admin/beta-queue/actions.ts
+++ b/src/app/admin/beta-queue/actions.ts
@@ -3,6 +3,7 @@
 import { revalidatePath } from 'next/cache';
 import { getCurrentAdmin, getAdminServiceClient, logModerationAction } from '@/modules/admin/admin';
 import { sendBetaApprovedEmail } from '@/modules/access/beta-access/email';
+import { isSelfModeration } from '@/modules/trust-safety/user-actions';
 
 /**
  * KAN-277 (epic KAN-273): approve a queued user into the beta.
@@ -23,6 +24,20 @@ export async function approveBetaUser(formData: FormData): Promise<void> {
   const userId = String(formData.get('user_id') ?? '').trim();
   if (!profileId || !userId) {
     throw new Error('Missing target profile');
+  }
+
+  // SEC-118: an admin may not grant themselves beta access. Found by CTL-075
+  // rather than by the ticket, which listed four moderation writers; this is a
+  // fifth. The same capability is ALREADY refused through the bulk path —
+  // `bulkUserAction` filters the acting admin out of `promote_live` — so
+  // allowing it here was an inconsistency between two routes to one outcome,
+  // which is the shape of the eight prior tickets in this family.
+  //
+  // It throws rather than redirecting because that is this action's own
+  // convention for a refused input (see the two checks above); the sibling
+  // actions in trust-safety/ redirect because they are page-bound.
+  if (isSelfModeration(admin.profileId, profileId)) {
+    throw new Error('You cannot approve your own beta access');
   }
 
   const svc = getAdminServiceClient();

--- a/src/app/admin/reports/[id]/page.tsx
+++ b/src/app/admin/reports/[id]/page.tsx
@@ -11,7 +11,7 @@
 
 import { notFound, redirect } from 'next/navigation';
 import Link from 'next/link';
-import { getAdminServiceClient } from '@/modules/admin/admin';
+import { getCurrentAdmin, getAdminServiceClient } from '@/modules/admin/admin';
 import {
   resolveReport,
   suspendProfileFromReport,
@@ -102,6 +102,13 @@ export default async function ReportDetailPage({
   const { id } = await params;
   const report = await loadReport(id);
   if (!report) notFound();
+
+  // SEC-118: the same `!isSelf` condition the users page puts on these
+  // buttons. The action defends itself too (report-actions.ts) — this only
+  // stops an admin being SHOWN a live "suspend" button for their own profile,
+  // which on dev/staging locks them out of the product with no way back in.
+  const admin = (await getCurrentAdmin())!; // layout already gated
+  const isSelf = report.profile?.id === admin.profileId;
 
   return (
     <div className="max-w-4xl mx-auto px-6 py-8 space-y-8">
@@ -202,7 +209,7 @@ export default async function ReportDetailPage({
             </button>
           </form>
 
-          {report.profile && !report.profile.is_suspended && (
+          {report.profile && !report.profile.is_suspended && !isSelf && (
             <form action={actionSuspendProfile} className="space-y-3 pt-2 border-t border-[var(--color-border)]">
               <input type="hidden" name="reportId" value={report.id} />
               <input type="hidden" name="profileId" value={report.profile.id} />

--- a/src/modules/trust-safety/report-actions.ts
+++ b/src/modules/trust-safety/report-actions.ts
@@ -38,6 +38,7 @@
  */
 import { redirect } from 'next/navigation';
 import { getCurrentAdmin, getAdminServiceClient, logModerationAction } from '@/modules/admin/admin';
+import { isSelfModeration } from './user-actions';
 
 /** The two ways a report can be closed without suspending anyone. */
 export type ReportResolution = 'actioned' | 'dismissed';
@@ -97,6 +98,24 @@ export async function resolveReport(
  * midway leaves the report open — an open report about an already-suspended
  * member is a visible inconsistency someone will resolve, whereas a closed
  * report about an un-suspended member looks like a decision that was made.
+ *
+ * SEC-118 — SELF-MODERATION. This was the ONLY writer of
+ * `profiles.is_suspended` with no self-moderation guard; its three siblings
+ * (`setSuspendState`, `setPublishedState`, `bulkUserAction`) all have one.
+ * The consequence was not privilege escalation — an admin can already suspend
+ * a peer through the sanctioned UI — it was an unrecoverable SELF-lockout:
+ * `src/app/api/reports/route.ts` blocks only self-REPORTS, so any member can
+ * report an admin, and on dev/staging `middleware.ts` then redirects that
+ * admin to `/suspended` on every path with no self-unsuspend route anywhere.
+ * Recovery needs a second admin or direct SQL.
+ *
+ * The guard is here, in the action, and not only in the page that hides the
+ * button: a server action is reachable by anyone who can post a form, so it
+ * must defend itself. That is the same reasoning `setSuspendState` states,
+ * and `isSelfModeration` is IMPORTED from it rather than re-implemented —
+ * re-implementing this guard per call site is precisely what produced the
+ * gap (the plan predicted it at D7, and `docs/DEFECT_FEEDBACK_LOOP.md` counts
+ * eight prior tickets in the same family).
  */
 export async function suspendProfileFromReport(
   reportId: string,
@@ -105,6 +124,13 @@ export async function suspendProfileFromReport(
 ): Promise<void> {
   const admin = await getCurrentAdmin();
   if (!admin) redirect('/');
+
+  // SEC-118: bail before the audit write, as the siblings do. Nothing is
+  // logged, because nothing happened — a refused action is not a moderation
+  // action, and writing one would put noise in the tamper-evident trail.
+  if (isSelfModeration(admin.profileId, profileId)) {
+    redirect(`/admin/reports/${reportId}`);
+  }
 
   const supabase = getAdminServiceClient();
   const effectiveReason = reason || 'Action taken following report';

--- a/tests/support/test-floor-baseline.json
+++ b/tests/support/test-floor-baseline.json
@@ -1,6 +1,6 @@
 {
   "$comment": "GENERATED — regenerate with `npm run gen:test-floor`. The enforced test floor. The guard fails if the counts DROP (a test was deleted) and also if they RISE (this baseline is stale and is overstating how much of the estate is actually protected). The rise case is the one that matters: the previous hand-maintained floor sat at 29 files / 320 blocks against an actual 260 / 2963, so ~89% of the tests could have been deleted silently. Raise it in the SAME commit as any net-new test.",
-  "measured_at": "2026-08-19",
+  "measured_at": "2026-08-20",
   "test_files": 309,
-  "test_blocks": 3581
+  "test_blocks": 3587
 }

--- a/tests/unit/beta-queue-approve.test.ts
+++ b/tests/unit/beta-queue-approve.test.ts
@@ -48,6 +48,30 @@ describe('approveBetaUser (KAN-277)', () => {
     expect(mockEmail).not.toHaveBeenCalled();
   });
 
+  // SEC-118 / CTL-075 — net-new. The control discovered this writer; the
+  // ticket listed four and this is a fifth. Refusing it here matches
+  // `bulkUserAction`, which already filters the acting admin out of
+  // `promote_live`, so the two routes to one outcome now agree.
+  it('refuses an admin approving their OWN beta access, and mutates nothing', async () => {
+    mockGetCurrentAdmin.mockResolvedValue(ADMIN);
+    await expect(
+      approveBetaUser(fd({ profile_id: ADMIN.profileId, user_id: 'a' })),
+    ).rejects.toThrow('cannot approve your own');
+    expect(mockUpdateEq).not.toHaveBeenCalled();
+    expect(mockLog).not.toHaveBeenCalled();
+    expect(mockEmail).not.toHaveBeenCalled();
+  });
+
+  // The negative control. Without it, throwing on EVERY call would satisfy the
+  // case above — a guard that refuses everything is indistinguishable from a
+  // correct one unless the permitted case is pinned too.
+  it('still approves a DIFFERENT profile', async () => {
+    mockGetCurrentAdmin.mockResolvedValue(ADMIN);
+    await approveBetaUser(fd({ profile_id: 'not-the-admin', user_id: 'u1' }));
+    expect(mockUpdateEq).toHaveBeenCalled();
+    expect(mockLog).toHaveBeenCalled();
+  });
+
   it('rejects a missing target profile', async () => {
     mockGetCurrentAdmin.mockResolvedValue(ADMIN);
     await expect(approveBetaUser(fd({ profile_id: '', user_id: '' }))).rejects.toThrow(

--- a/tests/unit/trust-safety-report-actions.test.ts
+++ b/tests/unit/trust-safety-report-actions.test.ts
@@ -176,3 +176,65 @@ describe('suspendProfileFromReport — the highest-consequence write', () => {
     expect(calls).toEqual(['redirect:/']);
   });
 });
+
+/**
+ * SEC-118 — the guard that was missing here and present in all three siblings.
+ *
+ * These are net-new; nothing above is modified. The existing block above runs
+ * with an `admin` fixture that has no `profileId` at all, so the guard added
+ * for SEC-118 cannot fire in any of those cases — which is why they still
+ * pass unchanged, and why this block has to supply its own admin.
+ *
+ * The property asserted is REFUSAL BEFORE THE AUDIT WRITE, not merely
+ * "nobody was suspended". A refused action is not a moderation action: if it
+ * logged first and then bailed, `moderation_logs` would accumulate rows for
+ * suspensions that never happened, and that trail is the tamper-evident
+ * record SEC-64 exists to protect.
+ */
+describe('suspendProfileFromReport — self-moderation is refused (SEC-118)', () => {
+  const selfAdmin = { userId: 'admin-user-1', email: 'ops@checklyra.com', profileId: 'profile-9' };
+
+  test('an admin cannot suspend themselves from a report — bails before logging', async () => {
+    currentAdmin = selfAdmin as typeof admin;
+    await expect(suspendProfileFromReport('report-1', 'profile-9', 'x')).rejects.toThrow(
+      /NEXT_REDIRECT/,
+    );
+    // The ONLY thing that happened is the redirect. No log row, no update.
+    expect(calls).toEqual(['redirect:/admin/reports/report-1']);
+    expect(adminModule.logModerationAction).not.toHaveBeenCalled();
+  });
+
+  test('the refusal happens BEFORE the audit write, not after it', async () => {
+    // Distinct from the case above: this one would still pass if the guard
+    // were placed after logModerationAction, so it is asserted separately.
+    currentAdmin = selfAdmin as typeof admin;
+    await expect(suspendProfileFromReport('report-1', 'profile-9', 'x')).rejects.toThrow(
+      /NEXT_REDIRECT/,
+    );
+    expect(calls.some((c) => c.startsWith('log:'))).toBe(false);
+    expect(calls.some((c) => c.startsWith('update:'))).toBe(false);
+  });
+
+  test('a DIFFERENT admin suspending this profile is still allowed', async () => {
+    // The negative control. Without it, `redirect()` on every call would also
+    // satisfy the two tests above — a guard that refuses everything is
+    // indistinguishable from a correct one unless the permitted case is
+    // pinned too.
+    currentAdmin = { ...selfAdmin, profileId: 'profile-OTHER' } as typeof admin;
+    await suspendProfileFromReport('report-1', 'profile-9', 'repeated abuse');
+    expect(calls).toEqual([
+      'log:suspend',
+      'update:profiles:is_suspended,suspended_at,suspension_reason',
+      'update:reports:resolved_at,resolved_by,status',
+    ]);
+  });
+
+  test('an admin with no profileId is NOT treated as matching a target', async () => {
+    // `isSelfModeration` requires both ids present AND equal. "Unknown" must
+    // never match and silently block a legitimate moderation action — the
+    // failure mode would be a moderation console that appears to do nothing.
+    currentAdmin = { userId: 'u', email: 'e' } as typeof admin;
+    await suspendProfileFromReport('report-1', 'profile-9', 'x');
+    expect(calls[0]).toBe('log:suspend');
+  });
+});


### PR DESCRIPTION
## Summary

`suspendProfileFromReport` was the only writer of a member's `profiles` row with **no self-moderation guard**. Its three siblings — `setSuspendState`, `setPublishedState`, `bulkUserAction` — all had one.

Not privilege escalation (an admin can already suspend a peer through the sanctioned UI) — an unrecoverable **self-lockout**. `src/app/api/reports/route.ts` blocks only self-*reports*, so any member can report an admin, and the report page rendered a live "Suspend profile + mark report actioned" button with nothing behind it. On dev/staging one click redirects that admin to `/suspended` on every path, and there is no self-unsuspend route anywhere. Recovery needs a second admin or direct SQL.

**Changed:**
- `src/modules/trust-safety/report-actions.ts` — bail on self-moderation **before** the audit write, as the siblings do. `isSelfModeration` is *imported* from `user-actions.ts`, not re-implemented; re-implementing per call site is what produced the gap.
- `src/app/admin/reports/[id]/page.tsx` — the `!isSelf` condition the users page already puts on these buttons. The action defends itself too: a server action is reachable by anyone who can post a form.
- `src/app/admin/beta-queue/actions.ts` — **a fifth writer the ticket did not list**, found by the new control rather than by reading. An admin could grant themselves beta access; `bulkUserAction` already refuses the equivalent `promote_live`. Two routes to one outcome now agree.

## Prevention: CTL-075

`scripts/check-self-moderation-guard.py`, wired into `pr-checks.yml`, registered in `controls/registry.json`.

`docs/DEFECT_FEEDBACK_LOOP.md` counts **eight** prior tickets in this family, so fixing the ninth call site without changing a control produces a tenth. CTL-028 named this class in its `prevents` list and could never fire on it; that claim was removed by an unrelated rewrite on 2026-08-12, leaving the class with **no control at all**.

Three design decisions worth review:
- **Keyed on the admin-moderation signature** (writes `profiles` **and** logs a moderation action), *not* on the column name. `bulkUserAction` writes `svc.from('profiles').update(transition.update)` — an opaque payload built in another module — so `is_suspended` appears nowhere in the writing function and a column-keyed matcher would report clean over the highest-volume moderation path in the product. Same lesson as CTL-055's `opaque-builder`. It is also what correctly excludes the member's own `is_published` write in `dashboard/profile/actions.ts`: self-targeting by definition, and no moderation log.
- **Function-scoped, not file-scoped** (gotcha #27): a guard in a sibling function must not cover its neighbour — that *is* the defect class.
- **Comments stripped before matching** (catalogue failure mode 2), and the case is live: the fixed file names `isSelfModeration` in a header paragraph explaining the defect, so raw matching would let the prose satisfy the guard. Two guard-the-guard self-test cases prove the stripper removes that token from prose and does *not* remove it from executable code.

Fails closed (exit 2) on a short corpus or an unreadable file rather than reporting a clean scan that never ran (gotcha #30).

## ⚠️ Two things NOT done — both need your call

1. **Re-deriving `profileId` from the reports row** (SEC-118 §2; the second half of acceptance criterion 1). It is a two-line change, but it adds a `select:reports` entry to the ordering log, so **one existing assertion** goes stale:
   `tests/unit/trust-safety-report-actions.test.ts:135` — `expect(calls).toEqual(['log:suspend', 'update:profiles:…', 'update:reports:…'])` would become `['select:reports', 'log:suspend', 'update:profiles:…', 'update:reports:…']`.
   Nothing is weakened (`toEqual` stays `toEqual`; the audit-first ordering it pins is preserved and the new entry mirrors what `resolveReport`'s own test already asserts) — but it *is* an assertion change, which needs Test Integrity sign-off. **Left untouched.** The security hole is closed regardless: the guard compares the supplied id against `admin.profileId`, so self-targeting is refused whether or not the id is re-derived. What re-derivation adds is *audit integrity* — stopping a forged post from tying a `moderation_logs` row to an unrelated report.
2. **`approveBetaUser` is audit-LAST.** It writes `profiles` *before* `logModerationAction`, inverting the frozen audit-first contract its siblings hold — if the log insert throws, the user is already approved with no forensic record. Found while fixing the guard; out of SEC-118's stated scope, so **reported, not fixed**.

## Stated gaps in CTL-075

- `deleteProfileItem` logs a moderation action with no self-guard, but writes `profile_items`, not `profiles` — out of the predicate **by design** (SEC-118 §D: a product decision with an owner, not a defect).
- It is a static scan: it proves a check is *present*, not that it is *correct*. The behavioural contract is pinned by the two mutation-proven suites.

## Verification

Every mutation asserted applied to the file before the result was trusted.

**Behaviour** — removing the guard from `suspendProfileFromReport` → 2 red; moving it after the audit write → 2 red; `isSelfModeration` forced `true` → 14 red, forced `false` → 5 red.
**Control** — removing the guard from any of the three writers → scan exit 1; moving one into a comment → exit 1; neutering the comment stripper → its own self-test exit 1.

`309 suites / 4183 tests` green (`npm run test:unit`), `tsc --noEmit` clean. Generated floor regenerated in the same commit after correctly failing STALE (3581 → 3587 = 4 new report-action tests + 2 new beta-queue tests).

## Jira Ticket

SEC-118

## Checklist

- [x] Unit tests added/updated for new/changed functionality — 6 net-new; **no existing assertion modified**
- [x] All existing tests pass (`npm run test:unit`) — 309/309 suites, 4183/4183 tests
- [x] Lint passes — no new findings (one pre-existing warning in `trust-safety-report-actions.test.ts:71`, present on `develop`, verified by stashing)
- [x] Type check passes (`npm run type-check`)
- [ ] Build succeeds (`npm run build`) — not run in this session; no `next/font` or build-surface change
- [x] Coverage has not decreased — net-new tests only
- [x] No eslint-disable or ts-ignore without KAN-XX reference
- [x] Dependency-rule gate reviewed — no new import edges beyond `admin/beta-queue → modules/trust-safety` (app → module, the permitted direction)
- [x] ARCHITECTURE.md updated if architectural changes were made — N/A: no new service, table, env var, route, job or security boundary; one existing action gains a guard
- [x] Ops routine / Control-Room registry updated — N/A: no scheduled-routine behaviour, cadence or ownership change
- [x] Docs / system map updated — N/A: logic + control only. The control is registered in `controls/registry.json`, which is the system of record for CTL ids
- [x] Design loop (KAN-441) — **N/A.** `src/app/admin/**` is a CARVE-OUT on `check-ui-copy-ownership.sh --describe` (re-run at claim, not recalled). The gate confirms it: `no founder-owned UI/copy paths changed — OK`. **No `UI-*` trailer is present, and none is needed.** The one `.tsx` change adds a boolean condition to a security-relevant button on an internal admin page

<!-- Extraction DoD section deleted: this PR moves no file under src/. -->


---
_Generated by [Claude Code](https://claude.ai/code/session_01Xu5NE7QgJrFambMn3qqhnj)_