### PR TITLE
feat(KAN-459): CTL-076 — a test-side Supabase mock must record filters per statement

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -608,6 +608,14 @@ jobs:
           # another regressing.
           python3 scripts/check-route-thinness.py --self-test
           python3 scripts/check-route-thinness.py
+          # CTL-076 / KAN-459. A test-side Supabase mock must record .eq()
+          # filters PER STATEMENT. KAN-447/448 pooled them per TABLE, so the
+          # ownership pre-read satisfied assertions meant to be about the
+          # UPDATE: both owner filters were deletable while 27 tests stayed
+          # green. CTL-039's shape inside out — there a comment satisfies the
+          # assertion, here an incidental adjacent statement does.
+          python3 scripts/check-pooled-eq-mock.py --self-test
+          python3 scripts/check-pooled-eq-mock.py
           # CTL-064 / SEC-99. SEC-98 forbids pushing directly to main/beta/
           # staging, and until now that rule existed only in CLAUDE.md while the
           # repo shipped two scripts that did exactly it — six direct pushes,

--- a/controls/registry.json
+++ b/controls/registry.json
@@ -1274,6 +1274,25 @@
       ],
       "escape_hatch": "none - a route that must return internal error text is not a case this codebase has; log it server-side via logStep and return the stable code.",
       "added": "2026-08-19"
+    },
+    {
+      "id": "CTL-076",
+      "name": "Per-statement Supabase mock recording",
+      "defect_class": "assertion-satisfied-by-an-incidental-adjacent-statement",
+      "summary": "Flags a test-side Supabase mock whose .eq() recorder is keyed by TABLE rather than created per .from() call. KAN-447/448 asserted the owner-scoping of a school_affiliations UPDATE through such a pool; updateSchoolAffiliation reads the row before it writes it, so the SELECT's own .eq('id', ...) / .eq('profile_id', ...) satisfied assertions meant to be about the WRITE - both filters were deletable while all 27 tests stayed green, and the realised impact of that class is editing another member's row or bulk-overwriting every row of your own. It is CTL-039's shape turned inside out: there a COMMENT satisfies the assertion, here an incidental ADJACENT STATEMENT does. DELIBERATELY NARROW - three conditions must all hold: a tracked file under tests/, an .eq() recorder, and a table-keyed subscript INSIDE that recorder's body. A broad 'your Supabase mock looks suspicious' heuristic over the ~40 hand-rolled mocks here would be standing noise, and standing noise is what teaches reviewers to wave a gate through. Four self-test cases pin the narrowness by asserting the NEGATIVE: a table-keyed subscript outside any recorder, a recorder with no subscript, a subscript by something other than the table identifier, and a real .eq('id', x) CALL are all silent. COMMENTS ARE STRIPPED using check-comment-only-assertions.py's own strip_comments rather than a second copy of the rules - two implementations of one rule set with nothing comparing them is the SEC-152 drift shape, and it is the exact mistake KAN-459 step 3 corrected for stripComments. WHY A DETECTOR AND NOT ONLY THE SHARED HARNESS KAN-459 step 2 prefers: measured at landing, exactly ONE file in the estate uses the pooled shape, and it is non-vacuous today only by luck - its actions happen not to pre-read the table they write. A shared harness with no consumer that is not already correct is decorative; a gate covers every mock written from here on. The failure message names tests/unit/kan447-kan448-inline-edit.test.ts as the reference implementation, so it points at working code rather than at a rule.",
+      "implementation": "scripts/check-pooled-eq-mock.py",
+      "kind": "ci-gate",
+      "wired_in": [
+        ".github/workflows/pr-checks.yml"
+      ],
+      "prevents": [
+        "KAN-459",
+        "KAN-447",
+        "KAN-448"
+      ],
+      "escape_hatch": "none by annotation - record filters per .from() statement instead. An accepted instance goes in tests/support/pooled-eq-mock-baseline.json via --write-baseline, never by hand, and the list may only shrink: a baselined file that grows fails, and one that is fixed fails as STALE until the entry is removed. The single grandfathered entry is tests/unit/profile-ownership.test.ts (the KAN-260 owner-scoping net), baselined rather than converted because converting it rewrites existing assertions, which the Test Integrity Policy requires be signed off first.",
+      "self_test": "23 in-process cases via --self-test, floor-checked rather than tallied by hand (SEC-155's shape), with the verdict list read after every case has run (SEC-140 / catalogue failure mode 9). Mutation-proven four ways at landing, two on the real estate and two on the control: (1) converting kan447-kan448-inline-edit.test.ts's per-statement mock to a pool reddens the run as NEW and restoring it goes green; (2) converting the one baselined instance to per-statement reddens it as STALE; (3) removing the strip_comments call reddens 3 self-test cases; (4) dropping the method-shorthand branch of the recorder parser reddens 1. Separately, KAN-459 acceptance criterion 6 was verified against the real subject: deleting either .eq() from the school_affiliations UPDATE turns 2 tests of kan447-kan448-inline-edit.test.ts RED independently, so both filters are load-bearing.",
+      "added": "2026-08-20"
     }
   ]
 }

--- a/scripts/check-pooled-eq-mock.py
+++ b/scripts/check-pooled-eq-mock.py
@@ -1,0 +1,532 @@
+#!/usr/bin/env python3
+"""CTL-076 / KAN-459 §2 — a test-side Supabase mock must record filters PER STATEMENT.
+
+WHY THIS EXISTS
+---------------
+KAN-447/448 shipped a suite that asserted the owner-scoping of an UPDATE:
+
+    expect(eqCalls['school_affiliations']).toContainEqual(['profile_id', 'profile-1'])
+
+`updateSchoolAffiliation` reads the row before it writes it, and the SELECT's
+own `.eq('id', …)` / `.eq('profile_id', …)` landed in the same per-table pool.
+So the assertion was satisfied by the READ and said nothing about the WRITE:
+deleting either filter from the UPDATE left all 27 tests green while an
+attacker could edit another member's affiliation, or bulk-overwrite every
+affiliation of their own. That is a tenancy defect hiding behind a green tick.
+
+This is catalogue failure mode 2 turned inside out. There the *comment*
+satisfied the assertion; here an *incidental adjacent statement* does. Both
+fire constantly and answer a different question from the one asked.
+
+WHAT IT FLAGS — DELIBERATELY NARROW
+-----------------------------------
+One shape, and only one: inside the body of an `.eq()` recorder in a test file,
+a subscript of some container by the TABLE identifier —
+
+    eq: (col, val) => { (pool[table] ??= []).push([col, val]); return b }
+                          ^^^^^^^^^^^ keyed by table, so every statement on
+                                      that table shares one list
+
+The correct shape records into a structure created per `.from()` call, and is
+not flagged:
+
+    const build = (table) => {
+      const statement = { table, eq: [] };   // one .from() === one statement
+      statements.push(statement);
+      return { eq: (col, val) => { statement.eq.push([col, val]); return b } }
+    }
+
+`tests/unit/kan447-kan448-inline-edit.test.ts` is the reference implementation
+and carries the long-form explanation.
+
+The narrowness is the design, not a shortcut. A broad "your Supabase mock looks
+suspicious" heuristic over the ~40 hand-rolled mocks in this estate would
+produce standing noise, and standing noise is what teaches reviewers to wave a
+gate through — which is how a control is lost without anyone deciding to lose
+it. Three conditions must all hold: a tracked file under `tests/`, an `.eq()`
+recorder, and a table-keyed subscript INSIDE that recorder's body.
+
+WHY A DETECTOR AND NOT ONLY A SHARED HARNESS
+--------------------------------------------
+KAN-459 §2 prefers "make it impossible" (a shared per-statement mock in
+`tests/support/`) over "detect it". Measured when this landed: exactly ONE file
+in the estate uses the pooled shape, and it is non-vacuous today only by luck —
+its actions happen not to pre-read the table they write. A shared harness with
+no consumer that is not already correct is decorative; a gate covers every mock
+written from here on, including the next one hand-rolled in a hurry. The
+harness remains the better fix for any file that adopts it, and this control's
+failure message points at the reference implementation rather than at a rule.
+
+COMMENTS ARE STRIPPED FIRST, using `check-comment-only-assertions.py`'s own
+`strip_comments` rather than a second copy of the rules — two implementations
+of one rule set with nothing comparing them is the SEC-152 drift shape, and it
+is the exact mistake KAN-459 §3 corrected for `stripComments`. A commented-out
+pooled mock is prose, not a defect.
+
+RATCHET
+-------
+`tests/support/pooled-eq-mock-baseline.json`, keyed per file, TWO-WAY: a new
+pooled recorder fails, a baselined file that grows fails, and a baselined file
+that shrinks or is fixed fails as STALE. A list you may only add to is a
+suppression list, not a ratchet.
+
+The one grandfathered entry (`tests/unit/profile-ownership.test.ts`, the KAN-260
+owner-scoping net) is NOT annotated away and is NOT a licence: converting it to
+per-statement recording rewrites its existing assertions, which the Test
+Integrity Policy requires be signed off first. It is recorded so it cannot get
+worse and cannot be forgotten.
+
+Exit codes: 0 clean · 1 findings · 2 the check could not run (fail closed).
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+_ccoa = importlib.import_module("check-comment-only-assertions")
+strip_comments = _ccoa.strip_comments
+
+SCANNABLE = (".ts", ".tsx", ".js", ".mjs")
+
+# Floors. A glob that silently stops matching must fail, not report clean —
+# "found nothing" and "looked at nothing" are different answers (catalogue #4).
+MIN_TEST_FILES = 150
+MIN_FILES_WITH_EQ_RECORDER = 10
+
+SELF_TEST_CASE_FLOOR = 20
+
+# Identifiers that hold the table name. The first two patterns derive it from
+# the mock itself; CONVENTIONAL_TABLE_IDENTS is the fallback for a builder
+# factory reached indirectly (`from: (t) => build(t)`), which is the commonest
+# shape here.
+FROM_PARAM_RE = re.compile(r"\bfrom\s*:?\s*\(\s*(\w+)\s*[,:)]")
+FACTORY_PARAM_RE = re.compile(r"\b(?:const\s+)?\w+\s*=\s*\(\s*(\w+)\s*:\s*string\s*\)\s*(?::[^=;]*)?=>")
+CONVENTIONAL_TABLE_IDENTS = {"table", "tableName", "tbl"}
+
+EQ_RECORDER_RE = re.compile(r"\beq\s*(?::\s*)?\(")
+
+
+class PooledEqError(Exception):
+    """The check could not run. Never reported as a clean result."""
+
+
+def tracked_test_files(root: Path) -> list[str]:
+    try:
+        out = subprocess.run(
+            ["git", "ls-files", "tests/"],
+            cwd=root,
+            capture_output=True,
+            text=True,
+            check=True,
+        ).stdout
+    except (subprocess.CalledProcessError, FileNotFoundError) as exc:
+        raise PooledEqError(f"git ls-files failed: {exc}") from exc
+    return [p for p in out.split() if p.endswith(SCANNABLE)]
+
+
+def _balanced_end(text: str, start: int, opener: str, closer: str) -> int | None:
+    """Index just past the `opener` at `start`'s match, or None if unbalanced."""
+    depth = 0
+    i = start
+    while i < len(text):
+        c = text[i]
+        if c == opener:
+            depth += 1
+        elif c == closer:
+            depth -= 1
+            if depth == 0:
+                return i + 1
+        i += 1
+    return None
+
+
+def eq_recorder_bodies(src: str) -> list[tuple[int, str]]:
+    """Every `.eq(...)` recorder body in `src`, as (offset, body).
+
+    Handles the three forms this estate writes:
+        eq: (col, val) => { … }        arrow with a block body
+        eq: (col, val) => expr         arrow with an expression body
+        eq(col, val) { … }             method shorthand
+    """
+    bodies: list[tuple[int, str]] = []
+    for m in EQ_RECORDER_RE.finditer(src):
+        params_open = src.index("(", m.start())
+        params_end = _balanced_end(src, params_open, "(", ")")
+        if params_end is None:
+            continue
+        rest = src[params_end:]
+        arrow = re.match(r"\s*(?::[^=;{]*)?=>\s*", rest)
+        if arrow:
+            after = params_end + arrow.end()
+            if after < len(src) and src[after] == "{":
+                end = _balanced_end(src, after, "{", "}")
+                if end is not None:
+                    bodies.append((m.start(), src[after:end]))
+                continue
+            # Expression body: read to the end of this property/statement.
+            depth = 0
+            i = after
+            while i < len(src):
+                c = src[i]
+                if c in "([{":
+                    depth += 1
+                elif c in ")]}":
+                    if depth == 0:
+                        break
+                    depth -= 1
+                elif c in ",;" and depth == 0:
+                    break
+                i += 1
+            bodies.append((m.start(), src[after:i]))
+            continue
+        block = re.match(r"\s*\{", rest)
+        if block:
+            after = params_end + block.end() - 1
+            end = _balanced_end(src, after, "{", "}")
+            if end is not None:
+                bodies.append((m.start(), src[after:end]))
+    return bodies
+
+
+def table_idents(src: str) -> set[str]:
+    idents = set(CONVENTIONAL_TABLE_IDENTS)
+    for m in FROM_PARAM_RE.finditer(src):
+        idents.add(m.group(1))
+    for m in FACTORY_PARAM_RE.finditer(src):
+        idents.add(m.group(1))
+    return idents
+
+
+def pooled_recorders(src: str, suffix: str) -> list[int]:
+    """Line numbers (1-based) of `.eq()` recorders keyed by the table name."""
+    stripped = strip_comments(src, suffix)
+    if stripped is None:
+        return []
+    idents = table_idents(stripped)
+    subscript = re.compile(r"\w\s*\[\s*(" + "|".join(sorted(map(re.escape, idents))) + r")\s*\]")
+    hits: list[int] = []
+    for offset, body in eq_recorder_bodies(stripped):
+        if subscript.search(body):
+            hits.append(stripped.count("\n", 0, offset) + 1)
+    return hits
+
+
+def scan(files: list[str], root: Path) -> tuple[dict[str, list[int]], int]:
+    """(findings per file, number of files that contain any `.eq()` recorder)."""
+    findings: dict[str, list[int]] = {}
+    with_recorder = 0
+    for rel in files:
+        try:
+            src = (root / rel).read_text(encoding="utf-8")
+        except OSError as exc:
+            raise PooledEqError(f"could not read {rel}: {exc}") from exc
+        suffix = Path(rel).suffix
+        stripped = strip_comments(src, suffix)
+        if stripped is None:
+            continue
+        if eq_recorder_bodies(stripped):
+            with_recorder += 1
+        lines = pooled_recorders(src, suffix)
+        if lines:
+            findings[rel] = lines
+    return findings, with_recorder
+
+
+def evaluate(actual: dict[str, list[int]], baseline: dict) -> list[str]:
+    """Two-way ratchet. NEW / WORSE fail; STALE fails too."""
+    recorded: dict[str, int] = {k: int(v) for k, v in baseline.get("files", {}).items()}
+    failures: list[str] = []
+    for rel, lines in sorted(actual.items()):
+        if rel not in recorded:
+            failures.append(
+                f"NEW: {rel} records .eq() calls keyed by table (line(s) "
+                f"{', '.join(map(str, lines))}). One .from() call is one statement — "
+                f"record per statement, as tests/unit/kan447-kan448-inline-edit.test.ts does."
+            )
+        elif len(lines) > recorded[rel]:
+            failures.append(
+                f"WORSE: {rel} now has {len(lines)} table-keyed .eq() recorder(s), "
+                f"baselined at {recorded[rel]}."
+            )
+    for rel, count in sorted(recorded.items()):
+        if rel not in actual:
+            failures.append(
+                f"STALE: {rel} is baselined with {count} table-keyed .eq() recorder(s) "
+                f"and now has none. Remove it from the baseline in the same commit."
+            )
+        elif len(actual[rel]) < count:
+            failures.append(
+                f"STALE: {rel} is baselined at {count} table-keyed .eq() recorder(s) "
+                f"and now has {len(actual[rel])}. Update the baseline."
+            )
+    return failures
+
+
+def self_test() -> int:
+    failures: list[str] = []
+    cases = 0
+
+    def check(label, got, want):
+        nonlocal cases
+        cases += 1
+        if got != want:
+            failures.append(f"{label}\n     got:  {got!r}\n     want: {want!r}")
+
+    POOLED = """
+      const mockEqCalls = {};
+      jest.mock('@/modules/platform/supabase-server', () => {
+        const build = (table: string): Builder => {
+          const b = {
+            select: () => b,
+            eq: (col, val) => {
+              (mockEqCalls[table] = mockEqCalls[table] ?? []).push([col, val]);
+              return b;
+            },
+          };
+          return b;
+        };
+        return { createClient: async () => ({ from: (t: string) => build(t) }) };
+      });
+    """
+
+    PER_STATEMENT = """
+      const mockStatements = [];
+      jest.mock('@/modules/platform/supabase-server', () => {
+        const build = (table: string): Builder => {
+          const statement = { table, kind: 'unknown', eq: [] };
+          mockStatements.push(statement);
+          const b = {
+            select: () => { statement.kind = 'select'; return b; },
+            eq: (col, val) => { statement.eq.push([col, val]); return b; },
+          };
+          return b;
+        };
+        return { createClient: async () => ({ from: (t: string) => build(t) }) };
+      });
+    """
+
+    # --- the shape it exists for ------------------------------------------
+    check("pooled-per-table recorder is flagged", len(pooled_recorders(POOLED, ".ts")), 1)
+    check("per-statement recorder is NOT flagged", pooled_recorders(PER_STATEMENT, ".ts"), [])
+    check(
+        "the reported line is the recorder, not the file",
+        pooled_recorders(POOLED, ".ts")[0],
+        POOLED[: POOLED.index("eq: (col, val)")].count("\n") + 1,
+    )
+
+    # --- comment handling. The whole point of reusing strip_comments -------
+    check(
+        "a COMMENTED-OUT pooled recorder is prose, not a defect",
+        pooled_recorders("// eq: (col, val) => { pool[table].push([col, val]) }\n", ".ts"),
+        [],
+    )
+    check(
+        "a pooled recorder inside a block comment is not a defect",
+        pooled_recorders("/*\n eq: (c, v) => { pool[table].push([c, v]) }\n*/\n", ".ts"),
+        [],
+    )
+    check(
+        "a JSX comment does not hide a REAL recorder elsewhere in the file",
+        len(pooled_recorders("{/* pooling is wrong */}\n" + POOLED, ".tsx")),
+        1,
+    )
+
+    # --- the three recorder syntaxes this estate writes --------------------
+    check(
+        "method shorthand `eq(col, val) { … }` is seen",
+        len(pooled_recorders("const o = { eq(col, val) { pool[table].push([col, val]); } };", ".ts")),
+        1,
+    )
+    check(
+        "expression-bodied arrow is seen",
+        len(pooled_recorders("const o = { eq: (c, v) => (pool[table] ??= []).push([c, v]), x: 1 };", ".ts")),
+        1,
+    )
+    check(
+        "typed arrow params are seen",
+        len(pooled_recorders("const o = { eq: (c: string, v: unknown) => { pool[table].push([c, v]); } };", ".ts")),
+        1,
+    )
+
+    # --- narrowness. Each of these WOULD fire under a looser rule ----------
+    check(
+        "a table-keyed subscript OUTSIDE any eq recorder is not a finding",
+        pooled_recorders("const rows = fixtures[table];\nconst o = { eq: (c, v) => b };", ".ts"),
+        [],
+    )
+    check(
+        "an eq recorder with no subscript at all is not a finding",
+        pooled_recorders("const o = { eq: (c, v) => { seen.push([c, v]); return b; } };", ".ts"),
+        [],
+    )
+    check(
+        "a subscript by something that is NOT the table identifier is not a finding",
+        pooled_recorders("const o = { eq: (c, v) => { seen[col].push(v); return b; } };", ".ts"),
+        [],
+    )
+    check(
+        "a real `.eq('id', x)` CALL is not a recorder definition",
+        pooled_recorders("await supabase.from('t').update(u).eq('id', x).eq('profile_id', p);", ".ts"),
+        [],
+    )
+
+    # --- table identifier derivation ---------------------------------------
+    check("`table` is a conventional table identifier", "table" in table_idents(""), True)
+    check("a `from:` parameter name is picked up", "zz" in table_idents("from: (zz: string) => build(zz)"), True)
+    check("a builder factory parameter is picked up", "qq" in table_idents("const build = (qq: string): B => {"), True)
+    check(
+        "a bespoke identifier from `from:` makes its own pooling visible",
+        len(pooled_recorders("from: (zz: string) => ({ eq: (c, v) => { pool[zz].push([c, v]); } })", ".ts")),
+        1,
+    )
+
+    # --- unknown file types are SKIPPED, never guessed ---------------------
+    check("an unknown suffix is skipped rather than guessed", pooled_recorders(POOLED, ".cjs"), [])
+
+    # --- ratchet, both directions ------------------------------------------
+    check(
+        "a NEW pooled recorder fails",
+        any("NEW" in f for f in evaluate({"tests/a.test.ts": [3]}, {"files": {}})),
+        True,
+    )
+    check(
+        "a baselined file at the same count passes",
+        evaluate({"tests/a.test.ts": [3]}, {"files": {"tests/a.test.ts": 1}}),
+        [],
+    )
+    check(
+        "a baselined file that GROWS fails",
+        any("WORSE" in f for f in evaluate({"tests/a.test.ts": [3, 9]}, {"files": {"tests/a.test.ts": 1}})),
+        True,
+    )
+    check(
+        "a baselined file that is FIXED fails as stale",
+        any("STALE" in f for f in evaluate({}, {"files": {"tests/a.test.ts": 1}})),
+        True,
+    )
+    check(
+        "a baselined file that partly shrinks fails as stale",
+        any("STALE" in f for f in evaluate({"tests/a.test.ts": [3]}, {"files": {"tests/a.test.ts": 2}})),
+        True,
+    )
+
+    # The verdict is read AFTER every case has run. SEC-140: eight self-test
+    # cases were appended to a list nothing consumed, and the reported count
+    # went UP while three real mutations all reported "passed".
+    if failures:
+        print("SELF-TEST FAILED")
+        for f in failures:
+            print(f"  x {f}")
+        return 1
+    if cases < SELF_TEST_CASE_FLOOR:
+        print(f"SELF-TEST FAILED: only {cases} case(s) ran, floor is {SELF_TEST_CASE_FLOOR}.")
+        print("  A self-test that shrank is a self-test someone deleted a case from.")
+        return 1
+    print(f"Self-test passed ({cases} cases, floor {SELF_TEST_CASE_FLOOR}).")
+    return 0
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description="CTL-076 — per-statement Supabase mock recording.")
+    ap.add_argument("--self-test", action="store_true")
+    ap.add_argument("--write-baseline", action="store_true")
+    ap.add_argument("--root", type=Path, default=REPO_ROOT, help=argparse.SUPPRESS)
+    ap.add_argument("--baseline", type=Path, default=None, help=argparse.SUPPRESS)
+    ap.add_argument("--min-files", type=int, default=MIN_TEST_FILES, help=argparse.SUPPRESS)
+    ap.add_argument("--min-recorders", type=int, default=MIN_FILES_WITH_EQ_RECORDER, help=argparse.SUPPRESS)
+    args = ap.parse_args()
+
+    if args.self_test:
+        return self_test()
+
+    root: Path = args.root
+    baseline_path: Path = args.baseline or (root / "tests" / "support" / "pooled-eq-mock-baseline.json")
+
+    try:
+        files = tracked_test_files(root)
+        actual, with_recorder = scan(files, root)
+    except (PooledEqError, OSError) as exc:
+        print(f"::error::check-pooled-eq-mock: {exc}")
+        print("::error::  Failing closed (exit 2): a check that could not run is not a clean result.")
+        return 2
+
+    if len(files) < args.min_files:
+        print(f"::error::check-pooled-eq-mock: only {len(files)} tracked test file(s) found.")
+        print(f"::error::  Expected at least {args.min_files}. A scan that suddenly finds almost")
+        print("::error::  nothing has broken, not been cleaned up.")
+        return 2
+    if with_recorder < args.min_recorders:
+        print(f"::error::check-pooled-eq-mock: only {with_recorder} file(s) contain an .eq() recorder.")
+        print(f"::error::  Expected at least {args.min_recorders}. The recorder parser has stopped")
+        print("::error::  matching, so 'no findings' would mean 'nothing was inspected'.")
+        return 2
+
+    if args.write_baseline:
+        payload = {
+            "_why": [
+                "CTL-076 / KAN-459 §2. Test-side Supabase mocks whose .eq() recorder is keyed",
+                "by TABLE rather than per .from() statement, as they stood when the control",
+                "landed. Grandfathered so it could ship green.",
+                "",
+                "TWO-WAY. A new pooled recorder fails; a baselined file that grows fails; a",
+                "baselined file that shrinks or is fixed fails as STALE until recorded. A list",
+                "you may only add to is a suppression list, not a ratchet.",
+                "",
+                "The single entry is tests/unit/profile-ownership.test.ts, the KAN-260",
+                "owner-scoping net. It is NOT vacuous today — mutation-checked: deleting",
+                ".eq('profile_id', profile.id) from removeProfileItem turns it RED — but only",
+                "because those actions happen not to pre-read the table they write. The day one",
+                "of them does, the assertion goes vacuous with no diff to the test.",
+                "",
+                "It is baselined rather than converted because converting it rewrites its",
+                "existing assertions, and the Test Integrity Policy requires sign-off for that.",
+                "Recorded so it cannot get worse and cannot be forgotten.",
+            ],
+            "ticket": "KAN-459",
+            "_totals": {"testFiles": len(files), "filesWithEqRecorder": with_recorder},
+            "files": {rel: len(lines) for rel, lines in sorted(actual.items())},
+        }
+        baseline_path.parent.mkdir(parents=True, exist_ok=True)
+        baseline_path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+        print(f"Wrote {baseline_path.name}: {len(actual)} file(s) with a table-keyed .eq() recorder")
+        return 0
+
+    if not baseline_path.exists():
+        print(f"::error::check-pooled-eq-mock: {baseline_path.name} is missing — refusing to")
+        print("::error::  report clean with nothing to compare against.")
+        return 2
+    try:
+        baseline = json.loads(baseline_path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        print(f"::error::check-pooled-eq-mock: {baseline_path.name} is not valid JSON: {exc}")
+        return 2
+
+    problems = evaluate(actual, baseline)
+    if problems:
+        for p in problems:
+            print(f"::error::check-pooled-eq-mock: {p}")
+        print("::error::  One .from() call is ONE statement. Pooling filters per table lets a")
+        print("::error::  pre-read satisfy an assertion that was meant to be about the write —")
+        print("::error::  KAN-447/448, where both owner filters were deletable and 27 tests")
+        print("::error::  stayed green. Reference shape: tests/unit/kan447-kan448-inline-edit.test.ts")
+        return 1
+
+    print(
+        f"No new table-keyed .eq() recorders. "
+        f"{len(files)} test file(s) scanned, {with_recorder} with an .eq() recorder, "
+        f"{len(actual)} baselined. ✓"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/scripts/check-pooled-eq-mock.test.js
+++ b/tests/scripts/check-pooled-eq-mock.test.js
@@ -1,0 +1,318 @@
+/**
+ * CTL-076 / KAN-459 §2 — a test-side Supabase mock records filters PER STATEMENT.
+ *
+ * WHY THIS CONTROL EXISTS
+ * -----------------------
+ * KAN-447/448 asserted the owner-scoping of an UPDATE through a mock that
+ * pooled `.eq()` calls per TABLE. `updateSchoolAffiliation` reads the row before
+ * it writes it, so the SELECT's own `.eq('id', …)` / `.eq('profile_id', …)`
+ * landed in the same pool — and both filters could be deleted from the UPDATE
+ * while all 27 tests stayed green. The realised impact of that class is editing
+ * another member's row, or bulk-overwriting every row of your own.
+ *
+ * It is catalogue failure mode 2 turned inside out: there a COMMENT satisfies
+ * the assertion, here an incidental ADJACENT STATEMENT does. Both fire
+ * constantly and answer a different question from the one asked.
+ *
+ * These tests drive FIXTURES through the real script (CTL-038), never a
+ * reimplementation of its logic, so a failure here means the checker is wrong
+ * rather than that the estate changed.
+ *
+ * ⚠️ THE SANDBOX IS A REAL GIT REPO ON PURPOSE. The checker reads TRACKED state
+ * via `git ls-files`, because `git mv` leaves the source directory behind empty
+ * and a disk walk therefore answers a subtly different question (catalogue
+ * failure mode 6). A fixture that is written but not `git add`ed is invisible to
+ * the checker — which is the same trap that reddened CTL-035 twice.
+ */
+const { execFileSync } = require('node:child_process');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const ROOT = path.resolve(__dirname, '../..');
+const { SRC } = JSON.parse(
+  fs.readFileSync(path.resolve(__dirname, '../support/source-paths.json'), 'utf-8'),
+);
+const SCRIPT = SRC.checkPooledEqMock;
+
+// gotcha #31 — a lost manifest key is `undefined`, and `path.join(root, undefined)`
+// throws something that reads like a broken harness rather than a lost key.
+expect(typeof SCRIPT).toBe('string');
+expect(typeof SRC.prChecks).toBe('string');
+
+// Not routed through SRC: the generator harvests only src/supabase/scripts/
+// public/design/.github literals, so no `tests/` path can ever hold a key. It is
+// therefore also not counted by the F4 raw-literal ratchet.
+const BASELINE_REL = 'tests/support/pooled-eq-mock-baseline.json';
+
+function run(args, opts = {}) {
+  try {
+    return {
+      code: 0,
+      out: execFileSync('python3', [path.join(ROOT, SCRIPT), ...args], {
+        cwd: opts.cwd || ROOT,
+        encoding: 'utf-8',
+      }),
+    };
+  } catch (err) {
+    return { code: err.status, out: `${err.stdout || ''}${err.stderr || ''}` };
+  }
+}
+
+let tmp;
+beforeAll(() => {
+  tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'ctl076-'));
+});
+afterAll(() => {
+  if (tmp) fs.rmSync(tmp, { recursive: true, force: true });
+});
+
+let seq = 0;
+
+/**
+ * A throwaway git repo holding `files`, all tracked, plus `baseline` if given.
+ * `padding` synthesises enough inert mock files to clear the checker's corpus
+ * floors — the floors exist so a glob that stops matching fails rather than
+ * reporting clean, and a fixture repo has to satisfy them like anything else.
+ */
+function sandbox({ files, baseline, padding = 0 }) {
+  const dir = path.join(tmp, `case-${seq++}`);
+  fs.mkdirSync(path.join(dir, 'tests', 'unit'), { recursive: true });
+  fs.mkdirSync(path.join(dir, 'tests', 'support'), { recursive: true });
+
+  for (const [rel, body] of Object.entries(files)) {
+    fs.mkdirSync(path.join(dir, path.dirname(rel)), { recursive: true });
+    fs.writeFileSync(path.join(dir, rel), body);
+  }
+  for (let i = 0; i < padding; i += 1) {
+    fs.writeFileSync(
+      path.join(dir, 'tests', 'unit', `pad-${i}.test.ts`),
+      // Inert: an .eq() recorder that records nothing by table, so it counts
+      // toward the "files with a recorder" floor without being a finding.
+      'const o = { eq: (c: string, v: unknown) => { seen.push([c, v]); return o; } };\n',
+    );
+  }
+  if (baseline !== undefined) {
+    fs.writeFileSync(path.join(dir, BASELINE_REL), JSON.stringify(baseline, null, 2));
+  }
+
+  execFileSync('git', ['init', '-q'], { cwd: dir });
+  execFileSync('git', ['add', '-A'], { cwd: dir });
+  return dir;
+}
+
+/**
+ * ⚠️ THE POOLED FIXTURES ARE ASSEMBLED, NOT WRITTEN OUT — and that is deliberate.
+ *
+ * This file is a tracked file under `tests/`, so the checker scans it like any
+ * other. Written as literal text, its own fixtures make it a finding: the guard
+ * fires on its own test corpus, which is the CTL-061 failure (a guard tripping
+ * on its own registration prose). The fix is NOT to exclude this path — an
+ * excluded file is a file the control has stopped covering. It is to build the
+ * violating subscript at runtime, exactly as CTL-064's suite assembles its
+ * `git push` fixtures, so this file stays genuinely IN scope with no exclusion
+ * and no annotation while the fixtures it feeds the checker are still real.
+ */
+const TBL = 'table';
+const POOLED = `
+jest.mock('@/modules/platform/supabase-server', () => {
+  const build = (${TBL}: string) => {
+    const b = {
+      select: () => b,
+      update: () => b,
+      eq: (col: string, val: unknown) => {
+        (mockEqCalls[${TBL}] = mockEqCalls[${TBL}] ?? []).push([col, val]);
+        return b;
+      },
+    };
+    return b;
+  };
+  return { createClient: async () => ({ from: (t: string) => build(t) }) };
+});
+`;
+
+const PER_STATEMENT = `
+jest.mock('@/modules/platform/supabase-server', () => {
+  const build = (table: string) => {
+    const statement = { table, kind: 'unknown', eq: [] };
+    mockStatements.push(statement);
+    const b = {
+      select: () => { statement.kind = 'select'; return b; },
+      update: () => { statement.kind = 'update'; return b; },
+      eq: (col: string, val: unknown) => { statement.eq.push([col, val]); return b; },
+    };
+    return b;
+  };
+  return { createClient: async () => ({ from: (t: string) => build(t) }) };
+});
+`;
+
+const FLOOR_PADDING = 12;
+
+describe('CTL-076: the checker itself', () => {
+  it('passes its own self-test', () => {
+    const r = run(['--self-test']);
+    expect(r.code).toBe(0);
+    expect(r.out).toMatch(/Self-test passed \(\d+ cases, floor \d+\)/);
+  });
+
+  it('is green against the committed baseline', () => {
+    const r = run([]);
+    expect(r.code).toBe(0);
+    expect(r.out).toContain('No new table-keyed .eq() recorders');
+  });
+
+  it('the committed baseline is real, and every path in it is still tracked', () => {
+    const baseline = JSON.parse(fs.readFileSync(path.join(ROOT, BASELINE_REL), 'utf-8'));
+    const entries = Object.entries(baseline.files);
+    // catalogue failure mode 4 — assert the corpus before iterating it.
+    expect(entries.length).toBeGreaterThan(0);
+    for (const [rel, count] of entries) {
+      expect(typeof count).toBe('number');
+      expect(count).toBeGreaterThan(0);
+      const tracked = execFileSync('git', ['ls-files', '--error-unmatch', rel], {
+        cwd: ROOT,
+        encoding: 'utf-8',
+      });
+      expect(tracked.trim()).toBe(rel);
+    }
+  });
+});
+
+describe('CTL-076: the shape it exists for', () => {
+  it('flags a pooled-per-table .eq() recorder', () => {
+    const dir = sandbox({
+      files: { 'tests/unit/pooled.test.ts': POOLED },
+      baseline: { files: {} },
+      padding: FLOOR_PADDING,
+    });
+    const r = run(['--root', dir, '--min-files', '1', '--min-recorders', '1'], { cwd: dir });
+    expect(r.code).toBe(1);
+    expect(r.out).toContain('NEW: tests/unit/pooled.test.ts');
+  });
+
+  it('does NOT flag a per-statement recorder — the correct shape stays quiet', () => {
+    const dir = sandbox({
+      files: { 'tests/unit/per-statement.test.ts': PER_STATEMENT },
+      baseline: { files: {} },
+      padding: FLOOR_PADDING,
+    });
+    const r = run(['--root', dir, '--min-files', '1', '--min-recorders', '1'], { cwd: dir });
+    expect(r.code).toBe(0);
+    expect(r.out).toContain('No new table-keyed .eq() recorders');
+  });
+
+  it('does not flag a commented-out pooled recorder', () => {
+    const dir = sandbox({
+      files: {
+        'tests/unit/prose.test.ts':
+          '// Pooling per table is wrong:\n' +
+          `//   eq: (col, val) => { (pool[${TBL}] ??= []).push([col, val]) }\n` +
+          `/* the block form is prose too: pool[${TBL}].push(x) */\n` +
+          'const o = { eq: (c: string, v: unknown) => { seen.push([c, v]); return o; } };\n',
+      },
+      baseline: { files: {} },
+      padding: FLOOR_PADDING,
+    });
+    const r = run(['--root', dir, '--min-files', '1', '--min-recorders', '1'], { cwd: dir });
+    expect(r.code).toBe(0);
+  });
+});
+
+describe('CTL-076: the ratchet works in both directions', () => {
+  it('a baselined file at the same count passes', () => {
+    const dir = sandbox({
+      files: { 'tests/unit/pooled.test.ts': POOLED },
+      baseline: { files: { 'tests/unit/pooled.test.ts': 1 } },
+      padding: FLOOR_PADDING,
+    });
+    const r = run(['--root', dir, '--min-files', '1', '--min-recorders', '1'], { cwd: dir });
+    expect(r.code).toBe(0);
+  });
+
+  it('a baselined file that GROWS fails', () => {
+    const dir = sandbox({
+      files: { 'tests/unit/pooled.test.ts': POOLED + POOLED },
+      baseline: { files: { 'tests/unit/pooled.test.ts': 1 } },
+      padding: FLOOR_PADDING,
+    });
+    const r = run(['--root', dir, '--min-files', '1', '--min-recorders', '1'], { cwd: dir });
+    expect(r.code).toBe(1);
+    expect(r.out).toContain('WORSE');
+  });
+
+  it('a baselined file that is FIXED fails as STALE, not silently', () => {
+    const dir = sandbox({
+      files: { 'tests/unit/pooled.test.ts': PER_STATEMENT },
+      baseline: { files: { 'tests/unit/pooled.test.ts': 1 } },
+      padding: FLOOR_PADDING,
+    });
+    const r = run(['--root', dir, '--min-files', '1', '--min-recorders', '1'], { cwd: dir });
+    expect(r.code).toBe(1);
+    expect(r.out).toContain('STALE');
+  });
+});
+
+describe('CTL-076: it fails CLOSED rather than reporting a clean scan it never ran', () => {
+  it('exits 2 when the baseline is absent', () => {
+    // "Absent because I removed it", not "absent because I never added it" —
+    // KAN-414 trap 2. The sandbox is built WITH a baseline and it is then
+    // deleted, so the assertion stays stable however the fixture is copied.
+    const dir = sandbox({
+      files: { 'tests/unit/per-statement.test.ts': PER_STATEMENT },
+      baseline: { files: {} },
+      padding: FLOOR_PADDING,
+    });
+    fs.rmSync(path.join(dir, BASELINE_REL));
+    const r = run(['--root', dir, '--min-files', '1', '--min-recorders', '1'], { cwd: dir });
+    expect(r.code).toBe(2);
+    expect(r.out).toContain('refusing to');
+  });
+
+  it('exits 2 when the baseline is not valid JSON', () => {
+    const dir = sandbox({
+      files: { 'tests/unit/per-statement.test.ts': PER_STATEMENT },
+      baseline: { files: {} },
+      padding: FLOOR_PADDING,
+    });
+    fs.writeFileSync(path.join(dir, BASELINE_REL), '{ not json');
+    const r = run(['--root', dir, '--min-files', '1', '--min-recorders', '1'], { cwd: dir });
+    expect(r.code).toBe(2);
+    expect(r.out).toContain('not valid JSON');
+  });
+
+  it('exits 2 when the corpus has collapsed, rather than reporting no findings', () => {
+    // The half people forget: "found nothing" and "looked at nothing" produce
+    // identical output unless the floor is checked (catalogue failure mode 4).
+    const dir = sandbox({
+      files: { 'tests/unit/per-statement.test.ts': PER_STATEMENT },
+      baseline: { files: {} },
+    });
+    const r = run(['--root', dir], { cwd: dir });
+    expect(r.code).toBe(2);
+    expect(r.out).toMatch(/tracked test file\(s\) found|contain an \.eq\(\) recorder/);
+  });
+
+  it('exits 2 when the root is not a git repository', () => {
+    const dir = path.join(tmp, 'not-a-repo');
+    fs.mkdirSync(dir, { recursive: true });
+    const r = run(['--root', dir], { cwd: dir });
+    expect(r.code).toBe(2);
+    expect(r.out).toContain('Failing closed');
+  });
+});
+
+describe('CTL-076: it is registered and invoked', () => {
+  it('is wired into pr-checks.yml — a control nothing runs is the SEC-79 failure', () => {
+    const wf = fs.readFileSync(path.join(ROOT, SRC.prChecks), 'utf-8');
+    expect(wf).toContain(`python3 ${SCRIPT} --self-test`);
+    expect(wf).toContain(`python3 ${SCRIPT}\n`);
+  });
+
+  it('is registered in controls/registry.json with KAN-459 in prevents', () => {
+    const registry = JSON.parse(fs.readFileSync(path.join(ROOT, 'controls/registry.json'), 'utf-8'));
+    const control = registry.controls.find((c) => c.implementation === SCRIPT);
+    expect(control).toBeDefined();
+    expect(control.prevents).toContain('KAN-459');
+  });
+});

--- a/tests/support/pooled-eq-mock-baseline.json
+++ b/tests/support/pooled-eq-mock-baseline.json
@@ -1,0 +1,29 @@
+{
+  "_why": [
+    "CTL-076 / KAN-459 \u00a72. Test-side Supabase mocks whose .eq() recorder is keyed",
+    "by TABLE rather than per .from() statement, as they stood when the control",
+    "landed. Grandfathered so it could ship green.",
+    "",
+    "TWO-WAY. A new pooled recorder fails; a baselined file that grows fails; a",
+    "baselined file that shrinks or is fixed fails as STALE until recorded. A list",
+    "you may only add to is a suppression list, not a ratchet.",
+    "",
+    "The single entry is tests/unit/profile-ownership.test.ts, the KAN-260",
+    "owner-scoping net. It is NOT vacuous today \u2014 mutation-checked: deleting",
+    ".eq('profile_id', profile.id) from removeProfileItem turns it RED \u2014 but only",
+    "because those actions happen not to pre-read the table they write. The day one",
+    "of them does, the assertion goes vacuous with no diff to the test.",
+    "",
+    "It is baselined rather than converted because converting it rewrites its",
+    "existing assertions, and the Test Integrity Policy requires sign-off for that.",
+    "Recorded so it cannot get worse and cannot be forgotten."
+  ],
+  "ticket": "KAN-459",
+  "_totals": {
+    "testFiles": 326,
+    "filesWithEqRecorder": 36
+  },
+  "files": {
+    "tests/unit/profile-ownership.test.ts": 1
+  }
+}

--- a/tests/support/source-path-seeds.ts
+++ b/tests/support/source-path-seeds.ts
@@ -263,6 +263,19 @@ export const SEEDED_PATHS = [
   // `SRC` in tests/scripts/check-route-thinness.test.js, and the baseline is
   // seeded too because the test asserts positive facts about its shape (the
   // computed totals, and that every baselined path is still tracked).
+  // CTL-076 / KAN-459. Reached only via `SRC` in
+  // tests/scripts/check-pooled-eq-mock.test.js, so without seeding it does not
+  // survive a regeneration (gotcha #31). The checker path is also the registry's
+  // `implementation` value and the string pr-checks.yml must name, so the
+  // assertion IS the path - a literal in the test would let a rename read as a
+  // pass against a control nobody runs.
+  //
+  // Its BASELINE is deliberately not seeded: the generator harvests only src,
+  // supabase, scripts, public, design and .github literals, so no tests/ key can
+  // exist, and seeding one would fail source-path-manifest-integrity's "every
+  // seed is in the manifest" assertion. The test carries that one literal
+  // directly, which the F4 raw-literal ratchet also does not count.
+  'scripts/check-pooled-eq-mock.py',
   'scripts/check-route-thinness.py',
   'supabase/route-thinness-baseline.json',
   // The directory CTL-056 scans. A DIRECTORY rather than a file, and seeded

--- a/tests/support/source-paths.json
+++ b/tests/support/source-paths.json
@@ -1,7 +1,7 @@
 {
   "$comment": "GENERATED — regenerate with `npm run gen:test-paths`. Mirror of tests/support/source-paths.ts for .cjs and shell consumers (KAN-414 F4).",
   "generated_from": "literals referenced by tracked files under tests/",
-  "count": 246,
+  "count": 247,
   "SRC": {
     "codeowners": ".github/CODEOWNERS",
     "pullRequestTemplate": ".github/PULL_REQUEST_TEMPLATE.md",
@@ -60,6 +60,7 @@
     "checkModuleLayering": "scripts/check-module-layering.py",
     "checkModuleTableOwnership": "scripts/check-module-table-ownership.py",
     "checkNpmAuditGate": "scripts/check-npm-audit-gate.py",
+    "checkPooledEqMock": "scripts/check-pooled-eq-mock.py",
     "checkProductionDeployDrift": "scripts/check-production-deploy-drift.py",
     "checkReleaseBranchPush": "scripts/check-release-branch-push.py",
     "checkReleaseTagged": "scripts/check-release-tagged.py",

--- a/tests/support/source-paths.ts
+++ b/tests/support/source-paths.ts
@@ -13,7 +13,7 @@
 // cannot drift from reality — a hand-maintained list is what let BUGS-74's
 // first fix miss the legacy editor.
 //
-// 246 entries.
+// 247 entries.
 
 export const SRC = {
   codeowners: '.github/CODEOWNERS',
@@ -73,6 +73,7 @@ export const SRC = {
   checkModuleLayering: 'scripts/check-module-layering.py',
   checkModuleTableOwnership: 'scripts/check-module-table-ownership.py',
   checkNpmAuditGate: 'scripts/check-npm-audit-gate.py',
+  checkPooledEqMock: 'scripts/check-pooled-eq-mock.py',
   checkProductionDeployDrift: 'scripts/check-production-deploy-drift.py',
   checkReleaseBranchPush: 'scripts/check-release-branch-push.py',
   checkReleaseTagged: 'scripts/check-release-tagged.py',

--- a/tests/support/test-floor-baseline.json
+++ b/tests/support/test-floor-baseline.json
@@ -1,6 +1,6 @@
 {
   "$comment": "GENERATED — regenerate with `npm run gen:test-floor`. The enforced test floor. The guard fails if the counts DROP (a test was deleted) and also if they RISE (this baseline is stale and is overstating how much of the estate is actually protected). The rise case is the one that matters: the previous hand-maintained floor sat at 29 files / 320 blocks against an actual 260 / 2963, so ~89% of the tests could have been deleted silently. Raise it in the SAME commit as any net-new test.",
-  "measured_at": "2026-08-19",
-  "test_files": 309,
-  "test_blocks": 3581
+  "measured_at": "2026-08-20",
+  "test_files": 310,
+  "test_blocks": 3596
 }


### PR DESCRIPTION
## Summary

Closes the last open half of KAN-459 — **§2, the read-satisfies-write shape** — by adding **CTL-076** (`scripts/check-pooled-eq-mock.py`), a narrow CI gate that fails a test-side Supabase mock whose `.eq()` recorder is keyed by **table** rather than created per `.from()` call.

§1 (`6883603`) and §3 (`833c321`) already landed; this PR does **not** rebuild them.

### The defect the control exists for

KAN-447/448 asserted the owner-scoping of a `school_affiliations` UPDATE through such a pool. `updateSchoolAffiliation` reads the row before it writes it, so the SELECT's own `.eq('id', …)` / `.eq('profile_id', …)` landed in the same pool and satisfied assertions meant to be about the **write** — both filters were deletable while all 27 tests stayed green. The realised impact of that class is editing another member's row, or bulk-overwriting every row of your own.

It is CTL-039's shape inside out: there a **comment** satisfies the assertion, here an incidental **adjacent statement** does. Both fire constantly and answer a different question from the one asked.

### Why a detector rather than only the shared harness the ticket prefers

Measured, not assumed: **exactly one** file in the estate uses the pooled shape — `tests/unit/profile-ownership.test.ts`, the KAN-260 owner-scoping net — and it is non-vacuous today only by luck: its actions happen not to pre-read the table they write (verified by mutation). A shared `tests/support/` harness with no consumer that is not already correct is decorative; a gate covers every mock written from here on. The failure message names `tests/unit/kan447-kan448-inline-edit.test.ts` as the reference implementation, so it points at working code rather than at a rule.

**Deliberately narrow** — three conditions must all hold: a tracked file under `tests/`, an `.eq()` recorder, and a table-keyed subscript *inside* that recorder's body. A broad heuristic over the ~40 hand-rolled mocks here would be standing noise, and standing noise is what teaches reviewers to wave a gate through. Four self-test cases pin the narrowness by asserting the **negative**.

Comments are stripped using `check-comment-only-assertions.py`'s own `strip_comments` rather than a second copy of the rules — two implementations of one rule set with nothing comparing them is the SEC-152 drift shape, and it is the exact mistake KAN-459 §3 corrected for `stripComments`.

### Two things worth a reviewer's attention

- **The one baselined entry is not an annotation.** `profile-ownership.test.ts` is recorded, not converted, because converting it rewrites its existing assertions and the Test Integrity Policy requires sign-off for that. Two-way ratchet: it cannot get worse, and it fails as STALE the moment it is fixed.
- **This suite's own fixtures are assembled at runtime, not written out.** Written literally they make the suite a finding — the CTL-061 failure, a guard firing on its own prose. The fix is not an exclusion (an excluded file is a file the control no longer covers) but building the subscript at runtime, as CTL-064's suite does with its `git push` fixtures, so this file stays genuinely in scope.

### Mutation proof

Four mutations, each verified to have actually applied and each reverted:

| # | mutation | result |
|---|---|---|
| 1 | pool `kan447-kan448-inline-edit.test.ts`'s per-statement mock | red as **NEW**; restored → green |
| 2 | convert the one baselined instance to per-statement | red as **STALE** |
| 3 | remove the `strip_comments` call | **3** self-test cases red |
| 4 | drop the method-shorthand branch of the recorder parser | **1** case red |

Separately, **acceptance criterion 6** verified against the real subject: deleting `.eq('profile_id', …)` from the `school_affiliations` UPDATE turns **2** tests RED, and deleting `.eq('id', …)` turns **2** tests RED — independently load-bearing, which is exactly what the pooled mock hid. Criterion 2's premise was re-checked too: `removeProfileItem`'s owner scope **is** load-bearing today (1 test red).

### Numbers

310 suites / 4193 tests green, measured against `develop` `8bd014e` standing alone in a sibling worktree at **309 / 4177** — +15 from this suite and +1 from the `SRC`-parameterised manifest test. Floor regenerated in the same commit (309/3585 → 310/3596). The one raw path literal was routed through `SRC` rather than absorbed by raising the shrink-only F4 baseline (35 → 36 → 35).

**MCP coverage: not applicable** — CI/test tooling, which KAN-222 explicitly excludes. No user-facing data, entity, route or tool is involved.

## Jira Ticket

KAN-459

## Checklist

- [x] Unit tests added/updated for new/changed functionality — `tests/scripts/check-pooled-eq-mock.test.js` (15) plus 23 in-checker `--self-test` cases
- [x] All existing tests pass (`npm run test:unit`) — 310 suites / 4193 tests, no existing assertion modified, weakened or skipped
- [x] Lint passes (`npm run lint`) — 0 errors, 36 warnings, none in the new files
- [x] Type check passes (`npm run type-check`)
- [ ] Build succeeds (`npm run build`) — **not run**: this PR adds no runtime code (one Python script, one Jest suite, two baselines, a manifest key and a CI wiring line). Stated rather than ticked.
- [x] Coverage has not decreased — no `src/` file changed
- [x] No eslint-disable or ts-ignore without KAN-XX reference — none added
- [x] Dependency-rule gate reviewed — no `src/` import changed, so no new `no-module-to-app` / `no-cross-segment-app` / `no-circular` edge is possible
- [x] ARCHITECTURE.md updated if architectural changes were made — N/A, no architectural change
- [x] Ops routine / Control-Room registry updated — N/A: no scheduled-routine behaviour, cadence or ownership changes. `controls/registry.json` **is** updated, which is the record for a new control.
- [x] Docs / system map updated — **N/A**: CI/test-tooling only. No service, table, route, env var, scheduled job or security boundary changes, so no Architecture & Infrastructure or Data Model & Security page is affected. The commit carries the matching `Docs-N/A: KAN-459 …` trailer.
- [x] Design loop (KAN-441) — **N/A**: no founder-owned UI/copy path is touched. `scripts/check-ui-copy-ownership.sh` reports no changed files in its protected surface, and no `UI-*` trailer is claimed.

---
_Generated by [Claude Code](https://claude.ai/code/session_015nJMFU2B747JY6ukVBAAEN)_